### PR TITLE
[SYCLomatic] Use rewriter to migrate 4 APIs to fix incorrect migration when API is in macro

### DIFF
--- a/clang/lib/DPCT/APINamesErrorHandling.inc
+++ b/clang/lib/DPCT/APINamesErrorHandling.inc
@@ -1,0 +1,47 @@
+//===--------------- APINamesErrorHandling.inc ----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+WARNING_FACTORY_ENTRY(
+    "cudaGetErrorString",
+    INSERT_AROUND_FACTORY(CALL_FACTORY_ENTRY("cudaGetErrorString",
+                                             CALL("cudaGetErrorString",
+                                                  ARG_WC(0))),
+                          "\"cudaGetErrorString not supported\"/*", "*/"),
+    Diagnostics::TRNA_WARNING_ERROR_HANDLING_API_COMMENTED)
+
+WARNING_FACTORY_ENTRY(
+    "cudaGetErrorName",
+    INSERT_AROUND_FACTORY(CALL_FACTORY_ENTRY("cudaGetErrorName",
+                                             CALL("cudaGetErrorName",
+                                                  ARG_WC(0))),
+                          "\"cudaGetErrorName not supported\"/*", "*/"),
+    Diagnostics::TRNA_WARNING_ERROR_HANDLING_API_COMMENTED)
+
+CONDITIONAL_FACTORY_ENTRY(
+    checkIsCallExprOnly(),
+    WARNING_FACTORY_ENTRY(
+        "cudaGetLastError",
+        TOSTRING_FACTORY_ENTRY("cudaGetLastError", LITERAL("")),
+        Diagnostics::FUNC_CALL_REMOVED, std::string("cudaGetLastError"),
+        std::string("the function call is redundant in DPC++.")),
+    WARNING_FACTORY_ENTRY(
+        "cudaGetLastError",
+        TOSTRING_FACTORY_ENTRY("cudaGetLastError", LITERAL("0")),
+        Diagnostics::TRNA_WARNING_ERROR_HANDLING_API_REPLACED_0))
+
+CONDITIONAL_FACTORY_ENTRY(
+    checkIsCallExprOnly(),
+    WARNING_FACTORY_ENTRY(
+        "cudaPeekAtLastError",
+        TOSTRING_FACTORY_ENTRY("cudaPeekAtLastError", LITERAL("")),
+        Diagnostics::FUNC_CALL_REMOVED, std::string("cudaPeekAtLastError"),
+        std::string("the function call is redundant in DPC++.")),
+    WARNING_FACTORY_ENTRY(
+        "cudaPeekAtLastError",
+        TOSTRING_FACTORY_ENTRY("cudaPeekAtLastError", LITERAL("0")),
+        Diagnostics::TRNA_WARNING_ERROR_HANDLING_API_REPLACED_0))

