### PR TITLE
[SYCLomatic] Fix queue.fill missing wait in CUB API

### DIFF
--- a/clang/lib/DPCT/APINamesCUB.inc
+++ b/clang/lib/DPCT/APINamesCUB.inc
@@ -13,13 +13,17 @@ CONDITIONAL_FACTORY_ENTRY(
     HEADER_INSERT_FACTORY(
         HeaderType::HT_DPL_Execution,
         HEADER_INSERT_FACTORY(
-        HeaderType::HT_DPL_Algorithm,
-        REMOVE_CUB_TEMP_STORAGE_FACTORY(MEMBER_CALL_FACTORY_ENTRY(
-            "cub::DeviceReduce::Sum", QUEUESTR, false, "fill", ARG(3),
-            CALL("oneapi::dpl::reduce",
-                 CALL("oneapi::dpl::execution::device_policy", QUEUESTR),
-                 ARG(2), BO(BinaryOperatorKind::BO_Add, ARG(2), ARG(4))),
-            LITERAL("1"))))))
+            HeaderType::HT_DPL_Algorithm,
+            REMOVE_CUB_TEMP_STORAGE_FACTORY(MEMBER_CALL_FACTORY_ENTRY(
+                "cub::DeviceReduce::Sum",
+                MEMBER_CALL(
+                    QUEUESTR, false, "fill", ARG(3),
+                    CALL(
+                        "oneapi::dpl::reduce",
+                        CALL("oneapi::dpl::execution::device_policy", QUEUESTR),
+                        ARG(2), BO(BinaryOperatorKind::BO_Add, ARG(2), ARG(4))),
+                    LITERAL("1")),
+                false, "wait")))))
 
 // cub::DeviceScan::ExclusiveSum
 CONDITIONAL_FACTORY_ENTRY(
@@ -28,13 +32,13 @@ CONDITIONAL_FACTORY_ENTRY(
     HEADER_INSERT_FACTORY(
         HeaderType::HT_DPL_Execution,
         HEADER_INSERT_FACTORY(
-        HeaderType::HT_DPL_Algorithm,
-        REMOVE_CUB_TEMP_STORAGE_FACTORY(CALL_FACTORY_ENTRY(
-            "cub::DeviceScan::ExclusiveSum",
-            CALL("oneapi::dpl::exclusive_scan",
-                 CALL("oneapi::dpl::execution::device_policy", QUEUESTR),
-                 ARG(2), BO(BinaryOperatorKind::BO_Add, ARG(2), ARG(4)), ARG(3),
-                 LITERAL("0")))))))
+            HeaderType::HT_DPL_Algorithm,
+            REMOVE_CUB_TEMP_STORAGE_FACTORY(CALL_FACTORY_ENTRY(
+                "cub::DeviceScan::ExclusiveSum",
+                CALL("oneapi::dpl::exclusive_scan",
+                     CALL("oneapi::dpl::execution::device_policy", QUEUESTR),
+                     ARG(2), BO(BinaryOperatorKind::BO_Add, ARG(2), ARG(4)),
+                     ARG(3), LITERAL("0")))))))
 
 // cub::DeviceScan::InclusiveSum
 CONDITIONAL_FACTORY_ENTRY(
@@ -43,13 +47,13 @@ CONDITIONAL_FACTORY_ENTRY(
     HEADER_INSERT_FACTORY(
         HeaderType::HT_DPL_Execution,
         HEADER_INSERT_FACTORY(
-        HeaderType::HT_DPL_Algorithm,
-        REMOVE_CUB_TEMP_STORAGE_FACTORY(CALL_FACTORY_ENTRY(
-            "cub::DeviceScan::InclusiveSum",
-            CALL("oneapi::dpl::inclusive_scan",
-                 CALL("oneapi::dpl::execution::device_policy", QUEUESTR),
-                 ARG(2), BO(BinaryOperatorKind::BO_Add, ARG(2), ARG(4)),
-                 ARG(3)))))))
+            HeaderType::HT_DPL_Algorithm,
+            REMOVE_CUB_TEMP_STORAGE_FACTORY(CALL_FACTORY_ENTRY(
+                "cub::DeviceScan::InclusiveSum",
+                CALL("oneapi::dpl::inclusive_scan",
+                     CALL("oneapi::dpl::execution::device_policy", QUEUESTR),
+                     ARG(2), BO(BinaryOperatorKind::BO_Add, ARG(2), ARG(4)),
+                     ARG(3)))))))
 
 // cub::DeviceScan::ExclusiveScan
 CONDITIONAL_FACTORY_ENTRY(
@@ -81,7 +85,6 @@ CONDITIONAL_FACTORY_ENTRY(
                      ARG(2), BO(BinaryOperatorKind::BO_Add, ARG(2), ARG(5)),
                      ARG(3), ARG(4)))))))
 
