### PR TITLE
[SYCLomatic] Fix the migration of cudaFree and cudaMallocManaged when the input pointer is __managed__ variable

### DIFF
--- a/clang/lib/DPCT/APINamesMemory.inc
+++ b/clang/lib/DPCT/APINamesMemory.inc
@@ -130,16 +130,40 @@ ASSIGNABLE_FACTORY(CONDITIONAL_FACTORY_ENTRY(
 
 ASSIGNABLE_FACTORY(CONDITIONAL_FACTORY_ENTRY(
     CheckCanUseTemplateMalloc(0, 1),
-    ASSIGN_FACTORY_ENTRY("cudaMallocManaged", DEREF(makeDerefArgCreatorWithCall(0)),
-                         CALL(TEMPLATED_CALLEE_WITH_ARGS(
-                                  MapNames::getClNamespace() + "malloc_shared",
-                                  getDoubleDerefedType(0)),
-                              getSizeForMalloc(0, 1), QUEUESTR)),
-    ASSIGN_FACTORY_ENTRY("cudaMallocManaged", DEREF(makeDerefArgCreatorWithCall(0)),
-                         CAST(getDerefedType(0),
-                              CALL(MapNames::getClNamespace() + "malloc_shared",
-                                   getSizeForMalloc(0, 1), QUEUESTR)
-                             ))))
+    CONDITIONAL_FACTORY_ENTRY(
+        hasManagedAttr(0),
+        ASSIGN_FACTORY_ENTRY(
+            "cudaMallocManaged",
+            makeCombinedArg(
+                makeCombinedArg(ARG("*("),
+                                DEREF(makeDerefArgCreatorWithCall(0))),
+                ARG(".get_ptr())")),
+            CALL(TEMPLATED_CALLEE_WITH_ARGS(MapNames::getClNamespace() +
+                                                "malloc_shared",
+                                            getDoubleDerefedType(0)),
+                 getSizeForMalloc(0, 1), QUEUESTR)),
+        ASSIGN_FACTORY_ENTRY(
+            "cudaMallocManaged", DEREF(makeDerefArgCreatorWithCall(0)),
+            CALL(TEMPLATED_CALLEE_WITH_ARGS(MapNames::getClNamespace() +
+                                                "malloc_shared",
+                                            getDoubleDerefedType(0)),
+                 getSizeForMalloc(0, 1), QUEUESTR))),
+    CONDITIONAL_FACTORY_ENTRY(
+        hasManagedAttr(0),
+        ASSIGN_FACTORY_ENTRY(
+            "cudaMallocManaged",
+            makeCombinedArg(
+                makeCombinedArg(ARG("*("),
+                                DEREF(makeDerefArgCreatorWithCall(0))),
+                ARG(".get_ptr())")),
+            CAST(getDerefedType(0),
+                 CALL(MapNames::getClNamespace() + "malloc_shared",
+                      getSizeForMalloc(0, 1), QUEUESTR))),
+        ASSIGN_FACTORY_ENTRY(
+            "cudaMallocManaged", DEREF(makeDerefArgCreatorWithCall(0)),
+            CAST(getDerefedType(0),
+                 CALL(MapNames::getClNamespace() + "malloc_shared",
+                      getSizeForMalloc(0, 1), QUEUESTR))))))
 
 ASSIGNABLE_FACTORY(CONDITIONAL_FACTORY_ENTRY(
     CheckCanUseTemplateMalloc(0, 1),

--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -11373,6 +11373,9 @@ void MemoryMigrationRule::freeMigration(const MatchFinder::MatchResult &Result,
                     AA.getRewritePostfix();
       std::ostringstream Repl;
       buildTempVariableMap(Index, C, HelperFuncType::HFT_DefaultQueue);
+      if (hasManagedAttr(0)(C)) {
+          ArgStr = "*(" + ArgStr + ".get_ptr())";
+      }
       Repl << MapNames::getClNamespace() + "free(" << ArgStr
            << ", {{NEEDREPLACEQ" + std::to_string(Index) + "}})";
       emplaceTransformation(new ReplaceStmt(C, std::move(Repl.str())));

--- a/clang/lib/DPCT/CallExprRewriter.cpp
+++ b/clang/lib/DPCT/CallExprRewriter.cpp
@@ -2722,6 +2722,25 @@ RemoveCubTempStorageFactory::create(const CallExpr *C) const {
   return Inner->create(C);
 }
 
+std::function<bool(const CallExpr *C)> hasManagedAttr(int Idx) {
+  return [=](const CallExpr *C) -> bool {
+    const Expr *Arg = C->getArg(Idx)->IgnoreImpCasts();
+    if (auto CSCE = dyn_cast_or_null<CStyleCastExpr>(Arg)) {
+      Arg = CSCE->getSubExpr();
+    }
+    if (auto UO = dyn_cast_or_null<UnaryOperator>(Arg)) {
+      Arg = UO->getSubExpr();
+    }
+    if (auto ArgDRE = dyn_cast_or_null<DeclRefExpr>(Arg)) {
+      auto D = ArgDRE->getDecl();
+      if (D->hasAttr<HIPManagedAttr>()) {
+        return true;
+      }
+    }
+    return false;
+  };
+}
+
 #define REMOVE_CUB_TEMP_STORAGE_FACTORY(INNER)                                 \
   createRemoveCubTempStorageFactory(INNER 0),
 #define ASSIGNABLE_FACTORY(x) createAssignableFactory(x 0),

--- a/clang/lib/DPCT/CallExprRewriter.h
+++ b/clang/lib/DPCT/CallExprRewriter.h
@@ -739,6 +739,22 @@ public:
   static DerefExpr create(const Expr *E, const CallExpr * C);
 };
 
+template <class StreamT>
+void print(StreamT &Stream,
+           std::pair<const llvm::StringRef, clang::dpct::DerefExpr> Pair) {
+  Stream << Pair.first;
+  ArgumentAnalysis AA;
+  Pair.second.printArg(Stream, AA);
+}
+template <class StreamT>
+void print(StreamT &Stream,
+           std::pair<std::pair<const llvm::StringRef, clang::dpct::DerefExpr>,
+                     const llvm::StringRef>
+               Pair) {
+  print(Stream, Pair.first);
+  Stream << Pair.second;
+}
+
 class RenameWithSuffix {
   StringRef OriginalName, SuffixStr;
 
@@ -1442,6 +1458,8 @@ public:
 
 using CheckIntergerTemplateArgValueNE = CheckIntergerTemplateArgValue<std::not_equal_to<std::int64_t>>;
 using CheckIntergerTemplateArgValueLE = CheckIntergerTemplateArgValue<std::less_equal<std::int64_t>>;
+
+std::function<bool(const CallExpr *C)> hasManagedAttr(int Idx);
 
 } // namespace dpct
 } // namespace clang

--- a/clang/test/dpct/memory_management_restricted.cu
+++ b/clang/test/dpct/memory_management_restricted.cu
@@ -394,3 +394,16 @@ void foo(int a, int b) {
   cudaMalloc((void **)&c[0].Pos1[0], b);
   cudaMalloc((void **)c[0].Pos2, b);
 }
+
+__managed__ char *a1;
+__managed__ char *a2;
+void foo2() {
+  // CHECK: *(a1.get_ptr()) = (char *)sycl::malloc_shared(4, q_ct1);
+  // CHECK-NEXT: *(a2.get_ptr()) = sycl::malloc_shared<char>(1, q_ct1);
+  // CHECK-NEXT: sycl::free(*(a1.get_ptr()), q_ct1);
+  // CHECK-NEXT: sycl::free(*(a2.get_ptr()), q_ct1);
+  cudaMallocManaged((void **)&a1, 4);
+  cudaMallocManaged((void **)&a2, sizeof(char));
+  cudaFree(a1);
+  cudaFree(a2);
+}


### PR DESCRIPTION
Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>