### PR TITLE
[SYCLomatic] Fix get_info in device.hpp to match SYCL 2020 standard (…

### DIFF
--- a/clang/runtime/dpct-rt/include/device.hpp.inc
+++ b/clang/runtime/dpct-rt/include/device.hpp.inc
@@ -562,7 +562,13 @@ public:
     prop.set_minor_version(minor);
 
     prop.set_max_work_item_sizes(
-        get_info<sycl::info::device::max_work_item_sizes>());
+#if (__SYCL_COMPILER_VERSION && __SYCL_COMPILER_VERSION<20220902)
+        // oneAPI DPC++ compiler older than 2022/09/02, where max_work_item_sizes is an enum class element
+        get_info<cl::sycl::info::device::max_work_item_sizes>());
+#else
+        // SYCL 2020-conformant code, max_work_item_sizes is a struct templated by an int
+        get_info<cl::sycl::info::device::max_work_item_sizes<3>>());
+#endif
     prop.set_host_unified_memory(
         get_info<sycl::info::device::host_unified_memory>());
 

--- a/clang/test/dpct/helper_files_ref/include/device.hpp
+++ b/clang/test/dpct/helper_files_ref/include/device.hpp
@@ -229,7 +229,13 @@ public:
     prop.set_minor_version(minor);
 
     prop.set_max_work_item_sizes(
-        get_info<sycl::info::device::max_work_item_sizes>());
+#if (__SYCL_COMPILER_VERSION && __SYCL_COMPILER_VERSION<20220902)
+        // oneAPI DPC++ compiler older than 2022/09/02, where max_work_item_sizes is an enum class element
+        get_info<cl::sycl::info::device::max_work_item_sizes>());
+#else
+        // SYCL 2020-conformant code, max_work_item_sizes is a struct templated by an int
+        get_info<cl::sycl::info::device::max_work_item_sizes<3>>());
+#endif
     prop.set_host_unified_memory(
         get_info<sycl::info::device::host_unified_memory>());
 


### PR DESCRIPTION
…#161)

Signed-off-by: Lu, John <john.lu@intel.com>
Co-authored-by: YuriPlyakhin <yury.plyakhin@intel.com>