### PR TITLE
[SYCLomatic] keep include of CL/opencl.h

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -1089,10 +1089,11 @@ void IncludesCallbacks::InclusionDirective(
     }
   }
 
-  // Always keep include of CL/opencl.h
+  // Always keep include of CL/*.  Do not delete even if
+  // they are found in a CUDA include directory.
   // Only CUDA code is migrated, not OpenCL.
-  // Thus CL/opencl.h header must be kept
-  if (FileName == "CL/opencl.h")
+  // Thus CL/* headers must be kept
+  if (FileName.startswith("CL/"))
     return;
   
   // Replace the complete include directive with an empty string.

--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -1089,6 +1089,12 @@ void IncludesCallbacks::InclusionDirective(
     }
   }
 
+  // Always keep include of CL/opencl.h
+  // Only CUDA code is migrated, not OpenCL.
+  // Thus CL/opencl.h header must be kept
+  if (FileName == "CL/opencl.h")
+    return;
+  
   // Replace the complete include directive with an empty string.
   // Also remove the trailing spaces to end of the line.
   TransformSet.emplace_back(new ReplaceInclude(

--- a/clang/test/dpct/opencl.cu
+++ b/clang/test/dpct/opencl.cu
@@ -1,0 +1,34 @@
+// ------ prepare test directory
+// RUN: cd %T
+// RUN: rm -rf opencl-build
+// RUN: mkdir  opencl-build
+// RUN: cd     opencl-build
+// RUN: cp %s opencl.cu
+//
+// ------ run dpct
+// RUN: dpct opencl.cu
+//
+// ------ ensure file inclusion of CL/opencl.h is kept
+// RUN: FileCheck --input-file dpct_output/opencl.dp.cpp --match-full-lines %s
+//
+// ------ cleanup test directory
+// RUN: cd ..
+// RUN: rm -rf ./opencl-build
+
+// CHECK: #include <CL/sycl.hpp>
+// CHECK: #include <dpct/dpct.hpp>
+// CHECK: #include <iostream>
+// CHECK: #include <math.h>
+// CHECK: #include <CL/opencl.h>
+
+#include <iostream>
+#include <math.h>
+#include <CL/opencl.h>
+
+__global__
+void recip( double *x, double *y)
+{
+    int a = *x;
+
+    *y = __drcp_rn(*x);
+}

--- a/clang/test/dpct/opencl.cu
+++ b/clang/test/dpct/opencl.cu
@@ -6,7 +6,7 @@
 // RUN: cp %s opencl.cu
 //
 // ------ run dpct
-// RUN: dpct opencl.cu
+// RUN: dpct opencl.cu --cuda-include-path="%cuda-path/include"
 //
 // ------ ensure file inclusion of CL/opencl.h is kept
 // RUN: FileCheck --input-file dpct_output/opencl.dp.cpp --match-full-lines %s

--- a/clang/test/dpct/opencl.cu
+++ b/clang/test/dpct/opencl.cu
@@ -15,7 +15,7 @@
 // RUN: cd ..
 // RUN: rm -rf ./opencl-build
 
-// CHECK: #include <CL/sycl.hpp>
+// CHECK: #include <sycl/sycl.hpp>
 // CHECK: #include <dpct/dpct.hpp>
 // CHECK: #include <iostream>
 // CHECK: #include <math.h>

--- a/clang/test/dpct/opencl.cu
+++ b/clang/test/dpct/opencl.cu
@@ -19,11 +19,23 @@
 // CHECK: #include <dpct/dpct.hpp>
 // CHECK: #include <iostream>
 // CHECK: #include <math.h>
+// CHECK: #include <CL/cl.h>
+// CHECK: #include <CL/cl_egl.h>
+// CHECK: #include <CL/cl_ext.h>
+// CHECK: #include <CL/cl_gl_ext.h>
+// CHECK: #include <CL/cl_platform.h>
 // CHECK: #include <CL/opencl.h>
 
 #include <iostream>
 #include <math.h>
+#include <CL/cl.h>
+#include <CL/cl_egl.h>
+#include <CL/cl_ext.h>
+#include <CL/cl_gl_ext.h>
+#include <CL/cl_platform.h>
 #include <CL/opencl.h>
+//#include <CL/cl.hpp>          do not test, needs GL/gl.h
+//#include <CL/cl_gl.h>         do not test, needs GL/gl.h
 
 __global__
 void recip( double *x, double *y)


### PR DESCRIPTION
Signed-off-by: Lu, John <john.lu@intel.com>

Do not remove include of CL/opencl.h
Only CUDA code is migrated.  OpenCL code is not, thus the OpenCL
header must be kept.