### PR TITLE
[SYCLomatic] Refine the migration of 2 CUB API

### DIFF
--- a/clang/lib/DPCT/APINamesCUB.inc
+++ b/clang/lib/DPCT/APINamesCUB.inc
@@ -22,10 +22,10 @@ CONDITIONAL_FACTORY_ENTRY(
                                       QUEUESTR),
                                  ARG(2),
                                  BO(BinaryOperatorKind::BO_Add, ARG(2), ARG(4)),
-                                 CALL(STATIC_MEMBER_EXPR(
+                                 ZERO_INITIALIZER(TYPENAME(STATIC_MEMBER_EXPR(
                                      TEMPLATED_NAME("std::iterator_traits",
                                                     CALL("decltype", ARG(3))),
-                                     LITERAL("value_type")))),
+                                     LITERAL("value_type"))))),
                             LITERAL("1")),
                 false, "wait")))))
 

--- a/clang/lib/DPCT/APINamesCUB.inc
+++ b/clang/lib/DPCT/APINamesCUB.inc
@@ -16,13 +16,17 @@ CONDITIONAL_FACTORY_ENTRY(
             HeaderType::HT_DPL_Algorithm,
             REMOVE_CUB_TEMP_STORAGE_FACTORY(MEMBER_CALL_FACTORY_ENTRY(
                 "cub::DeviceReduce::Sum",
-                MEMBER_CALL(
-                    QUEUESTR, false, "fill", ARG(3),
-                    CALL(
-                        "oneapi::dpl::reduce",
-                        CALL("oneapi::dpl::execution::device_policy", QUEUESTR),
-                        ARG(2), BO(BinaryOperatorKind::BO_Add, ARG(2), ARG(4))),
-                    LITERAL("1")),
+                MEMBER_CALL(QUEUESTR, false, "fill", ARG(3),
+                            CALL("oneapi::dpl::reduce",
+                                 CALL("oneapi::dpl::execution::device_policy",
+                                      QUEUESTR),
+                                 ARG(2),
+                                 BO(BinaryOperatorKind::BO_Add, ARG(2), ARG(4)),
+                                 CALL(STATIC_MEMBER_EXPR(
+                                     TEMPLATED_NAME("std::iterator_traits",
+                                                    CALL("decltype", ARG(3))),
+                                     LITERAL("value_type")))),
+                            LITERAL("1")),
                 false, "wait")))))
 
 // cub::DeviceReduce::Reduce

--- a/clang/lib/DPCT/APINamesCUB.inc
+++ b/clang/lib/DPCT/APINamesCUB.inc
@@ -95,7 +95,11 @@ CONDITIONAL_FACTORY_ENTRY(
                 CALL("oneapi::dpl::exclusive_scan",
                      CALL("oneapi::dpl::execution::device_policy", QUEUESTR),
                      ARG(2), BO(BinaryOperatorKind::BO_Add, ARG(2), ARG(4)),
-                     ARG(3), LITERAL("0")))))))
+                     ARG(3),
+                     ZERO_INITIALIZER(TYPENAME(STATIC_MEMBER_EXPR(
+                         TEMPLATED_NAME("std::iterator_traits",
+                                        CALL("decltype", ARG(2))),
+                         LITERAL("value_type"))))))))))
 
 // cub::DeviceScan::InclusiveSum
 CONDITIONAL_FACTORY_ENTRY(

--- a/clang/lib/DPCT/CallExprRewriter.cpp
+++ b/clang/lib/DPCT/CallExprRewriter.cpp
@@ -1730,6 +1730,13 @@ makeTypenameExprCreator(
                         std::function<SubExprT(const CallExpr *)>>(SubExpr);
 }
 
+template <class SubExprT>
+std::function<ZeroInitializerPrinter<SubExprT>(const CallExpr *)>
+makeZeroInitializerCreator(std::function<SubExprT(const CallExpr *)> SubExpr) {
+  return PrinterCreator<ZeroInitializerPrinter<SubExprT>,
+                        std::function<SubExprT(const CallExpr *)>>(SubExpr);
+}
+
 bool isCallAssigned(const CallExpr *C) { return isAssigned(C); }
 
 template <unsigned int Idx>
@@ -2825,6 +2832,7 @@ std::function<bool(const CallExpr *C)> hasManagedAttr(int Idx) {
                                         DOES_FIRST_LEVEL_POINTER_NEED_CONST)
 #define NEW(...) makeNewExprCreator(__VA_ARGS__)
 #define TYPENAME(SUBEXPR) makeTypenameExprCreator(SUBEXPR)
+#define ZERO_INITIALIZER(SUBEXPR) makeZeroInitializerCreator(SUBEXPR)
 #define SUBGROUP                                                               \
   std::function<SubGroupPrinter(const CallExpr *)>(SubGroupPrinter::create)
 #define NDITEM std::function<ItemPrinter(const CallExpr *)>(ItemPrinter::create)

--- a/clang/lib/DPCT/CallExprRewriter.h
+++ b/clang/lib/DPCT/CallExprRewriter.h
@@ -1039,7 +1039,17 @@ public:
   }
 };
 
