### PR TITLE
[SYCLomatic] Remove the unnecessary type cast in BLAS API migration

### DIFF
--- a/clang/test/dpct/cublas-usm-legacy.cu
+++ b/clang/test/dpct/cublas-usm-legacy.cu
@@ -220,8 +220,8 @@ int main() {
   cublasStrmm('L', 'L', 'N', 'N', n, n, alpha_S, A_S, n, C_S, n);
   //CHECK:oneapi::mkl::blas::column_major::trmm(*dpct::get_current_device().get_saved_queue(), oneapi::mkl::side::left, oneapi::mkl::uplo::lower, oneapi::mkl::transpose::nontrans, oneapi::mkl::diag::nonunit, n, n, alpha_D, A_D, n, C_D, n).wait();
   cublasDtrmm('L', 'L', 'N', 'N', n, n, alpha_D, A_D, n, C_D, n);
-  //CHECK:oneapi::mkl::blas::column_major::trmm(*dpct::get_current_device().get_saved_queue(), oneapi::mkl::side::left, oneapi::mkl::uplo::lower, oneapi::mkl::transpose::nontrans, oneapi::mkl::diag::nonunit, n, n, std::complex<float>(alpha_C.x(),alpha_C.y()), (std::complex<float>*)A_C, n,  (std::complex<float>*)C_C, n).wait();
-  cublasCtrmm('L', 'L', 'N', 'N', n, n, alpha_C, A_C, n, C_C, n);
+  //CHECK:oneapi::mkl::blas::column_major::trmm(*dpct::get_current_device().get_saved_queue(), oneapi::mkl::side::left, oneapi::mkl::uplo::lower, oneapi::mkl::transpose::nontrans, oneapi::mkl::diag::nonunit, n, n, std::complex<float>(alpha_C.x(),alpha_C.y()), (std::complex<float>*)A_S, n,  (std::complex<float>*)C_C, n).wait();
+  cublasCtrmm('L', 'L', 'N', 'N', n, n, alpha_C, (float2*)A_S, n, C_C, n);
   //CHECK:oneapi::mkl::blas::column_major::trmm(*dpct::get_current_device().get_saved_queue(), oneapi::mkl::side::left, oneapi::mkl::uplo::lower, oneapi::mkl::transpose::nontrans, oneapi::mkl::diag::nonunit, n, n, std::complex<double>(alpha_Z.x(),alpha_Z.y()), (std::complex<double>*)A_Z, n,  (std::complex<double>*)C_Z, n).wait();
   cublasZtrmm('L', 'L', 'N', 'N', n, n, alpha_Z, A_Z, n, C_Z, n);
 }

--- a/clang/test/dpct/cublas-usm.cu
+++ b/clang/test/dpct/cublas-usm.cu
@@ -858,3 +858,4 @@ void foo3() {
   cublasCdgmm(handle, CUBLAS_SIDE_LEFT, m, n, (float2*)a_f, lda, x_c, incx, c_c, ldc);
   cublasZdgmm(handle, CUBLAS_SIDE_LEFT, m, n, a_z, lda, x_z, incx, c_z, ldc);
 }
+

--- a/clang/test/dpct/cublas-usm.cu
+++ b/clang/test/dpct/cublas-usm.cu
@@ -851,10 +851,10 @@ void foo3() {
   int m, n, lda, incx, ldc;
   //CHECK:oneapi::mkl::blas::column_major::dgmm_batch(*handle, oneapi::mkl::side::left, m, n, a_f, lda, 0, x_f, incx, 0, c_f, ldc, ldc * n, 1);
   //CHECK-NEXT:oneapi::mkl::blas::column_major::dgmm_batch(*handle, oneapi::mkl::side::left, m, n, a_d, lda, 0, x_d, incx, 0, c_d, ldc, ldc * n, 1);
-  //CHECK-NEXT:oneapi::mkl::blas::column_major::dgmm_batch(*handle, oneapi::mkl::side::left, m, n, (std::complex<float>*)a_c, lda, 0, (std::complex<float>*)x_c, incx, 0, (std::complex<float>*)c_c, ldc, ldc * n, 1);
+  //CHECK-NEXT:oneapi::mkl::blas::column_major::dgmm_batch(*handle, oneapi::mkl::side::left, m, n, (std::complex<float>*)a_f, lda, 0, (std::complex<float>*)x_c, incx, 0, (std::complex<float>*)c_c, ldc, ldc * n, 1);
   //CHECK-NEXT:oneapi::mkl::blas::column_major::dgmm_batch(*handle, oneapi::mkl::side::left, m, n, (std::complex<double>*)a_z, lda, 0, (std::complex<double>*)x_z, incx, 0, (std::complex<double>*)c_z, ldc, ldc * n, 1);
   cublasSdgmm(handle, CUBLAS_SIDE_LEFT, m, n, a_f, lda, x_f, incx, c_f, ldc);
   cublasDdgmm(handle, CUBLAS_SIDE_LEFT, m, n, a_d, lda, x_d, incx, c_d, ldc);
-  cublasCdgmm(handle, CUBLAS_SIDE_LEFT, m, n, a_c, lda, x_c, incx, c_c, ldc);
+  cublasCdgmm(handle, CUBLAS_SIDE_LEFT, m, n, (float2*)a_f, lda, x_c, incx, c_c, ldc);
   cublasZdgmm(handle, CUBLAS_SIDE_LEFT, m, n, a_z, lda, x_z, incx, c_z, ldc);
 }


### PR DESCRIPTION
Original code:
```
foo((float2*)a);
```
Migration before:
```
foo((std::complex<float>*)(sycl::float2*)a);
```
Migration now:
```
foo((std::complex<float>*)a);
```

Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>