### PR TITLE
[SYCLomatic] Migrate 4 Cooperative Groups APIs

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -3123,8 +3123,11 @@ void TypeInDeclRule::runRule(const MatchFinder::MatchResult &Result) {
       EndLoc = SM->getExpansionRange(TL->getBeginLoc()).getEnd();
     }
 
-    if (DpctGlobalInfo::getTypeName(TL->getType().getCanonicalType()) ==
-        "cooperative_groups::__v1::thread_block_tile<32>") {
+    std::string CanonicalTypeStr =
+        DpctGlobalInfo::getTypeName(TL->getType().getCanonicalType());
+    StringRef CanonicalTypeStrRef(CanonicalTypeStr);
+    if (CanonicalTypeStrRef.startswith(
+            "cooperative_groups::__v1::thread_block_tile<")) {
       if (auto ETL = TL->getUnqualifiedLoc().getAs<ElaboratedTypeLoc>()) {
         SourceLocation Begin = ETL.getBeginLoc();
         SourceLocation End = ETL.getEndLoc();
@@ -3134,9 +3137,17 @@ void TypeInDeclRule::runRule(const MatchFinder::MatchResult &Result) {
             End, *SM, DpctGlobalInfo::getContext().getLangOpts()));
         if (End.isMacroID())
           return;
-        emplaceTransformation(new ReplaceText(
-            Begin, End.getRawEncoding() - Begin.getRawEncoding(),
-            MapNames::getClNamespace() + "sub_group"));
+        if (CanonicalTypeStrRef.equals(
+                "cooperative_groups::__v1::thread_block_tile<32>")) {
+          emplaceTransformation(new ReplaceText(
+              Begin, End.getRawEncoding() - Begin.getRawEncoding(),
+              MapNames::getClNamespace() + "sub_group"));
+        } else {
+          emplaceTransformation(new ReplaceText(
+              Begin, End.getRawEncoding() - Begin.getRawEncoding(),
+              MapNames::getDpctNamespace() + "logical_group"));
+          requestFeature(HelperFeatureEnum::Util_logical_group, Begin);
+        }
         return;
       }
     }
@@ -13179,20 +13190,26 @@ REGISTER_RULE(WarpFunctionsRule)
 void CooperativeGroupsFunctionRule::registerMatcher(MatchFinder &MF) {
   auto CGAPI = [&]() {
     return hasAnyName("this_thread_block", "sync", "tiled_partition",
-                      "thread_rank");
+                      "thread_rank", "size", "shfl_down");
   };
   MF.addMatcher(
-      callExpr(allOf(callee(functionDecl(CGAPI())), parentStmt(),
-                     hasAncestor(functionDecl(anyOf(hasAttr(attr::CUDADevice),
-                                                    hasAttr(attr::CUDAGlobal)))
-                                     .bind("FuncDecl"))))
+      callExpr(
+          allOf(callee(functionDecl(CGAPI(), hasAncestor(namespaceDecl(hasName(
+                                                 "cooperative_groups"))))),
+                parentStmt(),
+                hasAncestor(functionDecl(anyOf(hasAttr(attr::CUDADevice),
+                                               hasAttr(attr::CUDAGlobal)))
+                                .bind("FuncDecl"))))
           .bind("FuncCall"),
       this);
   MF.addMatcher(
-      callExpr(allOf(callee(functionDecl(CGAPI())), unless(parentStmt()),
-                     hasAncestor(functionDecl(anyOf(hasAttr(attr::CUDADevice),
-                                                    hasAttr(attr::CUDAGlobal)))
-                                     .bind("FuncDeclUsed"))))
+      callExpr(
+          allOf(callee(functionDecl(CGAPI(), hasAncestor(namespaceDecl(hasName(
+                                                 "cooperative_groups"))))),
+                unless(parentStmt()),
+                hasAncestor(functionDecl(anyOf(hasAttr(attr::CUDADevice),
+                                               hasAttr(attr::CUDAGlobal)))
+                                .bind("FuncDeclUsed"))))
           .bind("FuncCallUsed"),
       this);
 }
