### PR TITLE
[SYCLomatic] Use ldc*n instead of 0 for parameter stridec in oneapi::mkl::blas::column_major::dgmm_batch

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -6041,6 +6041,13 @@ void BLASFunctionCallRule::runRule(const MatchFinder::MatchResult &Result) {
       CallExprArguReplVec.push_back(EA.getReplacedString());
     }
 
+    std::string LdcTimesN =
+        (needExtraParens(CE->getArg(9)) ? ("(" + CallExprArguReplVec[9] + ")")
+                                        : CallExprArguReplVec[9]) +
+        " * " +
+        (needExtraParens(CE->getArg(3)) ? ("(" + CallExprArguReplVec[3] + ")")
+                                        : CallExprArguReplVec[3]);
+
     // update the replacement of four enmu arguments
     if (const CStyleCastExpr *CSCE = dyn_cast<CStyleCastExpr>(CE->getArg(1))) {
       std::string CurrentArgumentRepl;
@@ -6083,7 +6090,7 @@ void BLASFunctionCallRule::runRule(const MatchFinder::MatchResult &Result) {
     // Insert some arguments since we are now using batch API
     // If we have new dedicated API for migrating dgmm in the future,
     // then we can remove the argument insertion.
-    CallExprArguReplVec.push_back("0"); // stride_c
+    CallExprArguReplVec.push_back(LdcTimesN); // stride_c
     CallExprArguReplVec.push_back("1"); // batch_size
     auto Iter = CallExprArguReplVec.begin();
     std::advance(Iter, 8);

--- a/clang/test/dpct/cublas-create-Sgemm-destroy.cu
+++ b/clang/test/dpct/cublas-create-Sgemm-destroy.cu
@@ -269,25 +269,25 @@ void foo4() {
   //CHECK-NEXT:auto a_f_buf_ct{{[0-9]+}} = dpct::get_buffer<float>(a_f);
   //CHECK-NEXT:auto x_f_buf_ct{{[0-9]+}} = dpct::get_buffer<float>(x_f);
   //CHECK-NEXT:auto c_f_buf_ct{{[0-9]+}} = dpct::get_buffer<float>(c_f);
-  //CHECK-NEXT:oneapi::mkl::blas::column_major::dgmm_batch(*handle, oneapi::mkl::side::left, 2, 2, a_f_buf_ct{{[0-9]+}}, 2, 0, x_f_buf_ct{{[0-9]+}}, 1, 0, c_f_buf_ct{{[0-9]+}}, 2, 0, 1);
+  //CHECK-NEXT:oneapi::mkl::blas::column_major::dgmm_batch(*handle, oneapi::mkl::side::left, 2, 2, a_f_buf_ct{{[0-9]+}}, 2, 0, x_f_buf_ct{{[0-9]+}}, 1, 0, c_f_buf_ct{{[0-9]+}}, 2, 2 * 2, 1);
   //CHECK-NEXT:}
   //CHECK-NEXT:{
   //CHECK-NEXT:auto a_d_buf_ct{{[0-9]+}} = dpct::get_buffer<double>(a_d);
   //CHECK-NEXT:auto x_d_buf_ct{{[0-9]+}} = dpct::get_buffer<double>(x_d);
   //CHECK-NEXT:auto c_d_buf_ct{{[0-9]+}} = dpct::get_buffer<double>(c_d);
-  //CHECK-NEXT:oneapi::mkl::blas::column_major::dgmm_batch(*handle, oneapi::mkl::side::left, 2, 2, a_d_buf_ct{{[0-9]+}}, 2, 0, x_d_buf_ct{{[0-9]+}}, 1, 0, c_d_buf_ct{{[0-9]+}}, 2, 0, 1);
+  //CHECK-NEXT:oneapi::mkl::blas::column_major::dgmm_batch(*handle, oneapi::mkl::side::left, 2, 2, a_d_buf_ct{{[0-9]+}}, 2, 0, x_d_buf_ct{{[0-9]+}}, 1, 0, c_d_buf_ct{{[0-9]+}}, 2, 2 * 2, 1);
   //CHECK-NEXT:}
   //CHECK-NEXT:{
   //CHECK-NEXT:auto a_c_buf_ct{{[0-9]+}} = dpct::get_buffer<std::complex<float>>(a_c);
   //CHECK-NEXT:auto x_c_buf_ct{{[0-9]+}} = dpct::get_buffer<std::complex<float>>(x_c);
   //CHECK-NEXT:auto c_c_buf_ct{{[0-9]+}} = dpct::get_buffer<std::complex<float>>(c_c);
-  //CHECK-NEXT:oneapi::mkl::blas::column_major::dgmm_batch(*handle, oneapi::mkl::side::left, 2, 2, a_c_buf_ct{{[0-9]+}}, 2, 0, x_c_buf_ct{{[0-9]+}}, 1, 0, c_c_buf_ct{{[0-9]+}}, 2, 0, 1);
+  //CHECK-NEXT:oneapi::mkl::blas::column_major::dgmm_batch(*handle, oneapi::mkl::side::left, 2, 2, a_c_buf_ct{{[0-9]+}}, 2, 0, x_c_buf_ct{{[0-9]+}}, 1, 0, c_c_buf_ct{{[0-9]+}}, 2, 2 * 2, 1);
   //CHECK-NEXT:}
   //CHECK-NEXT:{
   //CHECK-NEXT:auto a_z_buf_ct{{[0-9]+}} = dpct::get_buffer<std::complex<double>>(a_z);
   //CHECK-NEXT:auto x_z_buf_ct{{[0-9]+}} = dpct::get_buffer<std::complex<double>>(x_z);
   //CHECK-NEXT:auto c_z_buf_ct{{[0-9]+}} = dpct::get_buffer<std::complex<double>>(c_z);
-  //CHECK-NEXT:oneapi::mkl::blas::column_major::dgmm_batch(*handle, oneapi::mkl::side::left, 2, 2, a_z_buf_ct{{[0-9]+}}, 2, 0, x_z_buf_ct{{[0-9]+}}, 1, 0, c_z_buf_ct{{[0-9]+}}, 2, 0, 1);
+  //CHECK-NEXT:oneapi::mkl::blas::column_major::dgmm_batch(*handle, oneapi::mkl::side::left, 2, 2, a_z_buf_ct{{[0-9]+}}, 2, 0, x_z_buf_ct{{[0-9]+}}, 1, 0, c_z_buf_ct{{[0-9]+}}, 2, 2 * 2, 1);
   //CHECK-NEXT:}
   cublasSdgmm(handle, CUBLAS_SIDE_LEFT, 2, 2, a_f, 2, x_f, 1, c_f, 2);
   cublasDdgmm(handle, CUBLAS_SIDE_LEFT, 2, 2, a_d, 2, x_d, 1, c_d, 2);

--- a/clang/test/dpct/cublas-usm.cu
+++ b/clang/test/dpct/cublas-usm.cu
@@ -848,12 +848,13 @@ void foo3() {
   cublasCherkx(handle, CUBLAS_FILL_MODE_UPPER, CUBLAS_OP_T, 2, 3, alpha_c, a_c, 3, b_c, 3, beta_f, c_c, 2);
   cublasZherkx(handle, CUBLAS_FILL_MODE_UPPER, CUBLAS_OP_T, 2, 3, alpha_z, a_z, 3, b_z, 3, beta_d, c_z, 2);
 
-  //CHECK:oneapi::mkl::blas::column_major::dgmm_batch(*handle, oneapi::mkl::side::left, 2, 2, a_f, 2, 0, x_f, 1, 0, c_f, 2, 0, 1);
-  //CHECK-NEXT:oneapi::mkl::blas::column_major::dgmm_batch(*handle, oneapi::mkl::side::left, 2, 2, a_d, 2, 0, x_d, 1, 0, c_d, 2, 0, 1);
-  //CHECK-NEXT:oneapi::mkl::blas::column_major::dgmm_batch(*handle, oneapi::mkl::side::left, 2, 2, (std::complex<float>*)a_c, 2, 0, (std::complex<float>*)x_c, 1, 0, (std::complex<float>*)c_c, 2, 0, 1);
-  //CHECK-NEXT:oneapi::mkl::blas::column_major::dgmm_batch(*handle, oneapi::mkl::side::left, 2, 2, (std::complex<double>*)a_z, 2, 0, (std::complex<double>*)x_z, 1, 0, (std::complex<double>*)c_z, 2, 0, 1);
-  cublasSdgmm(handle, CUBLAS_SIDE_LEFT, 2, 2, a_f, 2, x_f, 1, c_f, 2);
-  cublasDdgmm(handle, CUBLAS_SIDE_LEFT, 2, 2, a_d, 2, x_d, 1, c_d, 2);
-  cublasCdgmm(handle, CUBLAS_SIDE_LEFT, 2, 2, a_c, 2, x_c, 1, c_c, 2);
-  cublasZdgmm(handle, CUBLAS_SIDE_LEFT, 2, 2, a_z, 2, x_z, 1, c_z, 2);
+  int m, n, lda, incx, ldc;
+  //CHECK:oneapi::mkl::blas::column_major::dgmm_batch(*handle, oneapi::mkl::side::left, m, n, a_f, lda, 0, x_f, incx, 0, c_f, ldc, ldc * n, 1);
+  //CHECK-NEXT:oneapi::mkl::blas::column_major::dgmm_batch(*handle, oneapi::mkl::side::left, m, n, a_d, lda, 0, x_d, incx, 0, c_d, ldc, ldc * n, 1);
+  //CHECK-NEXT:oneapi::mkl::blas::column_major::dgmm_batch(*handle, oneapi::mkl::side::left, m, n, (std::complex<float>*)a_c, lda, 0, (std::complex<float>*)x_c, incx, 0, (std::complex<float>*)c_c, ldc, ldc * n, 1);
+  //CHECK-NEXT:oneapi::mkl::blas::column_major::dgmm_batch(*handle, oneapi::mkl::side::left, m, n, (std::complex<double>*)a_z, lda, 0, (std::complex<double>*)x_z, incx, 0, (std::complex<double>*)c_z, ldc, ldc * n, 1);
+  cublasSdgmm(handle, CUBLAS_SIDE_LEFT, m, n, a_f, lda, x_f, incx, c_f, ldc);
+  cublasDdgmm(handle, CUBLAS_SIDE_LEFT, m, n, a_d, lda, x_d, incx, c_d, ldc);
+  cublasCdgmm(handle, CUBLAS_SIDE_LEFT, m, n, a_c, lda, x_c, incx, c_c, ldc);
+  cublasZdgmm(handle, CUBLAS_SIDE_LEFT, m, n, a_z, lda, x_z, incx, c_z, ldc);
 }


### PR DESCRIPTION
Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>