### PR TITLE
[SYCLomatic] Fix incorrect template arg location

### DIFF
--- a/clang/lib/DPCT/AnalysisInfo.cpp
+++ b/clang/lib/DPCT/AnalysisInfo.cpp
@@ -1854,16 +1854,16 @@ void CallFunctionExpr::buildCalleeInfo(const Expr *Callee) {
     }
     setFuncInfo(DeviceFunctionDecl::LinkRedecls(CallDecl));
     if (auto DRE = dyn_cast<DeclRefExpr>(Callee)) {
-      buildTemplateArguments(DRE->template_arguments());
+      buildTemplateArguments(DRE->template_arguments(), Callee->getSourceRange());
     }
   } else if (auto Unresolved = dyn_cast<UnresolvedLookupExpr>(Callee)) {
     Name = Unresolved->getName().getAsString();
     setFuncInfo(DeviceFunctionDecl::LinkUnresolved(Unresolved));
-    buildTemplateArguments(Unresolved->template_arguments());
+    buildTemplateArguments(Unresolved->template_arguments(), Callee->getSourceRange());
   } else if (auto DependentScope =
                  dyn_cast<CXXDependentScopeMemberExpr>(Callee)) {
     Name = DependentScope->getMember().getAsString();
-    buildTemplateArguments(DependentScope->template_arguments());
+    buildTemplateArguments(DependentScope->template_arguments(), Callee->getSourceRange());
   } else if (auto DSDRE = dyn_cast<DependentScopeDeclRefExpr>(Callee)) {
     Name = DSDRE->getDeclName().getAsString();
     buildTemplateArgumentsFromTypeLoc(DSDRE->getQualifierLoc().getTypeLoc());
@@ -3133,7 +3133,6 @@ void CtTypeInfo::setName(const TypeLoc &TL) {
   ExprAnalysis EA;
   EA.analyze(TL);
   TDSI = EA.getTemplateDependentStringInfo();
-
   auto SetFromTL = EA.getHelperFeatureSet();
   HelperFeatureSet.insert(SetFromTL.begin(), SetFromTL.end());
 
@@ -3142,7 +3141,6 @@ void CtTypeInfo::setName(const TypeLoc &TL) {
 }
 
 void CtTypeInfo::updateName() {
-
   BaseNameWithoutQualifiers = TDSI->getSourceString();
   auto SetFromTTDSI = TDSI->getHelperFeatureSet();
   HelperFeatureSet.insert(SetFromTTDSI.begin(), SetFromTTDSI.end());

--- a/clang/lib/DPCT/AnalysisInfo.h
+++ b/clang/lib/DPCT/AnalysisInfo.h
@@ -3123,10 +3123,9 @@ class TemplateArgumentInfo {
 public:
   explicit TemplateArgumentInfo(const TemplateArgumentLoc &TAL,
                                 SourceRange Range)
-      : Kind(TAL.getArgument().getKind()),
-        ParentRange(
-            getDefinitionRange(Range.getBegin(), Range.getEnd())) {
-    setArgFromExprAnalysis(TAL);
+      : Kind(TAL.getArgument().getKind()) {
+    setArgFromExprAnalysis(
+        TAL, getDefinitionRange(Range.getBegin(), Range.getEnd()));
   }
 
   explicit TemplateArgumentInfo(std::string &&Str)
@@ -3177,7 +3176,8 @@ public:
   static bool isPlaceholderType(clang::QualType QT);
 
 private:
-  template <class T> void setArgFromExprAnalysis(const T &Arg) {
+  template <class T>
+  void setArgFromExprAnalysis(const T &Arg, SourceRange ParentRange = SourceRange()) {
     auto &SM = DpctGlobalInfo::getSourceManager();
     auto Range = getArgSourceRange(Arg);
     auto Begin = Range.getBegin();
@@ -3224,7 +3224,6 @@ private:
   }
   std::shared_ptr<TemplateDependentStringInfo> DependentStr;
   TemplateArgument::ArgKind Kind;
-  SourceRange ParentRange;
   bool IsWritten = true;
 };
 

--- a/clang/lib/DPCT/CallExprRewriter.cpp
+++ b/clang/lib/DPCT/CallExprRewriter.cpp
@@ -1448,7 +1448,7 @@ auto getTemplateArgsList =
     TemplateArgsList = ULE->template_arguments();
   }
   for (auto Arg : TemplateArgsList) {
-    Ret.emplace_back(Arg);
+    Ret.emplace_back(Arg, C->getSourceRange());
   }
   return Ret;
 };

--- a/clang/lib/DPCT/TypeLocRewriters.cpp
+++ b/clang/lib/DPCT/TypeLocRewriters.cpp
@@ -25,7 +25,7 @@ makeTemplateArgCreator(unsigned Idx) {
     if (auto TSTL = TL.getAs<TemplateSpecializationTypeLoc>()) {
       if (TSTL.getNumArgs() > Idx) {
         auto TAL = TSTL.getArgLoc(Idx);
-        return TemplateArgumentInfo(TAL);
+        return TemplateArgumentInfo(TAL, TL.getSourceRange());
       }
     }
     return TemplateArgumentInfo("");

--- a/clang/lib/DPCT/Utility.h
+++ b/clang/lib/DPCT/Utility.h
@@ -465,6 +465,9 @@ clang::SourceLocation getLocInRange(clang::SourceLocation Loc,
 std::pair<clang::SourceLocation, clang::SourceLocation>
 getRangeInRange(const clang::Stmt *E, clang::SourceLocation RangeBegin,
                 clang::SourceLocation RangeEnd);
+std::pair<clang::SourceLocation, clang::SourceLocation>
+getRangeInRange(clang::SourceRange Range, clang::SourceLocation RangeBegin,
+                clang::SourceLocation RangeEnd);
 unsigned int calculateIndentWidth(const clang::CUDAKernelCallExpr *Node,
                                   clang::SourceLocation SL, bool &Flag);
 bool isIncludedFile(const std::string &CurrentFile,

--- a/clang/test/dpct/macro_test.cu
+++ b/clang/test/dpct/macro_test.cu
@@ -1152,3 +1152,29 @@ void foo30(){
   foo29<<<1,1,0>>>();
   FOO31(1)
 }
+
+
+
+#define VA_CALL2(...) __VA_ARGS__()
+#define VA_CALL(...) VA_CALL2(__VA_ARGS__)
+
+template<class T>
+__global__ void template_kernel(T t){
+    __shared__ T t2;
+}
+
+int foo31(){
+  //CHECK: VA_CALL(([&] {
+  //CHECK-NEXT:   dpct::get_default_queue().submit([&](sycl::handler &cgh) {
+  //CHECK-NEXT:     sycl::accessor<int, 0, sycl::access_mode::read_write,
+  //CHECK-NEXT:                    sycl::access::target::local>
+  //CHECK-NEXT:         t2_acc_ct1(cgh);
+  //CHECK:     cgh.parallel_for(
+  //CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
+  //CHECK-NEXT:         [=](sycl::nd_item<3> item_ct1) {
+  //CHECK-NEXT:           template_kernel<int>(10, t2_acc_ct1.get_pointer());
+  //CHECK-NEXT:         });
+  //CHECK-NEXT:   });
+  //CHECK-NEXT: }));
+  VA_CALL( ([&]{ template_kernel<int><<<1,1,0>>>(10); }) );
+}


### PR DESCRIPTION
Fix incorrect source location of template args when the
entire kernel call is a macro arg.

Signed-off-by: Huang, Andy <andy.huang@intel.com>