### PR TITLE
[SYCLomatic] Support bfloat16 conversions

### DIFF
--- a/clang/lib/DPCT/APINames.inc
+++ b/clang/lib/DPCT/APINames.inc
@@ -543,6 +543,10 @@ ENTRY(h2sin, h2sin, true, NO_FLAG, P4, "Successful")
 ENTRY(h2sqrt, h2sqrt, true, NO_FLAG, P4, "Successful")
 ENTRY(h2trunc, h2trunc, true, NO_FLAG, P4, "Successful")
 
+// Bfloat16 Precision Conversion and Data Movement
+ENTRY(__bfloat162float, __bfloat162float, true, NO_FLAG, P4, "Successful")
+ENTRY(__float2bfloat16, __bfloat162float, true, NO_FLAG, P4, "Successful")
+
 // Single Precision Mathematical Functions
 ENTRY(log, log, true, NO_FLAG, P0, "Successful")
 ENTRY(logf, logf, true, NO_FLAG, P0, "Successful")

--- a/clang/lib/DPCT/APINamesMath.inc
+++ b/clang/lib/DPCT/APINamesMath.inc
@@ -445,6 +445,10 @@ ENTRY_TYPECAST("__ushort2half_rn")
 ENTRY_TYPECAST("__ushort2half_ru")
 ENTRY_TYPECAST("__ushort2half_rz")
 
+// Bfloat16 Precision Conversion and Data Movement
+ENTRY_TYPECAST("__bfloat162float")
+ENTRY_TYPECAST("__float2bfloat16")
+
 // Type Casting Intrinsics
 ENTRY_TYPECAST("__double2float_rd")
 ENTRY_TYPECAST("__double2float_rn")

--- a/clang/lib/DPCT/CallExprRewriter.cpp
+++ b/clang/lib/DPCT/CallExprRewriter.cpp
@@ -599,6 +599,12 @@ Optional<std::string> MathTypeCastRewriter::rewrite() {
     auto MigratedArg1 = getMigratedArg(1);
     OS << MapNames::getClNamespace() + "half2{" << MigratedArg0 << "[1], "
        << MigratedArg1 << "[1]}";
+  } else if (FuncName == "__float2bfloat16") {
+    DpctGlobalInfo::getInstance().insertHeader(Call->getBeginLoc(), HT_BFloat16);
+    OS << "oneapi::mkl::bfloat16(" << MigratedArg0 << ")";
+  } else if (FuncName == "__bfloat162float") {
+    DpctGlobalInfo::getInstance().insertHeader(Call->getBeginLoc(), HT_BFloat16);
+    OS << "static_cast<float>(" << MigratedArg0 << ")";
   } else {
     //__half2short_rd and __half2float
     static SSMap TypeMap{{"ll", "long long"},

--- a/clang/test/dpct/bfloat16.cu
+++ b/clang/test/dpct/bfloat16.cu
@@ -13,3 +13,11 @@ void foo(__nv_bfloat16 *a) {
 // CHECK: a[i] = (oneapi::mkl::bfloat16)f;
   a[i] = (__nv_bfloat16)f;
 }
+
+void test_conversions() {
+  // CHECK: const auto bf16 = oneapi::mkl::bfloat16(3.14f);
+  const auto bf16 = __float2bfloat16(3.14f);
+
+  // CHECK: const float f32 = static_cast<float>(bf16);
+  const float f32 = __bfloat162float(bf16);
+}


### PR DESCRIPTION
This PR adds support for the following API functions:

- `__bfloat162float`
- `__float2bfloat16`