### PR TITLE
[SYCLomatic] Fix incorrect variable name of kernel arg and kernel config

### DIFF
--- a/clang/lib/DPCT/AnalysisInfo.h
+++ b/clang/lib/DPCT/AnalysisInfo.h
@@ -3981,9 +3981,10 @@ private:
           ArgSize =
               MapNames::KernelArgTypeSizeMap.at(KernelArgType::KAT_Default);
       }
-
       if (IsRedeclareRequired || IsPointer || BASE->IsInMacroDefine) {
-        IdString = getTempNameForExpr(Arg, false, true, BASE->IsInMacroDefine);
+        IdString = getTempNameForExpr(Arg, false, true, BASE->IsInMacroDefine,
+                                      Analysis.CallSpellingBegin,
+                                      Analysis.CallSpellingEnd);
       }
     }
 
@@ -4131,6 +4132,9 @@ private:
                                   const Expr *ArgsArray) {}
   void buildArgsInfo(const CallExpr *CE) {
     KernelArgumentAnalysis Analysis(IsInMacroDefine);
+    auto KCallSpellingRange =
+        getTheLastCompleteImmediateRange(CE->getBeginLoc(), CE->getEndLoc());
+    Analysis.setCallSpelling(KCallSpellingRange.first, KCallSpellingRange.second);
     auto &TexList = getTextureObjectList();
 
     for (unsigned Idx = 0; Idx < CE->getNumArgs(); ++Idx) {
@@ -4160,7 +4164,8 @@ private:
   void buildNeedBracesInfo(const CallExpr *KernelCall);
   void buildLocationInfo(const CallExpr *KernelCall);
   template <class ArgsRange>
-  void buildExecutionConfig(const ArgsRange &ConfigArgs);
+  void buildExecutionConfig(const ArgsRange &ConfigArgs,
+                            const CallExpr *KernelCall);
 
   void removeExtraIndent() {
     DpctGlobalInfo::getInstance().addReplacement(

--- a/clang/lib/DPCT/ExprAnalysis.cpp
+++ b/clang/lib/DPCT/ExprAnalysis.cpp
@@ -272,24 +272,48 @@ ExprAnalysis::getOffsetAndLength(SourceLocation BeginLoc, SourceLocation EndLoc,
 
 std::pair<size_t, size_t> ExprAnalysis::getOffsetAndLength(const Expr *E) {
   SourceLocation BeginLoc, EndLoc;
-  // if the parent expr is inside macro and current expr is macro arg expansion,
-  // use the expansion location of the macro arg in the macro definition.
+  size_t End;
+
   if (IsInMacroDefine) {
-    if (SM.isMacroArgExpansion(E->getBeginLoc())) {
-      BeginLoc = SM.getSpellingLoc(
-          SM.getImmediateExpansionRange(E->getBeginLoc()).getBegin());
-      EndLoc = SM.getSpellingLoc(
-          SM.getImmediateExpansionRange(E->getEndLoc()).getEnd());
-    } else {
-      BeginLoc =
-          SM.getExpansionLoc(SM.getImmediateSpellingLoc(E->getBeginLoc()));
-      EndLoc = SM.getExpansionLoc(SM.getImmediateSpellingLoc(E->getEndLoc()));
-      if (isExprStraddle(E)) {
-        auto Range = getTheOneBeforeLastImmediateExapansion(E->getBeginLoc(),
-                                                            E->getEndLoc());
-        BeginLoc = SM.getImmediateSpellingLoc(Range.first);
-        EndLoc = SM.getImmediateSpellingLoc(Range.second);
+    // If the expr is in macro define, and the CallSpellingBegin/End is set,
+    // we can use the CallSpellingBegin/End to get a more precise range.
+    bool RangeInCall = false;
+    if (CallSpellingBegin.isValid() && CallSpellingEnd.isValid()) {
+      auto Range = getRangeInRange(E, CallSpellingBegin, CallSpellingEnd);
+      auto DLBegin = SM.getDecomposedLoc(Range.first);
+      auto DLEnd = SM.getDecomposedLoc(Range.second);
+      if (DLBegin.first == DLEnd.first &&
+          DLBegin.second <= DLEnd.second) {
+        BeginLoc = Range.first;
+        EndLoc = Range.second;
+        End = getOffset(EndLoc);
+        RangeInCall = true;
       }
+    }
+    // In cases like:
+    // #define CCC <<<1,1>>>()
+    // #define KERNEL foo CCC
+    // The getRangeInRange cannot find the correct range,
+    // fallback to use heuristics.
+    if (!RangeInCall) {
+      if (SM.isMacroArgExpansion(E->getBeginLoc())) {
+        BeginLoc = SM.getSpellingLoc(
+            SM.getImmediateExpansionRange(E->getBeginLoc()).getBegin());
+        EndLoc = SM.getSpellingLoc(
+            SM.getImmediateExpansionRange(E->getEndLoc()).getEnd());
+      } else {
+        BeginLoc =
+            SM.getExpansionLoc(SM.getImmediateSpellingLoc(E->getBeginLoc()));
+        EndLoc = SM.getExpansionLoc(SM.getImmediateSpellingLoc(E->getEndLoc()));
+        if (isExprStraddle(E)) {
+          auto Range = getTheOneBeforeLastImmediateExapansion(E->getBeginLoc(),
+                                                              E->getEndLoc());
+          BeginLoc = SM.getImmediateSpellingLoc(Range.first);
+          EndLoc = SM.getImmediateSpellingLoc(Range.second);
+        }
+      }
+      End = getOffset(EndLoc) +
+            Lexer::MeasureTokenLength(EndLoc, SM, Context.getLangOpts());
     }
   } else {
     // If the Expr is FileID or is macro arg
@@ -297,11 +321,8 @@ std::pair<size_t, size_t> ExprAnalysis::getOffsetAndLength(const Expr *E) {
     auto Range = getStmtExpansionSourceRange(E);
     BeginLoc = Range.getBegin();
     EndLoc = Range.getEnd();
+    End = getOffset(EndLoc) + Lexer::MeasureTokenLength(EndLoc, SM, Context.getLangOpts());
   }
-  // Calculate offset and length from SourceLocation
-  auto End = getOffset(EndLoc);
-  auto LastTokenLength =
-      Lexer::MeasureTokenLength(EndLoc, SM, Context.getLangOpts());
 
   // Find the begin/end location include prefix and postfix
   // Set Prefix and Postfix strings
@@ -338,7 +359,7 @@ std::pair<size_t, size_t> ExprAnalysis::getOffsetAndLength(const Expr *E) {
   // The offset of Expr used in ExprAnalysis is related to SrcBegin not
   // FileBegin
   auto Begin = DecompLoc.second - SrcBegin;
-  return std::pair<size_t, size_t>(Begin, End - Begin + LastTokenLength);
+  return std::pair<size_t, size_t>(Begin, End - Begin);
 }
 
 void ExprAnalysis::initExpression(const Expr *Expression) {

--- a/clang/lib/DPCT/ExprAnalysis.cpp
+++ b/clang/lib/DPCT/ExprAnalysis.cpp
@@ -338,7 +338,6 @@ std::pair<size_t, size_t> ExprAnalysis::getOffsetAndLength(const Expr *E) {
 
   ExprBeginLoc = BeginLoc;
   ExprEndLoc = EndLoc;
-
   RewritePrefix =
       std::string(SM.getCharacterData(BeginLoc), RewritePrefixLength);
 
@@ -811,7 +810,6 @@ void ExprAnalysis::analyzeExpr(const ExplicitCastExpr *Cast) {
 void ExprAnalysis::analyzeExpr(const CallExpr *CE) {
   // To set the RefString
   dispatch(CE->getCallee());
-
   // If the callee requires rewrite, get the rewriter
   if (!CallExprRewriterFactoryBase::RewriterMap)
     return;
@@ -855,7 +853,6 @@ void ExprAnalysis::analyzeExpr(const CallExpr *CE) {
                            false, RefString);
         } else {
           FCIMMR[LocStr] = ResultStr;
-
           // When migrating thrust API with usmnone and raw-ptr,
           // the CallExpr will be rewritten into an if-else stmt,
           // DPCT needs to remove the following semicolon.
@@ -1832,6 +1829,7 @@ std::vector<std::string>
 KernelConfigAnalysis::getCtorArgs(const CXXConstructExpr *Ctor) {
   std::vector<std::string> Args;
   ArgumentAnalysis A(IsInMacroDefine);
+  A.setCallSpelling(CallSpellingBegin, CallSpellingEnd);
   for (auto Arg : Ctor->arguments())
     Args.emplace_back(getCtorArg(A, Arg));
   return Args;
@@ -1849,8 +1847,6 @@ void KernelConfigAnalysis::analyze(const Expr *E, unsigned int Idx,
       addReplacement("0");
       return;
     }
-    initArgumentExpr(E);
-    return;
   }
 
   DoReverse = ReverseIfNeed;
@@ -1858,7 +1854,6 @@ void KernelConfigAnalysis::analyze(const Expr *E, unsigned int Idx,
     addReplacement("0");
     return;
   }
-
   ArgumentAnalysis::analyze(E);
 
   if (getTargetExpr()->IgnoreImplicit()->getStmtClass() ==

--- a/clang/lib/DPCT/ExprAnalysis.h
+++ b/clang/lib/DPCT/ExprAnalysis.h
@@ -377,7 +377,8 @@ public:
   std::set<HelperFeatureEnum> getHelperFeatureSet() { return HelperFeatureSet; }
 
   virtual ~ExprAnalysis() = default;
-
+  SourceLocation CallSpellingBegin;
+  SourceLocation CallSpellingEnd;
 private:
   SourceLocation getExprLocation(SourceLocation Loc);
   size_t getOffset(SourceLocation Loc) {
@@ -748,6 +749,11 @@ public:
     CallSpellingEnd = CallSpellingBegin.getLocWithOffset(LocInfo.second);
   }
 
+  inline void setCallSpelling(SourceLocation Begin, SourceLocation End) {
+    CallSpellingBegin = Begin;
+    CallSpellingEnd = End;
+  }
+
   std::string getRewriteString();
 
   std::pair<SourceLocation, SourceLocation> getLocInCallSpelling(const Expr *E);
@@ -770,8 +776,6 @@ protected:
 
 private:
   static const std::string &getDefaultArgument(const Expr *E);
-  SourceLocation CallSpellingBegin;
-  SourceLocation CallSpellingEnd;
   using DefaultArgMapTy = std::map<const Expr *, std::string>;
   static DefaultArgMapTy DefaultArgMap;
 };

--- a/clang/lib/DPCT/Utility.cpp
+++ b/clang/lib/DPCT/Utility.cpp
@@ -1429,12 +1429,13 @@ bool isAssigned(const Stmt *S) {
 /// \return A temporary variable name
 
 std::string getTempNameForExpr(const Expr *E, bool HandleLiteral,
-                               bool KeepLastUnderline, bool IsInMacroDefine) {
+                               bool KeepLastUnderline, bool IsInMacroDefine,
+                               SourceLocation CallBegin, SourceLocation CallEnd) {
   SourceManager &SM = dpct::DpctGlobalInfo::getSourceManager();
   E = E->IgnoreCasts();
-  dpct::ArgumentAnalysis EA(E, IsInMacroDefine);
-  auto TokenBegin = EA.getExprBeginSrcLoc();
-  auto ExprEndLoc = EA.getExprEndSrcLoc();
+  auto Range = getRangeInRange(E, CallBegin, CallEnd);
+  auto TokenBegin = Range.first;
+  auto ExprEndLoc = Range.second;
   std::string IdString;
   llvm::raw_string_ostream OS(IdString);
   Token Tok;
@@ -2554,7 +2555,6 @@ SourceRange getDefinitionRange(SourceLocation Begin, SourceLocation End) {
 
   // if there is still either one of begin/end is macro arg expansion
   if (SM.isMacroArgExpansion(Begin) || SM.isMacroArgExpansion(End)) {
-
     // In cases like CALL(FUNC_NAME CALL(ARGS))
     // If the Begin location is always the 1st token of macro defines,
     // it's safe to use the expansion location as the begin location.

--- a/clang/lib/DPCT/Utility.h
+++ b/clang/lib/DPCT/Utility.h
@@ -417,7 +417,9 @@ bool isAssigned(const clang::Stmt *S);
 
 std::string getTempNameForExpr(const clang::Expr *E, bool HandleLiteral = false,
                                bool KeepLastUnderline = true,
-                               bool IsInMacroDefine = false);
+                               bool IsInMacroDefine = false,
+                               clang::SourceLocation CallBegin = clang::SourceLocation(),
+                               clang::SourceLocation CallEnd = clang::SourceLocation());
 bool isOuterMostMacro(const clang::Stmt *E);
 bool isSameLocation(const clang::SourceLocation L1,
                     const clang::SourceLocation L2);

--- a/clang/test/dpct/macro_test.cu
+++ b/clang/test/dpct/macro_test.cu
@@ -1188,16 +1188,17 @@ int foo31(){
 //CHECK-NEXT: #define VACALL3(...) VACALL4(__VA_ARGS__)
 //CHECK-NEXT: #define VACALL2(...) VACALL3(__VA_ARGS__)
 //CHECK-NEXT: #define VACALL(x)                                                              \
-//CHECK-NEXT:  dpct::get_default_queue().submit([&](sycl::handler &cgh) {                    \
-//CHECK-NEXT:   auto i_ct0 = i;                                                              \
+//CHECK-NEXT:   dpct::get_default_queue().submit([&](sycl::handler &cgh) {                   \
+//CHECK-NEXT:     auto i_ct0 = i;                                                            \
 //CHECK-NEXT:                                                                                \
-//CHECK-NEXT:   cgh.parallel_for(sycl::nd_range<3>(1 * 1, 1),                                \
-//CHECK-NEXT:                    [=](sycl::nd_item<3> item_ct1) { foo32(i_ct0); });          \
-//CHECK-NEXT:  });
+//CHECK-NEXT:     cgh.parallel_for(                                                          \
+//CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, 2), sycl::range<3>(1, 1, 1)),   \
+//CHECK-NEXT:         [=](sycl::nd_item<3> item_ct1) { foo32(i_ct0); });                     \
+//CHECK-NEXT:   });
 #define VACALL4(...) __VA_ARGS__()
 #define VACALL3(...) VACALL4(__VA_ARGS__)
 #define VACALL2(...) VACALL3(__VA_ARGS__)
-#define VACALL(x) foo32<<<1,1,0>>>(i)
+#define VACALL(x) foo32<<<2,1,0>>>(i)
 __global__ void foo32(int a){}
 
 // CHECK: int foo33(){


### PR DESCRIPTION
1. Passing callexpr range to getOffsetAndLength to get preciese location
2. Using getRangeInRange in getTempNameForExpr

Signed-off-by: Huang, Andy <andy.huang@intel.com>