### PR TITLE
[SYCLomatic] Fix the qualified template in the TypeInDeclRule.

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -3082,7 +3082,7 @@ void TypeInDeclRule::runRule(const MatchFinder::MatchResult &Result) {
 
     // if TL is the T in
     // template<typename T> void foo(T a);
-    if (TL->getType()->getTypeClass() == clang::TypeLoc::SubstTemplateTypeParm ||
+    if (TL->getType()->getTypeClass() == clang::Type::SubstTemplateTypeParm ||
         TL->getBeginLoc().isInvalid()) {
       return;
     }

--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -3082,11 +3082,10 @@ void TypeInDeclRule::runRule(const MatchFinder::MatchResult &Result) {
 
     // if TL is the T in
     // template<typename T> void foo(T a);
-    if (TL->getTypeLocClass() == clang::TypeLoc::SubstTemplateTypeParm ||
+    if (TL->getType()->getTypeClass() == clang::TypeLoc::SubstTemplateTypeParm ||
         TL->getBeginLoc().isInvalid()) {
       return;
     }
-
     auto TypeStr =
         DpctGlobalInfo::getTypeName(TL->getType().getUnqualifiedType());
 
@@ -3115,7 +3114,6 @@ void TypeInDeclRule::runRule(const MatchFinder::MatchResult &Result) {
 
     if (isCapturedByLambda(TL))
       return;
-
     auto Range = getDefinitionRange(TL->getBeginLoc(), TL->getEndLoc());
     auto BeginLoc = Range.getBegin();
     auto EndLoc = Range.getEnd();
@@ -3214,7 +3212,6 @@ void TypeInDeclRule::runRule(const MatchFinder::MatchResult &Result) {
     if (replaceTransformIterator(SM, LOpts, TL)) {
       return;
     }
-
     if (TL->getTypeLocClass() == clang::TypeLoc::Elaborated) {
       auto ETC = TL->getAs<ElaboratedTypeLoc>();
       auto NTL = ETC.getNamedTypeLoc();
@@ -3348,7 +3345,6 @@ void TypeInDeclRule::runRule(const MatchFinder::MatchResult &Result) {
         }
       }
     }
-
     const DeclaratorDecl *DD = nullptr;
     const VarDecl *VarD = DpctGlobalInfo::findAncestor<VarDecl>(TL);
     const FieldDecl *FieldD = DpctGlobalInfo::findAncestor<FieldDecl>(TL);
@@ -3359,9 +3355,7 @@ void TypeInDeclRule::runRule(const MatchFinder::MatchResult &Result) {
           std::string::npos)
         report(BeginLoc, Diagnostics::HANDLE_IN_DEVICE, false, TypeStr);
     }
-
     const Expr *Init = nullptr;
-
     if (VarD) {
       DD = VarD;
       if (VarD->hasInit())

--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -3086,6 +3086,7 @@ void TypeInDeclRule::runRule(const MatchFinder::MatchResult &Result) {
         TL->getBeginLoc().isInvalid()) {
       return;
     }
+
     auto TypeStr =
         DpctGlobalInfo::getTypeName(TL->getType().getUnqualifiedType());
 
@@ -3114,6 +3115,7 @@ void TypeInDeclRule::runRule(const MatchFinder::MatchResult &Result) {
 
     if (isCapturedByLambda(TL))
       return;
+
     auto Range = getDefinitionRange(TL->getBeginLoc(), TL->getEndLoc());
     auto BeginLoc = Range.getBegin();
     auto EndLoc = Range.getEnd();
@@ -3212,6 +3214,7 @@ void TypeInDeclRule::runRule(const MatchFinder::MatchResult &Result) {
     if (replaceTransformIterator(SM, LOpts, TL)) {
       return;
     }
+
     if (TL->getTypeLocClass() == clang::TypeLoc::Elaborated) {
       auto ETC = TL->getAs<ElaboratedTypeLoc>();
       auto NTL = ETC.getNamedTypeLoc();
@@ -3345,6 +3348,7 @@ void TypeInDeclRule::runRule(const MatchFinder::MatchResult &Result) {
         }
       }
     }
+
     const DeclaratorDecl *DD = nullptr;
     const VarDecl *VarD = DpctGlobalInfo::findAncestor<VarDecl>(TL);
     const FieldDecl *FieldD = DpctGlobalInfo::findAncestor<FieldDecl>(TL);
@@ -3355,7 +3359,9 @@ void TypeInDeclRule::runRule(const MatchFinder::MatchResult &Result) {
           std::string::npos)
         report(BeginLoc, Diagnostics::HANDLE_IN_DEVICE, false, TypeStr);
     }
+
     const Expr *Init = nullptr;
+
     if (VarD) {
       DD = VarD;
       if (VarD->hasInit())

--- a/clang/test/dpct/qualified_template_func.cu
+++ b/clang/test/dpct/qualified_template_func.cu
@@ -1,0 +1,27 @@
+// RUN: dpct --format-range=none -out-root %T/qualified_template_func %s --cuda-include-path="%cuda-path/include" -- -x cuda --cuda-host-only -ptx
+// RUN: FileCheck %s --match-full-lines --input-file %T/qualified_template_func/qualified_template_func.dp.cpp
+
+#include<cuda.h>
+//CHECK: #define DEFINE_CHECK_FUNC(name, op)                               \
+//CHECK-NEXT:  template <typename X, typename Y>                               \
+//CHECK-NEXT:  inline void LogCheck##name(const X& x, const Y& y) {   \
+//CHECK-NEXT:																  \
+//CHECK-NEXT:  }
+#define DEFINE_CHECK_FUNC(name, op)                               \
+  template <typename X, typename Y>                               \
+  inline void LogCheck##name(const X& x, const Y& y) {            \
+								  \
+  }
+
+#define CHECK_BINARY_OP(name, op, x, y) LogCheck##name(x, y)
+
+#define CHECK_EQ(x, y) CHECK_BINARY_OP(_EQ, ==, x, y)
+
+DEFINE_CHECK_FUNC(_EQ, ==)
+
+int main() {
+	cudaError_t error ;
+	CHECK_EQ(error, 0);
+	return 0;
+}
+


### PR DESCRIPTION
The getTypeLocClass() will return the Qualifier type when the type is qualified.
To get the clang::TypeLoc::SubstTemplateTypeParm type, replace with the getType()->getTypeCall() API.