### PR TITLE
[SYCLomatic] Fix kernel migration in macro

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -9787,9 +9787,9 @@ void KernelCallRule::runRule(
 
     // Add kernel call to map,
     // will do code generation in Global.buildReplacements();
-    if (!FD->isTemplateInstantiation())
+    if (!FD->isTemplateInstantiation()){
       DpctGlobalInfo::getInstance().insertKernelCallExpr(KCall);
-
+    }
     const CallExpr *Config = KCall->getConfig();
     if (Config) {
       if (Config->getNumArgs() > 2) {
@@ -9847,7 +9847,7 @@ void KernelCallRule::removeTrailingSemicolon(
     const CallExpr *KCall,
     const ast_matchers::MatchFinder::MatchResult &Result) {
   const auto &SM = (*Result.Context).getSourceManager();
-  auto KELoc = getStmtExpansionSourceRange(KCall).getEnd();
+  auto KELoc = getTheLastCompleteImmediateRange(KCall->getBeginLoc(), KCall->getEndLoc()).second;
   auto Tok = Lexer::findNextToken(KELoc, SM, LangOptions()).getValue();
   if (Tok.is(tok::TokenKind::semi))
     emplaceTransformation(new ReplaceToken(Tok.getLocation(), ""));

--- a/clang/lib/DPCT/AnalysisInfo.h
+++ b/clang/lib/DPCT/AnalysisInfo.h
@@ -2287,35 +2287,7 @@ private:
   }
   // The result will be also stored in KernelCallExpr.BeginLoc
   static inline SourceLocation getLocation(const CUDAKernelCallExpr *CKC) {
-    // if the BeginLoc of CKC is in macro define, use getImmediateSpellingLoc.
     return getTheLastCompleteImmediateRange(CKC->getBeginLoc(), CKC->getEndLoc()).first;
-    // auto It = dpct::DpctGlobalInfo::getExpansionRangeToMacroRecord().find(
-    //     getCombinedStrFromLoc(SM->getSpellingLoc(CKC->getBeginLoc())));
-    // if (CKC->getBeginLoc().isMacroID() &&
-    //     It != dpct::DpctGlobalInfo::getExpansionRangeToMacroRecord().end()) {
-    //   return SM->getImmediateSpellingLoc(CKC->getBeginLoc());
-    // }
-
-    // if (CKC->getBeginLoc().isMacroID()) {
-    //   // if only the BeginLoc of CKC is in macro arg expansion,
-    //   // use getImmediateExpansionRange.
-    //   // #define CALL(Name, ...) NAME<<<...>>>(...)
-    //   if (SM->isMacroArgExpansion(CKC->getBeginLoc()) &&
-    //       !SM->isMacroArgExpansion(CKC->getEndLoc())) {
-    //     return SM->getImmediateSpellingLoc(
-    //         SM->getImmediateExpansionRange(CKC->getBeginLoc()).getBegin());
-    //   }
-    //   // if both BeginLoc/EndLoc of CKC is in macro arg expansion,
-    //   // use getImmediateExpansionRange.
-    //   // #define CALL(call) call
-    //   // CALL(NAME<<<...>>>(...))
-    //   if (SM->isMacroArgExpansion(CKC->getBeginLoc()) &&
-    //       SM->isMacroArgExpansion(CKC->getEndLoc())) {
-    //     return SM->getImmediateSpellingLoc(CKC->getBeginLoc());
-    //   }
-    // }
-
-    // return CKC->getBeginLoc();
   }
 
   std::unordered_map<std::string, std::shared_ptr<DpctFileInfo>> FileMap;

--- a/clang/lib/DPCT/AnalysisInfo.h
+++ b/clang/lib/DPCT/AnalysisInfo.h
@@ -2288,33 +2288,34 @@ private:
   // The result will be also stored in KernelCallExpr.BeginLoc
   static inline SourceLocation getLocation(const CUDAKernelCallExpr *CKC) {
     // if the BeginLoc of CKC is in macro define, use getImmediateSpellingLoc.
-    auto It = dpct::DpctGlobalInfo::getExpansionRangeToMacroRecord().find(
-        getCombinedStrFromLoc(SM->getSpellingLoc(CKC->getBeginLoc())));
-    if (CKC->getBeginLoc().isMacroID() &&
-        It != dpct::DpctGlobalInfo::getExpansionRangeToMacroRecord().end()) {
-      return SM->getImmediateSpellingLoc(CKC->getBeginLoc());
-    }
+    return getTheLastCompleteImmediateRange(CKC->getBeginLoc(), CKC->getEndLoc()).first;
+    // auto It = dpct::DpctGlobalInfo::getExpansionRangeToMacroRecord().find(
+    //     getCombinedStrFromLoc(SM->getSpellingLoc(CKC->getBeginLoc())));
+    // if (CKC->getBeginLoc().isMacroID() &&
+    //     It != dpct::DpctGlobalInfo::getExpansionRangeToMacroRecord().end()) {
+    //   return SM->getImmediateSpellingLoc(CKC->getBeginLoc());
+    // }
 
-    if (CKC->getBeginLoc().isMacroID()) {
-      // if only the BeginLoc of CKC is in macro arg expansion,
-      // use getImmediateExpansionRange.
-      // #define CALL(Name, ...) NAME<<<...>>>(...)
-      if (SM->isMacroArgExpansion(CKC->getBeginLoc()) &&
-          !SM->isMacroArgExpansion(CKC->getEndLoc())) {
-        return SM->getImmediateSpellingLoc(
-            SM->getImmediateExpansionRange(CKC->getBeginLoc()).getBegin());
-      }
-      // if both BeginLoc/EndLoc of CKC is in macro arg expansion,
-      // use getImmediateExpansionRange.
-      // #define CALL(call) call
-      // CALL(NAME<<<...>>>(...))
-      if (SM->isMacroArgExpansion(CKC->getBeginLoc()) &&
-          SM->isMacroArgExpansion(CKC->getEndLoc())) {
-        return SM->getImmediateSpellingLoc(CKC->getBeginLoc());
-      }
-    }
+    // if (CKC->getBeginLoc().isMacroID()) {
+    //   // if only the BeginLoc of CKC is in macro arg expansion,
+    //   // use getImmediateExpansionRange.
+    //   // #define CALL(Name, ...) NAME<<<...>>>(...)
+    //   if (SM->isMacroArgExpansion(CKC->getBeginLoc()) &&
+    //       !SM->isMacroArgExpansion(CKC->getEndLoc())) {
+    //     return SM->getImmediateSpellingLoc(
+    //         SM->getImmediateExpansionRange(CKC->getBeginLoc()).getBegin());
+    //   }
+    //   // if both BeginLoc/EndLoc of CKC is in macro arg expansion,
+    //   // use getImmediateExpansionRange.
+    //   // #define CALL(call) call
+    //   // CALL(NAME<<<...>>>(...))
+    //   if (SM->isMacroArgExpansion(CKC->getBeginLoc()) &&
+    //       SM->isMacroArgExpansion(CKC->getEndLoc())) {
+    //     return SM->getImmediateSpellingLoc(CKC->getBeginLoc());
+    //   }
+    // }
 
-    return CKC->getBeginLoc();
+    // return CKC->getBeginLoc();
   }
 
   std::unordered_map<std::string, std::shared_ptr<DpctFileInfo>> FileMap;

--- a/clang/lib/DPCT/TextModification.cpp
+++ b/clang/lib/DPCT/TextModification.cpp
@@ -537,16 +537,6 @@ void ReplaceDim3Ctor::setRange() {
       return;
     }
     if (S->getBeginLoc().isMacroID() && !isOuterMostMacro(S)) {
-      // auto results = getTheOneBeforeLastImmediateExapansion(S->getBeginLoc(),
-      //                                                       S->getEndLoc());
-      // auto Begin = SM.getImmediateSpellingLoc(results.first);
-      // auto End = SM.getImmediateSpellingLoc(results.second);
-      // printf("set begin %s\n", Begin.printToString(SM).c_str());
-      // printf("set end %s\n", End.printToString(SM).c_str());
-      // if (SM.isMacroArgExpansion(S->getBeginLoc())) {
-      //   Begin = SM.getImmediateSpellingLoc(S->getBeginLoc());
-      //   End = SM.getImmediateSpellingLoc(S->getEndLoc());
-      // }
       auto Range = getDefinitionRange(S->getBeginLoc(), S->getEndLoc());
       auto Begin = Range.getBegin();
       auto End = Range.getEnd();

--- a/clang/lib/DPCT/TextModification.cpp
+++ b/clang/lib/DPCT/TextModification.cpp
@@ -537,14 +537,19 @@ void ReplaceDim3Ctor::setRange() {
       return;
     }
     if (S->getBeginLoc().isMacroID() && !isOuterMostMacro(S)) {
-      auto results = getTheOneBeforeLastImmediateExapansion(S->getBeginLoc(),
-                                                            S->getEndLoc());
-      auto Begin = SM.getImmediateSpellingLoc(results.first);
-      auto End = SM.getImmediateSpellingLoc(results.second);
-      if (SM.isMacroArgExpansion(S->getBeginLoc())) {
-        Begin = SM.getImmediateSpellingLoc(S->getBeginLoc());
-        End = SM.getImmediateSpellingLoc(S->getEndLoc());
-      }
+      // auto results = getTheOneBeforeLastImmediateExapansion(S->getBeginLoc(),
+      //                                                       S->getEndLoc());
+      // auto Begin = SM.getImmediateSpellingLoc(results.first);
+      // auto End = SM.getImmediateSpellingLoc(results.second);
+      // printf("set begin %s\n", Begin.printToString(SM).c_str());
+      // printf("set end %s\n", End.printToString(SM).c_str());
+      // if (SM.isMacroArgExpansion(S->getBeginLoc())) {
+      //   Begin = SM.getImmediateSpellingLoc(S->getBeginLoc());
+      //   End = SM.getImmediateSpellingLoc(S->getEndLoc());
+      // }
+      auto Range = getDefinitionRange(S->getBeginLoc(), S->getEndLoc());
+      auto Begin = Range.getBegin();
+      auto End = Range.getEnd();
       End = End.getLocWithOffset(Lexer::MeasureTokenLength(
           End, SM, dpct::DpctGlobalInfo::getContext().getLangOpts()));
       CSR = CharSourceRange::getTokenRange(Begin, End);

--- a/clang/test/dpct/macro_test.cu
+++ b/clang/test/dpct/macro_test.cu
@@ -547,13 +547,13 @@ __global__ void templatefoo(){
   int y = b;
 }
 //CHECK: #define AAA 15 + 3
-//CHECK-NEXT: #define CCC <<<1,1>>>()
+//CHECK-NEXT: #define CCC <<<sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)>>>()
 //CHECK-NEXT: #define KERNEL(A, B)                                                           \
 //CHECK-NEXT:   dpct::get_default_queue().parallel_for(                                      \
 //CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),   \
 //CHECK-NEXT:         [=](sycl::nd_item<3> item_ct1) { templatefoo<A, B>(); });
 //CHECK-NEXT: #define CALL_KERNEL(C, D) KERNEL(C, D); int a = 0;
-//CHECK-NEXT: #define CALL_KERNEL2(E, F) sycl::range<3>(1, 1, 1)
+//CHECK-NEXT: #define CALL_KERNEL2(E, F) CALL_KERNEL(E, F)
 //CHECK-NEXT: void templatefoo2(){
 //CHECK-NEXT:   CALL_KERNEL2(8, AAA)
 //CHECK-NEXT: }


### PR DESCRIPTION
1. Fix incorrect kernel location when in mutiple levels of func-like macro
2. Fix the logic of insert "\" when the kernel is in macro define
3. Fix incorrect dim3 ctor range
4. Fix incorrect location in removeTrailingSemicolon

Signed-off-by: Huang, Andy <andy.huang@intel.com>