### PR TITLE
[SYCLomatic] Fix CUB API InclusiveScan and ExclusiveScan migration bug

### DIFF
--- a/clang/lib/DPCT/APINamesCUB.inc
+++ b/clang/lib/DPCT/APINamesCUB.inc
@@ -63,8 +63,8 @@ CONDITIONAL_FACTORY_ENTRY(
                 "cub::DeviceScan::ExclusiveScan",
                 CALL("oneapi::dpl::exclusive_scan",
                      CALL("oneapi::dpl::execution::device_policy", QUEUESTR),
-                     ARG(2), BO(BinaryOperatorKind::BO_Add, ARG(2), ARG(5)),
-                     ARG(3), ARG(4)))))))
+                     ARG(2), BO(BinaryOperatorKind::BO_Add, ARG(2), ARG(6)),
+                     ARG(3), ARG(5), ARG(4)))))))
 
 // cub::DeviceScan::InclusiveScan
 CONDITIONAL_FACTORY_ENTRY(

--- a/clang/lib/DPCT/APINamesCUB.inc
+++ b/clang/lib/DPCT/APINamesCUB.inc
@@ -63,8 +63,8 @@ CONDITIONAL_FACTORY_ENTRY(
                 "cub::DeviceScan::ExclusiveScan",
                 CALL("oneapi::dpl::exclusive_scan",
                      CALL("oneapi::dpl::execution::device_policy", QUEUESTR),
-                     ARG(2), BO(BinaryOperatorKind::BO_Add, ARG(2), ARG(4)),
-                     ARG(3), ARG(5), ARG(4)))))))
+                     ARG(2), BO(BinaryOperatorKind::BO_Add, ARG(2), ARG(5)),
+                     ARG(3), ARG(4)))))))
 
 // cub::DeviceScan::InclusiveScan
 CONDITIONAL_FACTORY_ENTRY(
@@ -78,8 +78,8 @@ CONDITIONAL_FACTORY_ENTRY(
                 "cub::DeviceScan::InclusiveScan",
                 CALL("oneapi::dpl::inclusive_scan",
                      CALL("oneapi::dpl::execution::device_policy", QUEUESTR),
-                     ARG(2), BO(BinaryOperatorKind::BO_Add, ARG(2), ARG(4)),
-                     ARG(3), ARG(5), ARG(4)))))))
+                     ARG(2), BO(BinaryOperatorKind::BO_Add, ARG(2), ARG(5)),
+                     ARG(3), ARG(4)))))))
 
 
 // cub::DeviceSelect::Flagged

--- a/clang/test/dpct/cub/devicelevel/device_exclusive_scan.cu
+++ b/clang/test/dpct/cub/devicelevel/device_exclusive_scan.cu
@@ -29,7 +29,7 @@ struct CustomSum {
 // CHECK: device_out = sycl::malloc_device<int>(N, q_ct1);
 // CHECK: q_ct1.memcpy(device_in, (void *)host_in, sizeof(host_in)).wait();
 // CHECK: DPCT1026:{{.*}}
-// CHECK: oneapi::dpl::exclusive_scan(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + op, device_out, 0, op);
+// CHECK: oneapi::dpl::exclusive_scan(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + N, device_out, 0, op);
 // CHECK: q_ct1.memcpy((void *)host_out, (void *)device_out, sizeof(host_out)).wait();
 // CHECK: sycl::free(device_in, q_ct1);
 // CHECK: sycl::free(device_out, q_ct1);
@@ -66,7 +66,7 @@ void test_1() {
 // CHECK: q_ct1.memcpy(device_in, (void *)host_in, sizeof(host_in)).wait();
 // CHECK: DPCT1027:{{.*}}
 // CHECK: 0, 0;
-// CHECK: oneapi::dpl::exclusive_scan(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + op, device_out, 0, op);
+// CHECK: oneapi::dpl::exclusive_scan(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + N, device_out, 0, op);
 // CHECK: q_ct1.memcpy((void *)host_out, (void *)device_out, sizeof(host_out)).wait();
 // CHECK: sycl::free(device_in, q_ct1);
 // CHECK: sycl::free(device_out, q_ct1);

--- a/clang/test/dpct/cub/devicelevel/device_inclusive_scan.cu
+++ b/clang/test/dpct/cub/devicelevel/device_inclusive_scan.cu
@@ -29,7 +29,7 @@ struct CustomSum {
 // CHECK: device_out = sycl::malloc_device<int>(N, q_ct1);
 // CHECK: q_ct1.memcpy(device_in, (void *)host_in, sizeof(host_in)).wait();
 // CHECK: DPCT1026:{{.*}}
-// CHECK: oneapi::dpl::inclusive_scan(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + op, device_out, N, op);
+// CHECK: oneapi::dpl::inclusive_scan(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + N, device_out, op);
 // CHECK: q_ct1.memcpy((void *)host_out, (void *)device_out, sizeof(host_out)).wait();
 // CHECK: sycl::free(device_in, q_ct1);
 // CHECK: sycl::free(device_out, q_ct1);
@@ -66,7 +66,7 @@ void test_1() {
 // CHECK: q_ct1.memcpy(device_in, (void *)host_in, sizeof(host_in)).wait();
 // CHECK: DPCT1027:{{.*}}
 // CHECK: 0, 0;
-// CHECK: oneapi::dpl::inclusive_scan(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + op, device_out, N, op);
+// CHECK: oneapi::dpl::inclusive_scan(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + N, device_out, op);
 // CHECK: q_ct1.memcpy((void *)host_out, (void *)device_out, sizeof(host_out)).wait();
 // CHECK: sycl::free(device_in, q_ct1);
 // CHECK: sycl::free(device_out, q_ct1);


### PR DESCRIPTION
Fix cub::DeviceScan::InclusiveScan and cub::DeviceScan::ExclusiveScan migration bug

Signed-off-by: Wang, Yihan <yihan.wang@intel.com>