### PR TITLE
[SYCLomatic] Remove unnecessary message when using --help-hidden

### DIFF
--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -2379,7 +2379,11 @@ protected:
       // Hide empty categories for --help, but show for --help-hidden.
       const auto &CategoryOptions = CategorizedOptions[Category];
       bool IsEmptyCategory = CategoryOptions.empty();
+#ifdef SYCLomatic_CUSTOMIZATION
+      if (IsEmptyCategory)
+#else
       if (!ShowHidden && IsEmptyCategory)
+#endif // SYCLomatic_CUSTOMIZATION
         continue;
 
       // Print category information.


### PR DESCRIPTION
Before this patch:
```
$ dpct --help-hidden
USAGE: dpct [options] [<source0> ... <sourceN>]

OPTIONS:

  This option category has no options.

  This option category has no options.

  --help-hidden                                  - Display all available options
  --help-list                                    - Display list of available options (--help-list-hidden for more)
  --help-list-hidden                             - Display list of all available options
  --print-all-options                            - Print all option values after command line parsing
  --print-options                                - Print non-default options after command line parsing

  --always-use-async-handler                     - Always create the cl::sycl::queue with an async exception handler. Default: off.
...
```
After this patch:
```
$ dpct --help-hidden
USAGE: dpct [options] [<source0> ... <sourceN>]

OPTIONS:

  --help-hidden                                  - Display all available options
  --help-list                                    - Display list of available options (--help-list-hidden for more)
  --help-list-hidden                             - Display list of all available options
  --print-all-options                            - Print all option values after command line parsing
  --print-options                                - Print non-default options after command line parsing

  --always-use-async-handler                     - Always create the cl::sycl::queue with an async exception handler. Default: off.
...
```