-
 // cub::DeviceSelect::Flagged
 CONDITIONAL_FACTORY_ENTRY(
     CheckCubRedundantFunctionCall(),
@@ -89,12 +92,18 @@ CONDITIONAL_FACTORY_ENTRY(
     HEADER_INSERT_FACTORY(
         HeaderType::HT_DPL_Utils,
         REMOVE_CUB_TEMP_STORAGE_FACTORY(MEMBER_CALL_FACTORY_ENTRY(
-            "cub::DeviceSelect::Flagged", QUEUESTR, false, "fill", ARG(5),
-            BO(BinaryOperatorKind::BO_Sub, CALL("dpct::copy_if",
-                 CALL("oneapi::dpl::execution::device_policy", QUEUESTR),
-                 ARG(2), BO(BinaryOperatorKind::BO_Add, ARG(2), ARG(6)), ARG(3),
-                 ARG(4), LITERAL("[](const auto &t) -> bool { return t; }")), ARG(4)),
-            LITERAL("1")))))
+            "cub::DeviceSelect::Flagged",
+            MEMBER_CALL(
+                QUEUESTR, false, "fill", ARG(5),
+                BO(BinaryOperatorKind::BO_Sub,
+                   CALL("dpct::copy_if",
+                        CALL("oneapi::dpl::execution::device_policy", QUEUESTR),
+                        ARG(2), BO(BinaryOperatorKind::BO_Add, ARG(2), ARG(6)),
+                        ARG(3), ARG(4),
+                        LITERAL("[](const auto &t) -> bool { return t; }")),
+                   ARG(4)),
+                LITERAL("1")),
+            false, "wait"))))
 
 // cub::DeviceSelect::Unique
 CONDITIONAL_FACTORY_ENTRY(
@@ -105,14 +114,19 @@ CONDITIONAL_FACTORY_ENTRY(
         HEADER_INSERT_FACTORY(
             HeaderType::HT_DPL_Algorithm,
             REMOVE_CUB_TEMP_STORAGE_FACTORY(MEMBER_CALL_FACTORY_ENTRY(
-                "cub::DeviceSelect::Unique", QUEUESTR, false, "fill", ARG(4),
-                BO(BinaryOperatorKind::BO_Sub,
-                   CALL("oneapi::dpl::unique_copy",
-                        CALL("oneapi::dpl::execution::device_policy", QUEUESTR),
-                        ARG(2), BO(BinaryOperatorKind::BO_Add, ARG(2), ARG(5)),
-                        ARG(3)),
-                   ARG(3)),
-                LITERAL("1"))))))
+                "cub::DeviceSelect::Unique",
+                MEMBER_CALL(
+                    QUEUESTR, false, "fill", ARG(4),
+                    BO(BinaryOperatorKind::BO_Sub,
+                       CALL("oneapi::dpl::unique_copy",
+                            CALL("oneapi::dpl::execution::device_policy",
+                                 QUEUESTR),
+                            ARG(2),
+                            BO(BinaryOperatorKind::BO_Add, ARG(2), ARG(5)),
+                            ARG(3)),
+                       ARG(3)),
+                    LITERAL("1")),
+                false, "wait")))))
 
 // cub::DeviceRunLengthEncode::Encode
 CONDITIONAL_FACTORY_ENTRY(
@@ -125,19 +139,24 @@ CONDITIONAL_FACTORY_ENTRY(
             HEADER_INSERT_FACTORY(
                 HeaderType::HT_DPL_Algorithm,
                 REMOVE_CUB_TEMP_STORAGE_FACTORY(MEMBER_CALL_FACTORY_ENTRY(
-                    "cub::DeviceRunLengthEncode::Encode", QUEUESTR, false,
-                    "fill", ARG(5),
-                    BO(BinaryOperatorKind::BO_Sub,
-                       MEMBER_EXPR(
-                           CALL("oneapi::dpl::reduce_by_segment",
-                                CALL("oneapi::dpl::execution::device_policy",
-                                     QUEUESTR),
-                                ARG(2),
-                                BO(BinaryOperatorKind::BO_Add, ARG(2), ARG(6)),
-                                MEMBER_CALL(CALL("dpct::device_vector<size_t>",
-                                                 ARG(6), LITERAL("1")),
-                                            false, "begin"),
-                                ARG(3), ARG(4)),
-                           false, LITERAL("first")),
-                       ARG(3)),
-                    LITERAL("1")))))))
+                    "cub::DeviceRunLengthEncode::Encode",
+                    MEMBER_CALL(
+                        QUEUESTR, false, "fill", ARG(5),
+                        BO(BinaryOperatorKind::BO_Sub,
+                           MEMBER_EXPR(
+                               CALL(
+                                   "oneapi::dpl::reduce_by_segment",
+                                   CALL("oneapi::dpl::execution::device_policy",
+                                        QUEUESTR),
+                                   ARG(2),
+                                   BO(BinaryOperatorKind::BO_Add, ARG(2),
+                                      ARG(6)),
+                                   MEMBER_CALL(
+                                       CALL("dpct::device_vector<size_t>",
+                                            ARG(6), LITERAL("1")),
+                                       false, "begin"),
+                                   ARG(3), ARG(4)),
+                               false, LITERAL("first")),
+                           ARG(3)),
+                        LITERAL("1")),
+                    false, "wait"))))))

