### PR TITLE
[SYCLomatic #276] Fix deprecated warning that 'strncpy' is deprecated when helper header file "device.hpp" is compiled on Windows

### DIFF
--- a/clang/runtime/dpct-rt/include/device.hpp.inc
+++ b/clang/runtime/dpct-rt/include/device.hpp.inc
@@ -277,7 +277,13 @@ public:
 // Device|device_info
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
-  void set_name(const char *name) { std::strncpy(_name, name, 256); }
+  void set_name(const char *name) {
+#if defined(_MSC_VER) && !defined(__clang__)
+    strncpy_s(_name, 256, name, 255);
+#else
+    std::strncpy(_name, name, 256);
+#endif
+}
 // DPCT_LABEL_END
 // DPCT_LABEL_BEGIN|device_info_set_max_work_item_sizes|dpct
 // DPCT_PARENT_FEATURE|device_info

--- a/clang/runtime/dpct-rt/include/device.hpp.inc
+++ b/clang/runtime/dpct-rt/include/device.hpp.inc
@@ -277,13 +277,15 @@ public:
 // Device|device_info
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
-  void set_name(const char *name) {
-#if defined(_MSC_VER) && !defined(__clang__)
-    strncpy_s(_name, 256, name, 255);
-#else
-    std::strncpy(_name, name, 256);
-#endif
-}
+  void set_name(const char* name) {
+    size_t length = strlen(name);
+    if (length < 256) {
+      std::memcpy(_name, name, length + 1);
+    } else {
+      std::memcpy(_name, name, 255);
+      _name[255] = '\0';
+    }
+  }
 // DPCT_LABEL_END
 // DPCT_LABEL_BEGIN|device_info_set_max_work_item_sizes|dpct
 // DPCT_PARENT_FEATURE|device_info

--- a/clang/test/dpct/helper_files_ref/include/device.hpp
+++ b/clang/test/dpct/helper_files_ref/include/device.hpp
@@ -115,7 +115,13 @@ public:
   size_t get_global_mem_size() const { return _global_mem_size; }
   size_t get_local_mem_size() const { return _local_mem_size; }
   // set interface
-  void set_name(const char *name) { std::strncpy(_name, name, 256); }
+  void set_name(const char *name) {
+#if defined(_MSC_VER) && !defined(__clang__)
+    strncpy_s(_name, 256, name, 255);
+#else
+    std::strncpy(_name, name, 256);
+#endif
+}
   void set_max_work_item_sizes(const sycl::id<3> max_work_item_sizes) {
     _max_work_item_sizes = max_work_item_sizes;
     for (int i = 0; i < 3; ++i)

--- a/clang/test/dpct/helper_files_ref/include/device.hpp
+++ b/clang/test/dpct/helper_files_ref/include/device.hpp
@@ -115,13 +115,15 @@ public:
   size_t get_global_mem_size() const { return _global_mem_size; }
   size_t get_local_mem_size() const { return _local_mem_size; }
   // set interface
-  void set_name(const char *name) {
-#if defined(_MSC_VER) && !defined(__clang__)
-    strncpy_s(_name, 256, name, 255);
-#else
-    std::strncpy(_name, name, 256);
-#endif
-}
+  void set_name(const char* name) {
+    size_t length = strlen(name);
+    if (length < 256) {
+      std::memcpy(_name, name, length + 1);
+    } else {
+      std::memcpy(_name, name, 255);
+      _name[255] = '\0';
+    }
+  }
   void set_max_work_item_sizes(const sycl::id<3> max_work_item_sizes) {
     _max_work_item_sizes = max_work_item_sizes;
     for (int i = 0; i < 3; ++i)


### PR DESCRIPTION

Signed-off-by: chenwei.sun <chenwei.sun@intel.com>