--- a/clang/lib/DPCT/APINamesErrorHandling.inc
+++ b/clang/lib/DPCT/APINamesErrorHandling.inc
@@ -11,7 +11,7 @@ WARNING_FACTORY_ENTRY(
     INSERT_AROUND_FACTORY(CALL_FACTORY_ENTRY("cudaGetErrorString",
                                              CALL("cudaGetErrorString",
                                                   ARG_WC(0))),
-                          "\"cudaGetErrorString not supported\"/*", "*/"),
+                          "\"cudaGetErrorString is not supported\"/*", "*/"),
     Diagnostics::TRNA_WARNING_ERROR_HANDLING_API_COMMENTED)
 
 WARNING_FACTORY_ENTRY(
@@ -19,7 +19,7 @@ WARNING_FACTORY_ENTRY(
     INSERT_AROUND_FACTORY(CALL_FACTORY_ENTRY("cudaGetErrorName",
                                              CALL("cudaGetErrorName",
                                                   ARG_WC(0))),
-                          "\"cudaGetErrorName not supported\"/*", "*/"),
+                          "\"cudaGetErrorName is not supported\"/*", "*/"),
     Diagnostics::TRNA_WARNING_ERROR_HANDLING_API_COMMENTED)
 
 CONDITIONAL_FACTORY_ENTRY(

--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -8619,28 +8619,12 @@ void FunctionCallRule::runRule(const MatchFinder::MatchResult &Result) {
     emplaceTransformation(new ReplaceStmt(CE, std::move(ReplStr)));
 
   } else if (FuncName == "cudaGetLastError" ||
-             FuncName == "cudaPeekAtLastError") {
-    if (IsAssigned) {
-      report(CE->getBeginLoc(),
-             Comments::TRNA_WARNING_ERROR_HANDLING_API_REPLACED_0, false,
-             MapNames::ITFName.at(FuncName));
-      emplaceTransformation(new ReplaceStmt(CE, "0"));
-    } else {
-      report(CE->getBeginLoc(), Diagnostics::FUNC_CALL_REMOVED, false,
-             MapNames::ITFName.at(FuncName),
-             "the function call is redundant in DPC++.");
-      emplaceTransformation(new ReplaceStmt(CE, true, ""));
-    }
-  } else if (FuncName == "cudaGetErrorString" ||
+             FuncName == "cudaPeekAtLastError" ||
+             FuncName == "cudaGetErrorString" ||
              FuncName == "cudaGetErrorName") {
-    // Insert warning messages into the spelling locations in case
-    // that these functions are contained in macro definitions
-    auto Loc = Result.SourceManager->getSpellingLoc(CE->getBeginLoc());
-    report(Loc, Comments::TRNA_WARNING_ERROR_HANDLING_API_COMMENTED, false,
-           MapNames::ITFName.at(FuncName));
-    emplaceTransformation(
-        new InsertBeforeStmt(CE, "\"" + FuncName + " not supported\"/*"));
-    emplaceTransformation(new InsertAfterStmt(CE, "*/"));
+    ExprAnalysis EA(CE);
+    emplaceTransformation(EA.getReplacement());
+    EA.applyAllSubExprRepl();
   } else if (FuncName == "clock" || FuncName == "clock64") {
     report(CE->getBeginLoc(), Diagnostics::API_NOT_MIGRATED_SYCL_UNDEF, false,
            FuncName);

--- a/clang/lib/DPCT/CallExprRewriter.cpp
+++ b/clang/lib/DPCT/CallExprRewriter.cpp
@@ -1916,6 +1916,29 @@ createAssignableFactory(
   return createAssignableFactory(std::move(Input));
 }
 
+
+std::pair<std::string, std::shared_ptr<CallExprRewriterFactoryBase>>
+createInsertAroundFactory(
+    std::pair<std::string, std::shared_ptr<CallExprRewriterFactoryBase>>
+        &&Input,
+    std::string &&Prefix, std::string &&Suffix) {
+  return std::pair<std::string, std::shared_ptr<CallExprRewriterFactoryBase>>(
+      std::move(Input.first),
+      std::make_shared<InsertAroundRewriterFactory>(
+          Input.second, std::move(Prefix), std::move(Suffix)));
+}
+
+template <class T>
+std::pair<std::string, std::shared_ptr<CallExprRewriterFactoryBase>>
+createInsertAroundFactory(
+    std::pair<std::string, std::shared_ptr<CallExprRewriterFactoryBase>>
+        &&Input,
+    std::string &&Prefix, std::string &&Suffix, T) {
+  return createInsertAroundFactory(std::move(Input), std::move(Prefix),
+                                   std::move(Suffix));
+}
+
+
 /// Create RewriterFactoryWithFeatureRequest key-value pair with inner
 /// key-value. Will call requestFeature when used to create CallExprRewriter.
 std::pair<std::string, std::shared_ptr<CallExprRewriterFactoryBase>>
@@ -2358,6 +2381,8 @@ public:
 };
 
 #define ASSIGNABLE_FACTORY(x) createAssignableFactory(x 0),
+#define INSERT_AROUND_FACTORY(x, PREFIX, SUFFIX)                               \
+  createInsertAroundFactory(x PREFIX, SUFFIX, 0),
 #define FEATURE_REQUEST_FACTORY(FEATURE, x)                                    \
   createFeatureRequestFactory(FEATURE, x 0),
 #define HEADER_INSERT_FACTORY(HEADER, x)                                       \
@@ -2529,6 +2554,7 @@ void CallExprRewriterFactoryBase::initRewriterMap() {
 #include "APINamesThrust.inc"
 #include "APINamesWarp.inc"
 #include "APINamesCUDNN.inc"
+#include "APINamesErrorHandling.inc"
 #undef ENTRY_RENAMED
 #undef ENTRY_TEXTURE
 #undef ENTRY_UNSUPPORTED

--- a/clang/lib/DPCT/CallExprRewriter.cpp
+++ b/clang/lib/DPCT/CallExprRewriter.cpp
@@ -1916,7 +1916,6 @@ createAssignableFactory(
   return createAssignableFactory(std::move(Input));
 }
 
-
 std::pair<std::string, std::shared_ptr<CallExprRewriterFactoryBase>>
 createInsertAroundFactory(
     std::pair<std::string, std::shared_ptr<CallExprRewriterFactoryBase>>
@@ -1927,17 +1926,6 @@ createInsertAroundFactory(
       std::make_shared<InsertAroundRewriterFactory>(
           Input.second, std::move(Prefix), std::move(Suffix)));
 }
-
-template <class T>
-std::pair<std::string, std::shared_ptr<CallExprRewriterFactoryBase>>
-createInsertAroundFactory(
-    std::pair<std::string, std::shared_ptr<CallExprRewriterFactoryBase>>
-        &&Input,
-    std::string &&Prefix, std::string &&Suffix, T) {
-  return createInsertAroundFactory(std::move(Input), std::move(Prefix),
-                                   std::move(Suffix));
-}
-
 
 /// Create RewriterFactoryWithFeatureRequest key-value pair with inner
 /// key-value. Will call requestFeature when used to create CallExprRewriter.
@@ -2382,7 +2370,7 @@ public:
 
 #define ASSIGNABLE_FACTORY(x) createAssignableFactory(x 0),
 #define INSERT_AROUND_FACTORY(x, PREFIX, SUFFIX)                               \
-  createInsertAroundFactory(x PREFIX, SUFFIX, 0),
+  createInsertAroundFactory(x PREFIX, SUFFIX),
 #define FEATURE_REQUEST_FACTORY(FEATURE, x)                                    \
   createFeatureRequestFactory(FEATURE, x 0),
 #define HEADER_INSERT_FACTORY(HEADER, x)                                       \

--- a/clang/test/dpct/cuda-get-error-string.cu
+++ b/clang/test/dpct/cuda-get-error-string.cu
@@ -6,14 +6,14 @@ int printf(const char *format, ...);
 // CHECK: /*
 // CHECK-NEXT: DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
 // CHECK-NEXT: */
-// CHECK-NEXT: #define PRINT_ERROR_STR(X) printf("%s\n", "cudaGetErrorString not supported"/*cudaGetErrorString(X)*/)
+// CHECK-NEXT: #define PRINT_ERROR_STR(X) printf("%s\n", "cudaGetErrorString is not supported"/*cudaGetErrorString(X)*/)
 #define PRINT_ERROR_STR(X) printf("%s\n", cudaGetErrorString(X))
 
 // CHECK:  /*
 // CHECK-NEXT:  DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
 // CHECK-NEXT:  */
 // CHECK-NEXT: #define PRINT_ERROR_STR2(X)\
-// CHECK-NEXT:  printf("%s\n", "cudaGetErrorString not supported"/*cudaGetErrorString(X)*/)
+// CHECK-NEXT:  printf("%s\n", "cudaGetErrorString is not supported"/*cudaGetErrorString(X)*/)
 #define PRINT_ERROR_STR2(X)\
   printf("%s\n", cudaGetErrorString(X))
 
@@ -22,7 +22,7 @@ int printf(const char *format, ...);
 // CHECK-NEXT: */
 // CHECK-NEXT: #define PRINT_ERROR_STR3(X)\
 // CHECK-NEXT:   printf("%s\
-// CHECK-NEXT:          \n", "cudaGetErrorString not supported"/*cudaGetErrorString(X)*/)
+// CHECK-NEXT:          \n", "cudaGetErrorString is not supported"/*cudaGetErrorString(X)*/)
 #define PRINT_ERROR_STR3(X)\
   printf("%s\
          \n", cudaGetErrorString(X))
@@ -30,14 +30,14 @@ int printf(const char *format, ...);
 // CHECK: /*
 // CHECK-NEXT: DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
 // CHECK-NEXT: */
-// CHECK-NEXT: #define PRINT_ERROR_NAME(X) printf("%s\n", "cudaGetErrorName not supported"/*cudaGetErrorName(X)*/)
+// CHECK-NEXT: #define PRINT_ERROR_NAME(X) printf("%s\n", "cudaGetErrorName is not supported"/*cudaGetErrorName(X)*/)
 #define PRINT_ERROR_NAME(X) printf("%s\n", cudaGetErrorName(X))
 
 // CHECK:   /*
 // CHECK-NEXT:   DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
 // CHECK-NEXT:   */
 // CHECK-NEXT: #define PRINT_ERROR_NAME2(X)\
-// CHECK-NEXT:   printf("%s\n", "cudaGetErrorName not supported"/*cudaGetErrorName(X)*/)
+// CHECK-NEXT:   printf("%s\n", "cudaGetErrorName is not supported"/*cudaGetErrorName(X)*/)
 #define PRINT_ERROR_NAME2(X)\
   printf("%s\n", cudaGetErrorName(X))
 
@@ -46,7 +46,7 @@ int printf(const char *format, ...);
 // CHECK-NEXT: */
 // CHECK-NEXT: #define PRINT_ERROR_NAME3(X)\
 // CHECK-NEXT:   printf("%s\
-// CHECK-NEXT:          \n", "cudaGetErrorName not supported"/*cudaGetErrorName(X)*/)
+// CHECK-NEXT:          \n", "cudaGetErrorName is not supported"/*cudaGetErrorName(X)*/)
 #define PRINT_ERROR_NAME3(X)\
   printf("%s\
          \n", cudaGetErrorName(X))
@@ -57,8 +57,8 @@ int printf(const char *format, ...);
 // CHECK-NEXT: #define PRINT_ERROR_STR_NAME(X)\
 // CHECK-NEXT:   printf("%s\
 // CHECK-NEXT:          %s\
-// CHECK-NEXT:          \n", "cudaGetErrorString not supported"/*cudaGetErrorString(X)*/,\
-// CHECK-NEXT:          "cudaGetErrorName not supported"/*cudaGetErrorName(X)*/)
+// CHECK-NEXT:          \n", "cudaGetErrorString is not supported"/*cudaGetErrorString(X)*/,\
+// CHECK-NEXT:          "cudaGetErrorName is not supported"/*cudaGetErrorName(X)*/)
 #define PRINT_ERROR_STR_NAME(X)\
   printf("%s\
          %s\
@@ -111,26 +111,26 @@ const char *test_function() {
 //CHECK-NEXT:/*
 //CHECK-NEXT:DPCT1010:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The call was replaced with 0. You need to rewrite this code.
 //CHECK-NEXT:*/
-//CHECK-NEXT:  printf("%s\n", "cudaGetErrorString not supported"/*cudaGetErrorString(0)*/);
+//CHECK-NEXT:  printf("%s\n", "cudaGetErrorString is not supported"/*cudaGetErrorString(0)*/);
   printf("%s\n", cudaGetErrorString(cudaGetLastError()));
 
 
 //CHECK:/*
 //CHECK-NEXT:DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
 //CHECK-NEXT:*/
-//CHECK-NEXT:  printf("%s\n", "cudaGetErrorString not supported"/*cudaGetErrorString(cudaSuccess)*/);
+//CHECK-NEXT:  printf("%s\n", "cudaGetErrorString is not supported"/*cudaGetErrorString(cudaSuccess)*/);
   printf("%s\n", cudaGetErrorString(cudaSuccess));
 
 //CHECK:/*
 //CHECK-NEXT:DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
 //CHECK-NEXT:*/
-//CHECK-NEXT:printf("%s\n", "cudaGetErrorName not supported"/*cudaGetErrorName(cudaSuccess)*/);
+//CHECK-NEXT:printf("%s\n", "cudaGetErrorName is not supported"/*cudaGetErrorName(cudaSuccess)*/);
   printf("%s\n", cudaGetErrorName(cudaSuccess));
 
 //CHECK:/*
 //CHECK-NEXT:DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
 //CHECK-NEXT:*/
-//CHECK-NEXT:  return "cudaGetErrorName not supported"/*cudaGetErrorName(cudaSuccess)*/;
+//CHECK-NEXT:  return "cudaGetErrorName is not supported"/*cudaGetErrorName(cudaSuccess)*/;
   return cudaGetErrorName(cudaSuccess);
 }
 

--- a/clang/test/dpct/cuda-get-error-string.cu
+++ b/clang/test/dpct/cuda-get-error-string.cu
@@ -54,9 +54,6 @@ int printf(const char *format, ...);
 // CHECK: /*
 // CHECK-NEXT: DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
 // CHECK-NEXT: */
-// CHECK-NEXT: /*
-// CHECK-NEXT: DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
-// CHECK-NEXT: */
 // CHECK-NEXT: #define PRINT_ERROR_STR_NAME(X)\
 // CHECK-NEXT:   printf("%s\
 // CHECK-NEXT:          %s\
@@ -121,19 +118,19 @@ const char *test_function() {
 //CHECK:/*
 //CHECK-NEXT:DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
 //CHECK-NEXT:*/
-//CHECK-NEXT:  printf("%s\n", "cudaGetErrorString not supported"/*cudaGetErrorString(0)*/);
+//CHECK-NEXT:  printf("%s\n", "cudaGetErrorString not supported"/*cudaGetErrorString(cudaSuccess)*/);
   printf("%s\n", cudaGetErrorString(cudaSuccess));
 
 //CHECK:/*
 //CHECK-NEXT:DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
 //CHECK-NEXT:*/
-//CHECK-NEXT:printf("%s\n", "cudaGetErrorName not supported"/*cudaGetErrorName(0)*/);
+//CHECK-NEXT:printf("%s\n", "cudaGetErrorName not supported"/*cudaGetErrorName(cudaSuccess)*/);
   printf("%s\n", cudaGetErrorName(cudaSuccess));
 
 //CHECK:/*
 //CHECK-NEXT:DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
 //CHECK-NEXT:*/
-//CHECK-NEXT:  return "cudaGetErrorName not supported"/*cudaGetErrorName(0)*/;
+//CHECK-NEXT:  return "cudaGetErrorName not supported"/*cudaGetErrorName(cudaSuccess)*/;
   return cudaGetErrorName(cudaSuccess);
 }
 

--- a/clang/test/dpct/macro_not_in_inroot/inroot/test.cu
+++ b/clang/test/dpct/macro_not_in_inroot/inroot/test.cu
@@ -8,7 +8,7 @@ void foo() {}
 
 // CHECK: #define MACRO_B \
 // CHECK-NEXT: foo();\
-// CHECK-NEXT: MACRO("cudaGetErrorString not supported"/*cudaGetErrorString(cudaErrorInvalidValue)*/);
+// CHECK-NEXT: MACRO("cudaGetErrorString is not supported"/*cudaGetErrorString(cudaErrorInvalidValue)*/);
 #define MACRO_B \
 foo();\
 MACRO(cudaGetErrorString(cudaErrorInvalidValue));

--- a/clang/test/dpct/macro_not_in_inroot/inroot/test.cu
+++ b/clang/test/dpct/macro_not_in_inroot/inroot/test.cu
@@ -1,0 +1,20 @@
+// RUN: dpct --format-range=none --out-root %T %s --cuda-include-path="%cuda-path/include" --in-root %S --extra-arg="-I  %S/.."
+// RUN: FileCheck --input-file %T/test.dp.cpp --match-full-lines %s
+
+#include "outer/macro_def.h"
+#include "cuda_runtime.h"
+
+void foo() {}
+
+// CHECK: #define MACRO_B \
+// CHECK-NEXT: foo();\
+// CHECK-NEXT: MACRO("cudaGetErrorString not supported"/*cudaGetErrorString(cudaErrorInvalidValue)*/);
+#define MACRO_B \
+foo();\
+MACRO(cudaGetErrorString(cudaErrorInvalidValue));
+
+int main() {
+  // CHECK: MACRO_B
+  MACRO_B
+  return 0;
+}

--- a/clang/test/dpct/macro_not_in_inroot/outer/macro_def.h
+++ b/clang/test/dpct/macro_not_in_inroot/outer/macro_def.h
@@ -1,0 +1,1 @@
+#define MACRO(X) X

--- a/clang/test/dpct/wildcard_test/abd.cu
+++ b/clang/test/dpct/wildcard_test/abd.cu
@@ -12,6 +12,6 @@ const char *test_function() {
 //CHECK-NEXT:/*
 //CHECK-NEXT:DPCT1010:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The call was replaced with 0. You need to rewrite this code.
 //CHECK-NEXT:*/
-//CHECK-NEXT:  printf("%s\n", "cudaGetErrorString not supported"/*cudaGetErrorString(0)*/);
+//CHECK-NEXT:  printf("%s\n", "cudaGetErrorString is not supported"/*cudaGetErrorString(0)*/);
   printf("%s\n", cudaGetErrorString(cudaGetLastError()));
 }


### PR DESCRIPTION
Covered APIs:
cudaGetErrorString
cudaGetErrorName
cudaGetLastError
cudaPeekAtLastError

Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>