@@ -13311,9 +13328,16 @@ void CooperativeGroupsFunctionRule::runRule(
         return;
       auto BaseType =
           DpctGlobalInfo::getTypeName(Base->getType().getCanonicalType());
-      if (BaseType == "cooperative_groups::__v1::thread_block_tile<32>") {
+      StringRef BaseTypeRef(BaseType);
+      if (BaseTypeRef.equals(
+              "cooperative_groups::__v1::thread_block_tile<32>")) {
         Replacement =
             DpctGlobalInfo::getSubGroup(CE) + ".get_local_linear_id()";
+      } else if (BaseTypeRef.startswith(
+                     "cooperative_groups::__v1::thread_block_tile<")) {
+        Replacement = ExprAnalysis::ref(Base) + ".get_local_linear_id()";
+        requestFeature(
+            HelperFeatureEnum::Util_logical_group_get_local_linear_id, ME);
       } else if (BaseType == "cooperative_groups::__v1::thread_block") {
         Replacement = DpctGlobalInfo::getItem(CE) + ".get_local_linear_id()";
       } else {
@@ -13323,9 +13347,17 @@ void CooperativeGroupsFunctionRule::runRule(
       // Usage 2
       std::string ArgType = DpctGlobalInfo::getTypeName(
           CE->getArg(0)->getType().getCanonicalType());
-      if (ArgType == "const cooperative_groups::__v1::thread_block_tile<32>") {
+      StringRef ArgTypeRef(ArgType);
+      if (ArgTypeRef.equals(
+                "const cooperative_groups::__v1::thread_block_tile<32>")) {
         Replacement =
             DpctGlobalInfo::getSubGroup(CE) + ".get_local_linear_id()";
+      } else if (ArgTypeRef.startswith(
+              "const cooperative_groups::__v1::thread_block_tile<")) {
+        Replacement = ExprAnalysis::ref(CE->getArg(0)) +
+                      ".get_local_linear_id()";
+        requestFeature(
+            HelperFeatureEnum::Util_logical_group_get_local_linear_id, CE);
       } else if (ArgType == "const cooperative_groups::__v1::thread_block") {
         Replacement = DpctGlobalInfo::getItem(CE) + ".get_local_linear_id()";
       } else {
@@ -13348,22 +13380,111 @@ void CooperativeGroupsFunctionRule::runRule(
     OS.flush();
     if (FullName != "cooperative_groups::__v1::tiled_partition")
       return;
+    if (CE->getNumArgs() < 1)
+      EMIT_WARNING_AND_RETURN;
+    std::string ArgType = DpctGlobalInfo::getTypeName(
+        CE->getArg(0)->getType().getCanonicalType());
+    if (ArgType != "const cooperative_groups::__v1::thread_block")
+      EMIT_WARNING_AND_RETURN;
 
-    if (auto TAL = CE->getDirectCallee()->getTemplateSpecializationArgs()) {
-      if (TAL->size() && (TAL->get(0).getAsIntegral().getExtValue() == 32)) {
-        auto FuncInfo = DeviceFunctionDecl::LinkRedecls(
-            DpctGlobalInfo::getParentFunction(CE));
-        if (FuncInfo) {
-          if (DpctGlobalInfo::useFreeQueries())
-            FuncInfo->addSubGroupSizeRequest(32, CE->getBeginLoc(),
-                                             "this_sub_group");
-          else
-            FuncInfo->addSubGroupSizeRequest(32, CE->getBeginLoc(),
-                                             "get_sub_group");
-          emplaceTransformation(
-              new ReplaceStmt(CE, DpctGlobalInfo::getSubGroup(CE, FD)));
+    auto FuncInfo =
+        DeviceFunctionDecl::LinkRedecls(DpctGlobalInfo::getParentFunction(CE));
+    if (FuncInfo) {
+      FuncInfo->addSubGroupSizeRequest(32, CE->getBeginLoc(),
+                                       MapNames::getDpctNamespace() +
+                                           "logical_group");
+      FuncInfo->getVarMap().Dim = 3;
+    } else {
+      EMIT_WARNING_AND_RETURN;
+    }
+
+    const Expr *Callee = CE->getCallee()->IgnoreParenImpCasts();
+    if (dyn_cast_or_null<FunctionDecl>(Callee->getReferencedDeclOfCallee())) {
+      if (auto DRE = dyn_cast<DeclRefExpr>(Callee)) {
+        auto TA = DRE->template_arguments();
+        if (TA.size()) {
+          auto &SM = DpctGlobalInfo::getSourceManager();
+          auto Begin = SM.getExpansionLoc(TA[0].getSourceRange().getBegin());
+          auto End = SM.getExpansionLoc(TA[0].getSourceRange().getEnd());
+          End = End.getLocWithOffset(Lexer::MeasureTokenLength(
+              End, SM, DpctGlobalInfo::getContext().getLangOpts()));
+          auto Len = End.getRawEncoding() - Begin.getRawEncoding();
+          auto C = SM.getCharacterData(Begin);
+          std::string PartitionSize = std::string(C, Len);
+
+          if (auto TSA =
+                  CE->getDirectCallee()->getTemplateSpecializationArgs()) {
+            if (TSA->size() && (TSA->get(0).getKind() ==
+                                clang::TemplateArgument::ArgKind::Integral)) {
+              auto I = TSA->get(0).getAsIntegral();
+              if (I.getMinSignedBits() <= 64 && I.getExtValue() == 32) {
+                emplaceTransformation(
+                    new ReplaceStmt(CE, DpctGlobalInfo::getSubGroup(CE)));
+                return;
+              }
+            }
+          }
+
+          std::string Replacement =
+              MapNames::getDpctNamespace() + "logical_group(" +
+              DpctGlobalInfo::getGroup(CE) + ", " + PartitionSize + ")";
+          emplaceTransformation(new ReplaceStmt(CE, Replacement));
+          return;
         }
       }
+    }
+    EMIT_WARNING_AND_RETURN;
+  } else if (FuncName == "size") {
+    auto ME = dyn_cast<MemberExpr>(CE->getCallee()->IgnoreImpCasts());
+    if (!ME)
+      EMIT_WARNING_AND_RETURN;
+    auto Base = ME->getBase()->IgnoreImpCasts();
+    if (!Base)
+      EMIT_WARNING_AND_RETURN;
+    auto BaseType =
+        DpctGlobalInfo::getTypeName(Base->getType().getCanonicalType());
+    StringRef BaseTypeRef(BaseType);
+    std::string Replacement;
+    if (BaseTypeRef.equals("cooperative_groups::__v1::thread_block_tile<32>")) {
+      Replacement =
+          DpctGlobalInfo::getSubGroup(CE) + ".get_local_linear_range()";
+    } else if (BaseTypeRef.startswith(
+                   "cooperative_groups::__v1::thread_block_tile<")) {
+      Replacement =
+          ExprAnalysis::ref(Base) + ".get_local_linear_range()";
+      requestFeature(
+          HelperFeatureEnum::Util_logical_group_get_local_linear_range, ME);
+    } else {
+      EMIT_WARNING_AND_RETURN;
+    }
+    emplaceTransformation(new ReplaceStmt(CE, std::move(Replacement)));
+  } else if (FuncName == "shfl_down") {
+    auto ME = dyn_cast<MemberExpr>(CE->getCallee()->IgnoreImpCasts());
+    if (!ME)
+      EMIT_WARNING_AND_RETURN;
+    auto Base = ME->getBase()->IgnoreImpCasts();
+    if (!Base)
+      EMIT_WARNING_AND_RETURN;
+    auto BaseType =
+        DpctGlobalInfo::getTypeName(Base->getType().getCanonicalType());
+    StringRef BaseTypeRef(BaseType);
+    if (BaseTypeRef.startswith(
+            "cooperative_groups::__v1::thread_block_tile<")) {
+      auto TST = Base->getType()->getAs<TemplateSpecializationType>();
+      std::string SizeStr;
+      llvm::raw_string_ostream OS(SizeStr);
+      TST->getArg(0).print(
+          DpctGlobalInfo::getContext().getPrintingPolicy(), OS, false);
+      OS.flush();
+      std::string Repl =
+          MapNames::getDpctNamespace() + "shift_sub_group_left(" +
+          DpctGlobalInfo::getSubGroup(CE) + ", " +
+          ExprAnalysis::ref(CE->getArg(0)) + ", " +
+          ExprAnalysis::ref(CE->getArg(1)) + ", " + SizeStr + ")";
+      emplaceTransformation(new ReplaceStmt(CE, Repl));
+      requestFeature(HelperFeatureEnum::Util_shift_sub_group_left, CE);
+    } else {
+      EMIT_WARNING_AND_RETURN;
     }
   }
 }

--- a/clang/runtime/dpct-rt/include/util.hpp.inc
+++ b/clang/runtime/dpct-rt/include/util.hpp.inc
@@ -462,6 +462,92 @@ T permute_sub_group_by_xor(sycl::sub_group g, T x, unsigned int mask,
 }
 // DPCT_LABEL_END
 
+// DPCT_LABEL_BEGIN|logical_group|dpct
+// DPCT_DEPENDENCY_BEGIN
+// Util|logical_group_1
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+/// The logical-group is the group of some work-items.
+/// Currently only cl::sycl::group<3> is supported to be the parent group of
+/// the logical-group.
+class logical_group {
+  cl::sycl::group<3> _g;
+  uint32_t _logical_group_size;
+  uint32_t _group_linear_range_in_parent;
+public:
+  /// Dividing \p parent_group into several logical-groups.
+  /// \param [in] parent_group The group to be divided.
+  /// \param [in] size The logical-group size.
+  logical_group(cl::sycl::group<3> parent_group, uint32_t size)
+      : _g(parent_group), _logical_group_size(size) {
+    _group_linear_range_in_parent =
+        (_g.get_local_linear_range() - 1) / _logical_group_size + 1;
+  }
+// DPCT_LABEL_END
+// DPCT_LABEL_BEGIN|logical_group_get_local_linear_id|dpct
+// DPCT_PARENT_FEATURE|logical_group
+// DPCT_DEPENDENCY_BEGIN
+// Util|logical_group
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+  /// Returns the index of the work-item within the logical-group.
+  uint32_t get_local_linear_id() const {
+    return _g.get_local_linear_id() % _logical_group_size;
+  }
+// DPCT_LABEL_END
+// DPCT_LABEL_BEGIN|logical_group_get_group_linear_id|dpct
+// DPCT_PARENT_FEATURE|logical_group
+// DPCT_DEPENDENCY_BEGIN
+// Util|logical_group
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+  /// Returns the index of the logical-group in the parent group.
+  uint32_t get_group_linear_id() const {
+    return _g.get_local_linear_id() / _logical_group_size;
+  }
+// DPCT_LABEL_END
+// DPCT_LABEL_BEGIN|logical_group_get_local_linear_range|dpct
+// DPCT_PARENT_FEATURE|logical_group
+// DPCT_DEPENDENCY_BEGIN
+// Util|logical_group
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+  /// Returns the number of work-items in the logical-group.
+  uint32_t get_local_linear_range() const {
+    if (_g.get_local_linear_range() % _logical_group_size == 0) {
+      return _logical_group_size;
+    }
+    uint32_t last_item_group_id =
+        _g.get_local_linear_range() / _logical_group_size;
+    if (_g.get_local_linear_id() >=
+        last_item_group_id * _logical_group_size) {
+      return _g.get_local_linear_range() -
+             last_item_group_id * _logical_group_size;
+    } else {
+      return _logical_group_size;
+    }
+  }
+// DPCT_LABEL_END
+// DPCT_LABEL_BEGIN|logical_group_get_group_linear_range|dpct
+// DPCT_PARENT_FEATURE|logical_group
+// DPCT_DEPENDENCY_BEGIN
+// Util|logical_group
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+  /// Returns the number of logical-group in the parent group.
+  uint32_t get_group_linear_range() const {
+    return _group_linear_range_in_parent;
+  }
+// DPCT_LABEL_END
+// DPCT_LABEL_BEGIN|logical_group_1|dpct
+// DPCT_PARENT_FEATURE|logical_group
+// DPCT_DEPENDENCY_BEGIN
+// Util|logical_group
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+};
+// DPCT_LABEL_END
+
 // DPCT_LABEL_BEGIN|cmul|dpct
 // DPCT_DEPENDENCY_EMPTY
 // DPCT_CODE

--- a/clang/test/dpct/helper_files_ref/include/util.hpp
+++ b/clang/test/dpct/helper_files_ref/include/util.hpp
@@ -346,6 +346,51 @@ T permute_sub_group_by_xor(sycl::sub_group g, T x, unsigned int mask,
                                      : id);
 }
 
+/// The logical-group is the group of some work-items.
+/// Currently only cl::sycl::group<3> is supported to be the parent group of
+/// the logical-group.
+class logical_group {
+  cl::sycl::group<3> _g;
+  uint32_t _logical_group_size;
+  uint32_t _group_linear_range_in_parent;
+public:
+  /// Dividing \p parent_group into several logical-groups.
+  /// \param [in] parent_group The group to be divided.
+  /// \param [in] size The logical-group size.
+  logical_group(cl::sycl::group<3> parent_group, uint32_t size)
+      : _g(parent_group), _logical_group_size(size) {
+    _group_linear_range_in_parent =
+        (_g.get_local_linear_range() - 1) / _logical_group_size + 1;
+  }
+  /// Returns the index of the work-item within the logical-group.
+  uint32_t get_local_linear_id() const {
+    return _g.get_local_linear_id() % _logical_group_size;
+  }
+  /// Returns the index of the logical-group in the parent group.
+  uint32_t get_group_linear_id() const {
+    return _g.get_local_linear_id() / _logical_group_size;
+  }
+  /// Returns the number of work-items in the logical-group.
+  uint32_t get_local_linear_range() const {
+    if (_g.get_local_linear_range() % _logical_group_size == 0) {
+      return _logical_group_size;
+    }
+    uint32_t last_item_group_id =
+        _g.get_local_linear_range() / _logical_group_size;
+    if (_g.get_local_linear_id() >=
+        last_item_group_id * _logical_group_size) {
+      return _g.get_local_linear_range() -
+             last_item_group_id * _logical_group_size;
+    } else {
+      return _logical_group_size;
+    }
+  }
+  /// Returns the number of logical-group in the parent group.
+  uint32_t get_group_linear_range() const {
+    return _group_linear_range_in_parent;
+  }
+};
+
 /// Computes the multiplication of two complex numbers.
 /// \tparam T Complex element type
 /// \param [in] x The first input complex number

--- a/clang/test/dpct/test_api_level/Util/api_test18.cu
+++ b/clang/test/dpct/test_api_level/Util/api_test18.cu
@@ -3,13 +3,13 @@
 // RUN: FileCheck --input-file %T/Util/api_test18_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/Util/api_test18_out
 
-// CHECK: 1
+// CHECK: 2
 // TEST_FEATURE: Util_cdiv
 
 #include <cuComplex.h>
 
 __device__ void foo1() {
-    float2 a, b;
+    double2 a, b;
 
     auto c = cuCdiv(a, b);
 

--- a/clang/test/dpct/test_api_level/Util/api_test19.cu
+++ b/clang/test/dpct/test_api_level/Util/api_test19.cu
@@ -3,13 +3,13 @@
 // RUN: FileCheck --input-file %T/Util/api_test19_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/Util/api_test19_out
 
-// CHECK: 1
+// CHECK: 2
 // TEST_FEATURE: Util_cmul
 
 #include <cuComplex.h>
 
 __device__ void foo1() {
-    float2 a, b;
+    double2 a, b;
 
     auto c = cuCmul(a, b);
 

--- a/clang/test/dpct/test_api_level/Util/api_test20.cu
+++ b/clang/test/dpct/test_api_level/Util/api_test20.cu
@@ -3,13 +3,13 @@
 // RUN: FileCheck --input-file %T/Util/api_test20_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/Util/api_test20_out
 
-// CHECK: 1
+// CHECK: 2
 // TEST_FEATURE: Util_cabs
 
 #include <cuComplex.h>
 
 __device__ void foo1() {
-    float2 a;
+    double2 a;
 
     auto c = cuCabs(a);
 

--- a/clang/test/dpct/test_api_level/Util/api_test21.cu
+++ b/clang/test/dpct/test_api_level/Util/api_test21.cu
@@ -3,13 +3,13 @@
 // RUN: FileCheck --input-file %T/Util/api_test21_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/Util/api_test21_out
 
-// CHECK: 1
+// CHECK: 2
 // TEST_FEATURE: Util_conj
 
 #include <cuComplex.h>
 
 __device__ void foo1() {
-    float2 a;
+    double2 a;
 
     auto c = cuConj(a);
 

--- a/clang/test/dpct/test_api_level/Util/api_test23.cu
+++ b/clang/test/dpct/test_api_level/Util/api_test23.cu
@@ -1,0 +1,18 @@
+// UNSUPPORTED: cuda-8.0
+// UNSUPPORTED: v8.0
+// RUN: dpct --format-range=none  --usm-level=none  --use-custom-helper=api -out-root %T/Util/api_test23_out %s --cuda-include-path="%cuda-path/include" -- -x cuda --cuda-host-only
+// RUN: grep "IsCalled" %T/Util/api_test23_out/MainSourceFiles.yaml | wc -l > %T/Util/api_test23_out/count.txt
+// RUN: FileCheck --input-file %T/Util/api_test23_out/count.txt --match-full-lines %s
+// RUN: rm -rf %T/Util/api_test23_out
+
+// CHECK: 4
+// TEST_FEATURE: Util_logical_group_get_local_linear_id
+
+#include <cooperative_groups.h>
+namespace cg = cooperative_groups;
+
+__device__ void foo() {
+  cg::thread_block ttb = cg::this_thread_block();
+  cg::thread_block_tile<8> tbt = cg::tiled_partition<8>(ttb);
+  tbt.thread_rank();
+}

--- a/clang/test/dpct/test_api_level/Util/api_test24.cu
+++ b/clang/test/dpct/test_api_level/Util/api_test24.cu
@@ -1,0 +1,18 @@
+// UNSUPPORTED: cuda-8.0
+// UNSUPPORTED: v8.0
+// RUN: dpct --format-range=none  --usm-level=none  --use-custom-helper=api -out-root %T/Util/api_test24_out %s --cuda-include-path="%cuda-path/include" -- -x cuda --cuda-host-only
+// RUN: grep "IsCalled" %T/Util/api_test24_out/MainSourceFiles.yaml | wc -l > %T/Util/api_test24_out/count.txt
+// RUN: FileCheck --input-file %T/Util/api_test24_out/count.txt --match-full-lines %s
+// RUN: rm -rf %T/Util/api_test24_out
+
+// CHECK: 4
+// TEST_FEATURE: Util_logical_group_get_local_linear_range
+
+#include <cooperative_groups.h>
+namespace cg = cooperative_groups;
+
+__device__ void foo() {
+  cg::thread_block ttb = cg::this_thread_block();
+  cg::thread_block_tile<8> tbt = cg::tiled_partition<8>(ttb);
+  tbt.size();
+}

--- a/clang/test/dpct/test_api_level/Util/api_test25.cu
+++ b/clang/test/dpct/test_api_level/Util/api_test25.cu
@@ -1,0 +1,17 @@
+// UNSUPPORTED: cuda-8.0
+// UNSUPPORTED: v8.0
+// RUN: dpct --format-range=none  --usm-level=none  --use-custom-helper=api -out-root %T/Util/api_test25_out %s --cuda-include-path="%cuda-path/include" -- -x cuda --cuda-host-only
+// RUN: grep "IsCalled" %T/Util/api_test25_out/MainSourceFiles.yaml | wc -l > %T/Util/api_test25_out/count.txt
+// RUN: FileCheck --input-file %T/Util/api_test25_out/count.txt --match-full-lines %s
+// RUN: rm -rf %T/Util/api_test25_out
+
+// CHECK: 3
+// TEST_FEATURE: Util_logical_group
+
+#include <cooperative_groups.h>
+namespace cg = cooperative_groups;
+
+__device__ void foo() {
+  cg::thread_block ttb = cg::this_thread_block();
+  cg::thread_block_tile<8> tbt = cg::tiled_partition<8>(ttb);
+}


### PR DESCRIPTION
cg::tiled_partition<SIZE>(thread_block) => dpct::logical_group(item.get_group(), SIZE)
cg::thread_block_tile::size() => dpct::logical_group::get_local_linear_range()
cg::thread_block_tile::thread_rank() => dpct::logical_group::get_local_linear_id()
cg::thread_block_tile::shfl_down() => dpct::shift_sub_group_left()