### PR TITLE
[SYCLomatic] Support user-defined API rule with namespace

### DIFF
--- a/clang/lib/DPCT/ExprAnalysis.cpp
+++ b/clang/lib/DPCT/ExprAnalysis.cpp
@@ -520,7 +520,7 @@ void ExprAnalysis::analyzeExpr(const MemberExpr *ME) {
 
   std::string FieldName = "";
   if (ME->getMemberDecl()->getIdentifier()) {
-    std::string FieldName = ME->getMemberDecl()->getName().str();
+    FieldName = ME->getMemberDecl()->getName().str();
     auto ItFieldRule = MapNames::ClassFieldMap.find(BaseType + "." + FieldName);
     if (ItFieldRule != MapNames::ClassFieldMap.end()) {
       if (ItFieldRule->second->GetterName == "") {

--- a/clang/lib/DPCT/ExprAnalysis.h
+++ b/clang/lib/DPCT/ExprAnalysis.h
@@ -711,7 +711,6 @@ public:
     initArgumentExpr(Arg);
   }
 
-  inline void analyze() { Base::analyze(); }
   // Special init is needed for argument expression.
   void analyze(const Expr *Expression) {
     initArgumentExpr(Expression);

--- a/clang/lib/DPCT/ExprAnalysis.h
+++ b/clang/lib/DPCT/ExprAnalysis.h
@@ -711,6 +711,8 @@ public:
     initArgumentExpr(Arg);
   }
 
+  inline void analyze() { Base::analyze(); }
+
   // Special init is needed for argument expression.
   void analyze(const Expr *Expression) {
     initArgumentExpr(Expression);

--- a/clang/lib/DPCT/Rules.h
+++ b/clang/lib/DPCT/Rules.h
@@ -14,6 +14,7 @@
 #include <string>
 #include <vector>
 
+
 enum RuleKind { API, DataType, Macro, Header, TypeRule, Class, Enum };
 
 enum RulePriority { Takeover, Default, Fallback };

--- a/clang/test/dpct/user_defined_rule.cu
+++ b/clang/test/dpct/user_defined_rule.cu
@@ -101,3 +101,23 @@ void foo2(){
       return ::min(::max(v, 10), 100);
     }});
 }
+
+
+struct MyStruct {
+  operator void *() { return NULL; }
+};
+
+namespace A1 {
+  namespace B1 {
+    MyStruct A1B1() { return MyStruct(); }
+  }
+}
+
+namespace A2 {
+  namespace B2 = A1::B1;
+}
+
+void foo4(){
+  // CHECK: A2B2();
+  A2::B2::A1B1();
+}

--- a/clang/test/dpct/user_defined_rule.yaml
+++ b/clang/test/dpct/user_defined_rule.yaml
@@ -77,3 +77,9 @@
   In: max
   Out: std::max($1, $2)
   Includes: []
+- Rule: A1B1
+  Kind: API
+  Priority: Takeover
+  In: A2::B2::A1B1
+  Out: A2B2()
+  Includes: []


### PR DESCRIPTION
Support namespace alias for user-defined API rules by adding a matcher

Fix bugs in ExprAnalysis(MemberExpr) and ExprAnalysis(MemberCallExpr) to make sure the callee will be dispatched