### PR TITLE
Migrate __habs, __habs2, and __hadd2

### DIFF
--- a/clang/lib/DPCT/APINames.inc
+++ b/clang/lib/DPCT/APINames.inc
@@ -367,6 +367,7 @@ ENTRY(atomicOr, atomicOr, true, NO_FLAG, P0, "Successful")
 ENTRY(atomicXor, atomicXor, true, NO_FLAG, P0, "Successful")
 
 // Half Arithmetic Functions
+ENTRY(__habs, __habs, true, NO_FLAG, P4, "Successful")
 ENTRY(__h2div, __h2div, true, NO_FLAG, P4, "Successful")
 ENTRY(__hadd_sat, __hadd_sat, true, NO_FLAG, P4, "no direct mapping yet")
 ENTRY(__hdiv, __hdiv, true, NO_FLAG, P4, "Successful")
@@ -379,6 +380,8 @@ ENTRY(__hsub, __hsub, true, NO_FLAG, P4, "Successful")
 ENTRY(__hsub_sat, __hsub_sat, true, NO_FLAG, P4, "no direct mapping yet")
 
 // Half2 Arithmetic Functions
+ENTRY(__habs2, __habs2, true, NO_FLAG, P4, "Successful")
+ENTRY(__hadd2, __hadd2, true, NO_FLAG, P0, "Successful")
 ENTRY(__hadd2_sat, __hadd2_sat, true, NO_FLAG, P4, "no direct mapping yet")
 ENTRY(__hfma2, __hfma2, true, NO_FLAG, P0, "Successful")
 ENTRY(__hfma2_sat, __hfma2_sat, true, NO_FLAG, P4, "no direct mapping yet")
@@ -1007,7 +1010,6 @@ ENTRY(__cudaRegisterSurface, __cudaRegisterSurface, false, NO_FLAG, P4, "comment
 ENTRY(__cudaRegisterTexture, __cudaRegisterTexture, false, NO_FLAG, P4, "comment")
 ENTRY(__cudaRegisterVar, __cudaRegisterVar, false, NO_FLAG, P4, "comment")
 ENTRY(__cudaUnregisterFatBinary, __cudaUnregisterFatBinary, false, NO_FLAG, P0, "comment")
-ENTRY(__hadd2, __hadd2, false, NO_FLAG, P0, "comment")
 ENTRY(h2div, h2div, false, NO_FLAG, P4, "comment")
 ENTRY(hdiv, hdiv, false, NO_FLAG, P0, "comment")
 ENTRY(make_char1, make_char1, true, NO_FLAG, P4, "Successful")

--- a/clang/lib/DPCT/APINamesMath.inc
+++ b/clang/lib/DPCT/APINamesMath.inc
@@ -305,6 +305,11 @@ ENTRY_EMULATED("__drcp_rz", MapNames::getClNamespace(false, true) + "native::rec
 
 
 // Half/Half2 Arithmetic Functions
+ENTRY_RENAMED("__habs", MapNames::getClNamespace(false, true) + "fabs")
+ENTRY_RENAMED("__habs2", MapNames::getClNamespace(false, true) + "fabs")
+
+ENTRY_OPERATOR("__hadd2", BinaryOperatorKind::BO_Add)
+
 ENTRY_OPERATOR("__h2div", BinaryOperatorKind::BO_Div)
 ENTRY_OPERATOR("__hdiv", BinaryOperatorKind::BO_Div)
 

--- a/clang/test/dpct/cuda-math-intrinsics.cu
+++ b/clang/test/dpct/cuda-math-intrinsics.cu
@@ -61,6 +61,8 @@ __global__ void kernelFuncHalf(double *deviceArrayDouble) {
 
   // Half Arithmetic Functions
 
+  // CHECK: h_2 = sycl::fabs(h);
+  h_2 = __habs(h);
   // TODO:1CHECK: h2_2 = h2 / h2_1;
   //h2_2 = __h2div(h2, h2_1);
   // TODO:1CHECK: h_2 = h / h_1;
@@ -76,6 +78,10 @@ __global__ void kernelFuncHalf(double *deviceArrayDouble) {
 
   // Half2 Arithmetic Functions
 
+  // CHECK: h2_2 = sycl::fabs(h2);
+  h2_2 = __habs2(h2);
+  // CHECK: h2_2 = h2 + h2_1;
+  h2_2 = __hadd2(h2, h2_1);
   // CHECK: h2_2 = sycl::fma(h2, h2_1, h2_2);
   h2_2 = __hfma2(h2, h2_1, h2_2);
   // CHECK: h2_2 = h2 * h2_1;


### PR DESCRIPTION
This PR implements the following migrations:

- `_habs` maps to `sycl::fabs`
- `__habs2` maps to `sycl::fabs`
- `__hadd2(x, y)` maps to `x + y`