### PR TITLE
[SYCLomatic] Refine migration of a NCCL API and a type

### DIFF
--- a/clang/lib/DPCT/APINamesNccl.inc
+++ b/clang/lib/DPCT/APINamesNccl.inc
@@ -19,6 +19,8 @@ FEATURE_REQUEST_FACTORY(HelperFeatureEnum::CclUtils_create_kvs_address,
 FEATURE_REQUEST_FACTORY(HelperFeatureEnum::CclUtils_create_kvs,
                         ASSIGNABLE_FACTORY(
                                   ASSIGN_FACTORY_ENTRY("ncclCommInitRank",DEREF(0),
-                                                        CALL("oneapi::ccl::create_communicator",
-                                                        ARG(1), ARG(3),
-                                                        CALL(MapNames::getDpctNamespace() + "ccl::create_kvs", ARG(2))))))
+                                                        NEW("oneapi::ccl::communicator",
+                                                            CALL("oneapi::ccl::create_communicator",
+                                                                 ARG(1), ARG(3),
+                                                                 CALL(MapNames::getDpctNamespace() + "ccl::create_kvs",
+                                                                      ARG(2)))))))

--- a/clang/lib/DPCT/MapNames.cpp
+++ b/clang/lib/DPCT/MapNames.cpp
@@ -388,7 +388,7 @@ void MapNames::setExplicitNamespaceMap() {
                            "oneapi::ccl::kvs::address_type",
                            HelperFeatureEnum::CclUtils_create_kvs_address)},
       {"ncclComm_t",
-       std::make_shared<TypeNameRule>("oneapi::ccl::communicator",
+       std::make_shared<TypeNameRule>("oneapi::ccl::communicator *",
                                       HelperFeatureEnum::CclUtils_create_kvs)},
       // ...
   };

--- a/clang/runtime/dpct-rt/include/ccl_utils.hpp.inc
+++ b/clang/runtime/dpct-rt/include/ccl_utils.hpp.inc
@@ -55,8 +55,13 @@ namespace detail {
 /// Get stored kvs with specified kvs address.
 inline std::shared_ptr<oneapi::ccl::kvs> &
 get_kvs(const oneapi::ccl::kvs::address_type &addr) {
+  struct hash {
+    std::size_t operator()(const oneapi::ccl::kvs::address_type &in) const {
+      return std::hash<std::string_view>()(std::string_view(in.data(), in.size()));
+    }
+  };
   static std::unordered_map<oneapi::ccl::kvs::address_type,
-                            std::shared_ptr<oneapi::ccl::kvs>>
+                            std::shared_ptr<oneapi::ccl::kvs>, hash>
       kvs_map;
   return kvs_map[addr];
 }

--- a/clang/test/dpct/helper_files_ref/include/ccl_utils.hpp
+++ b/clang/test/dpct/helper_files_ref/include/ccl_utils.hpp
@@ -21,8 +21,13 @@ namespace detail {
 /// Get stored kvs with specified kvs address.
 inline std::shared_ptr<oneapi::ccl::kvs> &
 get_kvs(const oneapi::ccl::kvs::address_type &addr) {
+  struct hash {
+    std::size_t operator()(const oneapi::ccl::kvs::address_type &in) const {
+      return std::hash<std::string_view>()(std::string_view(in.data(), in.size()));
+    }
+  };
   static std::unordered_map<oneapi::ccl::kvs::address_type,
-                            std::shared_ptr<oneapi::ccl::kvs>>
+                            std::shared_ptr<oneapi::ccl::kvs>, hash>
       kvs_map;
   return kvs_map[addr];
 }

--- a/clang/test/dpct/nccl.cu
+++ b/clang/test/dpct/nccl.cu
@@ -10,7 +10,7 @@ int main() {
     int version, nranks, rank;
     // CHECK: oneapi::ccl::kvs::address_type id;
     ncclUniqueId id;
-    // CHECK: oneapi::ccl::communicator comm;
+    // CHECK: oneapi::ccl::communicator * comm;
     ncclComm_t comm;
 
     // CHECK: version = dpct::ccl::get_version();
@@ -25,10 +25,10 @@ int main() {
     // CHECK: check((id = dpct::ccl::create_kvs_address(), 0));
     check(ncclGetUniqueId(&id));
 
-    // CHECK: comm = oneapi::ccl::create_communicator(nranks, rank, dpct::ccl::create_kvs(id));
+    // CHECK: comm = new oneapi::ccl::communicator(oneapi::ccl::create_communicator(nranks, rank, dpct::ccl::create_kvs(id)));
     ncclCommInitRank(&comm, nranks, id, rank);
 
-    // CHECK: check((comm = oneapi::ccl::create_communicator(nranks, rank, dpct::ccl::create_kvs(id)), 0));    
+    // CHECK: check((comm = new oneapi::ccl::communicator(oneapi::ccl::create_communicator(nranks, rank, dpct::ccl::create_kvs(id))), 0));    
     check(ncclCommInitRank(&comm, nranks, id, rank));
 
     void *buff;


### PR DESCRIPTION
Migrate ncclCommInitRank to new oneapi::ccl::communicator(oneapi::ccl::create_communicator(...)).
Migrate ncclComm_t to oneapi::ccl::communicator *.

Signed-off-by: Ziran Zhang <ziran.zhang@intel.com>