### PR TITLE
[SYCLomatic] Deprecate options --use-custom-helper and --custom-helper-name

### DIFF
--- a/clang/include/clang/DPCT/DPCTOptions.inc
+++ b/clang/include/clang/DPCT/DPCTOptions.inc
@@ -263,7 +263,7 @@ DPCT_ENUM_OPTION(DPCT_OPT_TYPE(static llvm::cl::opt<HelperFilesCustomizationLeve
            llvm::cl::Optional)
 
 DPCT_NON_ENUM_OPTION(DPCT_OPT_TYPE(static llvm::cl::opt<std::string>), CustomHelperFileName, "custom-helper-name",
-        llvm::cl::desc("Specifies the helper headers folder name and main helper header file name.\n"
+        llvm::cl::desc("DEPRECATED: Specifies the helper headers folder name and main helper header file name.\n"
         "Default: dpct."),
         llvm::cl::init("dpct"), llvm::cl::value_desc("name"), llvm::cl::cat(DPCTCat), llvm::cl::Optional)
 

--- a/clang/include/clang/DPCT/DPCTOptions.inc
+++ b/clang/include/clang/DPCT/DPCTOptions.inc
@@ -258,7 +258,7 @@ DPCT_ENUM_OPTION(DPCT_OPT_TYPE(static llvm::cl::opt<HelperFilesCustomizationLeve
             "Generate a complete set of helper header files and place them in the --out-root\n"
             "directory.", false)
            ),
-           llvm::cl::desc("Customize the helper header files for migrated code. The values are:\n"),
+           llvm::cl::desc("DEPRECATED: Customize the helper header files for migrated code. The values are:\n"),
            llvm::cl::init(HelperFilesCustomizationLevel::HFCL_None), llvm::cl::value_desc("value"), llvm::cl::cat(DPCTCat),
            llvm::cl::Optional)
 

--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -954,6 +954,10 @@ int runDPCT(int argc, const char **argv) {
   DpctGlobalInfo::setUsmLevel(USMLevel);
   DpctGlobalInfo::setIsIncMigration(!NoIncrementalMigration);
   DpctGlobalInfo::setHelperFilesCustomizationLevel(UseCustomHelperFileLevel);
+  if (UseCustomHelperFileLevel.getNumOccurrences()) {
+    clang::dpct::PrintMsg("Note: Option --use-custom-helper is deprecated and "
+                          "may be removed in the future.\n");
+  }
   DpctGlobalInfo::setCheckUnicodeSecurityFlag(CheckUnicodeSecurityFlag);
   DpctGlobalInfo::setCustomHelperFileName(CustomHelperFileName);
   HelperFileNameMap[HelperFileEnum::Dpct] =

--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -960,6 +960,10 @@ int runDPCT(int argc, const char **argv) {
   }
   DpctGlobalInfo::setCheckUnicodeSecurityFlag(CheckUnicodeSecurityFlag);
   DpctGlobalInfo::setCustomHelperFileName(CustomHelperFileName);
+  if (CustomHelperFileName.getNumOccurrences()) {
+    clang::dpct::PrintMsg("Note: Option --custom-helper-name is deprecated and "
+                          "may be removed in the future.\n");
+  }
   HelperFileNameMap[HelperFileEnum::Dpct] =
       DpctGlobalInfo::getCustomHelperFileName() + ".hpp";
   DpctGlobalInfo::setFormatRange(FormatRng);


### PR DESCRIPTION
This patch deprecates two options: --use-custom-helper and --custom-helper-name, which embed compatibility header files into the migrated codebase and may be removed in the future.

Signed-off-by: Cui, Dele <dele.cui@intel.com>