### PR TITLE
[SYClomatic] Fix migration error of cudaStream_t with initArg 0

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -2596,11 +2596,20 @@ void TypeInDeclRule::processCudaStreamType(const DeclaratorDecl *DD,
           InsertLoc = Tok.getEndLoc().getLocWithOffset(1);
           emplaceTransformation(
               new InsertText(InsertLoc, std::move(PointerType)));
+          if(const auto VD = dyn_cast<clang::VarDecl>(DD)){
+            if(VD->hasInit()){
+              if(const auto VarInitExpr=dyn_cast<InitListExpr>(VD->getInit())){
+                if(getStmtSpelling(VarInitExpr)=="{0}"){
+                  std::string Repl="{&"+MapNames::getDpctNamespace()+"get_default_queue()}";
+                  emplaceTransformation(new ReplaceStmt(VarInitExpr, Repl));
+                }
+              } 
+            }   
+          }
         }
       }
     } else if (Tok.getKind() == tok::raw_identifier &&
                Tok.getRawIdentifier() == "const") {
-
       // const cudaStream_t
       TypeStr = Tok2.getRawIdentifier().str();
       if (Tok.getKind() == tok::raw_identifier && TypeStr == "cudaStream_t") {
@@ -2647,6 +2656,16 @@ void TypeInDeclRule::processCudaStreamType(const DeclaratorDecl *DD,
     auto InsertLoc = L2.getLocWithOffset(P - SM->getCharacterData(L2));
     auto PointerType = deducePointerType(DD2, "CUstream_st");
     emplaceTransformation(new InsertText(InsertLoc, std::move(PointerType)));
+    if(const auto VD = dyn_cast<clang::VarDecl>(DD2)){
+      if(VD->hasInit()){
+        if(const auto VarInitExpr=dyn_cast<InitListExpr>(VD->getInit())){
+          if(getStmtSpelling(VarInitExpr)=="{0}"){
+            std::string Repl="{&"+MapNames::getDpctNamespace()+"get_default_queue()}";
+            emplaceTransformation(new ReplaceStmt(VarInitExpr, Repl));
+          }
+        } 
+      }   
+    }
   }
 }
 

--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -2599,9 +2599,15 @@ void TypeInDeclRule::processCudaStreamType(const DeclaratorDecl *DD,
           if(const auto VD = dyn_cast<clang::VarDecl>(DD)){
             if(VD->hasInit()){
               if(const auto VarInitExpr=dyn_cast<InitListExpr>(VD->getInit())){
-                if(getStmtSpelling(VarInitExpr)=="{0}"){
-                  std::string Repl="{&"+MapNames::getDpctNamespace()+"get_default_queue()}";
-                  emplaceTransformation(new ReplaceStmt(VarInitExpr, Repl));
+                if(VarInitExpr->getNumInits()==1){
+                  Expr::EvalResult ER;
+                  if (VarInitExpr->EvaluateAsInt(ER, dpct::DpctGlobalInfo::getContext())) {
+                    int64_t Value = ER.Val.getInt().getExtValue();
+                    if (Value == 0) {
+                      std::string Repl="{&"+MapNames::getDpctNamespace()+"get_default_queue()}";
+                      emplaceTransformation(new ReplaceStmt(VarInitExpr, Repl));
+                    }
+                  }
                 }
               } 
             }   
@@ -2659,9 +2665,15 @@ void TypeInDeclRule::processCudaStreamType(const DeclaratorDecl *DD,
     if(const auto VD = dyn_cast<clang::VarDecl>(DD2)){
       if(VD->hasInit()){
         if(const auto VarInitExpr=dyn_cast<InitListExpr>(VD->getInit())){
-          if(getStmtSpelling(VarInitExpr)=="{0}"){
-            std::string Repl="{&"+MapNames::getDpctNamespace()+"get_default_queue()}";
-            emplaceTransformation(new ReplaceStmt(VarInitExpr, Repl));
+          if(VarInitExpr->getNumInits()==1){
+            Expr::EvalResult ER;
+            if (VarInitExpr->EvaluateAsInt(ER, dpct::DpctGlobalInfo::getContext())) {
+              int64_t Value = ER.Val.getInt().getExtValue();
+              if (Value == 0) {
+                std::string Repl="{&"+MapNames::getDpctNamespace()+"get_default_queue()}";
+                emplaceTransformation(new ReplaceStmt(VarInitExpr, Repl));
+              }
+            }
           }
         } 
       }   

--- a/clang/test/dpct/cudaStream_test.cu
+++ b/clang/test/dpct/cudaStream_test.cu
@@ -1,0 +1,13 @@
+// RUN: dpct --usm-level=none -out-root %T/cudaStream_test %s --cuda-include-path="%cuda-path/include" --sycl-named-lambda -- -std=c++14 -x cuda --cuda-host-only
+// RUN: FileCheck --input-file %T/cudaStream_test/cudaStream_test.dp.cpp --match-full-lines %s
+
+int main(){
+  // CHECK: sycl::queue *s0, *s1{&dpct::get_default_queue()};
+  cudaStream_t s0, s1{0};
+
+  // CHECK: sycl::queue *s2{&dpct::get_default_queue()};
+  cudaStream_t s2{0};
+
+  // CHECK: s0 = dpct::get_current_device().create_queue();
+  cudaStreamCreate(&s0);
+}


### PR DESCRIPTION
cudaStream_t s{0} should be migrated by using get_default_queue
Signed-off-by: Ni, Wenhui <wenhui.ni@intel.com>