### PR TITLE
[SYCLomatic] Fix the location of closing brace in lib_common_utils.hpp

### DIFF
--- a/clang/runtime/dpct-rt/include/lib_common_utils.hpp.inc
+++ b/clang/runtime/dpct-rt/include/lib_common_utils.hpp.inc
@@ -61,8 +61,8 @@ template <typename T> inline auto get_memory(T *x) {
   return x;
 #endif
 }
-}
 // DPCT_LABEL_END
+}
 // DPCT_LABEL_BEGIN|version_field|dpct
 // DPCT_DEPENDENCY_EMPTY
 // DPCT_CODE


### PR DESCRIPTION
Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>