### PR TITLE
[SYCLomatic] make max_nd_range_size type compatible with CUDA

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -4041,19 +4041,10 @@ void DeviceInfoVarRule::runRule(const MatchFinder::MatchResult &Result) {
     // migrate to get_XXX() eg. "b=a.minor" to "b=a.get_minor_version()"
     requestFeature(PropToGetFeatureMap.at(MemberName), ME);
     std::string TmplArg = "";
-    if (MemberName == "maxGridSize" || MemberName == "maxThreadsDim") {
-      auto GradParents = Result.Context->getParents(*ICE);
-      if (GradParents.size() > 0 &&
-          !GradParents[0].get<clang::ArraySubscriptExpr>()) {
-        // migrate to get_XXX<int *>() if it's not used in array subscripting
-        // expr.
-        // e.g.
-        // "int *ptr=b.maxGridSize"
-        // => "int *ptr=get_get_max_nd_range_size<int *>()".
-        // "int *ptr=b.maxThreadsDim"
-        // => "int *ptr=get_max_work_item_sizes<int *>()"
-        TmplArg = "<int *>";
-      }
+    if (MemberName == "maxGridSize" ||
+        MemberName == "maxThreadsDim") {
+      // Similar code in ExprAnalysis.cpp
+      TmplArg = "<int *>";
     }
     emplaceTransformation(new RenameFieldInMemberExpr(
         ME, "get_" + Search->second + TmplArg + "()"));

--- a/clang/lib/DPCT/ExprAnalysis.cpp
+++ b/clang/lib/DPCT/ExprAnalysis.cpp
@@ -749,10 +749,17 @@ void ExprAnalysis::analyzeExpr(const MemberExpr *ME) {
         MapNames::findReplacedName(MapNames::Dim3MemberNamesMap,
                                    ME->getMemberNameInfo().getAsString()));
   } else if (BaseType == "cudaDeviceProp") {
-    std::string ReplacementStr = MapNames::findReplacedName(
-        DeviceInfoVarRule::PropNamesMap, ME->getMemberNameInfo().getAsString());
+    auto MemberName = ME->getMemberNameInfo().getAsString();
+
+    std::string ReplacementStr = MapNames::findReplacedName(DeviceInfoVarRule::PropNamesMap, MemberName);
     if (!ReplacementStr.empty()) {
-      addReplacement(ME->getMemberLoc(), "get_" + ReplacementStr + "()");
+      std::string TmplArg = "";
+      if (MemberName == "maxGridSize" ||
+          MemberName == "maxThreadsDim") {
+        // Similar code in ASTTraversal.cpp
+        TmplArg = "<int *>";
+      }
+      addReplacement(ME->getMemberLoc(), "get_" + ReplacementStr + TmplArg + "()");
       requestFeature(
           PropToGetFeatureMap.at(ME->getMemberNameInfo().getAsString()), ME);
     }

--- a/clang/test/dpct/device001.cu
+++ b/clang/test/dpct/device001.cu
@@ -71,7 +71,7 @@ int main(int argc, char **argv) {
   // CHECK:  /*
   // CHECK-NEXT:  DPCT1022:{{[0-9]+}}: There is no exact match between the maxGridSize and the max_nd_range size. Verify the correctness of the code.
   // CHECK-NEXT:  */
-  // CHECK-NEXT:  int maxGridSizeX = deviceProp.get_max_nd_range_size()[0];
+  // CHECK-NEXT:  int maxGridSizeX = deviceProp.get_max_nd_range_size<int *>()[0];
   int maxGridSizeX = deviceProp.maxGridSize[0];
 
   // CHECK:  /*
@@ -156,7 +156,7 @@ void test2() {
 void test3() {
   //CHECK:dpct::device_info deviceProp;
   cudaDeviceProp deviceProp;
-  //CHECK:int a1 = deviceProp.get_max_work_item_sizes()[2];
+  //CHECK:int a1 = deviceProp.get_max_work_item_sizes<int *>()[2];
   int a1 = deviceProp.maxThreadsDim[2];
   //CHECK:int *a1_ptr = deviceProp.get_max_work_item_sizes<int *>();
   int *a1_ptr = deviceProp.maxThreadsDim;
@@ -236,9 +236,9 @@ __device__ void test5() {
     // CHECK:/*
     // CHECK-NEXT:DPCT1022:{{[0-9]+}}: There is no exact match between the maxGridSize and the max_nd_range size. Verify the correctness of the code.
     // CHECK-NEXT:*/
-    // CHECK-NEXT: a = sycl::min(pDeviceProp->get_max_nd_range_size()[0], 1000);
+    // CHECK-NEXT: a = sycl::min(pDeviceProp->get_max_nd_range_size<int *>()[0], 1000);
     a = std::min(pDeviceProp->maxGridSize[0], 1000);
-    //CHECK:a = sycl::min(pDeviceProp->get_max_work_item_sizes()[0], 1000);
+    //CHECK:a = sycl::min(pDeviceProp->get_max_work_item_sizes<int *>()[0], 1000);
     a = std::min(pDeviceProp->maxThreadsDim[0], 1000);
     //CHECK:a = sycl::min(pDeviceProp->get_name()[0], 'A');
     a = std::min(pDeviceProp->name[0], 'A');


### PR DESCRIPTION
Signed-off-by: Lu, John <john.lu@intel.com>

Update SYCLomatic runtime to make the default return type of max_nd_range_size and max_work_item_sizes to be "int *" which
is compatible with CUDA.  This allows max_nd_range_size[X]/max_work_item_sizes[X] to be used in std::max and std::min expressions.