### PR TITLE
[SYCLomatic] Fix 4 thrust migration LIT test fails on CUDA 11.2+

### DIFF
--- a/clang/test/dpct/thrust-for-h2o4gpu.cu
+++ b/clang/test/dpct/thrust-for-h2o4gpu.cu
@@ -1,6 +1,6 @@
 // UNSUPPORTED: cuda-8.0
 // UNSUPPORTED: v8.0
-// RUN: dpct --format-range=none -out-root %T/thrust-for-h2o4gpu %s --cuda-include-path="%cuda-path/include" -- -std=c++14 -x cuda --cuda-host-only -fno-delayed-template-parsing
+// RUN: dpct --format-range=none -out-root %T/thrust-for-h2o4gpu %s --cuda-include-path="%cuda-path/include" -- -std=c++14 -x cuda --cuda-host-only -fno-delayed-template-parsing -ferror-limit=50
 // RUN: FileCheck --input-file %T/thrust-for-h2o4gpu/thrust-for-h2o4gpu.dp.cpp --match-full-lines %s
 
 

--- a/clang/test/dpct/thrust-reduce.cu
+++ b/clang/test/dpct/thrust-reduce.cu
@@ -1,6 +1,6 @@
 // UNSUPPORTED: cuda-8.0
 // UNSUPPORTED: v8.0
-// RUN: dpct --format-range=none -out-root %T/thrust-reduce %s --cuda-include-path="%cuda-path/include" -- -x cuda --cuda-host-only -fno-delayed-template-parsing -std=c++17 -fsized-deallocation
+// RUN: dpct --format-range=none -out-root %T/thrust-reduce %s --cuda-include-path="%cuda-path/include" -- -x cuda --cuda-host-only -fno-delayed-template-parsing -std=c++17 -fsized-deallocation -ferror-limit=50
 // RUN: FileCheck --input-file %T/thrust-reduce/thrust-reduce.dp.cpp --match-full-lines %s
 // CHECK: #include <oneapi/dpl/execution>
 // CHECK-NEXT: #include <oneapi/dpl/algorithm>

--- a/clang/test/dpct/thrust-transform-if.cu
+++ b/clang/test/dpct/thrust-transform-if.cu
@@ -1,6 +1,6 @@
 // UNSUPPORTED: cuda-8.0
 // UNSUPPORTED: v8.0
-// RUN: dpct --format-range=none -out-root %T/thrust-transform-if %s --cuda-include-path="%cuda-path/include" -- -x cuda --cuda-host-only -fno-delayed-template-parsing -std=c++17 -fsized-deallocation
+// RUN: dpct --format-range=none -out-root %T/thrust-transform-if %s --cuda-include-path="%cuda-path/include" -- -x cuda --cuda-host-only -fno-delayed-template-parsing -std=c++17 -fsized-deallocation -ferror-limit=50
 // RUN: FileCheck --input-file %T/thrust-transform-if/thrust-transform-if.dp.cpp --match-full-lines %s
 #include <thrust/device_vector.h>
 #include <thrust/transform.h>

--- a/clang/test/dpct/thrust_template.cu
+++ b/clang/test/dpct/thrust_template.cu
@@ -1,6 +1,6 @@
 // UNSUPPORTED: cuda-8.0
 // UNSUPPORTED: v8.0
-// RUN: dpct -out-root %T/thrust_template %s --cuda-include-path="%cuda-path/include" --extra-arg="-fno-delayed-template-parsing"
+// RUN: dpct -out-root %T/thrust_template %s --cuda-include-path="%cuda-path/include" --extra-arg="-fno-delayed-template-parsing" -- -ferror-limit=50
 // RUN: FileCheck --input-file %T/thrust_template/thrust_template.dp.cpp --match-full-lines %s
 
 #include <thrust/device_vector.h>


### PR DESCRIPTION
Signed-off-by: Cui, Dele <dele.cui@intel.com>