### PR TITLE
[SYCLomatic] Fix the migration of 4 types

### DIFF
--- a/clang/lib/DPCT/MapNames.cpp
+++ b/clang/lib/DPCT/MapNames.cpp
@@ -187,9 +187,20 @@ void MapNames::setExplicitNamespaceMap() {
       {"cublasStatus_t", std::make_shared<TypeNameRule>("int")},
       {"cublasStatus", std::make_shared<TypeNameRule>("int")},
       {"cublasGemmAlgo_t", std::make_shared<TypeNameRule>("int")},
-      {"cudaDataType_t", std::make_shared<TypeNameRule>("int")},
-      {"cudaDataType", std::make_shared<TypeNameRule>("int")},
-      {"cublasDataType_t", std::make_shared<TypeNameRule>("int")},
+      {"cudaDataType_t", std::make_shared<TypeNameRule>(
+                             getDpctNamespace() + "library_data_t",
+                             HelperFeatureEnum::LibCommonUtils_library_data_t)},
+      {"cudaDataType", std::make_shared<TypeNameRule>(
+                           getDpctNamespace() + "library_data_t",
+                           HelperFeatureEnum::LibCommonUtils_library_data_t)},
+      {"cublasDataType_t",
+       std::make_shared<TypeNameRule>(
+           getDpctNamespace() + "library_data_t",
+           HelperFeatureEnum::LibCommonUtils_library_data_t)},
+      {"cublasComputeType_t",
+       std::make_shared<TypeNameRule>(
+           getDpctNamespace() + "library_data_t",
+           HelperFeatureEnum::LibCommonUtils_library_data_t)},
       {"cuComplex",
        std::make_shared<TypeNameRule>(getClNamespace() + "float2")},
       {"cuFloatComplex",

--- a/clang/test/dpct/cublas-create-Sgemm-destroy.cu
+++ b/clang/test/dpct/cublas-create-Sgemm-destroy.cu
@@ -18,7 +18,7 @@ cublasStatus_t bar (cublasStatus_t s){
 // CHECK: extern sycl::queue* handle2;
 extern cublasHandle_t handle2;
 
-// CHECK: int foo2(int DT)  try {
+// CHECK: int foo2(dpct::library_data_t DT)  try {
 int foo2(cudaDataType DT) {
   // CHECK: dpct::device_ext &dev_ct1 = dpct::get_current_device();
   // CHECK-NEXT: sycl::queue &q_ct1 = dev_ct1.default_queue();
@@ -57,8 +57,8 @@ int foo2(cudaDataType DT) {
   //CHECK-NEXT: /*
   //CHECK-NEXT: DPCT1026:{{[0-9]+}}: The call to cublasSetPointerMode was removed because the function call is redundant in DPC++.
   //CHECK-NEXT: */
-  //CHECK-NEXT: int cdt;
-  //CHECK-NEXT: int cbdt;
+  //CHECK-NEXT: dpct::library_data_t cdt;
+  //CHECK-NEXT: dpct::library_data_t cbdt;
   cublasPointerMode_t mode = CUBLAS_POINTER_MODE_HOST;
   cublasGetPointerMode(handle, &mode);
   cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_DEVICE);

--- a/clang/test/dpct/types001.cu
+++ b/clang/test/dpct/types001.cu
@@ -594,3 +594,16 @@ namespace {
 cudaComputeMode M;
 cudaComputeMode fun(cudaComputeMode);
 }
+
+// CHECK: void foo_2(dpct::library_data_t a1, dpct::library_data_t a2, dpct::library_data_t a3, dpct::library_data_t a4) {
+// CHECK-NEXT:   dpct::library_data_t b1 = a1;
+// CHECK-NEXT:   dpct::library_data_t b2 = a2;
+// CHECK-NEXT:   dpct::library_data_t b3 = a3;
+// CHECK-NEXT:   dpct::library_data_t b4 = a4;
+// CHECK-NEXT: }
+void foo_2(cudaDataType_t a1, cudaDataType a2, cublasDataType_t a3, cublasComputeType_t a4) {
+  cudaDataType_t b1 = a1;
+  cudaDataType b2 = a2;
+  cublasDataType_t b3 = a3;
+  cublasComputeType_t b4 = a4;
+}


### PR DESCRIPTION
Migrate cudaDataType_t, cudaDataType, cublasDataType_t and
cublasComputeType_t to dpct::library_data_t

Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>