--- a/clang/test/dpct/cub/devicelevel/device_encode.cu
+++ b/clang/test/dpct/cub/devicelevel/device_encode.cu
@@ -31,7 +31,7 @@
 // CHECK: d_selected_num = sycl::malloc_device<int>(1, q_ct1);
 // CHECK: q_ct1.memcpy((void *)d_in, (void *)h_in, sizeof(h_in)).wait();
 // CHECK: DPCT1026:{{.*}}
-// CHECK: q_ct1.fill(d_selected_num, oneapi::dpl::reduce_by_segment(oneapi::dpl::execution::device_policy(q_ct1), d_in, d_in + N, dpct::device_vector<size_t>(N, 1).begin(), d_unique, d_counts).first - d_unique, 1);
+// CHECK: q_ct1.fill(d_selected_num, oneapi::dpl::reduce_by_segment(oneapi::dpl::execution::device_policy(q_ct1), d_in, d_in + N, dpct::device_vector<size_t>(N, 1).begin(), d_unique, d_counts).first - d_unique, 1).wait();
 // CHECK: q_ct1.memcpy((void *)&h_selected_num, (void *)d_selected_num, sizeof(int)){{.*}};
 // CHECK: q_ct1.memcpy((void *)h_unique, (void *)d_unique, h_selected_num * sizeof(int)){{.*}};
 // CHECK: q_ct1.memcpy((void *)h_counts, (void *)d_counts, h_selected_num * sizeof(int)).wait();
