### PR TITLE
[SYCLomatic]  In intercept-build do not filter out -shared option

### DIFF
--- a/clang/test/dpct/intercept.c
+++ b/clang/test/dpct/intercept.c
@@ -1,3 +1,6 @@
+// UNSUPPORTED: -windows-
+// intercept-build not found on windows
+//
 // ------ prepare test directory
 // RUN: cd %T
 // RUN: rm -rf intercept-build

--- a/clang/test/dpct/intercept.c
+++ b/clang/test/dpct/intercept.c
@@ -1,0 +1,28 @@
+// ------ prepare test directory
+// RUN: cd %T
+// RUN: rm -rf intercept-build
+// RUN: mkdir  intercept-build
+// RUN: cd     intercept-build
+// RUN: cp %s intercept.c
+//
+// ------ create makefile
+// RUN: echo "libintercept.a     :       intercept.c          "          >  intercept-Makefile
+// RUN: echo "	%clangxx -c -fpic intercept.c                 "          >> intercept-Makefile
+// RUN: echo "	%clangxx -shared -o libintercept.a intercept.o"          >> intercept-Makefile
+//
+// ------ test intercept-build
+// RUN: intercept-build --cdb intercept.json make -f intercept-Makefile
+//
+// ------ ensure that '-shared' option is recorded in compilation database
+// RUN: FileCheck --input-file intercept.json %s
+//
+// ------ cleanup test directory
+// RUN: cd ..
+// RUN: rm -rf ./intercept-build
+
+// CHECK: "command": "cc -c --driver-mode=g++ -fpic intercept.c",
+// CHECK: -shared -o libintercept.a
+
+void foo()
+{
+}

--- a/clang/tools/scan-build-py/lib/libear/__init__.py
+++ b/clang/tools/scan-build-py/lib/libear/__init__.py
@@ -25,6 +25,10 @@ def build_libear(compiler, dst_dir):
         prebuildlib = os.path.join(src_dir, "libear.so")
         if os.path.exists(prebuildlib):
             return prebuildlib
+
+        prebuildlib = os.path.join(src_dir, "../libear.so")
+        if os.path.exists(prebuildlib):
+            return prebuildlib
 # SYCLomatic_CUSTOMIZATION end
         toolset = make_toolset(src_dir)
         toolset.set_compiler(compiler)

--- a/clang/tools/scan-build-py/lib/libscanbuild/compilation.py
+++ b/clang/tools/scan-build-py/lib/libscanbuild/compilation.py
@@ -38,7 +38,7 @@ IGNORED_FLAGS = {
     # anyway. the benefit to get rid of them is to make the output more
     # readable.
     '-static': 0,
-    '-shared': 0,
+    #'-shared': 0,
     '-s': 0,
     '-rdynamic': 0,
     '-l': 1,
@@ -93,8 +93,8 @@ IGNORED_FLAGS = {
     '-g': 0,
     '--generate-line-info': 0,
     '-lineinfo': 0,
-    '--shared': 0,
-    '-shared' : 0,
+    #'--shared': 0,
+    #'-shared' : 0,
     '--x': 1,
     '-x': 1,
     '--no-host-device-initializer-list': 0,


### PR DESCRIPTION
Update compilation.py to not filter out -shared and --shared options.

Also, updated __init__.py to find libear.so in a second directory for LIT testing (intercept-build uses libear.so).
LIT testing uses intercept-build from the SYCLomatic build area, which has libear.so at  lib/libear.so
The release area has the shared library at lib/libear/libear.so.   Previously  __init__.py could only find this location.
This was not encountered before because this  commit has the first intercept-build LIT test.

Also added a LIT test intercept.c to check that the -shared option is in the compilation database.

Signed-off-by: Lu, John <john.lu@intel.com>