### PR TITLE
[SYCLomatic] Add new option --analysis-scope-path

### DIFF
--- a/clang/lib/DPCT/AnalysisInfo.cpp
+++ b/clang/lib/DPCT/AnalysisInfo.cpp
@@ -36,12 +36,13 @@ llvm::Optional<std::string> getReplacedName(const clang::NamedDecl *D) {
 }
 
 namespace clang {
-extern std::function<bool(SourceLocation)> IsInRootFunc;
+extern std::function<bool(SourceLocation)> IsInAnalysisScopeFunc;
 extern std::function<unsigned int()> GetRunRound;
 extern std::function<void(SourceLocation, unsigned)> RecordTokenSplit;
 namespace dpct {
 std::string DpctGlobalInfo::InRoot = std::string();
 std::string DpctGlobalInfo::OutRoot = std::string();
+std::string DpctGlobalInfo::AnalysisScope = std::string();
 // TODO: implement one of this for each source language.
 std::string DpctGlobalInfo::CudaPath = std::string();
 std::string DpctGlobalInfo::RuleFile = std::string();
@@ -301,7 +302,7 @@ void DpctGlobalInfo::resetInfo() {
 }
 
 DpctGlobalInfo::DpctGlobalInfo() {
-  IsInRootFunc = DpctGlobalInfo::checkInRoot;
+  IsInAnalysisScopeFunc = DpctGlobalInfo::checkInAnalysisScope;
   GetRunRound = DpctGlobalInfo::getRunRound;
   RecordTokenSplit = DpctGlobalInfo::recordTokenSplit;
   tooling::SetGetRunRound(DpctGlobalInfo::getRunRound);
@@ -349,7 +350,7 @@ void DpctGlobalInfo::insertFFTExecAPIInfo(SourceLocation SL,
   }
 }
 
-bool DpctFileInfo::isInRoot() { return DpctGlobalInfo::isInRoot(FilePath); }
+bool DpctFileInfo::isInAnalysisScope() { return DpctGlobalInfo::isInAnalysisScope(FilePath); }
 // TODO: implement one of this for each source language.
 bool DpctFileInfo::isInCudaPath() {
   return DpctGlobalInfo::isInCudaPath(FilePath);
@@ -408,7 +409,7 @@ void DpctFileInfo::buildKernelInfo() {
     Kernel.second->buildInfo();
 }
 void DpctFileInfo::postProcess() {
-  if (!isInRoot())
+  if (!isInAnalysisScope())
     return;
   for (auto &D : FuncMap)
     D.second->emplaceReplacement();
@@ -421,7 +422,7 @@ void DpctFileInfo::postProcess() {
 }
 
 void DpctFileInfo::buildReplacements() {
-  if (!isInRoot())
+  if (!isInAnalysisScope())
     return;
 
   if (FilePath.empty())
@@ -1727,7 +1728,7 @@ bool deduceTemplateArguments(const CallT *C, const FunctionTemplateDecl *FTD,
   if (!FTD)
     return false;
 
-  if (!DpctGlobalInfo::isInRoot(FTD->getBeginLoc()))
+  if (!DpctGlobalInfo::isInAnalysisScope(FTD->getBeginLoc()))
     return false;
   auto &TemplateParmsList = *FTD->getTemplateParameters();
   if (TAIList.size() == TemplateParmsList.size())
@@ -2616,7 +2617,7 @@ void DeviceFunctionDecl::setFuncInfo(std::shared_ptr<DeviceFunctionInfo> Info) {
 
 void DeviceFunctionDecl::LinkDecl(const FunctionDecl *FD, DeclList &List,
                                   std::shared_ptr<DeviceFunctionInfo> &Info) {
-  if (!DpctGlobalInfo::isInRoot(FD->getBeginLoc()))
+  if (!DpctGlobalInfo::isInAnalysisScope(FD->getBeginLoc()))
     return;
   if (!FD->hasAttr<CUDADeviceAttr>() && !FD->hasAttr<CUDAGlobalAttr>())
     return;
@@ -3298,7 +3299,7 @@ void BuiltinVarInfo::buildInfo(std::string FilePath, unsigned int Offset,
       std::make_shared<ExtReplacement>(FilePath, Offset, Len, R, nullptr));
 }
 
-bool isInRoot(SourceLocation SL) { return DpctGlobalInfo::isInRoot(SL); }
+bool isInAnalysisScope(SourceLocation SL) { return DpctGlobalInfo::isInAnalysisScope(SL); }
 
 std::vector<std::shared_ptr<FreeQueriesInfo>> FreeQueriesInfo::InfoList;
 std::vector<std::shared_ptr<FreeQueriesInfo::MacroInfo>>

--- a/clang/lib/DPCT/CallExprRewriter.cpp
+++ b/clang/lib/DPCT/CallExprRewriter.cpp
@@ -69,7 +69,7 @@ bool isTargetMathFunction(const FunctionDecl *FD) {
   if (!FD)
     return false;
   auto FilePath = DpctGlobalInfo::getLocInfo(FD).first;
-  if (isChildOrSamePath(DpctGlobalInfo::getInRoot(), FilePath))
+  if (isChildOrSamePath(DpctGlobalInfo::getAnalysisScope(), FilePath))
     return false;
   return true;
 }
@@ -124,7 +124,7 @@ bool isTargetPseudoObjectExpr(const Expr *E) {
   } else if (auto DRE = dyn_cast<DeclRefExpr>(E->IgnoreImpCasts())) {
     auto VarDecl = DRE->getDecl();
     if (VarDecl && (VarDecl->getNameAsString() == "warpSize")) {
-      return !DpctGlobalInfo::isInRoot(VarDecl->getLocation());
+      return !DpctGlobalInfo::isInAnalysisScope(VarDecl->getLocation());
     }
   }
   return false;
@@ -157,7 +157,7 @@ std::string MathFuncNameRewriter::getNewFuncName() {
       }
     }
 
-    if (dpct::DpctGlobalInfo::isInRoot(FD->getBeginLoc())) {
+    if (dpct::DpctGlobalInfo::isInAnalysisScope(FD->getBeginLoc())) {
       return "";
     }
 
@@ -670,7 +670,7 @@ Optional<std::string> MathSimulatedRewriter::rewrite() {
   if (!FD)
     return Base::rewrite();
 
-  if (dpct::DpctGlobalInfo::isInRoot(FD->getBeginLoc())) {
+  if (dpct::DpctGlobalInfo::isInAnalysisScope(FD->getBeginLoc())) {
     return {};
   }
 

--- a/clang/lib/DPCT/CallExprRewriter.h
+++ b/clang/lib/DPCT/CallExprRewriter.h
@@ -152,7 +152,7 @@ public:
           getHashStrFromLoc(SM.getImmediateSpellingLoc(SL)));
       if (ItMatch !=
           dpct::DpctGlobalInfo::getMacroTokenToMacroDefineLoc().end()) {
-        if (ItMatch->second->IsInRoot) {
+        if (ItMatch->second->IsInAnalysisScope) {
           SL = ItMatch->second->NameTokenLoc;
         }
       }

--- a/clang/lib/DPCT/DNNAPIMigration.cpp
+++ b/clang/lib/DPCT/DNNAPIMigration.cpp
@@ -50,7 +50,7 @@ void CuDNNTypeRule::runRule(const MatchFinder::MatchResult &Result) {
     auto TypeStr =
         DpctGlobalInfo::getTypeName(TL->getType().getUnqualifiedType());
 
-    if (!DpctGlobalInfo::isInRoot(SM->getSpellingLoc(TL->getBeginLoc()))) {
+    if (!DpctGlobalInfo::isInAnalysisScope(SM->getSpellingLoc(TL->getBeginLoc()))) {
       return;
     }
 

--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -125,6 +125,12 @@ static opt<std::string>
                 "of the first input source file is used."),
            value_desc("dir"), cat(DPCTCat),
            llvm::cl::Optional);
+static opt<std::string>
+    AnalysisScope("analysis-scope-path",
+        desc("The directory path for the analysis scope of the source tree that "
+             "needs to be migrated.\n"
+             "Default: the value of --in-root"),
+        value_desc("dir"), cat(DPCTCat));
 static opt<std::string> OutRoot(
     "out-root",
     desc("The directory path for root of generated files. A directory is "
@@ -526,7 +532,7 @@ JMP_BUF CPFormatCodeEnter;
 class DPCTConsumer : public ASTConsumer {
 public:
   DPCTConsumer(CompilerInstance &CI, StringRef InFile)
-      : ATM(CI, InRoot), PP(CI.getPreprocessor()), CI(CI) {
+      : ATM(CI, AnalysisScope), PP(CI.getPreprocessor()), CI(CI) {
     if (Passes != "") {
       // Separate string into list by comma
       auto Names = split(Passes, ',');
@@ -1069,6 +1075,11 @@ int runDPCT(int argc, const char **argv) {
     ShowStatus(MigrationErrorPathTooLong);
     dpctExit(MigrationErrorPathTooLong);
   }
+  if (AnalysisScope.size() >= MAX_PATH_LEN - 1) {
+    DpctLog() << "Error: --analysis-scope-path '" << AnalysisScope << "' is too long\n";
+    ShowStatus(MigrationErrorPathTooLong);
+    dpctExit(MigrationErrorPathTooLong);
+  }
   if (CudaIncludePath.size() >= MAX_PATH_LEN - 1) {
     DpctLog() << "Error: --cuda-include-path '" << CudaIncludePath
               << "' is too long\n";
@@ -1209,6 +1220,20 @@ int runDPCT(int argc, const char **argv) {
   }
   dpct::DpctGlobalInfo::setOutRoot(OutRoot);
 
+  if (AnalysisScope.empty()) {
+    // /p AnalysisScope defaults to the value of /p InRoot
+    AnalysisScope.setValue(InRoot.getValue(), true);
+  } else {
+    bool validAnalysisScope =
+        makeCanonical(AnalysisScope) &&
+        isChildOrSamePath(AnalysisScope, InRoot);
+    // /p AnalysisScope must be the same as or parent of /p InRoot
+    if (!validAnalysisScope) {
+      ShowStatus(MigrationErrorInvalidAnalysisScope);
+      dpctExit(MigrationErrorInvalidAnalysisScope);
+    }
+  }
+
   validateCustomHelperFileNameArg(UseCustomHelperFileLevel,
                                   CustomHelperFileName,
                                   dpct::DpctGlobalInfo::getOutRoot());
@@ -1257,6 +1282,7 @@ int runDPCT(int argc, const char **argv) {
 
   DpctGlobalInfo::setInRoot(InRoot);
   DpctGlobalInfo::setOutRoot(OutRoot);
+  DpctGlobalInfo::setAnalysisScope(AnalysisScope);
   DpctGlobalInfo::setCudaPath(CudaPath);
   DpctGlobalInfo::setKeepOriginCode(KeepOriginalCodeFlag);
   DpctGlobalInfo::setSyclNamedLambda(SyclNamedLambdaFlag);

--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -1404,6 +1404,9 @@ int runDPCT(int argc, const char **argv) {
                      OptimizeMigration.getNumOccurrences());
     setValueToOptMap(clang::dpct::OPTION_RuleFile, MetaRuleObject::RuleFiles,
                      RuleFile.getNumOccurrences());
+    setValueToOptMap(clang::dpct::OPTION_AnalysisScopePath,
+                     DpctGlobalInfo::getAnalysisScope(),
+                     AnalysisScope.getNumOccurrences());
 
     if (clang::dpct::DpctGlobalInfo::isIncMigration()) {
       std::string Msg;

--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -748,13 +748,13 @@ void ValidateInputDirectory(clang::tooling::RefactoringTool &Tool,
   }
 
   if (isChildOrSamePath(InRoot, CudaPath)) {
-    ShowStatus(MigrationErrorInRootContainSDKFolder);
-    dpctExit(MigrationErrorInRootContainSDKFolder);
+    ShowStatus(MigrationErrorInputDirContainSDKFolder);
+    dpctExit(MigrationErrorInputDirContainSDKFolder);
   }
 
   if (isChildOrSamePath(InRoot, DpctInstallPath)) {
-    ShowStatus(MigrationErrorInRootContainCTTool);
-    dpctExit(MigrationErrorInRootContainCTTool);
+    ShowStatus(MigrationErrorInputDirContainCTTool);
+    dpctExit(MigrationErrorInputDirContainCTTool);
   }
 }
 
@@ -1224,14 +1224,13 @@ int runDPCT(int argc, const char **argv) {
     // /p AnalysisScope defaults to the value of /p InRoot
     AnalysisScope.setValue(InRoot.getValue(), true);
   } else {
-    bool validAnalysisScope =
-        makeCanonical(AnalysisScope) &&
-        isChildOrSamePath(AnalysisScope, InRoot);
-    // /p AnalysisScope must be the same as or parent of /p InRoot
-    if (!validAnalysisScope) {
+    // /p InRoot must be the same as or child of /p AnalysisScope
+    if (!makeCanonical(AnalysisScope) ||
+        !isChildOrSamePath(AnalysisScope, InRoot)) {
       ShowStatus(MigrationErrorInvalidAnalysisScope);
       dpctExit(MigrationErrorInvalidAnalysisScope);
     }
+    ValidateInputDirectory(Tool, AnalysisScope);
   }
 
   validateCustomHelperFileNameArg(UseCustomHelperFileLevel,

--- a/clang/lib/DPCT/Diagnostics.h
+++ b/clang/lib/DPCT/Diagnostics.h
@@ -121,6 +121,9 @@ static inline std::string getMessagePrefix(int ID) {
 template <typename... Ts>
 void reportWarning(SourceLocation SL, const DiagnosticsMessage &Msg,
                    const CompilerInstance &CI, Ts &&...Vals) {
+  // Do not emit diagnostic message for source location outside --in-root
+  if (!DpctGlobalInfo::isInRoot(SL))
+    return;
   DiagnosticsEngine &DiagEngine = CI.getDiagnostics();
   std::string Message = getMessagePrefix(Msg.ID) + Msg.Msg;
 

--- a/clang/lib/DPCT/Error.cpp
+++ b/clang/lib/DPCT/Error.cpp
@@ -163,6 +163,9 @@ void ShowStatus(int Status, std::string Message) {
   case MigrationErrorCannotParseRuleFile:
     StatusString = "Error: Cannot parse rule file";
     break;
+  case MigrationErrorInvalidAnalysisScope:
+    StatusString = "Error: The path for --analysis-scope-path is not valid";
+    break;
   default:
     DpctLog() << "Unknown error\n";
     dpctExit(-1);

--- a/clang/lib/DPCT/Error.cpp
+++ b/clang/lib/DPCT/Error.cpp
@@ -104,16 +104,16 @@ void ShowStatus(int Status, std::string Message) {
   case MigrationErrorNoFileTypeAvail:
     StatusString = "Error: File Type not available for input file";
     break;
-  case MigrationErrorInRootContainCTTool:
+  case MigrationErrorInputDirContainCTTool:
     StatusString =
         "Error: Input folder is the parent of, or the same folder as, the "
         "installation directory of the dpct";
     break;
   case MigrationErrorRunFromSDKFolder:
-    StatusString = "Error: Input folder specified by --in-root option is "
-                   "in the CUDA_PATH folder";
+    StatusString = "Error: Input folder specified by --in-root or "
+                   "--analysis-scope-path option is in the CUDA_PATH folder";
     break;
-  case MigrationErrorInRootContainSDKFolder:
+  case MigrationErrorInputDirContainSDKFolder:
     StatusString = "Error: Input folder is the parent of, or the same folder "
                    "as, the CUDA_PATH folder";
     break;

--- a/clang/lib/DPCT/Error.cpp
+++ b/clang/lib/DPCT/Error.cpp
@@ -106,15 +106,17 @@ void ShowStatus(int Status, std::string Message) {
     break;
   case MigrationErrorInputDirContainCTTool:
     StatusString =
-        "Error: Input folder is the parent of, or the same folder as, the "
-        "installation directory of the dpct";
+        "Error: Input folder specified by --in-root or --analysis-scope-path "
+        "option is the parent of, or the same folder as, the installation "
+        "directory of the dpct";
     break;
   case MigrationErrorRunFromSDKFolder:
     StatusString = "Error: Input folder specified by --in-root or "
                    "--analysis-scope-path option is in the CUDA_PATH folder";
     break;
   case MigrationErrorInputDirContainSDKFolder:
-    StatusString = "Error: Input folder is the parent of, or the same folder "
+    StatusString = "Error: Input folder specified by --in-root or "
+                   "--analysis-scope-path is the parent of, or the same folder "
                    "as, the CUDA_PATH folder";
     break;
   case MigrationErrorCannotAccessDirInDatabase:
@@ -164,7 +166,8 @@ void ShowStatus(int Status, std::string Message) {
     StatusString = "Error: Cannot parse rule file";
     break;
   case MigrationErrorInvalidAnalysisScope:
-    StatusString = "Error: The path for --analysis-scope-path is not valid";
+    StatusString = "Error: The path for --analysis-scope-path is not the same "
+                   "as or a parent directory of --in-root";
     break;
   default:
     DpctLog() << "Unknown error\n";

--- a/clang/lib/DPCT/Error.h
+++ b/clang/lib/DPCT/Error.h
@@ -52,6 +52,7 @@ enum ProcessStatus {
   MigrationErrorDifferentOptSet = -37,
   MigrationErrorInvalidRuleFilePath = -38,
   MigrationErrorCannotParseRuleFile = -39,
+  MigrationErrorInvalidAnalysisScope = -40,
 };
 
 namespace clang {

--- a/clang/lib/DPCT/Error.h
+++ b/clang/lib/DPCT/Error.h
@@ -19,7 +19,7 @@ enum ProcessStatus {
   MigrationError = -1,
   MigrationSaveOutFail = -2, /*eg. have no write permission*/
   MigrationErrorRunFromSDKFolder = -3,
-  MigrationErrorInRootContainCTTool = -4,
+  MigrationErrorInputDirContainCTTool = -4,
   MigrationErrorInvalidCudaIncludePath = -5,
   MigrationErrorInvalidInRootOrOutRoot = -6,
   MigrationErrorInvalidInRootPath = -7,
@@ -40,7 +40,7 @@ enum ProcessStatus {
   MigrationErrorSpecialCharacter = -23,
   MigrationErrorPrefixTooLong = -25,
   MigrationErrorNoFileTypeAvail = -27,
-  MigrationErrorInRootContainSDKFolder = -28,
+  MigrationErrorInputDirContainSDKFolder = -28,
   MigrationErrorCannotAccessDirInDatabase = -29,
   MigrationErrorInconsistentFileInDatabase = -30,
   MigrationErrorCudaVersionUnsupported = -31,

--- a/clang/lib/DPCT/ExprAnalysis.cpp
+++ b/clang/lib/DPCT/ExprAnalysis.cpp
@@ -468,7 +468,7 @@ void ExprAnalysis::analyzeExpr(const DeclRefExpr *DRE) {
     }
   } else if (auto VD = dyn_cast<VarDecl>(DRE->getDecl())) {
     if (RefString == "warpSize" &&
-        !DpctGlobalInfo::isInRoot(VD->getLocation())) {
+        !DpctGlobalInfo::isInAnalysisScope(VD->getLocation())) {
       addReplacement(DRE, DpctGlobalInfo::getSubGroup(DRE) +
                               ".get_local_range().get(0)");
     }
@@ -634,7 +634,7 @@ void ExprAnalysis::analyzeExpr(const MemberExpr *ME) {
              MapNames::SupportedVectorTypes.end()) {
 
     // Skip user-defined type.
-    if (isTypeInRoot(ME->getBase()->getType().getTypePtr()))
+    if (isTypeInAnalysisScope(ME->getBase()->getType().getTypePtr()))
       return;
 
     if (*BaseType.rbegin() == '1') {

--- a/clang/lib/DPCT/IncrementalMigrationUtility.cpp
+++ b/clang/lib/DPCT/IncrementalMigrationUtility.cpp
@@ -303,6 +303,9 @@ bool printOptions(
       for (const auto &Item : ValueVec)
         Opts.emplace_back("--rule-file=\"" + Item + "\"");
     }
+    if (Key == clang::dpct::OPTION_AnalysisScopePath && Specified) {
+      Opts.emplace_back("--analysis-scope-path=\"" + Value + "\"");
+    }
   }
 
   Msg = "";

--- a/clang/lib/DPCT/IncrementalMigrationUtility.h
+++ b/clang/lib/DPCT/IncrementalMigrationUtility.h
@@ -38,6 +38,7 @@ const std::string OPTION_ExplicitNamespace = "ExplicitNamespace";
 const std::string OPTION_UsmLevel = "UsmLevel";
 const std::string OPTION_OptimizeMigration = "OptimizeMigration";
 const std::string OPTION_RuleFile = "RuleFile";
+const std::string OPTION_AnalysisScopePath = "AnalysisScopePath";
 
 bool isOnlyContainDigit(const std::string &Str);
 bool convertToIntVersion(std::string VersionStr, unsigned int &Result);

--- a/clang/lib/DPCT/SaveNewFiles.cpp
+++ b/clang/lib/DPCT/SaveNewFiles.cpp
@@ -422,6 +422,8 @@ int saveNewFiles(clang::tooling::RefactoringTool &Tool, StringRef InRoot,
       // This operation won't fail; it already succeeded once during argument
       // validation.
       makeCanonical(OutPath);
+      // inhibit generating migrated files outside --in-root
+      if(!DpctGlobalInfo::isInRoot(OutPath.c_str())) continue;
       rewriteFileName(OutPath);
       rewriteDir(OutPath, InRoot, OutRoot);
 

--- a/clang/lib/DPCT/Utility.h
+++ b/clang/lib/DPCT/Utility.h
@@ -536,7 +536,7 @@ void checkIsPrivateVar(const clang::Expr *Expr, LocalVarAddrSpaceEnum &Result);
 bool isModifiedRef(const clang::DeclRefExpr *DRE);
 bool isDefaultStream(const clang::Expr *StreamArg);
 const clang::NamedDecl *getNamedDecl(const clang::Type *TypePtr);
-bool isTypeInRoot(const clang::Type *TypePtr);
+bool isTypeInAnalysisScope(const clang::Type *TypePtr);
 void findAssignments(const clang::DeclaratorDecl *HandleDecl,
                      const clang::CompoundStmt *CS,
                      std::vector<const clang::DeclRefExpr *> &Refs);

--- a/clang/lib/Lex/Lexer.cpp
+++ b/clang/lib/Lex/Lexer.cpp
@@ -50,7 +50,7 @@
 using namespace clang;
 #ifdef SYCLomatic_CUSTOMIZATION
 namespace clang {
-  extern std::function<bool(SourceLocation)> IsInRootFunc;
+  extern std::function<bool(SourceLocation)> IsInAnalysisScopeFunc;
 }
 #endif // SYCLomatic_CUSTOMIZATION
 //===----------------------------------------------------------------------===//
@@ -1839,7 +1839,7 @@ bool Lexer::LexIdentifierContinue(Token &Result, const char *CurPtr) {
 #ifdef SYCLomatic_CUSTOMIZATION
   // if __CUDA_ARCH__ in in-root, perfrom HandleIdentifier anyway
   if (!II->isHandleIdentifierCase() && II->getName() == "__CUDA_ARCH__" &&
-      IsInRootFunc(Result.getLocation())) {
+      IsInAnalysisScopeFunc(Result.getLocation())) {
     return PP->HandleIdentifier(Result);
   }
 #endif // SYCLomatic_CUSTOMIZATION

--- a/clang/lib/Lex/Lexer.cpp
+++ b/clang/lib/Lex/Lexer.cpp
@@ -1837,7 +1837,7 @@ bool Lexer::LexIdentifierContinue(Token &Result, const char *CurPtr) {
   }
 
 #ifdef SYCLomatic_CUSTOMIZATION
-  // if __CUDA_ARCH__ in in-root, perfrom HandleIdentifier anyway
+  // if __CUDA_ARCH__ in analysis-scope-path, perfrom HandleIdentifier anyway
   if (!II->isHandleIdentifierCase() && II->getName() == "__CUDA_ARCH__" &&
       IsInAnalysisScopeFunc(Result.getLocation())) {
     return PP->HandleIdentifier(Result);

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -3056,7 +3056,7 @@ void Preprocessor::HandleUndefDirective() {
 
 #ifdef SYCLomatic_CUSTOMIZATION
 namespace clang{
-  extern std::function<bool(SourceLocation)> IsInRootFunc;
+  extern std::function<bool(SourceLocation)> IsInAnalysisScopeFunc;
   extern std::function<unsigned int()> GetRunRound;
 }
 #endif // SYCLomatic_CUSTOMIZATION
@@ -3128,7 +3128,7 @@ void Preprocessor::HandleIfdefDirective(Token &Result,
   // If macro name is '__CUDA_ARCH__' and is inside in-root folder, handle it as
   // defined.
   if (!MI && MII->getName() == "__CUDA_ARCH__" &&
-      IsInRootFunc(MacroNameTok.getLocation()) && GetRunRound() == 0) {
+      IsInAnalysisScopeFunc(MacroNameTok.getLocation()) && GetRunRound() == 0) {
     static MacroInfo CudaArchFaker(SourceLocation::getFromRawEncoding(0));
     MI = &CudaArchFaker;
   }

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -3125,8 +3125,8 @@ void Preprocessor::HandleIfdefDirective(Token &Result,
     getSourceManager().isInMainFile(DirectiveTok.getLocation());
 
 #ifdef SYCLomatic_CUSTOMIZATION
-  // If macro name is '__CUDA_ARCH__' and is inside in-root folder, handle it as
-  // defined.
+  // If macro name is '__CUDA_ARCH__' and is inside analysis-scope-path folder,
+  // handle it as defined.
   if (!MI && MII->getName() == "__CUDA_ARCH__" &&
       IsInAnalysisScopeFunc(MacroNameTok.getLocation()) && GetRunRound() == 0) {
     static MacroInfo CudaArchFaker(SourceLocation::getFromRawEncoding(0));

--- a/clang/lib/Lex/PPExpressions.cpp
+++ b/clang/lib/Lex/PPExpressions.cpp
@@ -40,9 +40,9 @@ using namespace clang;
 
 #ifdef SYCLomatic_CUSTOMIZATION
 namespace clang {
-inline bool isInRootNull(SourceLocation) { return false; }
+inline bool isInAnalysisScopeNull(SourceLocation) { return false; }
 inline unsigned int getRunRound() { return 0; }
-std::function<bool(SourceLocation)> IsInRootFunc = isInRootNull;
+std::function<bool(SourceLocation)> IsInAnalysisScopeFunc = isInAnalysisScopeNull;
 std::function<unsigned int()> GetRunRound = getRunRound;
 } // namespace clang
 #endif // SYCLomatic_CUSTOMIZATION
@@ -152,7 +152,7 @@ static bool EvaluateDefined(PPValue &Result, Token &PeekTok, DefinedTracker &DT,
   // If macro name is '__CUDA_ARCH__' and is inside in-root folder, handle is as
   // defined.
   if (!Result.Val && II->getName() == "__CUDA_ARCH__" &&
-      IsInRootFunc(PeekTok.getLocation()) && GetRunRound() == 0) {
+      IsInAnalysisScopeFunc(PeekTok.getLocation()) && GetRunRound() == 0) {
     Result.Val = true;
   }
 #endif // SYCLomatic_CUSTOMIZATION
@@ -295,7 +295,7 @@ static bool EvaluateValue(PPValue &Result, Token &PeekTok, DefinedTracker &DT,
         // If macro name is '__CUDA_ARCH__' and is inside in-root folder, handle
         // it as defined '600'
         if (II->getName() == "__CUDA_ARCH__" &&
-            IsInRootFunc(PeekTok.getLocation())) {
+            IsInAnalysisScopeFunc(PeekTok.getLocation())) {
           Result.Val = 600;
         }
 #endif // SYCLomatic_CUSTOMIZATION

--- a/clang/lib/Lex/PPExpressions.cpp
+++ b/clang/lib/Lex/PPExpressions.cpp
@@ -149,8 +149,8 @@ static bool EvaluateDefined(PPValue &Result, Token &PeekTok, DefinedTracker &DT,
     PP.markMacroAsUsed(Macro.getMacroInfo());
 
 #ifdef SYCLomatic_CUSTOMIZATION
-  // If macro name is '__CUDA_ARCH__' and is inside in-root folder, handle is as
-  // defined.
+  // If macro name is '__CUDA_ARCH__' and is inside analysis-scope-path folder,
+  // handle is as defined.
   if (!Result.Val && II->getName() == "__CUDA_ARCH__" &&
       IsInAnalysisScopeFunc(PeekTok.getLocation()) && GetRunRound() == 0) {
     Result.Val = true;
@@ -292,7 +292,7 @@ static bool EvaluateValue(PPValue &Result, Token &PeekTok, DefinedTracker &DT,
         }
         Result.Val = 0;
 #ifdef SYCLomatic_CUSTOMIZATION
-        // If macro name is '__CUDA_ARCH__' and is inside in-root folder, handle
+        // If macro name is '__CUDA_ARCH__' and is inside analysis-scope-path folder, handle
         // it as defined '600'
         if (II->getName() == "__CUDA_ARCH__" &&
             IsInAnalysisScopeFunc(PeekTok.getLocation())) {

--- a/clang/lib/Lex/Preprocessor.cpp
+++ b/clang/lib/Lex/Preprocessor.cpp
@@ -74,7 +74,7 @@ using namespace clang;
 #ifdef SYCLomatic_CUSTOMIZATION
 namespace clang {
   inline void recordTokenSplit(SourceLocation, unsigned) {}
-  extern std::function<bool(SourceLocation)> IsInRootFunc;
+  extern std::function<bool(SourceLocation)> IsInAnalysisScopeFunc;
   extern std::function<unsigned int()> GetRunRound;
   std::function<void(SourceLocation, unsigned)> RecordTokenSplit = recordTokenSplit;
 }
@@ -855,7 +855,7 @@ bool Preprocessor::HandleIdentifier(Token &Identifier) {
   }
 
 #ifdef SYCLomatic_CUSTOMIZATION
-  if (II.getName() == "__CUDA_ARCH__" && IsInRootFunc(Identifier.getLocation())) {
+  if (II.getName() == "__CUDA_ARCH__" && IsInAnalysisScopeFunc(Identifier.getLocation())) {
     // Make a MacroDefinition for __CUDA_ARCH__
     MacroInfo *MI = AllocateMacroInfo(SourceLocation());
     MI->setIsBuiltinMacro();

--- a/clang/test/dpct/warp_api_outside_inroot/inc/utils.cuh
+++ b/clang/test/dpct/warp_api_outside_inroot/inc/utils.cuh
@@ -1,0 +1,34 @@
+#pragma once
+
+#define C10_WARP_SIZE 32
+#include <cuda.h>
+
+template <typename T>
+__device__ __forceinline__ T WARP_SHFL_DOWN(T value, unsigned int delta, int width = C10_WARP_SIZE, unsigned int mask = 0xffffffff) {
+  return __shfl_down_sync(mask, value, delta, width);
+}
+
+template <typename T>
+__inline__ __device__ T WarpReduceSum(T val) {
+  for (int offset = (C10_WARP_SIZE >> 1); offset > 0; offset >>= 1) {
+    val += WARP_SHFL_DOWN(val, offset);
+  }
+  return val;
+}
+
+template <typename T>
+__inline__ __device__ T BlockReduceSum(T val, T *shared) {
+  const int lid = threadIdx.x % C10_WARP_SIZE;
+  const int wid = threadIdx.x / C10_WARP_SIZE;
+  val = WarpReduceSum(val);
+  __syncthreads();
+  if (lid == 0) {
+    shared[wid] = val;
+  }
+  __syncthreads();
+  val = (threadIdx.x < blockDim.x / C10_WARP_SIZE) ? shared[lid] : T(0);
+  if (wid == 0) {
+    val = WarpReduceSum(val);
+  }
+  return val;
+}

--- a/clang/test/dpct/warp_api_outside_inroot/src/kernel_warp.cu
+++ b/clang/test/dpct/warp_api_outside_inroot/src/kernel_warp.cu
@@ -1,0 +1,30 @@
+// UNSUPPORTED: cuda-8.0
+// UNSUPPORTED: v8.0
+// RUN: dpct --format-range=none --usm-level=none --in-root=%S --out-root=%T/kernel_warp_outside --analysis-scope-path=%S/.. %s --cuda-include-path="%cuda-path/include" -- -x cuda --cuda-host-only
+// RUN: FileCheck --input-file %T/kernel_warp_outside/kernel_warp.dp.cpp --match-full-lines %s
+// RUN: rm -rf %T/kernel_warp_outside
+#include "../inc/utils.cuh"
+
+//CHECK:void kernel(float *input, sycl::nd_item<3> item_ct1, float *smem) {
+__global__ void kernel(float *input) {
+  float sum = 0;
+  __shared__ float smem[128];
+  //CHECK:float total_sum = BlockReduceSum(sum, smem, item_ct1);
+  float total_sum = BlockReduceSum(sum, smem);
+}
+
+void foo() {
+  float *input = NULL;
+  //CHECK:dpct::get_default_queue().submit(
+  //CHECK-NEXT:  [&](sycl::handler &cgh) {
+  //CHECK-NEXT:    sycl::accessor<float, 1, sycl::access_mode::read_write, sycl::access::target::local> smem_acc_ct1(sycl::range<1>(128), cgh);
+  //CHECK-NEXT:    dpct::access_wrapper<float *> input_acc_ct0(input, cgh);
+  //CHECK-EMPTY:
+  //CHECK-NEXT:    cgh.parallel_for(
+  //CHECK-NEXT:      sycl::nd_range<3>(sycl::range<3>(1, 1, 128), sycl::range<3>(1, 1, 128)), 
+  //CHECK-NEXT:      [=](sycl::nd_item<3> item_ct1) {{\[\[}}intel::reqd_sub_group_size(32){{\]\]}} {
+  //CHECK-NEXT:        kernel(input_acc_ct0.get_raw_pointer(), item_ct1, smem_acc_ct1.get_pointer());
+  //CHECK-NEXT:      });
+  //CHECK-NEXT:  });
+  kernel<<<1, 128>>>(input);
+}


### PR DESCRIPTION
This option enables users to specify a larger analysis scope (e.g.,
any ancester directory of --in-root) with which the tool can collect
necessary information(e.g., device function's subgroup size requirement)
outside --in-root to generate correct migrated code.
The default value of this option is --in-root.

Signed-off-by: Cui, Dele <dele.cui@intel.com>