@@ -90,7 +90,7 @@ void test_1() {
 // CHECK: q_ct1.memcpy((void *)d_in, (void *)h_in, sizeof(h_in)).wait();
 // CHECK: DPCT1027:{{.*}}
 // CHECK: 0, 0;
-// CHECK: q_ct1.fill(d_selected_num, oneapi::dpl::reduce_by_segment(oneapi::dpl::execution::device_policy(q_ct1), d_in, d_in + N, dpct::device_vector<size_t>(N, 1).begin(), d_unique, d_counts).first - d_unique, 1);
+// CHECK: q_ct1.fill(d_selected_num, oneapi::dpl::reduce_by_segment(oneapi::dpl::execution::device_policy(q_ct1), d_in, d_in + N, dpct::device_vector<size_t>(N, 1).begin(), d_unique, d_counts).first - d_unique, 1).wait();
 // CHECK: q_ct1.memcpy((void *)&h_selected_num, (void *)d_selected_num, sizeof(int)){{.*}};
 // CHECK: q_ct1.memcpy((void *)h_unique, (void *)d_unique, h_selected_num * sizeof(int)){{.*}};
 // CHECK: q_ct1.memcpy((void *)h_counts, (void *)d_counts, h_selected_num * sizeof(int)).wait();

--- a/clang/test/dpct/cub/devicelevel/device_reduce_sum.cu
+++ b/clang/test/dpct/cub/devicelevel/device_reduce_sum.cu
@@ -21,7 +21,7 @@
 // CHECK:device_out = sycl::malloc_device<int>(n, q_ct1);
 // CHECK:q_ct1.memcpy(device_in, (void *)host_in, sizeof(host_in)).wait();
 // CHECK:DPCT1026{{.*}}
-// CHECK:q_ct1.fill(device_out, oneapi::dpl::reduce(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n), 1);
+// CHECK:q_ct1.fill(device_out, oneapi::dpl::reduce(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n), 1).wait();
 // CHECK:q_ct1.memcpy((void *)host_out, (void *)device_out, sizeof(host_out)).wait();
 // CHECK:sycl::free(device_in, q_ct1);
 // CHECK:sycl::free(device_out, q_ct1);
@@ -62,7 +62,7 @@ void test_1() {
 // CHECK:DPCT1026:{{.*}}
 // CHECK:DPCT1026:{{.*}}
 // CHECK:DPCT1026:{{.*}}
-// CHECK:q_ct1.fill(device_out, oneapi::dpl::reduce(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n), 1);
+// CHECK:q_ct1.fill(device_out, oneapi::dpl::reduce(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n), 1).wait();
 // CHECK:q_ct1.memcpy((void *)host_out, (void *)device_out, sizeof(host_out)).wait();
 // CHECK:sycl::free(device_in, q_ct1);
 // CHECK:sycl::free(device_out, q_ct1);
@@ -103,7 +103,7 @@ void test_2() {
 // CHECK:device_out = sycl::malloc_device<int>(n, q_ct1);
 // CHECK:q_ct1.memcpy(device_in, (void *)host_in, sizeof(host_in)).wait();
 // CHECK:DPCT1027{{.*}}
-// CHECK:q_ct1.fill(device_out, oneapi::dpl::reduce(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n), 1);
+// CHECK:q_ct1.fill(device_out, oneapi::dpl::reduce(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n), 1).wait();
 // CHECK:q_ct1.memcpy((void *)host_out, (void *)device_out, sizeof(host_out)).wait();
 // CHECK:sycl::free(device_in, q_ct1);
 // CHECK:sycl::free(device_out, q_ct1);

--- a/clang/test/dpct/cub/devicelevel/device_select_flagged.cu
+++ b/clang/test/dpct/cub/devicelevel/device_select_flagged.cu
@@ -18,7 +18,7 @@
 // CHECK: q_ct1.memcpy(device_in, (void *)host_in, sizeof(host_in));
 // CHECK: q_ct1.memcpy(device_flagged, host_flagged, sizeof(host_flagged)).wait();
 // CHECK: DPCT1026:{{.*}}
-// CHECK: q_ct1.fill(device_select_num, dpct::copy_if(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, device_flagged, device_out, [](const auto &t) -> bool { return t; }) - device_out, 1);
+// CHECK: q_ct1.fill(device_select_num, dpct::copy_if(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, device_flagged, device_out, [](const auto &t) -> bool { return t; }) - device_out, 1).wait();
 // CHECK: q_ct1.memcpy((void *)host_out, (void *)device_out, sizeof(host_out));
 // CHECK: q_ct1.memcpy((void *)&num, (void *)device_select_num, sizeof(int)).wait();
 // CHECK: sycl::free(device_in, q_ct1);
@@ -70,7 +70,7 @@ void test_1() {
 // CHECK: q_ct1.memcpy(device_flagged, host_flagged, sizeof(host_flagged)).wait();
 // CHECK: DPCT1027:{{.*}}
 // CHECK: 0, 0;
-// CHECK: q_ct1.fill(device_select_num, dpct::copy_if(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, device_flagged, device_out, [](const auto &t) -> bool { return t; }) - device_out, 1);
+// CHECK: q_ct1.fill(device_select_num, dpct::copy_if(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, device_flagged, device_out, [](const auto &t) -> bool { return t; }) - device_out, 1).wait();
 // CHECK: q_ct1.memcpy((void *)host_out, (void *)device_out, sizeof(host_out));
 // CHECK: q_ct1.memcpy((void *)&num, (void *)device_select_num, sizeof(int)).wait();
 // CHECK: sycl::free(device_in, q_ct1);

--- a/clang/test/dpct/cub/devicelevel/device_unique.cu
+++ b/clang/test/dpct/cub/devicelevel/device_unique.cu
@@ -27,7 +27,7 @@
 // CHECK:d_selected_num = sycl::malloc_device<int>(1, q_ct1);
 // CHECK:q_ct1.memcpy((void *)d_in, (void *)h_in, sizeof(h_in)).wait();
 // CHECK:DPCT1026{{.*}}
-// CHECK:q_ct1.fill(d_selected_num, oneapi::dpl::unique_copy(oneapi::dpl::execution::device_policy(q_ct1), d_in, d_in + N, d_out) - d_out, 1);
+// CHECK:q_ct1.fill(d_selected_num, oneapi::dpl::unique_copy(oneapi::dpl::execution::device_policy(q_ct1), d_in, d_in + N, d_out) - d_out, 1).wait();
 // CHECK:q_ct1.memcpy((void *)&h_selected_num, (void *)d_selected_num, sizeof(int)){{.*}};
 // CHECK:q_ct1.memcpy((void *)h_out, (void *)d_out, h_selected_num * sizeof(int)).wait();
 // CHECK:}
@@ -73,7 +73,7 @@ void test_1() {
 // CHECK:q_ct1.memcpy((void *)d_in, (void *)h_in, sizeof(h_in)).wait();
 // CHECK:DPCT1027:{{.*}}
 // CHECK:0, 0;
-// CHECK:q_ct1.fill(d_selected_num, oneapi::dpl::unique_copy(oneapi::dpl::execution::device_policy(q_ct1), d_in, d_in + N, d_out) - d_out, 1);
+// CHECK:q_ct1.fill(d_selected_num, oneapi::dpl::unique_copy(oneapi::dpl::execution::device_policy(q_ct1), d_in, d_in + N, d_out) - d_out, 1).wait();
 // CHECK:q_ct1.memcpy((void *)&h_selected_num, (void *)d_selected_num, sizeof(int)){{.*}};
 // CHECK:q_ct1.memcpy((void *)h_out, (void *)d_out, h_selected_num * sizeof(int)).wait();
 // }

--- a/clang/test/dpct/cub/devicelevel/redundent_call_with_gnu_ext.cu
+++ b/clang/test/dpct/cub/devicelevel/redundent_call_with_gnu_ext.cu
@@ -25,7 +25,7 @@
 // CHECK:DPCT1026:{{.*}}
 // CHECK:DPCT1026:{{.*}}
 // CHECK:DPCT1026:{{.*}}
-// CHECK:q_ct1.fill(device_out, oneapi::dpl::reduce(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n), 1);
+// CHECK:q_ct1.fill(device_out, oneapi::dpl::reduce(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n), 1).wait();
 // CHECK:q_ct1.memcpy((void *)host_out, (void *)device_out, sizeof(host_out)).wait();
 // CHECK:sycl::free(device_in, q_ct1);
 // CHECK:sycl::free(device_out, q_ct1);


### PR DESCRIPTION
Fix queue.fill missing wait in the migration of cub::DeviceReduce::Sum, cub::DeviceSelect::Unique, cub::DeviceSelect::Unique and cub::DeviceRunLengthEncode::Encode

Signed-off-by: Wang, Yihan <yihan.wang@intel.com>