### PR TITLE
[SYCLomatic] Fix exclusive_scan migration bug

### DIFF
--- a/clang/lib/DPCT/APINamesMapThrust.inc
+++ b/clang/lib/DPCT/APINamesMapThrust.inc
@@ -53,7 +53,6 @@ ENTRY_BOTH("thrust::generate_n", "std::generate_n", "oneapi::dpl::execution::syc
 ENTRY_BOTH("thrust::merge", "std::merge", "oneapi::dpl::execution::sycl")
 ENTRY_BOTH("thrust::uninitialized_fill", "std::uninitialized_fill", "")
 ENTRY_BOTH("thrust::unique", "std::unique", "")
-ENTRY_BOTH("thrust::exclusive_scan", "std::exclusive_scan", "oneapi::dpl::execution::sycl")
 ENTRY_BOTH("thrust::max_element", "std::max_element", "")
 ENTRY_BOTH("thrust::min_element", "std::min_element", "")
 ENTRY_BOTH("thrust::make_permutation_iterator", "oneapi::dpl::make_permutation_iterator", "")

--- a/clang/lib/DPCT/APINamesThrust.inc
+++ b/clang/lib/DPCT/APINamesThrust.inc
@@ -1566,3 +1566,65 @@ CONDITIONAL_FACTORY_ENTRY(
 
 // thrust::make_reverse_iterator
 CALL_FACTORY_ENTRY("thrust::make_reverse_iterator",  CALL("oneapi::dpl::make_reverse_iterator",  ARG(0)))
+
+// thrust::exclusive_scan
+CONDITIONAL_FACTORY_ENTRY(
+  CheckArgCount(3),
+  // thrust::exclusive_scan(data, data + 6, data)
+  CONDITIONAL_FACTORY_ENTRY(
+    CheckArgType(1, "thrust::device_ptr"),
+    CALL_FACTORY_ENTRY("thrust::exclusive_scan",
+      CALL("std::exclusive_scan",
+        CALL("oneapi::dpl::execution::make_device_policy", QUEUESTR),
+        ARG(0), ARG(1), ARG(2), ARG("0"))),
+    CALL_FACTORY_ENTRY("thrust::exclusive_scan",
+      CALL("std::exclusive_scan",
+        ARG("oneapi::dpl::execution::seq"), ARG(0), ARG(1), ARG(2), ARG("0")))
+  ),
+  CONDITIONAL_FACTORY_ENTRY(
+    CheckArgCount(4),
+    CONDITIONAL_FACTORY_ENTRY(
+      CompareArgType(0, 1),
+      // thrust::exclusive_scan(thrust::host, data, data + 6, data);
+      CALL_FACTORY_ENTRY("thrust::exclusive_scan",
+        CALL("std::exclusive_scan",
+          makeMappedThrustPolicyEnum(0), ARG(1), ARG(2), ARG(3), ARG("0"))),
+      // thrust::exclusive_scan(data, data + 6, data, 4);
+      CONDITIONAL_FACTORY_ENTRY(
+        CheckArgType(1, "thrust::device_ptr"),
+        CALL_FACTORY_ENTRY("thrust::exclusive_scan",
+          CALL("std::exclusive_scan",
+            CALL("oneapi::dpl::execution::make_device_policy", QUEUESTR),
+            ARG(0), ARG(1), ARG(2), ARG(3))),
+        CALL_FACTORY_ENTRY("thrust::exclusive_scan",
+          CALL("std::exclusive_scan",
+            ARG("oneapi::dpl::execution::seq"), ARG(0), ARG(1), ARG(2), ARG(3)))
+      )
+    ),
+    CONDITIONAL_FACTORY_ENTRY(
+      CheckArgCount(5),
+      CONDITIONAL_FACTORY_ENTRY(
+        CompareArgType(0, 1),
+        // thrust::exclusive_scan(thrust::host, data, data + 6, data, 4);
+        CALL_FACTORY_ENTRY("thrust::exclusive_scan",
+          CALL("std::exclusive_scan",
+            makeMappedThrustPolicyEnum(0), ARG(1), ARG(2), ARG(3), ARG(4))),
+        // thrust::exclusive_scan(data, data + 10, data, 1, binary_op);
+        CONDITIONAL_FACTORY_ENTRY(
+          CheckArgType(1, "thrust::device_ptr"),
+          CALL_FACTORY_ENTRY("thrust::exclusive_scan",
+            CALL("std::exclusive_scan",
+              CALL("oneapi::dpl::execution::make_device_policy", QUEUESTR),
+              ARG(0), ARG(1), ARG(2), ARG(3), ARG(4))),
+          CALL_FACTORY_ENTRY("thrust::exclusive_scan",
+            CALL("std::exclusive_scan",
+              ARG("oneapi::dpl::execution::seq"), ARG(0), ARG(1), ARG(2), ARG(3), ARG(4)))
+        )
+      ),
+      // thrust::exclusive_scan(thrust::host, data, data + 10, data, 1, binary_op);
+      CALL_FACTORY_ENTRY("thrust::exclusive_scan",
+        CALL("std::exclusive_scan",
+          makeMappedThrustPolicyEnum(0), ARG(1), ARG(2), ARG(3), ARG(4), ARG(5)))
+    )
+  )
+)

--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -2306,11 +2306,6 @@ void ThrustFunctionRule::thrustFuncMigration(
     return;
   }
 
-  if (ThrustFuncName == "exclusive_scan") {
-    DpctGlobalInfo::getInstance().insertHeader(CE->getBeginLoc(), HT_Numeric);
-    emplaceTransformation(new InsertText(CE->getEndLoc(), ", 0"));
-  }
-
   if (ULExpr) {
     auto BeginLoc = ULExpr->getBeginLoc();
     auto EndLoc = ULExpr->hasExplicitTemplateArgs()

--- a/clang/test/dpct/thrust-algo.cu
+++ b/clang/test/dpct/thrust-algo.cu
@@ -26,6 +26,41 @@ void k() {
   auto bo = [](int x, int y) -> int { return x + y; };
   auto gen = []() -> int { return 23; };
 
+  thrust::maximum<int> binary_op;
+  thrust::device_vector<int> tv, tv2, tv3, tv4;
+
+  // exclusive_scan
+
+  // CHECK: std::exclusive_scan(oneapi::dpl::execution::seq, v.begin(), v.end(), v2.begin(), 0);
+  // CHECK: std::exclusive_scan(oneapi::dpl::execution::make_device_policy(q_ct1), tv.begin(), tv.end(), tv2.begin(), 0);
+  thrust::exclusive_scan(thrust::host, v.begin(), v.end(), v2.begin());
+  thrust::exclusive_scan(thrust::device, tv.begin(), tv.end(), tv2.begin());
+
+  // CHECK: std::exclusive_scan(oneapi::dpl::execution::seq, v.begin(), v.end(), v2.begin(), 0);
+  // CHECK: std::exclusive_scan(oneapi::dpl::execution::make_device_policy(q_ct1), tv.begin(), tv.end(), tv2.begin(), 0);
+  thrust::exclusive_scan(v.begin(), v.end(), v2.begin());
+  thrust::exclusive_scan(tv.begin(), tv.end(), tv2.begin());
+
+  // CHECK: std::exclusive_scan(oneapi::dpl::execution::seq, v.begin(), v.end(), v2.begin(), 4);
+  // CHECK: std::exclusive_scan(oneapi::dpl::execution::make_device_policy(q_ct1), tv.begin(), tv.end(), tv2.begin(), 4);
+  thrust::exclusive_scan(thrust::host, v.begin(), v.end(), v2.begin(), 4);
+  thrust::exclusive_scan(thrust::device, tv.begin(), tv.end(), tv2.begin(), 4);
+
+  // CHECK: std::exclusive_scan(oneapi::dpl::execution::seq, v.begin(), v.end(), v2.begin(), 4);
+  // CHECK: std::exclusive_scan(oneapi::dpl::execution::make_device_policy(q_ct1), tv.begin(), tv.end(), tv2.begin(), 4);
+  thrust::exclusive_scan(v.begin(), v.end(), v2.begin(), 4);
+  thrust::exclusive_scan(tv.begin(), tv.end(), tv2.begin(), 4);
+
+  // CHECK: std::exclusive_scan(oneapi::dpl::execution::seq, v.begin(), v.end(), v2.begin(), 1, binary_op);
+  // CHECK: std::exclusive_scan(oneapi::dpl::execution::make_device_policy(q_ct1), tv.begin(), tv.end(), tv2.begin(), 1, binary_op);
+  thrust::exclusive_scan(thrust::host, v.begin(), v.end(), v2.begin(), 1, binary_op);
+  thrust::exclusive_scan(thrust::device, tv.begin(), tv.end(), tv2.begin(), 1, binary_op);
+
+  // CHECK: std::exclusive_scan(oneapi::dpl::execution::seq, v.begin(), v.end(), v2.begin(), 1, binary_op);
+  // CHECK: std::exclusive_scan(oneapi::dpl::execution::make_device_policy(q_ct1), tv.begin(), tv.end(), tv2.begin(), 1, binary_op);
+  thrust::exclusive_scan(v.begin(), v.end(), v2.begin(), 1, binary_op);
+  thrust::exclusive_scan(tv.begin(), tv.end(), tv2.begin(), 1, binary_op);
+
   // exclusive_scan_by_key
 
   // CHECK: oneapi::dpl::exclusive_scan_by_segment(oneapi::dpl::execution::seq, v.begin(), v.end(), v2.begin(), v3.begin());

--- a/clang/test/dpct/thrust-for-RapidCFD.cu
+++ b/clang/test/dpct/thrust-for-RapidCFD.cu
@@ -8,7 +8,6 @@
 // CHECK-NEXT:#include <CL/sycl.hpp>
 // CHECK-NEXT: #include <dpct/dpct.hpp>
 // CHECK-NEXT: #include <dpct/dpl_utils.hpp>
-// CHECK-NEXT: #include <numeric>
 #include <thrust/scan.h>
 #include <thrust/host_vector.h>
 #include <thrust/functional.h>
@@ -56,7 +55,7 @@ void foo_host(){
     thrust::uninitialized_fill(h_input.begin(), h_input.end(), 10);
     //CHECK: std::unique(h_input.begin(), h_input.end());
     thrust::unique(h_input.begin(), h_input.end());
-    //CHECK: std::exclusive_scan(oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()), h_input.begin(), h_input.end(), h_output.begin(), 0);
+    //CHECK: std::exclusive_scan(oneapi::dpl::execution::seq, h_input.begin(), h_input.end(), h_output.begin(), 0);
     thrust::exclusive_scan(h_input.begin(), h_input.end(), h_output.begin());
     //CHECK: std::max_element(h_input.begin(), h_input.end());
     thrust::max_element(h_input.begin(), h_input.end());


### PR DESCRIPTION
This change fixes migration of `thrust::exclusive_scan` calls where the initial value is not specified.

Signed-off-by: Michael Aziz <michael.aziz@intel.com>