### PR TITLE
[SYCLomatic] Disable cuda11.0 and 11.1 in lit test of libcu_atomic

### DIFF
--- a/clang/test/dpct/LibCU/libcu_atomic.cu
+++ b/clang/test/dpct/LibCU/libcu_atomic.cu
@@ -1,6 +1,6 @@
-// UNSUPPORTED: v7.0, v7.5, v8.0, v9.0, v9.2, v10.0, v10.1, v10.2
-// UNSUPPORTED: cuda-7.0, cuda-7.5, cuda-8.0, cuda-9.0, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2
-// RUN: dpct -in-root %S -out-root %T/Libcu %S/libcu_atomic.cu --cuda-include-path="%cuda-path/include" -- -std=c++14 -x cuda --cuda-host-only
+// UNSUPPORTED: v7.0, v7.5, v8.0, v9.0, v9.2, v10.0, v10.1, v10.2, v11.0, v11.1, v11.2
+// UNSUPPORTED: cuda-7.0, cuda-7.5, cuda-8.0, cuda-9.0, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.1, cuda-11.2
+// RUN: dpct --format-range=none -in-root %S -out-root %T/Libcu %S/libcu_atomic.cu --cuda-include-path="%cuda-path/include" -- -std=c++14 -x cuda --cuda-host-only
 // RUN: FileCheck --input-file %T/Libcu/libcu_atomic.dp.cpp --match-full-lines %s
 
 
@@ -24,7 +24,7 @@ int main(){
   cuda::atomic<int> b(0);
   cuda::atomic<int, cuda::thread_scope_block> c(0);
   int ans = c.load(cuda::std::memory_order_relaxed);
-  a.store(0,cuda::std::memory_order_relaxed);
+  a.store(0, cuda::std::memory_order_relaxed);
   int ans2 = a.load();
 
   //CHECK: int tmp =1,tmp1=2;

--- a/clang/test/dpct/LibCU/libcu_atomic.cu
+++ b/clang/test/dpct/LibCU/libcu_atomic.cu
@@ -1,5 +1,5 @@
-// UNSUPPORTED: v7.0, v7.5, v8.0, v9.0, v9.2, v10.0, v10.1, v10.2, v11.0, v11.1, v11.2
-// UNSUPPORTED: cuda-7.0, cuda-7.5, cuda-8.0, cuda-9.0, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.1, cuda-11.2
+// UNSUPPORTED: v7.0, v7.5, v8.0, v9.0, v9.2, v10.0, v10.1, v10.2, v11.0, v11.1
+// UNSUPPORTED: cuda-7.0, cuda-7.5, cuda-8.0, cuda-9.0, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.1
 // RUN: dpct --format-range=none -in-root %S -out-root %T/Libcu %S/libcu_atomic.cu --cuda-include-path="%cuda-path/include" -- -std=c++14 -x cuda --cuda-host-only
 // RUN: FileCheck --input-file %T/Libcu/libcu_atomic.dp.cpp --match-full-lines %s
 

--- a/clang/test/dpct/LibCU/libcu_atomic_withusingnamespace.cu
+++ b/clang/test/dpct/LibCU/libcu_atomic_withusingnamespace.cu
@@ -1,6 +1,6 @@
 // UNSUPPORTED: v7.0, v7.5, v8.0, v9.0, v9.2, v10.0, v10.1, v10.2
 // UNSUPPORTED: cuda-7.0, cuda-7.5, cuda-8.0, cuda-9.0, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2
-// RUN: dpct -in-root %S -out-root %T/Libcu %S/libcu_std_atomic.cu --cuda-include-path="%cuda-path/include" -- -std=c++14 -x cuda --cuda-host-only
+// RUN: dpct --format-range=none -in-root %S -out-root %T/Libcu %S/libcu_std_atomic.cu --cuda-include-path="%cuda-path/include" -- -std=c++14 -x cuda --cuda-host-only
 // RUN: FileCheck --input-file %T/Libcu/libcu_std_atomic.dp.cpp --match-full-lines %s
 
 

--- a/clang/test/dpct/LibCU/libcu_std_atomic.cu
+++ b/clang/test/dpct/LibCU/libcu_std_atomic.cu
@@ -1,5 +1,5 @@
-// UNSUPPORTED: v7.0, v7.5, v8.0, v9.0, v9.2, v10.0, v10.1, v10.2, v11.0, v11.1, v11.2
-// UNSUPPORTED: cuda-7.0, cuda-7.5, cuda-8.0, cuda-9.0, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.1, cuda-11.2
+// UNSUPPORTED: v7.0, v7.5, v8.0, v9.0, v9.2, v10.0, v10.1, v10.2, v11.0, v11.1
+// UNSUPPORTED: cuda-7.0, cuda-7.5, cuda-8.0, cuda-9.0, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.1
 // RUN: dpct --format-range=none -in-root %S -out-root %T/Libcu %S/libcu_std_atomic.cu --cuda-include-path="%cuda-path/include" -- -std=c++14 -x cuda --cuda-host-only
 // RUN: FileCheck --input-file %T/Libcu/libcu_std_atomic.dp.cpp --match-full-lines %s
 

--- a/clang/test/dpct/LibCU/libcu_std_atomic.cu
+++ b/clang/test/dpct/LibCU/libcu_std_atomic.cu
@@ -1,6 +1,6 @@
-// UNSUPPORTED: v7.0, v7.5, v8.0, v9.0, v9.2, v10.0, v10.1, v10.2
-// UNSUPPORTED: cuda-7.0, cuda-7.5, cuda-8.0, cuda-9.0, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2
-// RUN: dpct -in-root %S -out-root %T/Libcu %S/libcu_std_atomic.cu --cuda-include-path="%cuda-path/include" -- -std=c++14 -x cuda --cuda-host-only
+// UNSUPPORTED: v7.0, v7.5, v8.0, v9.0, v9.2, v10.0, v10.1, v10.2, v11.0, v11.1, v11.2
+// UNSUPPORTED: cuda-7.0, cuda-7.5, cuda-8.0, cuda-9.0, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.1, cuda-11.2
+// RUN: dpct --format-range=none -in-root %S -out-root %T/Libcu %S/libcu_std_atomic.cu --cuda-include-path="%cuda-path/include" -- -std=c++14 -x cuda --cuda-host-only
 // RUN: FileCheck --input-file %T/Libcu/libcu_std_atomic.dp.cpp --match-full-lines %s
 
 


### PR DESCRIPTION
Due to clang can not parse libcu/atomic in cuda11.0 and cuda11.1.
Signed-off-by: Ni, Wenhui <wenhui.ni@intel.com>