### PR TITLE
[SYCLomatic] Fix get_info in device.hpp

### DIFF
--- a/clang/runtime/dpct-rt/include/device.hpp.inc
+++ b/clang/runtime/dpct-rt/include/device.hpp.inc
@@ -562,13 +562,12 @@ public:
     prop.set_minor_version(minor);
 
     prop.set_max_work_item_sizes(
-// SYCL 2020 uses structs as information descriptors. Previous versions of SYCL use enum class elements
-#if (SYCL_LANGUAGE_VERSION && SYCL_LANGUAGE_VERSION>=202001)
-        // SYCL 2020, max_work_item_sizes is a struct templated by an int
-        get_info<cl::sycl::info::device::max_work_item_sizes<3>>());
-#else
-        // Pre-SYCL 2020, max_work_item_sizes is an enum class element
+#if (__SYCL_COMPILER_VERSION && __SYCL_COMPILER_VERSION<20220902)
+        // syclos compiler older than 2022/09/02, where max_work_item_sizes is an enum class element
         get_info<cl::sycl::info::device::max_work_item_sizes>());
+#else
+        // SYCL 2020-conformant code, max_work_item_sizes is a struct templated by an int
+        get_info<cl::sycl::info::device::max_work_item_sizes<3>>());
 #endif
     prop.set_host_unified_memory(
         get_info<cl::sycl::info::device::host_unified_memory>());

--- a/clang/runtime/dpct-rt/include/device.hpp.inc
+++ b/clang/runtime/dpct-rt/include/device.hpp.inc
@@ -562,7 +562,7 @@ public:
     prop.set_minor_version(minor);
 
     prop.set_max_work_item_sizes(
-        get_info<cl::sycl::info::device::max_work_item_sizes>());
+        get_info<cl::sycl::info::device::max_work_item_sizes<3>>());
     prop.set_host_unified_memory(
         get_info<cl::sycl::info::device::host_unified_memory>());
 

--- a/clang/runtime/dpct-rt/include/device.hpp.inc
+++ b/clang/runtime/dpct-rt/include/device.hpp.inc
@@ -563,7 +563,7 @@ public:
 
     prop.set_max_work_item_sizes(
 #if (__SYCL_COMPILER_VERSION && __SYCL_COMPILER_VERSION<20220902)
-        // syclos compiler older than 2022/09/02, where max_work_item_sizes is an enum class element
+        // oneAPI DPC++ compiler older than 2022/09/02, where max_work_item_sizes is an enum class element
         get_info<cl::sycl::info::device::max_work_item_sizes>());
 #else
         // SYCL 2020-conformant code, max_work_item_sizes is a struct templated by an int

--- a/clang/runtime/dpct-rt/include/device.hpp.inc
+++ b/clang/runtime/dpct-rt/include/device.hpp.inc
@@ -562,7 +562,14 @@ public:
     prop.set_minor_version(minor);
 
     prop.set_max_work_item_sizes(
+// SYCL 2020 uses structs as information descriptors. Previous versions of SYCL use enum class elements
+#if (SYCL_LANGUAGE_VERSION && SYCL_LANGUAGE_VERSION>=202001)
+        // SYCL 2020, max_work_item_sizes is a struct templated by an int
         get_info<cl::sycl::info::device::max_work_item_sizes<3>>());
+#else
+        // Pre-SYCL 2020, max_work_item_sizes is an enum class element
+        get_info<cl::sycl::info::device::max_work_item_sizes>());
+#endif
     prop.set_host_unified_memory(
         get_info<cl::sycl::info::device::host_unified_memory>());
 

--- a/clang/test/dpct/helper_files_ref/include/device.hpp
+++ b/clang/test/dpct/helper_files_ref/include/device.hpp
@@ -229,13 +229,12 @@ public:
     prop.set_minor_version(minor);
 
     prop.set_max_work_item_sizes(
-// SYCL 2020 uses structs as information descriptors. Previous versions of SYCL use enum class elements
-#if (SYCL_LANGUAGE_VERSION && SYCL_LANGUAGE_VERSION>=202001)
-        // SYCL 2020, max_work_item_sizes is a struct templated by an int
-        get_info<cl::sycl::info::device::max_work_item_sizes<3>>());
-#else
-        // Pre-SYCL 2020, max_work_item_sizes is an enum class element
+#if (__SYCL_COMPILER_VERSION && __SYCL_COMPILER_VERSION<20220902)
+        // syclos compiler older than 2022/09/02, where max_work_item_sizes is an enum class element
         get_info<cl::sycl::info::device::max_work_item_sizes>());
+#else
+        // SYCL 2020-conformant code, max_work_item_sizes is a struct templated by an int
+        get_info<cl::sycl::info::device::max_work_item_sizes<3>>());
 #endif
     prop.set_host_unified_memory(
         get_info<cl::sycl::info::device::host_unified_memory>());

--- a/clang/test/dpct/helper_files_ref/include/device.hpp
+++ b/clang/test/dpct/helper_files_ref/include/device.hpp
@@ -229,7 +229,14 @@ public:
     prop.set_minor_version(minor);
 
     prop.set_max_work_item_sizes(
+// SYCL 2020 uses structs as information descriptors. Previous versions of SYCL use enum class elements
+#if (SYCL_LANGUAGE_VERSION && SYCL_LANGUAGE_VERSION>=202001)
+        // SYCL 2020, max_work_item_sizes is a struct templated by an int
         get_info<cl::sycl::info::device::max_work_item_sizes<3>>());
+#else
+        // Pre-SYCL 2020, max_work_item_sizes is an enum class element
+        get_info<cl::sycl::info::device::max_work_item_sizes>());
+#endif
     prop.set_host_unified_memory(
         get_info<cl::sycl::info::device::host_unified_memory>());
 

--- a/clang/test/dpct/helper_files_ref/include/device.hpp
+++ b/clang/test/dpct/helper_files_ref/include/device.hpp
@@ -229,7 +229,7 @@ public:
     prop.set_minor_version(minor);
 
     prop.set_max_work_item_sizes(
-        get_info<cl::sycl::info::device::max_work_item_sizes>());
+        get_info<cl::sycl::info::device::max_work_item_sizes<3>>());
     prop.set_host_unified_memory(
         get_info<cl::sycl::info::device::host_unified_memory>());
 

--- a/clang/test/dpct/helper_files_ref/include/device.hpp
+++ b/clang/test/dpct/helper_files_ref/include/device.hpp
@@ -230,7 +230,7 @@ public:
 
     prop.set_max_work_item_sizes(
 #if (__SYCL_COMPILER_VERSION && __SYCL_COMPILER_VERSION<20220902)
-        // syclos compiler older than 2022/09/02, where max_work_item_sizes is an enum class element
+        // oneAPI DPC++ compiler older than 2022/09/02, where max_work_item_sizes is an enum class element
         get_info<cl::sycl::info::device::max_work_item_sizes>());
 #else
         // SYCL 2020-conformant code, max_work_item_sizes is a struct templated by an int


### PR DESCRIPTION
Fix get_info call in device.hpp to match SYCL 2020 standard.

Signed-off-by: Lu, John <john.lu@intel.com>