-// typename SubExpr
+template <class SubExprT> class ZeroInitializerPrinter {
+  SubExprT SubExpr;
+
+public:
+  ZeroInitializerPrinter(SubExprT &&SubExpr)
+      : SubExpr(std::forward<SubExprT>(SubExpr)) {}
+  template <typename StreamT> void print(StreamT &&Stream) const {
+    dpct::print(Stream, SubExpr);
+    Stream << "{}";
+  }
+};
 
 template <class FirstPrinter, class... RestPrinter>
 class MultiStmtsPrinter : MultiStmtsPrinter<RestPrinter...> {

--- a/clang/test/dpct/cub/devicelevel/device_exclusive_sum.cu
+++ b/clang/test/dpct/cub/devicelevel/device_exclusive_sum.cu
@@ -1,7 +1,7 @@
 // UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2
 // UNSUPPORTED: v8.0, v9.0, v9.1, v9.2, v10.0, v10.1, v10.2
 // RUN: dpct --format-range=none -in-root %S -out-root %T/devicelevel/device_exclusive_sum %S/device_exclusive_sum.cu --cuda-include-path="%cuda-path/include" -- -std=c++14 -x cuda --cuda-host-only
-// RUN: FileCheck --input-file %T/devicelevel/device_exclusive_sum/device_exclusive_sum.dp.cpp --match-full-lines %s
+// RUN: FileCheck --input-file %T/devicelevel/device_exclusive_sum/device_exclusive_sum.dp.cpp %s
 
 // CHECK:#include <oneapi/dpl/execution>
 // CHECK:#include <oneapi/dpl/algorithm>
@@ -9,23 +9,23 @@
 #include <cub/cub.cuh>
 #include <stdio.h>
 
-// void test_1() {
-// dpct::device_ext &dev_ct1 = dpct::get_current_device();
-// sycl::queue &q_ct1 = dev_ct1.default_queue();
-// int n = 10;
-// int *device_in = nullptr;
-// int *device_out = nullptr;
-// int host_in[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-// int host_out[10];
-// device_in = sycl::malloc_device<int>(n, q_ct1);
-// device_out = sycl::malloc_device<int>(n, q_ct1);
-// q_ct1.memcpy(device_in, (void *)host_in, sizeof(host_in)).wait();
-// DPCT1026:{{.*}}
-// oneapi::dpl::exclusive_scan(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, device_out, 0);
-// q_ct1.memcpy((void *)host_out, (void *)device_out, sizeof(host_out)).wait();
-// sycl::free(device_in, q_ct1);
-// sycl::free(device_out, q_ct1);
-// }
+// CHECK:void test_1() {
+// CHECK:dpct::device_ext &dev_ct1 = dpct::get_current_device();
+// CHECK:sycl::queue &q_ct1 = dev_ct1.default_queue();
+// CHECK:int n = 10;
+// CHECK:int *device_in = nullptr;
+// CHECK:int *device_out = nullptr;
+// CHECK:int host_in[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+// CHECK:int host_out[10];
+// CHECK:device_in = sycl::malloc_device<int>(n, q_ct1);
+// CHECK:device_out = sycl::malloc_device<int>(n, q_ct1);
+// CHECK:q_ct1.memcpy(device_in, (void *)host_in, sizeof(host_in)).wait();
+// CHECK:DPCT1026:{{.*}}
+// CHECK:oneapi::dpl::exclusive_scan(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, device_out, 0);
+// CHECK:q_ct1.memcpy((void *)host_out, (void *)device_out, sizeof(host_out)).wait();
+// CHECK:sycl::free(device_in, q_ct1);
+// CHECK:sycl::free(device_out, q_ct1);
+// CHECK:}
 void test_1() {
   int n = 10;
   int *device_in = nullptr;
@@ -46,24 +46,24 @@ void test_1() {
   cudaFree(device_tmp);
 }
 
-// void test_2() {
-// dpct::device_ext &dev_ct1 = dpct::get_current_device();
-// sycl::queue &q_ct1 = dev_ct1.default_queue();
-// int n = 10;
-// int *device_in = nullptr;
-// int *device_out = nullptr;
-// int host_in[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-// int host_out[10];
-// device_in = sycl::malloc_device<int>(n, q_ct1);
-// device_out = sycl::malloc_device<int>(n, q_ct1);
-// q_ct1.memcpy(device_in, (void *)host_in, sizeof(host_in)).wait();
-// DPCT1027:{{.*}}
-// 0, 0;
-// oneapi::dpl::exclusive_scan(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, device_out, 0);
-// q_ct1.memcpy((void *)host_out, (void *)device_out, sizeof(host_out)).wait();
-// sycl::free(device_in, q_ct1);
-// sycl::free(device_out, q_ct1);
-// }
+// CHECK:void test_2() {
+// CHECK:dpct::device_ext &dev_ct1 = dpct::get_current_device();
+// CHECK:sycl::queue &q_ct1 = dev_ct1.default_queue();
+// CHECK:int n = 10;
+// CHECK:int *device_in = nullptr;
+// CHECK:int *device_out = nullptr;
+// CHECK:int host_in[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+// CHECK:int host_out[10];
+// CHECK:device_in = sycl::malloc_device<int>(n, q_ct1);
+// CHECK:device_out = sycl::malloc_device<int>(n, q_ct1);
+// CHECK:q_ct1.memcpy(device_in, (void *)host_in, sizeof(host_in)).wait();
+// CHECK:DPCT1027:{{.*}}
+// CHECK:0, 0;
+// CHECK:oneapi::dpl::exclusive_scan(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, device_out, 0);
+// CHECK:q_ct1.memcpy((void *)host_out, (void *)device_out, sizeof(host_out)).wait();
+// CHECK:sycl::free(device_in, q_ct1);
+// CHECK:sycl::free(device_out, q_ct1);
+// CHECK:}
 void test_2() {
   int n = 10;
   int *device_in = nullptr;

--- a/clang/test/dpct/cub/devicelevel/device_exclusive_sum.cu
+++ b/clang/test/dpct/cub/devicelevel/device_exclusive_sum.cu
@@ -21,7 +21,7 @@
 // CHECK:device_out = sycl::malloc_device<int>(n, q_ct1);
 // CHECK:q_ct1.memcpy(device_in, (void *)host_in, sizeof(host_in)).wait();
 // CHECK:DPCT1026:{{.*}}
-// CHECK:oneapi::dpl::exclusive_scan(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, device_out, 0);
+// CHECK:oneapi::dpl::exclusive_scan(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, device_out, typename std::iterator_traits<decltype(device_in)>::value_type{});
 // CHECK:q_ct1.memcpy((void *)host_out, (void *)device_out, sizeof(host_out)).wait();
 // CHECK:sycl::free(device_in, q_ct1);
 // CHECK:sycl::free(device_out, q_ct1);
@@ -59,7 +59,7 @@ void test_1() {
 // CHECK:q_ct1.memcpy(device_in, (void *)host_in, sizeof(host_in)).wait();
 // CHECK:DPCT1027:{{.*}}
 // CHECK:0, 0;
-// CHECK:oneapi::dpl::exclusive_scan(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, device_out, 0);
+// CHECK:oneapi::dpl::exclusive_scan(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, device_out, typename std::iterator_traits<decltype(device_in)>::value_type{});
 // CHECK:q_ct1.memcpy((void *)host_out, (void *)device_out, sizeof(host_out)).wait();
 // CHECK:sycl::free(device_in, q_ct1);
 // CHECK:sycl::free(device_out, q_ct1);

--- a/clang/test/dpct/cub/devicelevel/device_inclusive_sum.cu
+++ b/clang/test/dpct/cub/devicelevel/device_inclusive_sum.cu
@@ -1,7 +1,7 @@
 // UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2
 // UNSUPPORTED: v8.0, v9.0, v9.1, v9.2, v10.0, v10.1, v10.2
 // RUN: dpct --format-range=none -in-root %S -out-root %T/devicelevel/device_inclusive_sum %S/device_inclusive_sum.cu --cuda-include-path="%cuda-path/include" -- -std=c++14 -x cuda --cuda-host-only
-// RUN: FileCheck --input-file %T/devicelevel/device_inclusive_sum/device_inclusive_sum.dp.cpp --match-full-lines %s
+// RUN: FileCheck --input-file %T/devicelevel/device_inclusive_sum/device_inclusive_sum.dp.cpp %s
 
 // CHECK:#include <oneapi/dpl/execution>
 // CHECK:#include <oneapi/dpl/algorithm>
@@ -46,24 +46,24 @@ void test_1() {
   cudaFree(device_tmp);
 }
 
-// void test_2() {
-// dpct::device_ext &dev_ct1 = dpct::get_current_device();
-// sycl::queue &q_ct1 = dev_ct1.default_queue();
-// int n = 10;
-// int *device_in = nullptr;
-// int *device_out = nullptr;
-// int host_in[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-// int host_out[10];
-// device_in = sycl::malloc_device<int>(n, q_ct1);
-// device_out = sycl::malloc_device<int>(n, q_ct1);
-// q_ct1.memcpy(device_in, (void *)host_in, sizeof(host_in)).wait();
-// DPCT1027:{{.*}}
-// 0, 0;
-// oneapi::dpl::inclusive_scan(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, device_out);
-// q_ct1.memcpy((void *)host_out, (void *)device_out, sizeof(host_out)).wait();
-// sycl::free(device_in, q_ct1);
-// sycl::free(device_out, q_ct1);
-// }
+// CHECK: void test_2() {
+// CHECK: dpct::device_ext &dev_ct1 = dpct::get_current_device();
+// CHECK: sycl::queue &q_ct1 = dev_ct1.default_queue();
+// CHECK: int n = 10;
+// CHECK: int *device_in = nullptr;
+// CHECK: int *device_out = nullptr;
+// CHECK: int host_in[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+// CHECK: int host_out[10];
+// CHECK: device_in = sycl::malloc_device<int>(n, q_ct1);
+// CHECK: device_out = sycl::malloc_device<int>(n, q_ct1);
+// CHECK: q_ct1.memcpy(device_in, (void *)host_in, sizeof(host_in)).wait();
+// CHECK: DPCT1027:{{.*}}
+// CHECK: 0, 0;
+// CHECK: oneapi::dpl::inclusive_scan(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, device_out);
+// CHECK: q_ct1.memcpy((void *)host_out, (void *)device_out, sizeof(host_out)).wait();
+// CHECK: sycl::free(device_in, q_ct1);
+// CHECK: sycl::free(device_out, q_ct1);
+// CHECK: }
 void test_2() {
   int n = 10;
   int *device_in = nullptr;
@@ -75,7 +75,7 @@ void test_2() {
   cudaMalloc((void **)&device_in, n * sizeof(int));
   cudaMalloc((void **)&device_out, n * sizeof(int));
   cudaMemcpy(device_in, (void *)host_in, sizeof(host_in), cudaMemcpyHostToDevice);
-  cub::DeviceScan::InclusiveSum(nullptr, n_device_tmp, device_in, device_out, n),0;
+  cub::DeviceScan::InclusiveSum(nullptr, n_device_tmp, device_in, device_out, n), 0;
   cudaMalloc((void **)&device_tmp, n_device_tmp);
   cub::DeviceScan::InclusiveSum((void *)device_tmp, n_device_tmp, device_in, device_out, n);
   cudaMemcpy((void *)host_out, (void *)device_out, sizeof(host_out), cudaMemcpyDeviceToHost);

--- a/clang/test/dpct/cub/devicelevel/device_reduce_sum.cu
+++ b/clang/test/dpct/cub/devicelevel/device_reduce_sum.cu
@@ -21,7 +21,7 @@
 // CHECK:device_out = sycl::malloc_device<int>(n, q_ct1);
 // CHECK:q_ct1.memcpy(device_in, (void *)host_in, sizeof(host_in)).wait();
 // CHECK:DPCT1026{{.*}}
-// CHECK:q_ct1.fill(device_out, oneapi::dpl::reduce(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n), 1).wait();
+// CHECK:q_ct1.fill(device_out, oneapi::dpl::reduce(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, std::iterator_traits<decltype(device_out)>::value_type()), 1).wait();
 // CHECK:q_ct1.memcpy((void *)host_out, (void *)device_out, sizeof(host_out)).wait();
 // CHECK:sycl::free(device_in, q_ct1);
 // CHECK:sycl::free(device_out, q_ct1);
@@ -62,7 +62,7 @@ void test_1() {
 // CHECK:DPCT1026:{{.*}}
 // CHECK:DPCT1026:{{.*}}
 // CHECK:DPCT1026:{{.*}}
-// CHECK:q_ct1.fill(device_out, oneapi::dpl::reduce(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n), 1).wait();
+// CHECK:q_ct1.fill(device_out, oneapi::dpl::reduce(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, std::iterator_traits<decltype(device_out)>::value_type()), 1).wait();
 // CHECK:q_ct1.memcpy((void *)host_out, (void *)device_out, sizeof(host_out)).wait();
 // CHECK:sycl::free(device_in, q_ct1);
 // CHECK:sycl::free(device_out, q_ct1);
@@ -103,7 +103,7 @@ void test_2() {
 // CHECK:device_out = sycl::malloc_device<int>(n, q_ct1);
 // CHECK:q_ct1.memcpy(device_in, (void *)host_in, sizeof(host_in)).wait();
 // CHECK:DPCT1027{{.*}}
-// CHECK:q_ct1.fill(device_out, oneapi::dpl::reduce(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n), 1).wait();
+// CHECK:q_ct1.fill(device_out, oneapi::dpl::reduce(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, std::iterator_traits<decltype(device_out)>::value_type()), 1).wait();
 // CHECK:q_ct1.memcpy((void *)host_out, (void *)device_out, sizeof(host_out)).wait();
 // CHECK:sycl::free(device_in, q_ct1);
 // CHECK:sycl::free(device_out, q_ct1);

--- a/clang/test/dpct/cub/devicelevel/device_reduce_sum.cu
+++ b/clang/test/dpct/cub/devicelevel/device_reduce_sum.cu
@@ -21,7 +21,7 @@
 // CHECK:device_out = sycl::malloc_device<int>(n, q_ct1);
 // CHECK:q_ct1.memcpy(device_in, (void *)host_in, sizeof(host_in)).wait();
 // CHECK:DPCT1026{{.*}}
-// CHECK:q_ct1.fill(device_out, oneapi::dpl::reduce(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, std::iterator_traits<decltype(device_out)>::value_type()), 1).wait();
+// CHECK:q_ct1.fill(device_out, oneapi::dpl::reduce(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, typename std::iterator_traits<decltype(device_out)>::value_type{}), 1).wait();
 // CHECK:q_ct1.memcpy((void *)host_out, (void *)device_out, sizeof(host_out)).wait();
 // CHECK:sycl::free(device_in, q_ct1);
 // CHECK:sycl::free(device_out, q_ct1);
@@ -62,7 +62,7 @@ void test_1() {
 // CHECK:DPCT1026:{{.*}}
 // CHECK:DPCT1026:{{.*}}
 // CHECK:DPCT1026:{{.*}}
-// CHECK:q_ct1.fill(device_out, oneapi::dpl::reduce(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, std::iterator_traits<decltype(device_out)>::value_type()), 1).wait();
+// CHECK:q_ct1.fill(device_out, oneapi::dpl::reduce(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, typename std::iterator_traits<decltype(device_out)>::value_type{}), 1).wait();
 // CHECK:q_ct1.memcpy((void *)host_out, (void *)device_out, sizeof(host_out)).wait();
 // CHECK:sycl::free(device_in, q_ct1);
 // CHECK:sycl::free(device_out, q_ct1);
@@ -103,7 +103,7 @@ void test_2() {
 // CHECK:device_out = sycl::malloc_device<int>(n, q_ct1);
 // CHECK:q_ct1.memcpy(device_in, (void *)host_in, sizeof(host_in)).wait();
 // CHECK:DPCT1027{{.*}}
-// CHECK:q_ct1.fill(device_out, oneapi::dpl::reduce(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, std::iterator_traits<decltype(device_out)>::value_type()), 1).wait();
+// CHECK:q_ct1.fill(device_out, oneapi::dpl::reduce(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, typename std::iterator_traits<decltype(device_out)>::value_type{}), 1).wait();
 // CHECK:q_ct1.memcpy((void *)host_out, (void *)device_out, sizeof(host_out)).wait();
 // CHECK:sycl::free(device_in, q_ct1);
 // CHECK:sycl::free(device_out, q_ct1);

--- a/clang/test/dpct/cub/devicelevel/redundent_call_with_gnu_ext.cu
+++ b/clang/test/dpct/cub/devicelevel/redundent_call_with_gnu_ext.cu
@@ -25,7 +25,7 @@
 // CHECK:DPCT1026:{{.*}}
 // CHECK:DPCT1026:{{.*}}
 // CHECK:DPCT1026:{{.*}}
-// CHECK:q_ct1.fill(device_out, oneapi::dpl::reduce(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, std::iterator_traits<decltype(device_out)>::value_type()), 1).wait();
+// CHECK:q_ct1.fill(device_out, oneapi::dpl::reduce(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, typename std::iterator_traits<decltype(device_out)>::value_type{}), 1).wait();
 // CHECK:q_ct1.memcpy((void *)host_out, (void *)device_out, sizeof(host_out)).wait();
 // CHECK:sycl::free(device_in, q_ct1);
 // CHECK:sycl::free(device_out, q_ct1);

--- a/clang/test/dpct/cub/devicelevel/redundent_call_with_gnu_ext.cu
+++ b/clang/test/dpct/cub/devicelevel/redundent_call_with_gnu_ext.cu
@@ -25,7 +25,7 @@
 // CHECK:DPCT1026:{{.*}}
 // CHECK:DPCT1026:{{.*}}
 // CHECK:DPCT1026:{{.*}}
-// CHECK:q_ct1.fill(device_out, oneapi::dpl::reduce(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n), 1).wait();
+// CHECK:q_ct1.fill(device_out, oneapi::dpl::reduce(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, std::iterator_traits<decltype(device_out)>::value_type()), 1).wait();
 // CHECK:q_ct1.memcpy((void *)host_out, (void *)device_out, sizeof(host_out)).wait();
 // CHECK:sycl::free(device_in, q_ct1);
 // CHECK:sycl::free(device_out, q_ct1);


### PR DESCRIPTION
# Summary

- Refine the migration of cub::DeviceReduce::Sum
- Refine the migration of cub::DeviceScan::ExclusiveSum

# Detail

##  cub::DeviceReduce::Sum
This bug caused by function template auto deduction, the return type of oneapi::dpl::reduce was deducted to bool, so the return value will always be true or false, but the expected return type is std::type_traits<decltype(d_out)>::value_type

example:

```
template<typename T>
struct NonZeroOp {
    __host__ __device__ __forceinline__ bool operator()(const T& a) const {
      return (a!=T(0));
    }
};

int num_items;  // e.g., 4
int *d_out;     // e.g., [-]
float *d_in;    // e.g., [0.1, 0.2, 0.3, 0.4]
void *d_temp_storage = NULL;
size_t temp_storage_bytes = 0;
cub::TransformInputIterator<bool, NonZeroOp<float>, float *> itr(d_in, NonZeroOp<float>());
cub::DeviceReduce::Sum(d_temp_storage, temp_storage_bytes, itr, d_out, num_items);

// Allocate temporary storage
cudaMalloc(&d_temp_storage, temp_storage_bytes);
cub::DeviceReduce::Sum(d_temp_storage, temp_storage_bytes, itr, d_out, num_items);

// cub::DeviceReduce::Sum will been migrated to 
// q_ct1.fill(device_out, oneapi::dpl::reduce(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n), 1).wait();
// 
// Our expected result in d_out is [4], but got [1] with the migrated SYCL code
//
// The correct migration is:
// q_ct1.fill(device_out, oneapi::dpl::reduce(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, typename std::iterator_traits<decltype(d_out)>::value_type{}), 1).wait();

```

## cub::DeviceScan::ExclusiveSum

This bug caused by function template auto deduction, the 4st arg type of  `oneapi::dpl::exclusive_scan` was deducted to int, so  `oneapi::dpl::exclusive_scan` will use integer value to scan, but if the input/output value type is floating point type, the migrated onedpl code returned an incorrect value.

example:
```
int num_items;  // e.g., 4
float *d_in;    // e.g., [0.1, 0.2, 0.3, 0.4]
float *d_out;   // e.g., [4]
void *d_temp_storage = NULL;
size_t temp_storage_bytes = 0;
cub::DeviceScan::ExclusiveSum(d_temp_storage, temp_storage_bytes, d_in, d_out, 4);
cudaMalloc((void **)&d_temp_storage, temp_storage_bytes);
cub::DeviceScan::ExclusiveSum(d_temp_storage, temp_storage_bytes, d_in, d_out, 4);

// cub::DeviceScan::ExclusiveSum will been migrated to 
// oneapi::dpl::exclusive_scan(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, device_out, 0);
// 
// Our expected result in d_out is [0.0, 0.1, 0.3, 0.6], but got [0.0, 0.0, 0.0, 0.0] with the migrated SYCL code
//
// The correct migration is:
// oneapi::dpl::exclusive_scan(oneapi::dpl::execution::device_policy(q_ct1), device_in, device_in + n, device_out, typename std::iterator_traits<decltype(d_in)>::value_type{});
```


Signed-off-by: Wang, Yihan <yihan.wang@intel.com>