### PR TITLE
[SYCLomatic] Skip the migration of variable type when it is captured by lambda

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.h
+++ b/clang/lib/DPCT/ASTTraversal.h
@@ -585,6 +585,7 @@ private:
                                    const TypeLoc *TL);
   bool replaceTransformIterator(SourceManager *SM, LangOptions &LOpts,
                                 const TypeLoc *TL);
+  bool isCapturedByLambda(const TypeLoc *TL);
 };
 
 class UserDefinedAPIRule

--- a/clang/test/dpct/types006.cu
+++ b/clang/test/dpct/types006.cu
@@ -1,0 +1,15 @@
+// RUN: dpct -out-root %T/types006 %s --cuda-include-path="%cuda-path/include" -- -x cuda --cuda-host-only
+// RUN: FileCheck %s --match-full-lines --input-file %T/types006/types006.dp.cpp
+
+#include <curand_kernel.h>
+
+void foo() {
+// CHECK: dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> bar;
+// CHECK-NEXT: auto lambda = [&bar] () {
+// CHECK-NEXT:   return bar.generate<oneapi::mkl::rng::device::uniform<float>, 1>();
+// CHECK-NEXT: };
+  curandStatePhilox4_32_10_t bar;
+  auto lambda = [&bar] __device__ () {
+    return curand_uniform(&bar);
+  };
+}


### PR DESCRIPTION
Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>