### PR TITLE
[SYCLomatic] Fix missing API report entry

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -3011,7 +3011,7 @@ void TypeInDeclRule::runRule(const MatchFinder::MatchResult &Result) {
         if (replaceTemplateSpecialization(SM, LOpts, BeginLoc, TSL)) {
           return;
         }
-      } else if (NTL.getType()->isElaboratedTypeSpecifier()) {
+      } else if (NTL.getTypeLocClass() == clang::TypeLoc::Record) {
         auto TSL = NTL.getUnqualifiedLoc().getAs<RecordTypeLoc>();
 
         const std::string TyName =
@@ -3022,6 +3022,7 @@ void TypeInDeclRule::runRule(const MatchFinder::MatchResult &Result) {
         insertHeaderForTypeRule(TyName, TL->getBeginLoc());
 
         if (!Replacement.empty()) {
+          SrcAPIStaticsMap[TyName]++;
           emplaceTransformation(new ReplaceToken(BeginLoc, TSL.getEndLoc(),
                                                  std::move(Replacement)));
           return;


### PR DESCRIPTION
This PR reverts https://github.com/0x12CC/SYCLomatic/commit/ea05cff4b6ee6e1c32ff5bd84d642351adba6d29 and fixes the API report test failure.