### PR TITLE
 Revert "[SYCLomatic] Refine migration of __syncthreads() with sycl::group_barrier() (#118)" due to performance regression

### DIFF
--- a/clang/lib/DPCT/APINamesWarp.inc
+++ b/clang/lib/DPCT/APINamesWarp.inc
@@ -311,7 +311,3 @@ SUBGROUPSIZE_FACTORY(
                                  ARG(".get_local_linear_id()) : 0, " +
                                      MapNames::getClNamespace() +
                                      "ext::oneapi::plus<>()")))))))))
-
-// __syncthreads
-CALL_FACTORY_ENTRY("__syncthreads",
-                   CALL(MapNames::getClNamespace() + "group_barrier", GROUP))

--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -8,6 +8,7 @@
 
 #include "ASTTraversal.h"
 #include "AnalysisInfo.h"
+#include "BarrierFenceSpaceAnalyzer.h"
 #include "CallExprRewriter.h"
 #include "CustomHelperFiles.h"
 #include "ExprAnalysis.h"
@@ -13060,19 +13061,20 @@ void SyncThreadsRule::runRule(const MatchFinder::MatchResult &Result) {
 
   std::string FuncName =
       CE->getDirectCallee()->getNameInfo().getName().getAsString();
-  
-  if (!CallExprRewriterFactoryBase::RewriterMap)
-    return;
-  
-  auto Itr = CallExprRewriterFactoryBase::RewriterMap->find(FuncName);
-  if (Itr != CallExprRewriterFactoryBase::RewriterMap->end()) {
-    ExprAnalysis EA;
-    EA.analyze(CE);
-    EA.applyAllSubExprRepl();
-    return;
-  }
-
- if (FuncName == "this_thread_block") {
+  if (FuncName == "__syncthreads") {
+    BarrierFenceSpaceAnalyzer A;
+    if (A.canSetLocalFenceSpace(CE)) {
+      std::string Replacement = DpctGlobalInfo::getItem(CE) + ".barrier(" +
+                                MapNames::getClNamespace() +
+                                "access::fence_space::local_space)";
+      emplaceTransformation(new ReplaceStmt(CE, std::move(Replacement)));
+    } else {
+      report(CE->getBeginLoc(), Diagnostics::BARRIER_PERFORMANCE_TUNNING, true,
+             "nd_item");
+      std::string Replacement = DpctGlobalInfo::getItem(CE) + ".barrier()";
+      emplaceTransformation(new ReplaceStmt(CE, std::move(Replacement)));
+    }
+  } else if (FuncName == "this_thread_block") {
     if (auto P = getAncestorDeclStmt(CE)) {
       if (auto VD = dyn_cast<VarDecl>(*P->decl_begin())) {
         emplaceTransformation(new ReplaceTypeInDecl(VD, "auto"));

--- a/clang/lib/DPCT/BarrierFenceSpaceAnalyzer.cpp
+++ b/clang/lib/DPCT/BarrierFenceSpaceAnalyzer.cpp
@@ -1,0 +1,340 @@
+//===--------------- BarrierFenceSpaceAnalyzer.cpp ------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "BarrierFenceSpaceAnalyzer.h"
+#include "AnalysisInfo.h"
+
+#include "llvm/Support/Casting.h"
+
+#include <algorithm>
+
+using namespace llvm;
+
+bool clang::dpct::BarrierFenceSpaceAnalyzer::Visit(clang::ForStmt *FS) {
+  Level Lvl;
+  Lvl.CurrentLoc = CurrentLevel.CurrentLoc;
+  Lvl.LevelBeginLoc = FS->getBeginLoc();
+  LevelStack.push(CurrentLevel);
+  CurrentLevel = Lvl;
+  return true;
+}
+void clang::dpct::BarrierFenceSpaceAnalyzer::PostVisit(clang::ForStmt *FS) {
+  if (!CurrentLevel.SyncCallsVec.empty()) {
+    CurrentLevel.SyncCallsVec.front().second.Predecessors.push_back(
+        clang::SourceRange(CurrentLevel.CurrentLoc, FS->getEndLoc()));
+    CurrentLevel.SyncCallsVec.back().second.Successors.push_back(
+        clang::SourceRange(CurrentLevel.LevelBeginLoc,
+                           CurrentLevel.FirstSyncBeginLoc));
+
+    LevelMap.insert(std::make_pair(LevelStack.size(), CurrentLevel));
+  }
+  CurrentLevel = LevelStack.top();
+  LevelStack.pop();
+  return;
+}
+bool clang::dpct::BarrierFenceSpaceAnalyzer::Visit(clang::CallExpr *CE) {
+  const clang::FunctionDecl *FuncDecl = CE->getDirectCallee();
+  std::string FuncName;
+  if (FuncDecl)
+    FuncName = FuncDecl->getNameInfo().getName().getAsString();
+
+  if (FuncName == "__syncthreads") {
+    if (!clang::dpct::DpctGlobalInfo::findAncestor<IfStmt>(CE) &&
+        !clang::dpct::DpctGlobalInfo::findAncestor<DoStmt>(CE) &&
+        !clang::dpct::DpctGlobalInfo::findAncestor<WhileStmt>(CE) &&
+        !clang::dpct::DpctGlobalInfo::findAncestor<SwitchStmt>(CE)) {
+      if (LevelStack.size() > 1) {
+        // We will further refine it if meet real request.
+        return false;
+      }
+
+      if (CurrentLevel.FirstSyncBeginLoc.isInvalid()) {
+        CurrentLevel.FirstSyncBeginLoc = CE->getBeginLoc();
+      }
+
+      clang::SourceRange Range(CurrentLevel.CurrentLoc, CE->getBeginLoc());
+      if (!CurrentLevel.SyncCallsVec.empty()) {
+        CurrentLevel.SyncCallsVec.back().second.Successors.push_back(Range);
+      }
+      CurrentLevel.SyncCallsVec.emplace_back(CE, SyncCallInfo({Range}, {}));
+
+      unsigned int LevelNum = LevelStack.size();
+      auto UpperBoundIter = LevelMap.upper_bound(LevelNum);
+      for (auto Iter = UpperBoundIter; Iter != LevelMap.end(); Iter++) {
+        Iter->second.SyncCallsVec.back().second.Successors.push_back(
+            clang::SourceRange(Iter->second.CurrentLoc, CE->getBeginLoc()));
+        LevelVec.push_back(Iter->second);
+      }
+      LevelMap.erase(UpperBoundIter, LevelMap.end());
+
+      CurrentLevel.CurrentLoc = CE->getEndLoc();
+    }
+  } else {
+    if (auto FD = CE->getDirectCallee()) {
+      std::string FuncName = FD->getNameInfo().getName().getAsString();
+      if (!AllowedDeviceFunctions.count(FuncName) ||
+          isUserDefinedFunction(FD)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+void clang::dpct::BarrierFenceSpaceAnalyzer::PostVisit(clang::CallExpr *) {}
+
+bool clang::dpct::BarrierFenceSpaceAnalyzer::Visit(clang::DeclRefExpr *DRE) {
+  // Collect all DREs and its Decl
+  DREDeclMap.insert(std::make_pair(DRE, DRE->getDecl()));
+  return true;
+}
+void clang::dpct::BarrierFenceSpaceAnalyzer::PostVisit(clang::DeclRefExpr *) {}
+
+bool clang::dpct::BarrierFenceSpaceAnalyzer::Visit(clang::GotoStmt *) {
+  // We will further refine it if meet real request.
+  // By default, goto/label stmt is not supported.
+  return false;
+}
+void clang::dpct::BarrierFenceSpaceAnalyzer::PostVisit(clang::GotoStmt *) {}
+
+bool clang::dpct::BarrierFenceSpaceAnalyzer::Visit(clang::LabelStmt *) {
+  // We will further refine it if meet real request.
+  // By default, goto/label stmt is not supported.
+  return false;
+}
+void clang::dpct::BarrierFenceSpaceAnalyzer::PostVisit(clang::LabelStmt *) {}
+
+bool clang::dpct::BarrierFenceSpaceAnalyzer::Visit(clang::MemberExpr *ME) {
+  if (ME->getType()->isPointerType() || ME->getType()->isArrayType()) {
+    return false;
+  }
+  return true;
+}
+void clang::dpct::BarrierFenceSpaceAnalyzer::PostVisit(clang::MemberExpr *) {}
+bool clang::dpct::BarrierFenceSpaceAnalyzer::Visit(
+    clang::CXXDependentScopeMemberExpr *) {
+  return false;
+}
+void clang::dpct::BarrierFenceSpaceAnalyzer::PostVisit(
+    clang::CXXDependentScopeMemberExpr *) {}
+bool clang::dpct::BarrierFenceSpaceAnalyzer::Visit(
+    clang::CXXConstructExpr *CCE) {
+  auto Ctor = CCE->getConstructor();
+  std::string CtorName = Ctor->getParent()->getQualifiedNameAsString();
+  if (AllowedDeviceFunctions.count(CtorName) && !isUserDefinedFunction(Ctor))
+    return true;
+  return false;
+}
+void clang::dpct::BarrierFenceSpaceAnalyzer::PostVisit(
+    clang::CXXConstructExpr *) {}
+
+bool clang::dpct::BarrierFenceSpaceAnalyzer::traverseFunction(
+    const clang::FunctionDecl *FD) {
+  CurrentLevel.CurrentLoc = FD->getBody()->getBeginLoc();
+  CurrentLevel.LevelBeginLoc = FD->getBody()->getBeginLoc();
+
+  if (!this->TraverseDecl(const_cast<clang::FunctionDecl *>(FD))) {
+    return false;
+  }
+
+  if (!CurrentLevel.SyncCallsVec.empty()) {
+    CurrentLevel.SyncCallsVec.back().second.Successors.push_back(
+        clang::SourceRange(CurrentLevel.CurrentLoc, FD->getEndLoc()));
+  }
+  for (auto &Iter : LevelMap) {
+    Iter.second.SyncCallsVec.back().second.Successors.push_back(
+        clang::SourceRange(Iter.second.CurrentLoc, FD->getEndLoc()));
+    LevelVec.push_back(Iter.second);
+  }
+  LevelMap.clear();
+  LevelVec.push_back(CurrentLevel);
+  return true;
+}
+
+bool isPointerOperationSafe(const clang::Expr *Pointer) {
+  auto P = getNonImplicitCastNonParenExprParentStmt(Pointer);
+  if (!P)
+    return false;
+
+  if (auto ASE = dyn_cast<clang::ArraySubscriptExpr>(P)) {
+    auto PP = getNonImplicitCastNonParenExprParentStmt(ASE);
+    if (auto UO = dyn_cast_or_null<clang::UnaryOperator>(PP)) {
+      if (UO->getOpcode() == clang::UnaryOperatorKind::UO_AddrOf) {
+        return isPointerOperationSafe(UO);
+      }
+    }
+    return true;
+  }
+  if (auto UO = dyn_cast<clang::UnaryOperator>(P)) {
+    if (UO->getOpcode() == clang::UnaryOperatorKind::UO_Deref) {
+      auto PP = getNonImplicitCastNonParenExprParentStmt(UO);
+      if (auto OuterUO = dyn_cast_or_null<clang::UnaryOperator>(PP)) {
+        if (OuterUO->getOpcode() == clang::UnaryOperatorKind::UO_AddrOf) {
+          return isPointerOperationSafe(OuterUO);
+        }
+      }
+      return true;
+    }
+    return false;
+  }
+
+  // Special case for atomicAdd.
+  // If the Pointer is the first arg of atomicAdd function, return true.
+  if (auto CE = dyn_cast<clang::CallExpr>(P)) {
+    if (auto FD = CE->getDirectCallee()) {
+      std::string FuncName = FD->getNameInfo().getName().getAsString();
+      if (FuncName == "atomicAdd" && (CE->getArg(0) == Pointer) &&
+          !isUserDefinedFunction(FD)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+bool clang::dpct::BarrierFenceSpaceAnalyzer::canSetLocalFenceSpace(
+    const clang::CallExpr *CE) {
+  if (CE->getBeginLoc().isMacroID() || CE->getEndLoc().isMacroID())
+    return false;
+  auto FD = dpct::DpctGlobalInfo::findAncestor<clang::FunctionDecl>(CE);
+  if (!FD)
+    return false;
+  if (!FD->hasAttr<clang::CUDAGlobalAttr>())
+    return false;
+  if (FD->getTemplateSpecializationKind() !=
+          TemplateSpecializationKind::TSK_Undeclared ||
+      FD->getDescribedFunctionTemplate()) {
+    return false;
+  }
+
+  CELoc = getHashStrFromLoc(CE->getBeginLoc());
+  FDLoc = getHashStrFromLoc(FD->getBeginLoc());
+
+  auto FDIter = CachedResults.find(FDLoc);
+  if (FDIter != CachedResults.end()) {
+    auto CEIter = FDIter->second.find(CELoc);
+    if (CEIter != FDIter->second.end()) {
+      return CEIter->second;
+    } else {
+      return false;
+    }
+  }
+
+  // analyze this FD
+  // Traverse AST, analysis the context info of kernel calling sycthreads()
+  //   1. Find each syncthreads call's predecessor parts and successor parts.
+  //   2. When meet __device__ function is called, if the device function is not
+  //      in allow list, exit.
+  //   3. Check all DREs(Declare Ref Expr), if __device__ variable is used,
+  //      exit.
+  if (!traverseFunction(FD)) {
+    setFalseForThisFunctionDecl();
+    return false;
+  }
+
+  std::unordered_set<clang::ParmVarDecl *> PointerParams;
+  for (auto &Param : FD->parameters()) {
+    if (Param->getType()->isPointerType()) {
+      PointerParams.insert(Param);
+    }
+  }
+
+  // Check whether each input pointer of kernel is "safe" (no an alias name
+  // used) or not. If it is not "safe", exit.
+  std::set<clang::SourceLocation> DRELocs;
+  for (auto &Iter : DREDeclMap) {
+    if (auto VD = dyn_cast_or_null<VarDecl>(Iter.second)) {
+      if (VD->hasAttr<clang::CUDADeviceAttr>() &&
+          !(VD->getName().str() == "threadIdx" ||
+            VD->getName().str() == "blockIdx" ||
+            VD->getName().str() == "blockDim" ||
+            VD->getName().str() == "gridDim")) {
+        setFalseForThisFunctionDecl();
+        return false; // not support to check __device__ variables
+      }
+    }
+    if (dyn_cast<clang::ParmVarDecl>(Iter.second) &&
+        PointerParams.count(dyn_cast<clang::ParmVarDecl>(Iter.second))) {
+      if (!isPointerOperationSafe(Iter.first)) {
+        setFalseForThisFunctionDecl();
+        return false; // avoid the alias of input pointers
+      }
+      DRELocs.insert(Iter.first->getBeginLoc());
+    }
+  }
+
+  auto isInRanges = [](clang::SourceLocation SL,
+                       std::vector<clang::SourceRange> Ranges) -> bool {
+    auto &SM = dpct::DpctGlobalInfo::getSourceManager();
+    for (auto &Range : Ranges) {
+      if (SM.getFileOffset(Range.getBegin()) < SM.getFileOffset(SL) &&
+          SM.getFileOffset(SL) < SM.getFileOffset(Range.getEnd())) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  auto containsMacro = [](clang::SourceLocation SL,
+                          std::vector<clang::SourceRange> Ranges) -> bool {
+    if (SL.isMacroID())
+      return true;
+    for (auto &Range : Ranges) {
+      if (Range.getBegin().isMacroID() || Range.getEnd().isMacroID()) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  // DRELoc: input pointer parameter's usage location
+  // For a syncthreads call, tool will use local_space fence for this barrier,
+  // if it meets:
+  // For arbitrary input pointer of kernel, all DREs of this pointer are only
+  // used in either predecessor parts or successor parts
+  for (auto &I : LevelVec) {
+    for (auto &SyncCall : I.SyncCallsVec) {
+      bool Result = true;
+      for (auto &Loc : DRELocs) {
+        if (containsMacro(Loc, SyncCall.second.Predecessors) ||
+            containsMacro(Loc, SyncCall.second.Successors) ||
+            (isInRanges(Loc, SyncCall.second.Predecessors) &&
+             isInRanges(Loc, SyncCall.second.Successors))) {
+          Result = false;
+          break;
+        }
+      }
+      CachedResults[FDLoc][getHashStrFromLoc(SyncCall.first->getBeginLoc())] =
+          Result;
+    }
+  }
+
+  // find the result in the new map
+  FDIter = CachedResults.find(FDLoc);
+  if (FDIter != CachedResults.end()) {
+    auto CEIter = FDIter->second.find(CELoc);
+    if (CEIter != FDIter->second.end()) {
+      return CEIter->second;
+    } else {
+      return false;
+    }
+  }
+  return false;
+}
+
+std::unordered_map<std::string, std::unordered_map<std::string, bool>>
+    clang::dpct::BarrierFenceSpaceAnalyzer::CachedResults;
+
+// Functions in this set should not create alias name for input pointer
+const std::unordered_set<std::string>
+    clang::dpct::BarrierFenceSpaceAnalyzer::AllowedDeviceFunctions = {
+        "__popc",
+        "atomicAdd",
+        "__fetch_builtin_x",
+        "__fetch_builtin_y",
+        "__fetch_builtin_z",
+        "uint4"};

--- a/clang/lib/DPCT/BarrierFenceSpaceAnalyzer.h
+++ b/clang/lib/DPCT/BarrierFenceSpaceAnalyzer.h
@@ -1,0 +1,98 @@
+//===--------------- BarrierFenceSpaceAnalyzer.h --------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef DPCT_BARRIER_FENCE_SPACE_ANALYZER_H
+#define DPCT_BARRIER_FENCE_SPACE_ANALYZER_H
+
+#include "Utility.h"
+
+#include "clang/AST/RecursiveASTVisitor.h"
+
+#include <map>
+#include <stack>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace clang {
+namespace dpct {
+
+class BarrierFenceSpaceAnalyzer
+    : public clang::RecursiveASTVisitor<BarrierFenceSpaceAnalyzer> {
+public:
+  bool shouldVisitImplicitCode() const { return true; }
+  bool shouldTraversePostOrder() const { return false; }
+
+#define VISIT_NODE(CLASS)                                                      \
+  bool Visit(CLASS *Node);                                                     \
+  void PostVisit(CLASS *FS);                                                   \
+  bool Traverse##CLASS(CLASS *Node) {                                          \
+    if (!Visit(Node))                                                          \
+      return false;                                                            \
+    if (!clang::RecursiveASTVisitor<                                           \
+            BarrierFenceSpaceAnalyzer>::Traverse##CLASS(Node))                 \
+      return false;                                                            \
+    PostVisit(Node);                                                           \
+    return true;                                                               \
+  }
+
+  VISIT_NODE(ForStmt)
+  VISIT_NODE(CallExpr)
+  VISIT_NODE(DeclRefExpr)
+  VISIT_NODE(GotoStmt)
+  VISIT_NODE(LabelStmt)
+  VISIT_NODE(MemberExpr)
+  VISIT_NODE(CXXDependentScopeMemberExpr)
+  VISIT_NODE(CXXConstructExpr)
+#undef VISIT_NODE
+
+public:
+  bool canSetLocalFenceSpace(const clang::CallExpr *CE);
+
+private:
+  bool traverseFunction(const clang::FunctionDecl *FD);
+  using Ranges = std::vector<clang::SourceRange>;
+  struct SyncCallInfo {
+    SyncCallInfo(Ranges Predecessors, Ranges Successors)
+        : Predecessors(Predecessors), Successors(Successors){};
+    Ranges Predecessors;
+    Ranges Successors;
+  };
+  struct Level {
+    clang::SourceLocation CurrentLoc;
+    clang::SourceLocation LevelBeginLoc;
+    clang::SourceLocation FirstSyncBeginLoc;
+    std::vector<std::pair<clang::CallExpr *, SyncCallInfo>> SyncCallsVec;
+  };
+
+  Level CurrentLevel;
+  std::stack<Level> LevelStack;
+  std::multimap<unsigned int, Level> LevelMap;
+  std::vector<Level> LevelVec;
+  std::unordered_map<clang::DeclRefExpr *, clang::ValueDecl *> DREDeclMap;
+  std::string CELoc;
+  std::string FDLoc;
+
+  // If meets exit condition when visit AST nodes, all __syncthreads() in this
+  // kernel function cannot set local fence space.
+  // FDLoc is in the map means this kernel function is analyzed.
+  // CELoc is not in the map means cannot set local fence space.
+  void setFalseForThisFunctionDecl() {
+    CachedResults[FDLoc] = std::unordered_map<std::string, bool>();
+  }
+
+  /// (FD location, (Call location, result))
+  static std::unordered_map<std::string, std::unordered_map<std::string, bool>>
+      CachedResults;
+  static const std::unordered_set<std::string> AllowedDeviceFunctions;
+};
+} // namespace dpct
+} // namespace clang
+
+#endif // DPCT_BARRIER_FENCE_SPACE_ANALYZER_H

--- a/clang/lib/DPCT/cmake/libDPCT.cmake
+++ b/clang/lib/DPCT/cmake/libDPCT.cmake
@@ -24,6 +24,7 @@ macro(build_lib_dpct)
     Rules.cpp
     Homoglyph.cpp
     MisleadingBidirectional.cpp
+    BarrierFenceSpaceAnalyzer.cpp
     BLASAPIMigration.cpp
     FFTAPIMigration.cpp
     DNNAPIMigration.cpp

--- a/clang/test/dpct/atomic_functions.cu
+++ b/clang/test/dpct/atomic_functions.cu
@@ -475,14 +475,14 @@ __global__ void mykernel(unsigned int *dev) {
 // CHECK-NEXT:                             unsigned int *temp) {
 // CHECK-EMPTY:
 // CHECK-NEXT:  temp[item_ct1.get_local_id(2)] = 0;
-// CHECK-NEXT:  sycl::group_barrier(item_ct1.get_group());
+// CHECK-NEXT:  item_ct1.barrier(sycl::access::fence_space::local_space);
 // CHECK-NEXT:  int i = item_ct1.get_local_id(2) + item_ct1.get_group(2) * item_ct1.get_local_range(2);
 // CHECK-NEXT:  int offset = item_ct1.get_local_range(2) * item_ct1.get_group_range(2);
 // CHECK-NEXT:  while (i < size) {
 // CHECK-NEXT:    dpct::atomic_fetch_add<unsigned int, sycl::access::address_space::generic_space>(&temp[buffer[i]], (unsigned int)1);
 // CHECK-NEXT:    i += offset;
 // CHECK-NEXT:  }
-// CHECK-NEXT:  sycl::group_barrier(item_ct1.get_group());
+// CHECK-NEXT:  item_ct1.barrier(sycl::access::fence_space::local_space);
 // CHECK-NEXT:  dpct::atomic_fetch_add<unsigned int, sycl::access::address_space::generic_space>(&(histo[item_ct1.get_local_id(2)]), temp[item_ct1.get_local_id(2)]);
 // CHECK-NEXT:}
 __global__ void mykernel_1(unsigned char *buffer, long size,

--- a/clang/test/dpct/atomic_functions_no_use_generic_space.cu
+++ b/clang/test/dpct/atomic_functions_no_use_generic_space.cu
@@ -481,14 +481,14 @@ __global__ void mykernel(unsigned int *dev) {
 // CHECK-NEXT:                             unsigned int *temp) {
 // CHECK-EMPTY:
 // CHECK-NEXT:  temp[item_ct1.get_local_id(2)] = 0;
-// CHECK-NEXT:  sycl::group_barrier(item_ct1.get_group());
+// CHECK-NEXT:  item_ct1.barrier(sycl::access::fence_space::local_space);
 // CHECK-NEXT:  int i = item_ct1.get_local_id(2) + item_ct1.get_group(2) * item_ct1.get_local_range(2);
 // CHECK-NEXT:  int offset = item_ct1.get_local_range(2) * item_ct1.get_group_range(2);
 // CHECK-NEXT:  while (i < size) {
 // CHECK-NEXT:    sycl::atomic<unsigned int, sycl::access::address_space::local_space>(sycl::local_ptr<unsigned int>(&temp[buffer[i]])).fetch_add(1);
 // CHECK-NEXT:    i += offset;
 // CHECK-NEXT:  }
-// CHECK-NEXT:  sycl::group_barrier(item_ct1.get_group());
+// CHECK-NEXT:  item_ct1.barrier(sycl::access::fence_space::local_space);
 // CHECK-NEXT:  sycl::atomic<unsigned int>(sycl::global_ptr<unsigned int>(&(histo[item_ct1.get_local_id(2)]))).fetch_add(temp[item_ct1.get_local_id(2)]);
 // CHECK-NEXT:}
 __global__ void mykernel_1(unsigned char *buffer, long size,

--- a/clang/test/dpct/kernel-call-origcode-embedded.cu
+++ b/clang/test/dpct/kernel-call-origcode-embedded.cu
@@ -247,8 +247,12 @@ __device__ static void foo_1(unsigned int* g_odata,
                               int bankOffsetA, int bankOffsetB)
 {
 // CHECK: /* DPCT_ORIG     __syncthreads();*/
-// CHECK-NEXT:    sycl::group_barrier(item_ct1.get_group());
+// CHECK-NEXT:    /*
+// CHECK-NEXT:    DPCT1065:{{[0-9]+}}: Consider replacing sycl::nd_item::barrier() with sycl::nd_item::barrier(sycl::access::fence_space::local_space) for better performance if there is no access to global memory.
+// CHECK-NEXT:    */
+// CHECK-NEXT:    item_ct1.barrier();
     __syncthreads();
+
 }
 
 // CHECK:/* DPCT_ORIG template <bool storeSum, bool isNP2>

--- a/clang/test/dpct/sync_api.cu
+++ b/clang/test/dpct/sync_api.cu
@@ -25,7 +25,7 @@ __global__ void k() {
 
   // CHECK: auto block = item_ct1.get_group();
   cg::thread_block block = cg::this_thread_block();
-  // CHECK: sycl::group_barrier(item_ct1.get_group());
+  // CHECK: item_ct1.barrier();
   __syncthreads();
   // CHECK: item_ct1.barrier();
   block.sync();

--- a/clang/test/dpct/sync_api_noneusm.cu
+++ b/clang/test/dpct/sync_api_noneusm.cu
@@ -25,7 +25,7 @@ __global__ void k() {
 
   // CHECK: auto block = item_ct1.get_group();
   cg::thread_block block = cg::this_thread_block();
-  // CHECK: sycl::group_barrier(item_ct1.get_group());
+  // CHECK: item_ct1.barrier();
   __syncthreads();
   // CHECK: item_ct1.barrier();
   block.sync();

--- a/clang/test/dpct/syncthreads.cu
+++ b/clang/test/dpct/syncthreads.cu
@@ -3,7 +3,7 @@
 
 // CHECK: void test_syncthreads(int *arr, sycl::nd_item<3> [[ITEMNAME:item_ct1]]) {
 __global__ void test_syncthreads(int *arr) {
-  // CHECK: sycl::group_barrier([[ITEMNAME]].get_group());
+  // CHECK: [[ITEMNAME]].barrier(sycl::access::fence_space::local_space);
   __syncthreads();
   arr[threadIdx.x] = threadIdx.x;
 }
@@ -58,9 +58,9 @@ __global__ void test1(unsigned int *ptr1, unsigned int *ptr2, unsigned int *ptr3
       nnn += __popc(mmm.x) + __popc(mmm.y) + __popc(mmm.z) + __popc(mmm.w);
     }
   }
-//     CHECK:  sycl::group_barrier(item_ct1.get_group());
+//     CHECK:  item_ct1.barrier(sycl::access::fence_space::local_space);
 //CHECK-NEXT:  for (;;) {
-//CHECK-NEXT:    sycl::group_barrier(item_ct1.get_group());
+//CHECK-NEXT:    item_ct1.barrier(sycl::access::fence_space::local_space);
   __syncthreads();
   for (;;) {
     __syncthreads();
@@ -77,11 +77,11 @@ __global__ void test2(float *ptr1, float *ptr2) {
   const int aaa(threadIdx.z);
   for (;;) {
     ptr1[aaa];
-    // CHECK: sycl::group_barrier(item_ct1.get_group());
+    // CHECK:item_ct1.barrier(sycl::access::fence_space::local_space);
     __syncthreads();
 #pragma unroll
     for (;;) {}
-    // CHECK: sycl::group_barrier(item_ct1.get_group());
+    // CHECK:item_ct1.barrier(sycl::access::fence_space::local_space);
     __syncthreads();
   }
   ptr2[aaa];
@@ -92,7 +92,7 @@ __global__ void test3() {
   int a;
   int b;
   goto label;
-  // CHECK: sycl::group_barrier(item_ct1.get_group());
+  //CHECK:item_ct1.barrier();
   __syncthreads();
   a++;
 label:
@@ -105,7 +105,7 @@ struct S1 {
 };
 __global__ void test4(S1 s1) {
   s1.data;
-  // CHECK: sycl::group_barrier(item_ct1.get_group());
+  // CHECK:item_ct1.barrier();
   __syncthreads();
 }
 
@@ -114,7 +114,7 @@ struct S2 {
 };
 __global__ void test5(S2 s2) {
   s2.data;
-  // CHECK: sycl::group_barrier(item_ct1.get_group());
+  // CHECK:item_ct1.barrier(sycl::access::fence_space::local_space);
   __syncthreads();
 }
 
@@ -124,14 +124,14 @@ struct S3 {
 };
 __global__ void test7(S3 s3) {
   s3.data;
-  // CHECK: sycl::group_barrier(item_ct1.get_group());
+  // CHECK:item_ct1.barrier();
   __syncthreads();
 }
 
 __global__ void test8(S3 *s3) {
   int a = 1;
   s3[a].data;
-  // CHECK: sycl::group_barrier(item_ct1.get_group());
+  // CHECK:item_ct1.barrier();
   __syncthreads();
 }
 
@@ -147,6 +147,6 @@ struct S4 {
 
 __global__ void test9(S4 a) {
   S4 b(a);
-  // CHECK: sycl::group_barrier(item_ct1.get_group());
+  // CHECK:item_ct1.barrier();
   __syncthreads();
 }

--- a/clang/test/dpct/syncthreads_template.cu
+++ b/clang/test/dpct/syncthreads_template.cu
@@ -10,12 +10,12 @@ struct S1 {
 template<class Q>
 __global__ void test1(S1<Q> s1) {
   s1.data;
-  // CHECK: sycl::group_barrier(item_ct1.get_group());
+  // CHECK:item_ct1.barrier();
   __syncthreads();
 }
 
 template<class Q>
 __global__ void test2() {
-  // CHECK: sycl::group_barrier(item_ct1.get_group());
+  // CHECK:item_ct1.barrier();
   __syncthreads();
 }


### PR DESCRIPTION
Revert "[SYCLomatic] Refine migration of __syncthreads() with sycl::group_barrier() (#118)" due to performance regression

This reverts commit 4ab7f882edd4bd77848603b3400924c03e9e0f3e.

Signed-off-by: Wang, Yihan <yihan.wang@intel.com>