### PR TITLE
[SYCLomatic] Use rewriter to migrate 4 APIs to fix incorrect migration when API is in macro

### DIFF
--- a/clang/lib/DPCT/APINamesErrorHandling.inc
+++ b/clang/lib/DPCT/APINamesErrorHandling.inc
@@ -6,36 +6,42 @@
 //
 //===----------------------------------------------------------------------===//
 
-WARNING_FACTORY_ENTRY("cudaGetErrorString",
-INSERT_AROUND_FACTORY(
-    CALL_FACTORY_ENTRY("cudaGetErrorString",
-                       CALL("cudaGetErrorString",
-                            ARG(0))),"\"cudaGetErrorString not supported\"/*","*/"),
-Diagnostics::TRNA_WARNING_ERROR_HANDLING_API_COMMENTED)
+WARNING_FACTORY_ENTRY(
+    "cudaGetErrorString",
+    INSERT_AROUND_FACTORY(CALL_FACTORY_ENTRY("cudaGetErrorString",
+                                             CALL("cudaGetErrorString",
+                                                  ARG_WC(0))),
+                          "\"cudaGetErrorString not supported\"/*", "*/"),
+    Diagnostics::TRNA_WARNING_ERROR_HANDLING_API_COMMENTED)
 
-WARNING_FACTORY_ENTRY("cudaGetErrorName",
-INSERT_AROUND_FACTORY(
-    CALL_FACTORY_ENTRY("cudaGetErrorName",
-                       CALL("cudaGetErrorName",
-                            ARG(0))),"\"cudaGetErrorName not supported\"/*","*/"),
-Diagnostics::TRNA_WARNING_ERROR_HANDLING_API_COMMENTED)
+WARNING_FACTORY_ENTRY(
+    "cudaGetErrorName",
+    INSERT_AROUND_FACTORY(CALL_FACTORY_ENTRY("cudaGetErrorName",
+                                             CALL("cudaGetErrorName",
+                                                  ARG_WC(0))),
+                          "\"cudaGetErrorName not supported\"/*", "*/"),
+    Diagnostics::TRNA_WARNING_ERROR_HANDLING_API_COMMENTED)
 
 CONDITIONAL_FACTORY_ENTRY(
     checkIsCallExprOnly(),
-    WARNING_FACTORY_ENTRY("cudaGetLastError",
+    WARNING_FACTORY_ENTRY(
+        "cudaGetLastError",
         TOSTRING_FACTORY_ENTRY("cudaGetLastError", LITERAL("")),
-        Diagnostics::FUNC_CALL_REMOVED,
-        std::string("cudaGetLastError"), std::string("the function call is redundant in DPC++.")),
-    WARNING_FACTORY_ENTRY("cudaGetLastError",
+        Diagnostics::FUNC_CALL_REMOVED, std::string("cudaGetLastError"),
+        std::string("the function call is redundant in DPC++.")),
+    WARNING_FACTORY_ENTRY(
+        "cudaGetLastError",
         TOSTRING_FACTORY_ENTRY("cudaGetLastError", LITERAL("0")),
         Diagnostics::TRNA_WARNING_ERROR_HANDLING_API_REPLACED_0))
 
 CONDITIONAL_FACTORY_ENTRY(
     checkIsCallExprOnly(),
-    WARNING_FACTORY_ENTRY("cudaPeekAtLastError",
+    WARNING_FACTORY_ENTRY(
+        "cudaPeekAtLastError",
         TOSTRING_FACTORY_ENTRY("cudaPeekAtLastError", LITERAL("")),
-        Diagnostics::FUNC_CALL_REMOVED,
-        std::string("cudaPeekAtLastError"), std::string("the function call is redundant in DPC++.")),
-    WARNING_FACTORY_ENTRY("cudaPeekAtLastError",
+        Diagnostics::FUNC_CALL_REMOVED, std::string("cudaPeekAtLastError"),
+        std::string("the function call is redundant in DPC++.")),
+    WARNING_FACTORY_ENTRY(
+        "cudaPeekAtLastError",
         TOSTRING_FACTORY_ENTRY("cudaPeekAtLastError", LITERAL("0")),
         Diagnostics::TRNA_WARNING_ERROR_HANDLING_API_REPLACED_0))

--- a/clang/lib/DPCT/APINamesErrorHandling.inc
+++ b/clang/lib/DPCT/APINamesErrorHandling.inc
@@ -1,0 +1,41 @@
+//===--------------- APINamesErrorHandling.inc ----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+WARNING_FACTORY_ENTRY("cudaGetErrorString",
+INSERT_AROUND_FACTORY(
+    CALL_FACTORY_ENTRY("cudaGetErrorString",
+                       CALL("cudaGetErrorString",
+                            ARG(0))),"\"cudaGetErrorString not supported\"/*","*/"),
+Diagnostics::TRNA_WARNING_ERROR_HANDLING_API_COMMENTED)
+
+WARNING_FACTORY_ENTRY("cudaGetErrorName",
+INSERT_AROUND_FACTORY(
+    CALL_FACTORY_ENTRY("cudaGetErrorName",
+                       CALL("cudaGetErrorName",
+                            ARG(0))),"\"cudaGetErrorName not supported\"/*","*/"),
+Diagnostics::TRNA_WARNING_ERROR_HANDLING_API_COMMENTED)
+
+CONDITIONAL_FACTORY_ENTRY(
+    checkIsCallExprOnly(),
+    WARNING_FACTORY_ENTRY("cudaGetLastError",
+        TOSTRING_FACTORY_ENTRY("cudaGetLastError", LITERAL("")),
+        Diagnostics::FUNC_CALL_REMOVED,
+        std::string("cudaGetLastError"), std::string("the function call is redundant in DPC++.")),
+    WARNING_FACTORY_ENTRY("cudaGetLastError",
+        TOSTRING_FACTORY_ENTRY("cudaGetLastError", LITERAL("0")),
+        Diagnostics::TRNA_WARNING_ERROR_HANDLING_API_REPLACED_0))
+
+CONDITIONAL_FACTORY_ENTRY(
+    checkIsCallExprOnly(),
+    WARNING_FACTORY_ENTRY("cudaPeekAtLastError",
+        TOSTRING_FACTORY_ENTRY("cudaPeekAtLastError", LITERAL("")),
+        Diagnostics::FUNC_CALL_REMOVED,
+        std::string("cudaPeekAtLastError"), std::string("the function call is redundant in DPC++.")),
+    WARNING_FACTORY_ENTRY("cudaPeekAtLastError",
+        TOSTRING_FACTORY_ENTRY("cudaPeekAtLastError", LITERAL("0")),
+        Diagnostics::TRNA_WARNING_ERROR_HANDLING_API_REPLACED_0))

--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -8619,28 +8619,12 @@ void FunctionCallRule::runRule(const MatchFinder::MatchResult &Result) {
     emplaceTransformation(new ReplaceStmt(CE, std::move(ReplStr)));
 
   } else if (FuncName == "cudaGetLastError" ||
-             FuncName == "cudaPeekAtLastError") {
-    if (IsAssigned) {
-      report(CE->getBeginLoc(),
-             Comments::TRNA_WARNING_ERROR_HANDLING_API_REPLACED_0, false,
-             MapNames::ITFName.at(FuncName));
-      emplaceTransformation(new ReplaceStmt(CE, "0"));
-    } else {
-      report(CE->getBeginLoc(), Diagnostics::FUNC_CALL_REMOVED, false,
-             MapNames::ITFName.at(FuncName),
-             "the function call is redundant in DPC++.");
-      emplaceTransformation(new ReplaceStmt(CE, true, ""));
-    }
-  } else if (FuncName == "cudaGetErrorString" ||
+             FuncName == "cudaPeekAtLastError" ||
+             FuncName == "cudaGetErrorString" ||
              FuncName == "cudaGetErrorName") {
-    // Insert warning messages into the spelling locations in case
-    // that these functions are contained in macro definitions
-    auto Loc = Result.SourceManager->getSpellingLoc(CE->getBeginLoc());
-    report(Loc, Comments::TRNA_WARNING_ERROR_HANDLING_API_COMMENTED, false,
-           MapNames::ITFName.at(FuncName));
-    emplaceTransformation(
-        new InsertBeforeStmt(CE, "\"" + FuncName + " not supported\"/*"));
-    emplaceTransformation(new InsertAfterStmt(CE, "*/"));
+    ExprAnalysis EA(CE);
+    emplaceTransformation(EA.getReplacement());
+    EA.applyAllSubExprRepl();
   } else if (FuncName == "clock" || FuncName == "clock64") {
     report(CE->getBeginLoc(), Diagnostics::API_NOT_MIGRATED_SYCL_UNDEF, false,
            FuncName);

--- a/clang/lib/DPCT/CallExprRewriter.cpp
+++ b/clang/lib/DPCT/CallExprRewriter.cpp
@@ -1916,6 +1916,29 @@ createAssignableFactory(
   return createAssignableFactory(std::move(Input));
 }
 
+
+std::pair<std::string, std::shared_ptr<CallExprRewriterFactoryBase>>
+createInsertAroundFactory(
+    std::pair<std::string, std::shared_ptr<CallExprRewriterFactoryBase>>
+        &&Input,
+    std::string &&Prefix, std::string &&Suffix) {
+  return std::pair<std::string, std::shared_ptr<CallExprRewriterFactoryBase>>(
+      std::move(Input.first),
+      std::make_shared<InsertAroundRewriterFactory>(
+          Input.second, std::move(Prefix), std::move(Suffix)));
+}
+
+template <class T>
+std::pair<std::string, std::shared_ptr<CallExprRewriterFactoryBase>>
+createInsertAroundFactory(
+    std::pair<std::string, std::shared_ptr<CallExprRewriterFactoryBase>>
+        &&Input,
+    std::string &&Prefix, std::string &&Suffix, T) {
+  return createInsertAroundFactory(std::move(Input), std::move(Prefix),
+                                   std::move(Suffix));
+}
+
+
 /// Create RewriterFactoryWithFeatureRequest key-value pair with inner
 /// key-value. Will call requestFeature when used to create CallExprRewriter.
 std::pair<std::string, std::shared_ptr<CallExprRewriterFactoryBase>>
@@ -2358,6 +2381,8 @@ public:
 };
 
 #define ASSIGNABLE_FACTORY(x) createAssignableFactory(x 0),
+#define INSERT_AROUND_FACTORY(x, PREFIX, SUFFIX)                               \
+  createInsertAroundFactory(x PREFIX, SUFFIX, 0),
 #define FEATURE_REQUEST_FACTORY(FEATURE, x)                                    \
   createFeatureRequestFactory(FEATURE, x 0),
 #define HEADER_INSERT_FACTORY(HEADER, x)                                       \
@@ -2529,6 +2554,7 @@ void CallExprRewriterFactoryBase::initRewriterMap() {
 #include "APINamesThrust.inc"
 #include "APINamesWarp.inc"
 #include "APINamesCUDNN.inc"
+#include "APINamesErrorHandling.inc"
 #undef ENTRY_RENAMED
 #undef ENTRY_TEXTURE
 #undef ENTRY_UNSUPPORTED

--- a/clang/test/dpct/cuda-get-error-string.cu
+++ b/clang/test/dpct/cuda-get-error-string.cu
@@ -6,18 +6,12 @@ int printf(const char *format, ...);
 // CHECK: /*
 // CHECK-NEXT: DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
 // CHECK-NEXT: */
-// CHECK-NEXT: /*
-// CHECK-NEXT: DPCT1064:{{[0-9]+}}: Migrated cudaGetErrorString call is used in a macro definition and is not valid for all macro uses. Adjust the code.
-// CHECK-NEXT: */
 // CHECK-NEXT: #define PRINT_ERROR_STR(X) printf("%s\n", "cudaGetErrorString not supported"/*cudaGetErrorString(X)*/)
 #define PRINT_ERROR_STR(X) printf("%s\n", cudaGetErrorString(X))
 
 // CHECK:  /*
 // CHECK-NEXT:  DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
 // CHECK-NEXT:  */
-// CHECK-NEXT: /*
-// CHECK-NEXT: DPCT1064:{{[0-9]+}}: Migrated cudaGetErrorString call is used in a macro definition and is not valid for all macro uses. Adjust the code.
-// CHECK-NEXT: */
 // CHECK-NEXT: #define PRINT_ERROR_STR2(X)\
 // CHECK-NEXT:  printf("%s\n", "cudaGetErrorString not supported"/*cudaGetErrorString(X)*/)
 #define PRINT_ERROR_STR2(X)\
@@ -25,9 +19,6 @@ int printf(const char *format, ...);
 
 // CHECK: /*
 // CHECK-NEXT: DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
-// CHECK-NEXT: */
-// CHECK-NEXT: /*
-// CHECK-NEXT: DPCT1064:{{[0-9]+}}: Migrated cudaGetErrorString call is used in a macro definition and is not valid for all macro uses. Adjust the code.
 // CHECK-NEXT: */
 // CHECK-NEXT: #define PRINT_ERROR_STR3(X)\
 // CHECK-NEXT:   printf("%s\
@@ -39,18 +30,12 @@ int printf(const char *format, ...);
 // CHECK: /*
 // CHECK-NEXT: DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
 // CHECK-NEXT: */
-// CHECK-NEXT: /*
-// CHECK-NEXT: DPCT1064:{{[0-9]+}}: Migrated cudaGetErrorName call is used in a macro definition and is not valid for all macro uses. Adjust the code.
-// CHECK-NEXT: */
 // CHECK-NEXT: #define PRINT_ERROR_NAME(X) printf("%s\n", "cudaGetErrorName not supported"/*cudaGetErrorName(X)*/)
 #define PRINT_ERROR_NAME(X) printf("%s\n", cudaGetErrorName(X))
 
 // CHECK:   /*
 // CHECK-NEXT:   DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
 // CHECK-NEXT:   */
-// CHECK-NEXT: /*
-// CHECK-NEXT: DPCT1064:{{[0-9]+}}: Migrated cudaGetErrorName call is used in a macro definition and is not valid for all macro uses. Adjust the code.
-// CHECK-NEXT: */
 // CHECK-NEXT: #define PRINT_ERROR_NAME2(X)\
 // CHECK-NEXT:   printf("%s\n", "cudaGetErrorName not supported"/*cudaGetErrorName(X)*/)
 #define PRINT_ERROR_NAME2(X)\
@@ -58,9 +43,6 @@ int printf(const char *format, ...);
 
 // CHECK: /*
 // CHECK-NEXT: DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
-// CHECK-NEXT: */
-// CHECK-NEXT: /*
-// CHECK-NEXT: DPCT1064:{{[0-9]+}}: Migrated cudaGetErrorName call is used in a macro definition and is not valid for all macro uses. Adjust the code.
 // CHECK-NEXT: */
 // CHECK-NEXT: #define PRINT_ERROR_NAME3(X)\
 // CHECK-NEXT:   printf("%s\
@@ -71,12 +53,6 @@ int printf(const char *format, ...);
 
 // CHECK: /*
 // CHECK-NEXT: DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
-// CHECK-NEXT: */
-// CHECK-NEXT: /*
-// CHECK-NEXT: DPCT1064:{{[0-9]+}}: Migrated cudaGetErrorString call is used in a macro definition and is not valid for all macro uses. Adjust the code.
-// CHECK-NEXT: */
-// CHECK-NEXT: /*
-// CHECK-NEXT: DPCT1064:{{[0-9]+}}: Migrated cudaGetErrorName call is used in a macro definition and is not valid for all macro uses. Adjust the code.
 // CHECK-NEXT: */
 // CHECK-NEXT: #define PRINT_ERROR_STR_NAME(X)\
 // CHECK-NEXT:   printf("%s\
@@ -142,19 +118,19 @@ const char *test_function() {
 //CHECK:/*
 //CHECK-NEXT:DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
 //CHECK-NEXT:*/
-//CHECK-NEXT:  printf("%s\n", "cudaGetErrorString not supported"/*cudaGetErrorString(0)*/);
+//CHECK-NEXT:  printf("%s\n", "cudaGetErrorString not supported"/*cudaGetErrorString(cudaSuccess)*/);
   printf("%s\n", cudaGetErrorString(cudaSuccess));
 
 //CHECK:/*
 //CHECK-NEXT:DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
 //CHECK-NEXT:*/
-//CHECK-NEXT:printf("%s\n", "cudaGetErrorName not supported"/*cudaGetErrorName(0)*/);
+//CHECK-NEXT:printf("%s\n", "cudaGetErrorName not supported"/*cudaGetErrorName(cudaSuccess)*/);
   printf("%s\n", cudaGetErrorName(cudaSuccess));
 
 //CHECK:/*
 //CHECK-NEXT:DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
 //CHECK-NEXT:*/
-//CHECK-NEXT:  return "cudaGetErrorName not supported"/*cudaGetErrorName(0)*/;
+//CHECK-NEXT:  return "cudaGetErrorName not supported"/*cudaGetErrorName(cudaSuccess)*/;
   return cudaGetErrorName(cudaSuccess);
 }
 

--- a/clang/test/dpct/cuda-get-error-string.cu
+++ b/clang/test/dpct/cuda-get-error-string.cu
@@ -6,12 +6,18 @@ int printf(const char *format, ...);
 // CHECK: /*
 // CHECK-NEXT: DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
 // CHECK-NEXT: */
+// CHECK-NEXT: /*
+// CHECK-NEXT: DPCT1064:{{[0-9]+}}: Migrated cudaGetErrorString call is used in a macro definition and is not valid for all macro uses. Adjust the code.
+// CHECK-NEXT: */
 // CHECK-NEXT: #define PRINT_ERROR_STR(X) printf("%s\n", "cudaGetErrorString not supported"/*cudaGetErrorString(X)*/)
 #define PRINT_ERROR_STR(X) printf("%s\n", cudaGetErrorString(X))
 
 // CHECK:  /*
 // CHECK-NEXT:  DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
 // CHECK-NEXT:  */
+// CHECK-NEXT: /*
+// CHECK-NEXT: DPCT1064:{{[0-9]+}}: Migrated cudaGetErrorString call is used in a macro definition and is not valid for all macro uses. Adjust the code.
+// CHECK-NEXT: */
 // CHECK-NEXT: #define PRINT_ERROR_STR2(X)\
 // CHECK-NEXT:  printf("%s\n", "cudaGetErrorString not supported"/*cudaGetErrorString(X)*/)
 #define PRINT_ERROR_STR2(X)\
@@ -19,6 +25,9 @@ int printf(const char *format, ...);
 
 // CHECK: /*
 // CHECK-NEXT: DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
+// CHECK-NEXT: */
+// CHECK-NEXT: /*
+// CHECK-NEXT: DPCT1064:{{[0-9]+}}: Migrated cudaGetErrorString call is used in a macro definition and is not valid for all macro uses. Adjust the code.
 // CHECK-NEXT: */
 // CHECK-NEXT: #define PRINT_ERROR_STR3(X)\
 // CHECK-NEXT:   printf("%s\
@@ -30,12 +39,18 @@ int printf(const char *format, ...);
 // CHECK: /*
 // CHECK-NEXT: DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
 // CHECK-NEXT: */
+// CHECK-NEXT: /*
+// CHECK-NEXT: DPCT1064:{{[0-9]+}}: Migrated cudaGetErrorName call is used in a macro definition and is not valid for all macro uses. Adjust the code.
+// CHECK-NEXT: */
 // CHECK-NEXT: #define PRINT_ERROR_NAME(X) printf("%s\n", "cudaGetErrorName not supported"/*cudaGetErrorName(X)*/)
 #define PRINT_ERROR_NAME(X) printf("%s\n", cudaGetErrorName(X))
 
 // CHECK:   /*
 // CHECK-NEXT:   DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
 // CHECK-NEXT:   */
+// CHECK-NEXT: /*
+// CHECK-NEXT: DPCT1064:{{[0-9]+}}: Migrated cudaGetErrorName call is used in a macro definition and is not valid for all macro uses. Adjust the code.
+// CHECK-NEXT: */
 // CHECK-NEXT: #define PRINT_ERROR_NAME2(X)\
 // CHECK-NEXT:   printf("%s\n", "cudaGetErrorName not supported"/*cudaGetErrorName(X)*/)
 #define PRINT_ERROR_NAME2(X)\
@@ -43,6 +58,9 @@ int printf(const char *format, ...);
 
 // CHECK: /*
 // CHECK-NEXT: DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
+// CHECK-NEXT: */
+// CHECK-NEXT: /*
+// CHECK-NEXT: DPCT1064:{{[0-9]+}}: Migrated cudaGetErrorName call is used in a macro definition and is not valid for all macro uses. Adjust the code.
 // CHECK-NEXT: */
 // CHECK-NEXT: #define PRINT_ERROR_NAME3(X)\
 // CHECK-NEXT:   printf("%s\
@@ -55,7 +73,10 @@ int printf(const char *format, ...);
 // CHECK-NEXT: DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
 // CHECK-NEXT: */
 // CHECK-NEXT: /*
-// CHECK-NEXT: DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
+// CHECK-NEXT: DPCT1064:{{[0-9]+}}: Migrated cudaGetErrorString call is used in a macro definition and is not valid for all macro uses. Adjust the code.
+// CHECK-NEXT: */
+// CHECK-NEXT: /*
+// CHECK-NEXT: DPCT1064:{{[0-9]+}}: Migrated cudaGetErrorName call is used in a macro definition and is not valid for all macro uses. Adjust the code.
 // CHECK-NEXT: */
 // CHECK-NEXT: #define PRINT_ERROR_STR_NAME(X)\
 // CHECK-NEXT:   printf("%s\

--- a/clang/test/dpct/macro_not_in_inroot/inroot/test.cu
+++ b/clang/test/dpct/macro_not_in_inroot/inroot/test.cu
@@ -2,20 +2,19 @@
 // RUN: FileCheck --input-file %T/test.dp.cpp --match-full-lines %s
 
 #include "outer/macro_def.h"
+#include "cuda_runtime.h"
 
-void bar() {
-  // some work
-}
+void foo() {}
 
-//      CHECK: #define BAR(X)         \
-// CHECK-NEXT:   bar();               \
-// CHECK-NEXT:   CHECK("cudaGetErrorString not supported"/*cudaGetErrorString(cudaErrorInvalidValue)*/);
+// CHECK: #define MACRO_B \
+// CHECK-NEXT: foo();\
+// CHECK-NEXT: MACRO("cudaGetErrorString not supported"/*cudaGetErrorString(cudaErrorInvalidValue)*/);
+#define MACRO_B \
+foo();\
+MACRO(cudaGetErrorString(cudaErrorInvalidValue));
 
-#define BAR(X)         \
-  bar();               \
-  CHECK(cudaGetErrorString(cudaErrorInvalidValue));
-
-void foo() {
-  // CHECK: BAR(0)
-  BAR(0)
+int main() {
+  // CHECK: MACRO_B
+  MACRO_B
+  return 0;
 }

--- a/clang/test/dpct/macro_not_in_inroot/inroot/test.cu
+++ b/clang/test/dpct/macro_not_in_inroot/inroot/test.cu
@@ -1,0 +1,21 @@
+// RUN: dpct --format-range=none --out-root %T %s --cuda-include-path="%cuda-path/include" --in-root %S --extra-arg="-I  %S/.."
+// RUN: FileCheck --input-file %T/test.dp.cpp --match-full-lines %s
+
+#include "outer/macro_def.h"
+
+void bar() {
+  // some work
+}
+
+//      CHECK: #define BAR(X)         \
+// CHECK-NEXT:   bar();               \
+// CHECK-NEXT:   CHECK("cudaGetErrorString not supported"/*cudaGetErrorString(cudaErrorInvalidValue)*/);
+
+#define BAR(X)         \
+  bar();               \
+  CHECK(cudaGetErrorString(cudaErrorInvalidValue));
+
+void foo() {
+  // CHECK: BAR(0)
+  BAR(0)
+}

--- a/clang/test/dpct/macro_not_in_inroot/outer/macro_def.h
+++ b/clang/test/dpct/macro_not_in_inroot/outer/macro_def.h
@@ -1,0 +1,4 @@
+#include <cuda.h>
+
+#define CHECK1(X) X
+#define CHECK(Y) CHECK1(Y)

--- a/clang/test/dpct/macro_not_in_inroot/outer/macro_def.h
+++ b/clang/test/dpct/macro_not_in_inroot/outer/macro_def.h
@@ -1,4 +1,1 @@
-#include <cuda.h>
-
-#define CHECK1(X) X
-#define CHECK(Y) CHECK1(Y)
+#define MACRO(X) X


### PR DESCRIPTION
Covered APIs:
cudaGetErrorString
cudaGetErrorName
cudaGetLastError
cudaPeekAtLastError

Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>