### PR TITLE
[SYCLomatic] Fix constant_iterator: declare __my_value_ as non const

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/iterators.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/iterators.h.inc
@@ -155,7 +155,7 @@ public:
   }
 
 private:
-  const _Tp __my_value_;
+  _Tp __my_value_;
   uint64_t __my_counter_;
 };
 // DPCT_LABEL_END

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/iterators.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/iterators.h
@@ -106,7 +106,7 @@ public:
   }
 
 private:
-  const _Tp __my_value_;
+  _Tp __my_value_;
   uint64_t __my_counter_;
 };
 


### PR DESCRIPTION
Rebases this PR: https://github.com/oneapi-src/SYCLomatic/pull/264.