### PR TITLE
[SYCLomatic] Fix habs lit test errors

### DIFF
--- a/clang/test/dpct/cuda-math-habs.cu
+++ b/clang/test/dpct/cuda-math-habs.cu
@@ -1,0 +1,18 @@
+// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1
+// UNSUPPORTED: v8.0, v9.0, v9.1, v9.2, v10.0, v10.1
+// RUN: dpct --format-range=none -out-root %T/cuda-math-habs %s --cuda-include-path="%cuda-path/include" -- -x cuda --cuda-host-only --std=c++14
+// RUN: FileCheck --input-file %T/cuda-math-habs/cuda-math-habs.dp.cpp --match-full-lines %s
+
+#include <cuda.h>
+#include <cuda_fp16.h>
+
+__global__ void test() {
+  __half h, h_2;
+  __half2 h2, h2_2;
+
+  // CHECK: h_2 = sycl::fabs(h);
+  h_2 = __habs(h);
+
+  // CHECK: h2_2 = sycl::fabs(h2);
+  h2_2 = __habs2(h2);
+}

--- a/clang/test/dpct/cuda-math-intrinsics.cu
+++ b/clang/test/dpct/cuda-math-intrinsics.cu
@@ -61,8 +61,6 @@ __global__ void kernelFuncHalf(double *deviceArrayDouble) {
 
   // Half Arithmetic Functions
 
-  // CHECK: h_2 = sycl::fabs(h);
-  h_2 = __habs(h);
   // TODO:1CHECK: h2_2 = h2 / h2_1;
   //h2_2 = __h2div(h2, h2_1);
   // TODO:1CHECK: h_2 = h / h_1;
@@ -78,8 +76,6 @@ __global__ void kernelFuncHalf(double *deviceArrayDouble) {
 
   // Half2 Arithmetic Functions
 
-  // CHECK: h2_2 = sycl::fabs(h2);
-  h2_2 = __habs2(h2);
   // CHECK: h2_2 = h2 + h2_1;
   h2_2 = __hadd2(h2, h2_1);
   // CHECK: h2_2 = sycl::fma(h2, h2_1, h2_2);


### PR DESCRIPTION
Moves lit tests for the `__habs` and `__habs2` functions into a separate file since they're unsupported in CUDA versions earlier than v10.2.