### PR TITLE
[SYCLomatic] Update the migrated code and helper function to align with SYCL2020

### DIFF
--- a/clang/runtime/dpct-rt/include/device.hpp.inc
+++ b/clang/runtime/dpct-rt/include/device.hpp.inc
@@ -989,7 +989,7 @@ private:
   mutable std::mutex m_mutex;
   dev_mgr() {
     sycl::device default_device =
-        sycl::device(sycl::default_selector{});
+        sycl::device(sycl::default_selector_v);
     _devs.push_back(std::make_shared<device_ext>(default_device));
 
     std::vector<sycl::device> sycl_all_devs =

--- a/clang/runtime/dpct-rt/include/memory.hpp.inc
+++ b/clang/runtime/dpct-rt/include/memory.hpp.inc
@@ -397,9 +397,8 @@ public:
       typename std::conditional<Memory == constant, const T, T>::type;
   using value_t = typename std::remove_cv<T>::type;
   template <size_t Dimension = 1>
-  using accessor_t = std::conditional<
-      Memory == local,
-      sycl::local_accessor<value_t, Dimension>,
+  using accessor_t = typename std::conditional<
+      Memory == local, sycl::local_accessor<value_t, Dimension>,
       sycl::accessor<T, Dimension, mode, target>>::type;
   using pointer_t = T *;
 };

--- a/clang/runtime/dpct-rt/include/memory.hpp.inc
+++ b/clang/runtime/dpct-rt/include/memory.hpp.inc
@@ -386,17 +386,9 @@ private:
 template <class T, memory_region Memory, size_t Dimension> class accessor;
 template <memory_region Memory, class T = byte_t> class memory_traits {
 public:
-  static constexpr sycl::access::address_space asp =
-      (Memory == local)
-          ? sycl::access::address_space::local_space
-          : ((Memory == constant)
-                 ? sycl::access::address_space::constant_space
-                 : sycl::access::address_space::global_space);
   static constexpr sycl::access::target target =
-      (Memory == local)
-          ? sycl::access::target::local
-          : ((Memory == constant) ? sycl::access::target::constant_buffer
-                                  : sycl::access::target::device);
+      (Memory == constant) ? sycl::access::target::constant_buffer
+                           : sycl::access::target::device;
   static constexpr sycl::access_mode mode =
       (Memory == constant) ? sycl::access_mode::read
                            : sycl::access_mode::read_write;
@@ -405,7 +397,10 @@ public:
       typename std::conditional<Memory == constant, const T, T>::type;
   using value_t = typename std::remove_cv<T>::type;
   template <size_t Dimension = 1>
-  using accessor_t = sycl::accessor<T, Dimension, mode, target>;
+  using accessor_t = std::conditional<
+      Memory == local,
+      sycl::local_accessor<value_t, Dimension>,
+      sycl::accessor<T, Dimension, mode, target>>::type;
   using pointer_t = T *;
 };
 // DPCT_LABEL_END

--- a/clang/test/dpct/checkFormatMigrated.cu
+++ b/clang/test/dpct/checkFormatMigrated.cu
@@ -109,7 +109,7 @@ typedef struct
 //CHECK-NEXT:                                 const int loop_trip,
 //CHECK-NEXT:                                 cl::sycl::nd_item<3> item_ct1, float *sp_lj,
 //CHECK-NEXT:                                 float *sp_coul, int *ljd,
-//CHECK-NEXT:                                 cl::sycl::accessor<double, 2, cl::sycl::access_mode::read_write, cl::sycl::access::target::local> la) {
+//CHECK-NEXT:                                 cl::sycl::local_accessor<double, 2> la) {
 template <int EFLAG>
 __global__ void k_mdppp_outer_nn(const int * __restrict__ pos,
                                  const float * __restrict__ q,
@@ -154,7 +154,7 @@ void test() {
 
      //CHECK:void k_mdppp_outer_n0(cl::sycl::nd_item<3> item_ct1, float *sp_lj,
 //CHECK-NEXT:                      float *sp_coul, int *ljd,
-//CHECK-NEXT:                      cl::sycl::accessor<double, 2, cl::sycl::access_mode::read_write, cl::sycl::access::target::local> la) {
+//CHECK-NEXT:                      cl::sycl::local_accessor<double, 2> la) {
 __global__ void k_mdppp_outer_n0() {
   __shared__ float sp_lj[4];
   __shared__ float sp_coul[4];
@@ -166,7 +166,7 @@ __global__ void k_mdppp_outer_n0() {
      //CHECK:void k_mdppp_outer_n1(const int * __restrict__ pos,
 //CHECK-NEXT:                      cl::sycl::nd_item<3> item_ct1, float *sp_lj,
 //CHECK-NEXT:                      float *sp_coul, int *ljd,
-//CHECK-NEXT:                      cl::sycl::accessor<double, 2, cl::sycl::access_mode::read_write, cl::sycl::access::target::local> la) {
+//CHECK-NEXT:                      cl::sycl::local_accessor<double, 2> la) {
 __global__ void k_mdppp_outer_n1(const int * __restrict__ pos) {
   __shared__ float sp_lj[4];
   __shared__ float sp_coul[4];
@@ -181,7 +181,7 @@ __global__ void k_mdppp_outer_n1(const int * __restrict__ pos) {
 //CHECK-NEXT:                                 float *sp_lj,
 //CHECK-NEXT:                                 float *sp_coul,
 //CHECK-NEXT:                                 int *ljd,
-//CHECK-NEXT:                                 cl::sycl::accessor<double, 2, cl::sycl::access_mode::read_write, cl::sycl::access::target::local> la) {
+//CHECK-NEXT:                                 cl::sycl::local_accessor<double, 2> la) {
 __global__ void k_mdppp_outer_22(const int * __restrict__ pos,
                                  const float * __restrict__ q) {
   __shared__ float sp_lj[4];
@@ -195,7 +195,7 @@ __global__ void k_mdppp_outer_22(const int * __restrict__ pos,
      //CHECK:void k_mdppp_outer_n2(const int * __restrict__ pos, const float * __restrict__ q,
 //CHECK-NEXT:                      cl::sycl::nd_item<3> item_ct1, float *sp_lj,
 //CHECK-NEXT:                      float *sp_coul, int *ljd,
-//CHECK-NEXT:                      cl::sycl::accessor<double, 2, cl::sycl::access_mode::read_write, cl::sycl::access::target::local> la) {
+//CHECK-NEXT:                      cl::sycl::local_accessor<double, 2> la) {
 void __device__ k_mdppp_outer_n2(const int * __restrict__ pos, const float * __restrict__ q) {
   __shared__ float sp_lj[4];
   __shared__ float sp_coul[4];
@@ -209,7 +209,7 @@ void __device__ k_mdppp_outer_n2(const int * __restrict__ pos, const float * __r
      //CHECK:void k_mdppp_outer_n3(const int * __restrict__ pos, const float * __restrict__ q,
 //CHECK-NEXT:                      cl::sycl::nd_item<3> item_ct1, float *sp_lj,
 //CHECK-NEXT:                      float *sp_coul, int *ljd,
-//CHECK-NEXT:                      cl::sycl::accessor<double, 2, cl::sycl::access_mode::read_write, cl::sycl::access::target::local> la) {
+//CHECK-NEXT:                      cl::sycl::local_accessor<double, 2> la) {
 __device__
 void k_mdppp_outer_n3(const int * __restrict__ pos, const float * __restrict__ q) {
   __shared__ float sp_lj[4];
@@ -223,8 +223,7 @@ void k_mdppp_outer_n3(const int * __restrict__ pos, const float * __restrict__ q
 #define BBB const float * __restrict__ q
 
      //CHECK:void foo1(AAA, BBB, cl::sycl::nd_item<3> item_ct1, float *sp_lj, float *sp_coul,
-//CHECK-NEXT:          int *ljd,
-//CHECK-NEXT:          cl::sycl::accessor<double, 2, cl::sycl::access_mode::read_write, cl::sycl::access::target::local> la) {
+//CHECK-NEXT:          int *ljd, cl::sycl::local_accessor<double, 2> la) {
 __device__ void foo1(AAA, BBB) {
   __shared__ float sp_lj[4];
   __shared__ float sp_coul[4];
@@ -235,7 +234,7 @@ __device__ void foo1(AAA, BBB) {
 
      //CHECK:void foo2(const int * __restrict__ pos, BBB, cl::sycl::nd_item<3> item_ct1,
 //CHECK-NEXT:          float *sp_lj, float *sp_coul, int *ljd,
-//CHECK-NEXT:          cl::sycl::accessor<double, 2, cl::sycl::access_mode::read_write, cl::sycl::access::target::local> la) {
+//CHECK-NEXT:          cl::sycl::local_accessor<double, 2> la) {
 __device__ void foo2(const int * __restrict__ pos, BBB) {
   __shared__ float sp_lj[4];
   __shared__ float sp_coul[4];
@@ -246,7 +245,7 @@ __device__ void foo2(const int * __restrict__ pos, BBB) {
 
      //CHECK:void foo3(AAA, const float * __restrict__ q, cl::sycl::nd_item<3> item_ct1,
 //CHECK-NEXT:          float *sp_lj, float *sp_coul, int *ljd,
-//CHECK-NEXT:          cl::sycl::accessor<double, 2, cl::sycl::access_mode::read_write, cl::sycl::access::target::local> la) {
+//CHECK-NEXT:          cl::sycl::local_accessor<double, 2> la) {
 __device__ void foo3(AAA, const float * __restrict__ q) {
   __shared__ float sp_lj[4];
   __shared__ float sp_coul[4];
@@ -255,7 +254,7 @@ __device__ void foo3(AAA, const float * __restrict__ q) {
   const int tid = threadIdx.x;
 }
 
-//CHECK:#define FFFFF(aaa,bbb) void foo4(const int * __restrict__ aaa, const float * __restrict__ bbb, cl::sycl::nd_item<3> item_ct1, float *sp_lj, float *sp_coul, int *ljd, cl::sycl::accessor<double, 2, cl::sycl::access_mode::read_write, cl::sycl::access::target::local> la)
+//CHECK:#define FFFFF(aaa,bbb) void foo4(const int * __restrict__ aaa, const float * __restrict__ bbb, cl::sycl::nd_item<3> item_ct1, float *sp_lj, float *sp_coul, int *ljd, cl::sycl::local_accessor<double, 2> la)
 #define FFFFF(aaa,bbb) __device__ void foo4(const int * __restrict__ aaa, const float * __restrict__ bbb)
 
 FFFFF(pos, q)

--- a/clang/test/dpct/comments.cu
+++ b/clang/test/dpct/comments.cu
@@ -44,8 +44,8 @@ int main() {
 // CHECK-NEXT:          auto al_ptr_ct1 = al.get_ptr();
 // CHECK-EMPTY:  
 // CHECK-NEXT:          // accessors to device memory
-// CHECK-NEXT:          sycl::accessor<int, 1, sycl::access_mode::read_write, sycl::access::target::local> cl_acc_ct1(sycl::range<1>(36), cgh);
-// CHECK-NEXT:          sycl::accessor<int, 2, sycl::access_mode::read_write, sycl::access::target::local> bl_acc_ct1(sycl::range<2>(12, 12), cgh);
+// CHECK-NEXT:          sycl::local_accessor<int, 1> cl_acc_ct1(sycl::range<1>(36), cgh);
+// CHECK-NEXT:          sycl::local_accessor<int, 2> bl_acc_ct1(sycl::range<2>(12, 12), cgh);
 // CHECK-NEXT:          auto b_acc_ct1 = b.get_access(cgh);
 // CHECK-EMPTY:  
 // CHECK-NEXT:          // accessors to image objects

--- a/clang/test/dpct/ctad.cu
+++ b/clang/test/dpct/ctad.cu
@@ -86,7 +86,7 @@ int main() {
   dim3 gpu_blocks(1 / (castini.x * 200));
   // CHECK:   q_ct1.submit(
   // CHECK-NEXT:     [&](sycl::handler &cgh) {
-  // CHECK-NEXT:       sycl::accessor<int, 1, sycl::access_mode::read_write, sycl::access::target::local> k_acc_ct1(sycl::range(32), cgh);
+  // CHECK-NEXT:       sycl::local_accessor<int, 1> k_acc_ct1(sycl::range(32), cgh);
   // CHECK-EMPTY:
   // CHECK-NEXT:       cgh.parallel_for<dpct_kernel_name<class kernel_{{[a-f0-9]+}}>>(
   // CHECK-NEXT:         sycl::nd_range(sycl::range(1, 1, 1), sycl::range(1, 1, 1)),
@@ -97,7 +97,7 @@ int main() {
   kernel<<<1, 1>>>(1);
   // CHECK:   q_ct1.submit(
   // CHECK-NEXT:     [&](sycl::handler &cgh) {
-  // CHECK-NEXT:       sycl::accessor<int, 1, sycl::access_mode::read_write, sycl::access::target::local> k_acc_ct1(sycl::range(32), cgh);
+  // CHECK-NEXT:       sycl::local_accessor<int, 1> k_acc_ct1(sycl::range(32), cgh);
   // CHECK-EMPTY:
   // CHECK-NEXT:       cgh.parallel_for<dpct_kernel_name<class kernel_{{[a-f0-9]+}}>>(
   // CHECK-NEXT:         sycl::nd_range(sycl::range(1, 1, NUM) * sycl::range(1, 1, NUM), sycl::range(1, 1, NUM)),

--- a/clang/test/dpct/curand-device.cu
+++ b/clang/test/dpct/curand-device.cu
@@ -76,7 +76,7 @@ int main(int argc, char **argv) {
   int *dOut;
   //CHECK:q_ct1.submit(
   //CHECK-NEXT:  [&](sycl::handler &cgh) {
-  //CHECK-NEXT:    sycl::accessor<int, 1, sycl::access_mode::read_write, sycl::access::target::local> counter_acc_ct1(sycl::range<1>(32/*WARP_SIZE*/), cgh);
+  //CHECK-NEXT:    sycl::local_accessor<int, 1> counter_acc_ct1(sycl::range<1>(32/*WARP_SIZE*/), cgh);
   //CHECK-NEXT:    dpct::access_wrapper<int *> dOut_acc_ct0(dOut, cgh);
   //CHECK-EMPTY:
   //CHECK-NEXT:    cgh.parallel_for(

--- a/clang/test/dpct/formatMigratedExplicitly.cu
+++ b/clang/test/dpct/formatMigratedExplicitly.cu
@@ -107,7 +107,7 @@ typedef struct
 //CHECK-NEXT:                                 const int loop_trip,
 //CHECK-NEXT:                                 cl::sycl::nd_item<3> item_ct1, float *sp_lj,
 //CHECK-NEXT:                                 float *sp_coul, int *ljd,
-//CHECK-NEXT:                                 cl::sycl::accessor<double, 2, cl::sycl::access_mode::read_write, cl::sycl::access::target::local> la) {
+//CHECK-NEXT:                                 cl::sycl::local_accessor<double, 2> la) {
 template <int EFLAG>
 __global__ void k_mdppp_outer_nn(const int * __restrict__ pos,
                                  const float * __restrict__ q,

--- a/clang/test/dpct/formatMigratedGoogle.cu
+++ b/clang/test/dpct/formatMigratedGoogle.cu
@@ -107,7 +107,7 @@ typedef struct
 //CHECK-NEXT:                                 const int loop_trip,
 //CHECK-NEXT:                                 cl::sycl::nd_item<3> item_ct1, float *sp_lj,
 //CHECK-NEXT:                                 float *sp_coul, int *ljd,
-//CHECK-NEXT:                                 cl::sycl::accessor<double, 2, cl::sycl::access_mode::read_write, cl::sycl::access::target::local> la) {
+//CHECK-NEXT:                                 cl::sycl::local_accessor<double, 2> la) {
 template <int EFLAG>
 __global__ void k_mdppp_outer_nn(const int * __restrict__ pos,
                                  const float * __restrict__ q,

--- a/clang/test/dpct/formatMigratedLLVM.cu
+++ b/clang/test/dpct/formatMigratedLLVM.cu
@@ -107,7 +107,7 @@ typedef struct
 //CHECK-NEXT:                                 const int loop_trip,
 //CHECK-NEXT:                                 cl::sycl::nd_item<3> item_ct1, float *sp_lj,
 //CHECK-NEXT:                                 float *sp_coul, int *ljd,
-//CHECK-NEXT:                                 cl::sycl::accessor<double, 2, cl::sycl::access_mode::read_write, cl::sycl::access::target::local> la) {
+//CHECK-NEXT:                                 cl::sycl::local_accessor<double, 2> la) {
 template <int EFLAG>
 __global__ void k_mdppp_outer_nn(const int * __restrict__ pos,
                                  const float * __restrict__ q,

--- a/clang/test/dpct/helper_files_ref/include/device.hpp
+++ b/clang/test/dpct/helper_files_ref/include/device.hpp
@@ -460,7 +460,7 @@ private:
   mutable std::mutex m_mutex;
   dev_mgr() {
     sycl::device default_device =
-        sycl::device(sycl::default_selector{});
+        sycl::device(sycl::default_selector_v);
     _devs.push_back(std::make_shared<device_ext>(default_device));
 
     std::vector<sycl::device> sycl_all_devs =

--- a/clang/test/dpct/helper_files_ref/include/memory.hpp
+++ b/clang/test/dpct/helper_files_ref/include/memory.hpp
@@ -211,9 +211,8 @@ public:
       typename std::conditional<Memory == constant, const T, T>::type;
   using value_t = typename std::remove_cv<T>::type;
   template <size_t Dimension = 1>
-  using accessor_t = std::conditional<
-      Memory == local,
-      sycl::local_accessor<value_t, Dimension>,
+  using accessor_t = typename std::conditional<
+      Memory == local, sycl::local_accessor<value_t, Dimension>,
       sycl::accessor<T, Dimension, mode, target>>::type;
   using pointer_t = T *;
 };

--- a/clang/test/dpct/helper_files_ref/include/memory.hpp
+++ b/clang/test/dpct/helper_files_ref/include/memory.hpp
@@ -200,17 +200,9 @@ private:
 template <class T, memory_region Memory, size_t Dimension> class accessor;
 template <memory_region Memory, class T = byte_t> class memory_traits {
 public:
-  static constexpr sycl::access::address_space asp =
-      (Memory == local)
-          ? sycl::access::address_space::local_space
-          : ((Memory == constant)
-                 ? sycl::access::address_space::constant_space
-                 : sycl::access::address_space::global_space);
   static constexpr sycl::access::target target =
-      (Memory == local)
-          ? sycl::access::target::local
-          : ((Memory == constant) ? sycl::access::target::constant_buffer
-                                  : sycl::access::target::device);
+      (Memory == constant) ? sycl::access::target::constant_buffer
+                           : sycl::access::target::device;
   static constexpr sycl::access_mode mode =
       (Memory == constant) ? sycl::access_mode::read
                            : sycl::access_mode::read_write;
@@ -219,7 +211,10 @@ public:
       typename std::conditional<Memory == constant, const T, T>::type;
   using value_t = typename std::remove_cv<T>::type;
   template <size_t Dimension = 1>
-  using accessor_t = sycl::accessor<T, Dimension, mode, target>;
+  using accessor_t = std::conditional<
+      Memory == local,
+      sycl::local_accessor<value_t, Dimension>,
+      sycl::accessor<T, Dimension, mode, target>>::type;
   using pointer_t = T *;
 };
 

--- a/clang/test/dpct/kernel-call.cu
+++ b/clang/test/dpct/kernel-call.cu
@@ -395,7 +395,7 @@ void run_foo4(dim3 c, dim3 d) {
 //CHECK-NEXT:int run_foo5 () {
 //CHECK-NEXT:  dpct::get_default_queue().submit(
 //CHECK-NEXT:    [&](cl::sycl::handler &cgh) {
-//CHECK-NEXT:      cl::sycl::accessor<float, 1, cl::sycl::access_mode::read_write, cl::sycl::access::target::local> resultInGroup_acc_ct1(cl::sycl::range<1>(8), cgh);
+//CHECK-NEXT:      cl::sycl::local_accessor<float, 1> resultInGroup_acc_ct1(cl::sycl::range<1>(8), cgh);
 //CHECK-NEXT:      dpct::access_wrapper<float *> result_acc_ct0(result.get_ptr(), cgh);
 //CHECK-EMPTY:
 //CHECK-NEXT:      cgh.parallel_for<dpct_kernel_name<class my_kernel_{{[0-9a-z]+}}>>(
@@ -421,7 +421,7 @@ int run_foo5 () {
 //CHECK-NEXT:int run_foo6 () {
 //CHECK-NEXT:  dpct::get_default_queue().submit(
 //CHECK-NEXT:    [&](cl::sycl::handler &cgh) {
-//CHECK-NEXT:      cl::sycl::accessor<float, 1, cl::sycl::access_mode::read_write, cl::sycl::access::target::local> resultInGroup_acc_ct1(cl::sycl::range<1>(8), cgh);
+//CHECK-NEXT:      cl::sycl::local_accessor<float, 1> resultInGroup_acc_ct1(cl::sycl::range<1>(8), cgh);
 //CHECK-NEXT:      dpct::access_wrapper<float *> result2_acc_ct0(result2.get_ptr(), cgh);
 //CHECK-EMPTY:
 //CHECK-NEXT:      cgh.parallel_for<dpct_kernel_name<class my_kernel_{{[0-9a-z]+}}>>(
@@ -442,7 +442,7 @@ int run_foo6 () {
 //CHECK-NEXT:int run_foo7 () {
 //CHECK-NEXT:  dpct::get_default_queue().submit(
 //CHECK-NEXT:    [&](cl::sycl::handler &cgh) {
-//CHECK-NEXT:      cl::sycl::accessor<float, 1, cl::sycl::access_mode::read_write, cl::sycl::access::target::local> resultInGroup_acc_ct1(cl::sycl::range<1>(8), cgh);
+//CHECK-NEXT:      cl::sycl::local_accessor<float, 1> resultInGroup_acc_ct1(cl::sycl::range<1>(8), cgh);
 //CHECK-NEXT:      dpct::access_wrapper<float *> result3_acc_ct0(result3.get_ptr(), cgh);
 //CHECK-EMPTY:
 //CHECK-NEXT:      cgh.parallel_for<dpct_kernel_name<class my_kernel_{{[0-9a-z]+}}>>(
@@ -574,7 +574,7 @@ int run_foo9() {
 //CHECK-NEXT:int run_foo10() {
 //CHECK-NEXT: dpct::get_default_queue().submit(
 //CHECK-NEXT:   [&](cl::sycl::handler &cgh) {
-//CHECK-NEXT:     cl::sycl::accessor<float *, 1, cl::sycl::access_mode::read_write, cl::sycl::access::target::local> afn_s_acc_ct1(cl::sycl::range<1>(3), cgh);
+//CHECK-NEXT:     cl::sycl::local_accessor<float *, 1> afn_s_acc_ct1(cl::sycl::range<1>(3), cgh);
 //CHECK-EMPTY:
 //CHECK-NEXT:     cgh.parallel_for<dpct_kernel_name<class cuda_pme_forces_dev_{{[0-9a-z]+}}>>(
 //CHECK-NEXT:       cl::sycl::nd_range<3>(cl::sycl::range<3>(1, 1, 1), cl::sycl::range<3>(1, 1, 1)),
@@ -638,9 +638,9 @@ __global__ void kernel_ctor() {
 void test_ctor() {
   // CHECK: dpct::get_default_queue().submit(
   // CHECK-NEXT:   [&](cl::sycl::handler &cgh) {
-  // CHECK-NEXT:     cl::sycl::accessor<int, 1, cl::sycl::access_mode::read_write, cl::sycl::access::target::local> s1_acc_ct1(cl::sycl::range<1>(10), cgh);
-  // CHECK-NEXT:     cl::sycl::accessor<float, 0, cl::sycl::access_mode::read_write, cl::sycl::access::target::local> s2_acc_ct1(cgh);
-  // CHECK-NEXT:     cl::sycl::accessor<float, 0, cl::sycl::access_mode::read_write, cl::sycl::access::target::local> s3_acc_ct1(cgh);
+  // CHECK-NEXT:     cl::sycl::local_accessor<int, 1> s1_acc_ct1(cl::sycl::range<1>(10), cgh);
+  // CHECK-NEXT:     cl::sycl::local_accessor<float, 0> s2_acc_ct1(cgh);
+  // CHECK-NEXT:     cl::sycl::local_accessor<float, 0> s3_acc_ct1(cgh);
   // CHECK-EMPTY:
   // CHECK-NEXT:     cgh.parallel_for<dpct_kernel_name<class kernel_ctor_{{[0-9a-z]+}}>>(
   // CHECK-NEXT:       cl::sycl::nd_range<3>(cl::sycl::range<3>(1, 1, 1), cl::sycl::range<3>(1, 1, 1)),
@@ -670,11 +670,11 @@ void test_ctor() {
 //CHECK-NEXT:      /*
 //CHECK-NEXT:      DPCT1054:{{[0-9]+}}: The type of variable temp is declared in device function with the name type_ct1. Adjust the code to make the type_ct1 declaration visible at the accessor declaration point.
 //CHECK-NEXT:      */
-//CHECK-NEXT:      cl::sycl::accessor<uint8_t[sizeof(type_ct1)], 0, cl::sycl::access_mode::read_write, cl::sycl::access::target::local> temp_ct1_acc_ct1(cgh);
+//CHECK-NEXT:      cl::sycl::local_accessor<uint8_t[sizeof(type_ct1)], 0> temp_ct1_acc_ct1(cgh);
 //CHECK-NEXT:      /*
 //CHECK-NEXT:      DPCT1054:{{[0-9]+}}: The type of variable temp2 is declared in device function with the name type_ct1. Adjust the code to make the type_ct1 declaration visible at the accessor declaration point.
 //CHECK-NEXT:      */
-//CHECK-NEXT:      cl::sycl::accessor<uint8_t[sizeof(type_ct1)], 0, cl::sycl::access_mode::read_write, cl::sycl::access::target::local> temp2_ct1_acc_ct1(cgh);
+//CHECK-NEXT:      cl::sycl::local_accessor<uint8_t[sizeof(type_ct1)], 0> temp2_ct1_acc_ct1(cgh);
 //CHECK-EMPTY:
 //CHECK-NEXT:      cgh.parallel_for<dpct_kernel_name<class k11_{{[0-9a-z]+}}, TT>>(
 //CHECK-NEXT:        cl::sycl::nd_range<3>(cl::sycl::range<3>(1, 1, 1), cl::sycl::range<3>(1, 1, 1)),
@@ -719,11 +719,11 @@ void foo11() {
 //CHECK-NEXT:      /*
 //CHECK-NEXT:      DPCT1054:{{[0-9]+}}: The type of variable temp is declared in device function with the name UnionType. Adjust the code to make the UnionType declaration visible at the accessor declaration point.
 //CHECK-NEXT:      */
-//CHECK-NEXT:      cl::sycl::accessor<uint8_t[sizeof(UnionType)], 0, cl::sycl::access_mode::read_write, cl::sycl::access::target::local> temp_ct1_acc_ct1(cgh);
+//CHECK-NEXT:      cl::sycl::local_accessor<uint8_t[sizeof(UnionType)], 0> temp_ct1_acc_ct1(cgh);
 //CHECK-NEXT:      /*
 //CHECK-NEXT:      DPCT1054:{{[0-9]+}}: The type of variable temp2 is declared in device function with the name type_ct2. Adjust the code to make the type_ct2 declaration visible at the accessor declaration point.
 //CHECK-NEXT:      */
-//CHECK-NEXT:      cl::sycl::accessor<uint8_t[sizeof(type_ct2)], 0, cl::sycl::access_mode::read_write, cl::sycl::access::target::local> temp2_ct1_acc_ct1(cgh);
+//CHECK-NEXT:      cl::sycl::local_accessor<uint8_t[sizeof(type_ct2)], 0> temp2_ct1_acc_ct1(cgh);
 //CHECK-EMPTY:
 //CHECK-NEXT:      cgh.parallel_for<dpct_kernel_name<class k12_{{[0-9a-z]+}}, TT>>(
 //CHECK-NEXT:        cl::sycl::nd_range<3>(cl::sycl::range<3>(1, 1, 1), cl::sycl::range<3>(1, 1, 1)),
@@ -793,7 +793,7 @@ void run_foo13(float* a_host[]) {
   //CHECK-NEXT:*/
   //CHECK-NEXT:dpct::get_default_queue().submit(
   //CHECK-NEXT:  [&](cl::sycl::handler &cgh) {
-  //CHECK-NEXT:    cl::sycl::accessor<float *, 0, cl::sycl::access_mode::read_write, cl::sycl::access::target::local> aa_acc_ct1(cgh);
+  //CHECK-NEXT:    cl::sycl::local_accessor<float *, 0> aa_acc_ct1(cgh);
   //CHECK-NEXT:    dpct::access_wrapper<float **> a_host_acc_ct0(a_host, cgh);
   //CHECK-EMPTY:
   //CHECK-NEXT:    cgh.parallel_for<dpct_kernel_name<class my_kernel5_{{[0-9a-z]+}}, float>>(

--- a/clang/test/dpct/kernel-usm.cu
+++ b/clang/test/dpct/kernel-usm.cu
@@ -51,7 +51,7 @@ int main() {
 // CHECK-NEXT:int run_foo5 () {
 // CHECK-NEXT:  dpct::get_default_queue().submit(
 // CHECK-NEXT:    [&](sycl::handler &cgh) {
-// CHECK-NEXT:      sycl::accessor<float, 1, sycl::access_mode::read_write, sycl::access::target::local> resultInGroup_acc_ct1(sycl::range<1>(8), cgh);
+// CHECK-NEXT:      sycl::local_accessor<float, 1> resultInGroup_acc_ct1(sycl::range<1>(8), cgh);
 // CHECK-EMPTY:
 // CHECK-NEXT:      auto result_ct0 = result.get_ptr();
 // CHECK-EMPTY:
@@ -78,7 +78,7 @@ int run_foo5 () {
 // CHECK-NEXT:int run_foo6 () {
 // CHECK-NEXT:  dpct::get_default_queue().submit(
 // CHECK-NEXT:    [&](sycl::handler &cgh) {
-// CHECK-NEXT:      sycl::accessor<float, 1, sycl::access_mode::read_write, sycl::access::target::local> resultInGroup_acc_ct1(sycl::range<1>(8), cgh);
+// CHECK-NEXT:      sycl::local_accessor<float, 1> resultInGroup_acc_ct1(sycl::range<1>(8), cgh);
 // CHECK-EMPTY:
 // CHECK-NEXT:      auto result2_ct0 = result2.get_ptr();
 // CHECK-EMPTY:
@@ -100,7 +100,7 @@ int run_foo6 () {
 // CHECK-NEXT:int run_foo7 () {
 // CHECK-NEXT:  dpct::get_default_queue().submit(
 // CHECK-NEXT:    [&](sycl::handler &cgh) {
-// CHECK-NEXT:      sycl::accessor<float, 1, sycl::access_mode::read_write, sycl::access::target::local> resultInGroup_acc_ct1(sycl::range<1>(8), cgh);
+// CHECK-NEXT:      sycl::local_accessor<float, 1> resultInGroup_acc_ct1(sycl::range<1>(8), cgh);
 // CHECK-EMPTY:
 // CHECK-NEXT:      auto result3_ct0 = result3.get_ptr();
 // CHECK-EMPTY:
@@ -201,7 +201,7 @@ int run_foo9() {
 // CHECK-NEXT:int run_foo10() {
 // CHECK-NEXT: dpct::get_default_queue().submit(
 // CHECK-NEXT:   [&](sycl::handler &cgh) {
-// CHECK-NEXT:     sycl::accessor<float *, 1, sycl::access_mode::read_write, sycl::access::target::local> afn_s_acc_ct1(sycl::range<1>(3), cgh);
+// CHECK-NEXT:     sycl::local_accessor<float *, 1> afn_s_acc_ct1(sycl::range<1>(3), cgh);
 // CHECK-EMPTY:
 // CHECK-NEXT:     cgh.parallel_for<dpct_kernel_name<class cuda_pme_forces_dev_{{[0-9a-z]+}}>>(
 // CHECK-NEXT:       sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -297,7 +297,7 @@ __global__ void my_kernel5(T** a_dev){
 void run_foo13(float* a_host[]) {
   //CHECK:dpct::get_default_queue().submit(
   //CHECK-NEXT:  [&](sycl::handler &cgh) {
-  //CHECK-NEXT:    sycl::accessor<float *, 0, sycl::access_mode::read_write, sycl::access::target::local> aa_acc_ct1(cgh);
+  //CHECK-NEXT:    sycl::local_accessor<float *, 0> aa_acc_ct1(cgh);
   //CHECK-EMPTY:
   //CHECK-NEXT:    cgh.parallel_for<dpct_kernel_name<class my_kernel5_{{[0-9a-z]+}}, float>>(
   //CHECK-NEXT:      sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),

--- a/clang/test/dpct/launch-kernel-cooperative-usm.cu
+++ b/clang/test/dpct/launch-kernel-cooperative-usm.cu
@@ -66,8 +66,8 @@ int main() {
 
   // CHECK: stream->submit(
   // CHECK-NEXT:  [&](sycl::handler &cgh) {
-  // CHECK-NEXT:    sycl::accessor<uint8_t, 1, sycl::access_mode::read_write, sycl::access::target::local> dpct_local_acc_ct1(sycl::range<1>(32), cgh);
-  // CHECK-NEXT:    sycl::accessor<int, 1, sycl::access_mode::read_write, sycl::access::target::local> s_acc_ct1(sycl::range<1>(16), cgh);
+  // CHECK-NEXT:    sycl::local_accessor<uint8_t, 1> dpct_local_acc_ct1(sycl::range<1>(32), cgh);
+  // CHECK-NEXT:    sycl::local_accessor<int, 1> s_acc_ct1(sycl::range<1>(16), cgh);
   // CHECK-EMPTY:
   // CHECK-NEXT:    auto d_ct0 = *(int **)args[0];
   // CHECK-EMPTY:

--- a/clang/test/dpct/launch-kernel-cooperative.cu
+++ b/clang/test/dpct/launch-kernel-cooperative.cu
@@ -66,8 +66,8 @@ int main() {
 
   // CHECK: stream->submit(
   // CHECK-NEXT:   [&](sycl::handler &cgh) {
-  // CHECK-NEXT:     sycl::accessor<uint8_t, 1, sycl::access_mode::read_write, sycl::access::target::local> dpct_local_acc_ct1(sycl::range<1>(32), cgh);
-  // CHECK-NEXT:     sycl::accessor<int, 1, sycl::access_mode::read_write, sycl::access::target::local> s_acc_ct1(sycl::range<1>(16), cgh);
+  // CHECK-NEXT:     sycl::local_accessor<uint8_t, 1> dpct_local_acc_ct1(sycl::range<1>(32), cgh);
+  // CHECK-NEXT:     sycl::local_accessor<int, 1> s_acc_ct1(sycl::range<1>(16), cgh);
   // CHECK-NEXT:     dpct::access_wrapper<int *> d_acc_ct0(*(int **)args[0], cgh);
   // CHECK-EMPTY:
   // CHECK-NEXT:     cgh.parallel_for(

--- a/clang/test/dpct/launch-kernel-usm.cu
+++ b/clang/test/dpct/launch-kernel-usm.cu
@@ -63,8 +63,8 @@ int main() {
   cudaStreamCreate(&stream);
   // CHECK: stream->submit(
   // CHECK-NEXT:  [&](sycl::handler &cgh) {
-  // CHECK-NEXT:    sycl::accessor<uint8_t, 1, sycl::access_mode::read_write, sycl::access::target::local> dpct_local_acc_ct1(sycl::range<1>(32), cgh);
-  // CHECK-NEXT:    sycl::accessor<int, 1, sycl::access_mode::read_write, sycl::access::target::local> s_acc_ct1(sycl::range<1>(16), cgh);
+  // CHECK-NEXT:    sycl::local_accessor<uint8_t, 1> dpct_local_acc_ct1(sycl::range<1>(32), cgh);
+  // CHECK-NEXT:    sycl::local_accessor<int, 1> s_acc_ct1(sycl::range<1>(16), cgh);
   // CHECK-EMPTY:
   // CHECK-NEXT:    auto d_ct0 = *(int **)args[0];
   // CHECK-EMPTY:

--- a/clang/test/dpct/launch-kernel.cu
+++ b/clang/test/dpct/launch-kernel.cu
@@ -64,8 +64,8 @@ int main() {
 
   // CHECK: stream->submit(
   // CHECK-NEXT:   [&](sycl::handler &cgh) {
-  // CHECK-NEXT:     sycl::accessor<uint8_t, 1, sycl::access_mode::read_write, sycl::access::target::local> dpct_local_acc_ct1(sycl::range<1>(32), cgh);
-  // CHECK-NEXT:     sycl::accessor<int, 1, sycl::access_mode::read_write, sycl::access::target::local> s_acc_ct1(sycl::range<1>(16), cgh);
+  // CHECK-NEXT:     sycl::local_accessor<uint8_t, 1> dpct_local_acc_ct1(sycl::range<1>(32), cgh);
+  // CHECK-NEXT:     sycl::local_accessor<int, 1> s_acc_ct1(sycl::range<1>(16), cgh);
   // CHECK-NEXT:     dpct::access_wrapper<int *> d_acc_ct0(*(int **)args[0], cgh);
   // CHECK-EMPTY:
   // CHECK-NEXT:     cgh.parallel_for(

--- a/clang/test/dpct/macro_test.cu
+++ b/clang/test/dpct/macro_test.cu
@@ -365,17 +365,17 @@ void bar() {
 #define AAA int *a
 #define BBB int *BB
 
-// CHECK: #define CCC AAA, float *sp_lj, float *sp_coul, int *ljd, sycl::accessor<double, 2, sycl::access_mode::read_write, sycl::access::target::local> la, int *b=0
+// CHECK: #define CCC AAA, float *sp_lj, float *sp_coul, int *ljd, sycl::local_accessor<double, 2> la, int *b=0
 // CHECK-NEXT: #define CC AAA, BBB
 #define CCC AAA, int *b=0
 #define CC AAA, BBB
 
 // CHECK: #define CCCC(x) void fooc(x)
-// CHECK-NEXT: #define CCCCC(x) void foocc(x, float *sp_lj, float *sp_coul, int *ljd, sycl::accessor<double, 2, sycl::access_mode::read_write, sycl::access::target::local> la)
+// CHECK-NEXT: #define CCCCC(x) void foocc(x, float *sp_lj, float *sp_coul, int *ljd, sycl::local_accessor<double, 2> la)
 #define CCCC(x) __device__ void fooc(x)
 #define CCCCC(x) __device__ void foocc(x)
 
-// CHECK: #define XX(x) void foox(x, float *sp_lj, float *sp_coul, int *ljd, sycl::accessor<double, 2, sycl::access_mode::read_write, sycl::access::target::local> la)
+// CHECK: #define XX(x) void foox(x, float *sp_lj, float *sp_coul, int *ljd, sycl::local_accessor<double, 2> la)
 // CHECK-NEXT: #define FF XX(CC)
 #define XX(x) __device__ void foox(x)
 #define FF XX(CC)
@@ -414,7 +414,7 @@ CCCC(CCC)
   __shared__ double la[8][0];
 }
 
-// CHECK: #define FFF void foo(AAA, BBB, float *sp_lj, float *sp_coul, int *ljd, sycl::accessor<double, 2, sycl::access_mode::read_write, sycl::access::target::local> la)
+// CHECK: #define FFF void foo(AAA, BBB, float *sp_lj, float *sp_coul, int *ljd, sycl::local_accessor<double, 2> la)
 #define FFF __device__ void foo(AAA, BBB)
 
 // CHECK: FFF
@@ -429,7 +429,7 @@ FFF
 
 }
 
-// CHECK: #define FFFFF(aaa,bbb) void foo4(const int * __restrict__ aaa, const float * __restrict__ bbb, int *c, BBB, sycl::nd_item<3> item_ct1, float *sp_lj, float *sp_coul, int *ljd, sycl::accessor<double, 2, sycl::access_mode::read_write, sycl::access::target::local> la)
+// CHECK: #define FFFFF(aaa,bbb) void foo4(const int * __restrict__ aaa, const float * __restrict__ bbb, int *c, BBB, sycl::nd_item<3> item_ct1, float *sp_lj, float *sp_coul, int *ljd, sycl::local_accessor<double, 2> la)
 #define FFFFF(aaa,bbb) __device__ void foo4(const int * __restrict__ aaa, const float * __restrict__ bbb, int *c, BBB)
 
 // CHECK: FFFFF(pos, q)
@@ -446,7 +446,7 @@ FFFFF(pos, q)
   const int tid = threadIdx.x;
 }
 
-// CHECK: #define FFFFFF(aaa,bbb) void foo5(const int * __restrict__ aaa, const float * __restrict__ bbb, sycl::nd_item<3> item_ct1, float *sp_lj, float *sp_coul, int *ljd, sycl::accessor<double, 2, sycl::access_mode::read_write, sycl::access::target::local> la)
+// CHECK: #define FFFFFF(aaa,bbb) void foo5(const int * __restrict__ aaa, const float * __restrict__ bbb, sycl::nd_item<3> item_ct1, float *sp_lj, float *sp_coul, int *ljd, sycl::local_accessor<double, 2> la)
 #define FFFFFF(aaa,bbb) __device__ void foo5(const int * __restrict__ aaa, const float * __restrict__ bbb)
 
 // CHECK: FFFFFF(pos, q)
@@ -464,7 +464,7 @@ FFFFFF(pos, q)
 }
 
 // CHECK: void foo6(AAA, BBB, float *sp_lj, float *sp_coul, int *ljd,
-// CHECK-NEXT:   sycl::accessor<double, 2, sycl::access_mode::read_write, sycl::access::target::local> la)
+// CHECK-NEXT:   sycl::local_accessor<double, 2> la)
 // CHECK-NEXT: {
 // CHECK-NEXT: }
 __device__ void foo6(AAA, BBB)
@@ -1122,7 +1122,7 @@ void foo28(){
 #define local_allocate_store_charge()                                       \
     __shared__ double red_acc[8][BLOCK_PAIR / SIMD_SIZE];
 
-//CHECK: void foo29(sycl::accessor<double, 2, sycl::access_mode::read_write, sycl::access::target::local> red_acc) {
+//CHECK: void foo29(sycl::local_accessor<double, 2> red_acc) {
 //CHECK-NEXT: }
 __global__ void foo29() {
   local_allocate_store_charge();
@@ -1139,10 +1139,8 @@ template<class T1, class T2, int N> __global__ void foo31();
 #define FOO31(DIMS) foo31<unsigned int, float, DIMS><<<1,1>>>();
 
 //CHECK:   q_ct1.submit([&](sycl::handler &cgh) {
-//CHECK-NEXT:     sycl::accessor<double, 2, sycl::access_mode::read_write,
-//CHECK-NEXT:                    sycl::access::target::local>
-//CHECK-NEXT:         red_acc_acc_ct1(sycl::range<2>(8 /*8*/, 8 /*BLOCK_PAIR / SIMD_SIZE*/),
-//CHECK-NEXT:                         cgh);
+//CHECK-NEXT:     sycl::local_accessor<double, 2> red_acc_acc_ct1(
+//CHECK-NEXT:         sycl::range<2>(8 /*8*/, 8 /*BLOCK_PAIR / SIMD_SIZE*/), cgh);
 
 //CHECK:     cgh.parallel_for(
 //CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -1170,9 +1168,7 @@ __global__ void template_kernel(T t){
 int foo31(){
   //CHECK: VA_CALL(([&] {
   //CHECK-NEXT:   dpct::get_default_queue().submit([&](sycl::handler &cgh) {
-  //CHECK-NEXT:     sycl::accessor<int, 0, sycl::access_mode::read_write,
-  //CHECK-NEXT:                    sycl::access::target::local>
-  //CHECK-NEXT:         t2_acc_ct1(cgh);
+  //CHECK-NEXT:     sycl::local_accessor<int, 0> t2_acc_ct1(cgh);
   //CHECK:     cgh.parallel_for(
   //CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
   //CHECK-NEXT:         [=](sycl::nd_item<3> item_ct1) {

--- a/clang/test/dpct/mf-test.cu
+++ b/clang/test/dpct/mf-test.cu
@@ -50,7 +50,7 @@ void test() {
 
   // CHECK:          q_ct1.submit(
   // CHECK-NEXT:       [&](sycl::handler &cgh) {
-  // CHECK-NEXT:         sycl::accessor<int, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(360), cgh);
+  // CHECK-NEXT:         sycl::local_accessor<int, 1> a_acc_ct1(sycl::range<1>(360), cgh);
   // CHECK-EMPTY:
   // CHECK-NEXT:         cgh.parallel_for<dpct_kernel_name<class kernel_extern_{{[a-f0-9]+}}>>(
   // CHECK-NEXT:           sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),

--- a/clang/test/dpct/module_kernel.cu
+++ b/clang/test/dpct/module_kernel.cu
@@ -38,7 +38,7 @@ __constant__ unsigned int const_data[3] = {1, 2, 3};
 //CHECK-NEXT:  [&](sycl::handler &cgh) {
 //CHECK-NEXT:    const_data.init(queue);
 //CHECK:    auto const_data_ptr_ct1 = const_data.get_ptr();
-//CHECK:    sycl::accessor<uint8_t, 1, sycl::access_mode::read_write, sycl::access::target::local> dpct_local_acc_ct1(sycl::range<1>(localMemSize), cgh);
+//CHECK:    sycl::local_accessor<uint8_t, 1> dpct_local_acc_ct1(sycl::range<1>(localMemSize), cgh);
 //CHECK:    cgh.parallel_for(
 //CHECK-NEXT:      nr,
 //CHECK-NEXT:      [=](sycl::nd_item<3> item_ct1) {
@@ -60,7 +60,7 @@ __global__ void foo(float* k, float* y){
 //CHECK-NEXT:       [&](sycl::handler &cgh) {
 //CHECK-NEXT:         const_data.init();
 //CHECK:         auto const_data_ptr_ct1 = const_data.get_ptr();
-//CHECK:         sycl::accessor<uint8_t, 1, sycl::access_mode::read_write, sycl::access::target::local> dpct_local_acc_ct1(sycl::range<1>(0), cgh);
+//CHECK:         sycl::local_accessor<uint8_t, 1> dpct_local_acc_ct1(sycl::range<1>(0), cgh);
 //CHECK:         cgh.parallel_for(
 //CHECK-NEXT:           sycl::nd_range<3>(sycl::range<3>(1, 1, 2), sycl::range<3>(1, 1, 2)), 
 //CHECK-NEXT:           [=](sycl::nd_item<3> item_ct1) {

--- a/clang/test/dpct/module_kernel_win.cu
+++ b/clang/test/dpct/module_kernel_win.cu
@@ -31,7 +31,7 @@ __global__ void foo(float* k, float* y);
 //CHECK-NEXT: }
 //CHECK-NEXT: queue.submit(
 //CHECK-NEXT:   [&](sycl::handler &cgh) {
-//CHECK-NEXT:     sycl::accessor<uint8_t, 1, sycl::access_mode::read_write, sycl::access::target::local> dpct_local_acc_ct1(sycl::range<1>(localMemSize), cgh);
+//CHECK-NEXT:     sycl::local_accessor<uint8_t, 1> dpct_local_acc_ct1(sycl::range<1>(localMemSize), cgh);
 //CHECK:     cgh.parallel_for(
 //CHECK-NEXT: nr,
 //CHECK-NEXT:       [=](sycl::nd_item<3> item_ct1) {
@@ -50,7 +50,7 @@ __global__ void foo(float* k, float* y){
 //CHECK-NEXT:     float *a, *b;
 //CHECK-NEXT:     dpct::get_default_queue().submit(
 //CHECK-NEXT:       [&](sycl::handler &cgh) {
-//CHECK-NEXT:         sycl::accessor<uint8_t, 1, sycl::access_mode::read_write, sycl::access::target::local> dpct_local_acc_ct1(sycl::range<1>(0), cgh);
+//CHECK-NEXT:         sycl::local_accessor<uint8_t, 1> dpct_local_acc_ct1(sycl::range<1>(0), cgh);
 
 //CHECK:         cgh.parallel_for(
 //CHECK-NEXT:           sycl::nd_range<3>(sycl::range<3>(1, 1, 2), sycl::range<3>(1, 1, 2)), 

--- a/clang/test/dpct/sharedmem-dim-noUSM.cu
+++ b/clang/test/dpct/sharedmem-dim-noUSM.cu
@@ -41,7 +41,7 @@ int main(void)
 // CHECK: /*
 // CHECK-NEXT: DPCT1060:{{[0-9]+}}: SYCL range can only be a 1D, 2D or 3D vector. Adjust the code.
 // CHECK-NEXT: */
-// CHECK-NEXT: sycl::accessor<int, 4, sycl::access_mode::read_write, sycl::access::target::local> sha2_mem_acc_ct1(sycl::range<4>(10, 10, 10, 10), cgh);
+// CHECK-NEXT: sycl::local_accessor<int, 4> sha2_mem_acc_ct1(sycl::range<4>(10, 10, 10, 10), cgh);
 
   staticReverse<<<10,10>>>();
 
@@ -51,7 +51,7 @@ int main(void)
 // CHECK: /*
 // CHECK-NEXT: DPCT1060:{{[0-9]+}}: SYCL range can only be a 1D, 2D or 3D vector. Adjust the code.
 // CHECK-NEXT: */
-// CHECK-NEXT: sycl::accessor<uint8_t, 4, sycl::access_mode::read_write, sycl::access::target::local> dpct_local_acc_ct1(sycl::range<4>(16*sizeof(int), 2, 2, 2), cgh);
+// CHECK-NEXT: sycl::local_accessor<uint8_t, 4> dpct_local_acc_ct1(sycl::range<4>(16*sizeof(int), 2, 2, 2), cgh);
 
   dynamicReverse<<<10,10,16*sizeof(int)>>>();
   return 0;
@@ -86,6 +86,6 @@ void foo3() {
   // CHECK: /*
   // CHECK-NEXT: DPCT1083:{{[0-9]+}}: The size of local memory in the migrated code may be different from the original code. Check that the allocated memory size in the migrated code is correct.
   // CHECK-NEXT: */
-  // CHECK-NEXT: sycl::accessor<int, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(36/*sizeof(float3) * 3*/), cgh);
+  // CHECK-NEXT: sycl::local_accessor<int, 1> a_acc_ct1(sycl::range<1>(36/*sizeof(float3) * 3*/), cgh);
   kernel3<<<1, 1>>>();
 }

--- a/clang/test/dpct/sharedmem-dim.cu
+++ b/clang/test/dpct/sharedmem-dim.cu
@@ -43,7 +43,7 @@ int main(void)
 // CHECK: /*
 // CHECK-NEXT: DPCT1060:{{[0-9]+}}: SYCL range can only be a 1D, 2D or 3D vector. Adjust the code.
 // CHECK-NEXT: */
-// CHECK-NEXT: sycl::accessor<int, 4, sycl::access_mode::read_write, sycl::access::target::local> sha2_mem_acc_ct1(sycl::range<4>(10, 10, 10, 10), cgh);
+// CHECK-NEXT: sycl::local_accessor<int, 4> sha2_mem_acc_ct1(sycl::range<4>(10, 10, 10, 10), cgh);
 
   staticReverse<<<10,10>>>();
 
@@ -53,7 +53,7 @@ int main(void)
 // CHECK: /*
 // CHECK-NEXT: DPCT1060:{{[0-9]+}}: SYCL range can only be a 1D, 2D or 3D vector. Adjust the code.
 // CHECK-NEXT: */
-// CHECK-NEXT: sycl::accessor<uint8_t, 4, sycl::access_mode::read_write, sycl::access::target::local> dpct_local_acc_ct1(sycl::range<4>(16*sizeof(int), 2, 2, 2), cgh);
+// CHECK-NEXT: sycl::local_accessor<uint8_t, 4> dpct_local_acc_ct1(sycl::range<4>(16*sizeof(int), 2, 2, 2), cgh);
 
   dynamicReverse<<<10,10,16*sizeof(int)>>>();
   return 0;
@@ -88,6 +88,6 @@ void foo3() {
   // CHECK: /*
   // CHECK-NEXT: DPCT1083:{{[0-9]+}}: The size of local memory in the migrated code may be different from the original code. Check that the allocated memory size in the migrated code is correct.
   // CHECK-NEXT: */
-  // CHECK-NEXT: sycl::accessor<int, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(36/*sizeof(float3) * 3*/), cgh);
+  // CHECK-NEXT: sycl::local_accessor<int, 1> a_acc_ct1(sycl::range<1>(36/*sizeof(float3) * 3*/), cgh);
   kernel3<<<1, 1>>>();
 }

--- a/clang/test/dpct/sharedmem_var_dynamic.cu
+++ b/clang/test/dpct/sharedmem_var_dynamic.cu
@@ -41,7 +41,7 @@ void testTemplate(){
 
   // CHECK: dpct::get_default_queue().submit(
   // CHECK-NEXT:   [&](sycl::handler &cgh) {
-  // CHECK-NEXT:     sycl::accessor<uint8_t, 1, sycl::access_mode::read_write, sycl::access::target::local> dpct_local_acc_ct1(sycl::range<1>(mem_size), cgh);
+  // CHECK-NEXT:     sycl::local_accessor<uint8_t, 1> dpct_local_acc_ct1(sycl::range<1>(mem_size), cgh);
   // CHECK-NEXT:     dpct::access_wrapper<T *> d_d_acc_ct0(d_d, cgh);
   // CHECK-EMPTY:
   // CHECK-NEXT:     cgh.parallel_for<dpct_kernel_name<class templateReverse_{{[a-f0-9]+}}, T>>(
@@ -64,7 +64,7 @@ int main(void) {
   cudaMemcpy(d_d, a, mem_size, cudaMemcpyHostToDevice);
   // CHECK: q_ct1.submit(
   // CHECK-NEXT:   [&](sycl::handler &cgh) {
-  // CHECK-NEXT:     sycl::accessor<uint8_t, 1, sycl::access_mode::read_write, sycl::access::target::local> dpct_local_acc_ct1(sycl::range<1>(mem_size), cgh);
+  // CHECK-NEXT:     sycl::local_accessor<uint8_t, 1> dpct_local_acc_ct1(sycl::range<1>(mem_size), cgh);
   // CHECK-NEXT:     auto d_d_acc_ct0 = dpct::get_access(d_d, cgh);
   // CHECK-EMPTY:
   // CHECK-NEXT:     cgh.parallel_for<dpct_kernel_name<class staticReverse_{{[a-f0-9]+}}>>(
@@ -81,7 +81,7 @@ int main(void) {
   // CHECK-NEXT:     /*
   // CHECK-NEXT:     DPCT1083:{{[0-9]+}}: The size of local memory in the migrated code may be different from the original code. Check that the allocated memory size in the migrated code is correct.
   // CHECK-NEXT:     */
-  // CHECK-NEXT:     sycl::accessor<uint8_t, 1, sycl::access_mode::read_write, sycl::access::target::local> dpct_local_acc_ct1(sycl::range<1>(sizeof(int)), cgh);
+  // CHECK-NEXT:     sycl::local_accessor<uint8_t, 1> dpct_local_acc_ct1(sycl::range<1>(sizeof(int)), cgh);
   // CHECK-NEXT:     auto d_d_acc_ct0 = dpct::get_access(d_d, cgh);
   // CHECK-EMPTY:
   // CHECK-NEXT:     cgh.parallel_for<dpct_kernel_name<class staticReverse_{{[a-f0-9]+}}>>(
@@ -94,7 +94,7 @@ int main(void) {
 
   // CHECK: q_ct1.submit(
   // CHECK-NEXT:   [&](sycl::handler &cgh) {
-  // CHECK-NEXT:     sycl::accessor<uint8_t, 1, sycl::access_mode::read_write, sycl::access::target::local> dpct_local_acc_ct1(sycl::range<1>(4), cgh);
+  // CHECK-NEXT:     sycl::local_accessor<uint8_t, 1> dpct_local_acc_ct1(sycl::range<1>(4), cgh);
   // CHECK-NEXT:     auto d_d_acc_ct0 = dpct::get_access(d_d, cgh);
   // CHECK-EMPTY:
   // CHECK-NEXT:     cgh.parallel_for<dpct_kernel_name<class templateReverse_{{[a-f0-9]+}}, int>>(
@@ -164,7 +164,7 @@ __host__ void foo_4_h() { char *p = Env_cuda_shared_memory(); }
 
 // CHECK: void call_foo4() { dpct::get_default_queue().submit(
 // CHECK-NEXT:  [&](sycl::handler &cgh) {
-// CHECK-NEXT:    sycl::accessor<char, 1, sycl::access_mode::read_write, sycl::access::target::local> cuda_shared_memory_acc_ct1(sycl::range<1>(10), cgh);
+// CHECK-NEXT:    sycl::local_accessor<char, 1> cuda_shared_memory_acc_ct1(sycl::range<1>(10), cgh);
 // CHECK-EMPTY: 
 // CHECK-NEXT:    cgh.parallel_for<dpct_kernel_name<class foo_4_g_{{[a-f0-9]+}}>>(
 // CHECK-NEXT:      sycl::nd_range<3>(sycl::range<3>(1, 1, 16) * sycl::range<3>(1, 1, 64), sycl::range<3>(1, 1, 64)), 

--- a/clang/test/dpct/sharedmem_var_static.cu
+++ b/clang/test/dpct/sharedmem_var_static.cu
@@ -56,8 +56,8 @@ __global__ void staticReverse(int *d, int n) {
 
 // CHECK: template<typename TData>
 // CHECK-NEXT: void templateReverse(TData *d, TData n, sycl::nd_item<3> [[ITEM:item_ct1]],
-// CHECK-NEXT:                      sycl::accessor<TData, 2, sycl::access_mode::read_write, sycl::access::target::local> s,
-// CHECK-NEXT:                      sycl::accessor<TData, 3, sycl::access_mode::read_write, sycl::access::target::local> s3) {
+// CHECK-NEXT:                      sycl::local_accessor<TData, 2> s,
+// CHECK-NEXT:                      sycl::local_accessor<TData, 3> s3) {
 template<typename TData>
 __global__ void templateReverse(TData *d, TData n) {
   const int size = 32;
@@ -82,8 +82,8 @@ void testTemplate() {
 
   // CHECK: dpct::get_default_queue().submit(
   // CHECK-NEXT:   [&](sycl::handler &cgh) {
-  // CHECK-NEXT:     sycl::accessor<T, 2, sycl::access_mode::read_write, sycl::access::target::local> s_acc_ct1(sycl::range<2>(64/*size * 2*/, 128/*size * 4*/), cgh);
-  // CHECK-NEXT:     sycl::accessor<T, 3, sycl::access_mode::read_write, sycl::access::target::local> s3_acc_ct1(sycl::range<3>(64/*size * 2*/, 128/*size * 4*/, 32/*size*/), cgh);
+  // CHECK-NEXT:     sycl::local_accessor<T, 2> s_acc_ct1(sycl::range<2>(64/*size * 2*/, 128/*size * 4*/), cgh);
+  // CHECK-NEXT:     sycl::local_accessor<T, 3> s3_acc_ct1(sycl::range<3>(64/*size * 2*/, 128/*size * 4*/, 32/*size*/), cgh);
   // CHECK-NEXT:     dpct::access_wrapper<T *> d_d_acc_ct0(d_d, cgh);
   // CHECK-EMPTY:
   // CHECK-NEXT:     cgh.parallel_for<dpct_kernel_name<class templateReverse_{{[a-f0-9]+}}, T>>(
@@ -107,7 +107,7 @@ int main(void) {
 
   // CHECK: q_ct1.submit(
   // CHECK-NEXT:    [&](sycl::handler &cgh) {
-  // CHECK-NEXT:      sycl::accessor<TestObject, 0, sycl::access_mode::read_write, sycl::access::target::local> s_acc_ct1(cgh);
+  // CHECK-NEXT:      sycl::local_accessor<TestObject, 0> s_acc_ct1(cgh);
   // CHECK-EMPTY:
   // CHECK-NEXT:       cgh.parallel_for<dpct_kernel_name<class memberAcc_{{[a-f0-9]+}}>>(
   // CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -118,8 +118,8 @@ int main(void) {
   memberAcc<<<1, 1>>>();
   // CHECK: q_ct1.submit(
   // CHECK-NEXT:   [&](sycl::handler &cgh) {
-  // CHECK-NEXT:     sycl::accessor<int, 0, sycl::access_mode::read_write, sycl::access::target::local> a0_acc_ct1(cgh);
-  // CHECK-NEXT:     sycl::accessor<int, 1, sycl::access_mode::read_write, sycl::access::target::local> s_acc_ct1(sycl::range<1>(64/*size*/), cgh);
+  // CHECK-NEXT:     sycl::local_accessor<int, 0> a0_acc_ct1(cgh);
+  // CHECK-NEXT:     sycl::local_accessor<int, 1> s_acc_ct1(sycl::range<1>(64/*size*/), cgh);
   // CHECK-NEXT:     auto d_d_acc_ct0 = dpct::get_access(d_d, cgh);
   // CHECK-EMPTY:
   // CHECK-NEXT:     cgh.parallel_for<dpct_kernel_name<class staticReverse_{{[a-f0-9]+}}>>(
@@ -133,8 +133,8 @@ int main(void) {
 
   // CHECK: q_ct1.submit(
   // CHECK-NEXT:   [&](sycl::handler &cgh) {
-  // CHECK-NEXT:     sycl::accessor<int, 2, sycl::access_mode::read_write, sycl::access::target::local> s_acc_ct1(sycl::range<2>(64/*size * 2*/, 128/*size * 4*/), cgh);
-  // CHECK-NEXT:     sycl::accessor<int, 3, sycl::access_mode::read_write, sycl::access::target::local> s3_acc_ct1(sycl::range<3>(64/*size * 2*/, 128/*size * 4*/, 32/*size*/), cgh);
+  // CHECK-NEXT:     sycl::local_accessor<int, 2> s_acc_ct1(sycl::range<2>(64/*size * 2*/, 128/*size * 4*/), cgh);
+  // CHECK-NEXT:     sycl::local_accessor<int, 3> s3_acc_ct1(sycl::range<3>(64/*size * 2*/, 128/*size * 4*/, 32/*size*/), cgh);
   // CHECK-NEXT:     auto d_d_acc_ct0 = dpct::get_access(d_d, cgh);
   // CHECK-EMPTY:
   // CHECK-NEXT:     cgh.parallel_for<dpct_kernel_name<class templateReverse_{{[a-f0-9]+}}, int>>(
@@ -147,7 +147,7 @@ int main(void) {
 
   // CHECK: q_ct1.submit(
   // CHECK-NEXT:   [&](sycl::handler &cgh) {
-  // CHECK-NEXT:     sycl::accessor<std::complex<int>, 1, sycl::access_mode::read_write, sycl::access::target::local> s_acc_ct1(sycl::range<1>(2*SIZE*SIZE), cgh);
+  // CHECK-NEXT:     sycl::local_accessor<std::complex<int>, 1> s_acc_ct1(sycl::range<1>(2*SIZE*SIZE), cgh);
   // CHECK-NEXT:     auto d_d_acc_ct0 = dpct::get_access(d_d, cgh);
   // CHECK-EMPTY:
   // CHECK-NEXT:     cgh.parallel_for<dpct_kernel_name<class nonTypeTemplateReverse_{{[a-f0-9]+}}, dpct_kernel_scalar<SIZE>>>(

--- a/clang/test/dpct/sycl_style_double2.cu
+++ b/clang/test/dpct/sycl_style_double2.cu
@@ -89,7 +89,7 @@ int main() {
 
   // CHECK:   q_ct1.submit(
   // CHECK-NEXT:     [&](sycl::handler &cgh) {
-  // CHECK-NEXT:       sycl::accessor<sycl::double2, 1, sycl::access_mode::read_write, sycl::access::target::local> ctemp2_acc_ct1(sycl::range<1>(2), cgh);
+  // CHECK-NEXT:       sycl::local_accessor<sycl::double2, 1> ctemp2_acc_ct1(sycl::range<1>(2), cgh);
   // CHECK-EMPTY:
   // CHECK-NEXT:       cgh.parallel_for<dpct_kernel_name<class gpuMain_{{[a-f0-9]+}}>>(
   // CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, 64) * sycl::range<3>(1, 1, 64), sycl::range<3>(1, 1, 64)),

--- a/clang/test/dpct/template-deduce.cu
+++ b/clang/test/dpct/template-deduce.cu
@@ -38,7 +38,7 @@ template<class T> __global__ void template_kernel4() {
 
 template<class T1, class T2, size_t S> void template_host() {
 
-    // CHECK:  sycl::accessor<TemplateClass<T2, T1>, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(10), cgh);
+    // CHECK:  sycl::local_accessor<TemplateClass<T2, T1>, 1> a_acc_ct1(sycl::range<1>(10), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -47,7 +47,7 @@ template<class T1, class T2, size_t S> void template_host() {
     // CHECK-NEXT:    });
     template_kernel1<T2, T1><<<1,1>>>();
 
-    // CHECK:  sycl::accessor<TemplateClass<T2, int>, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(10), cgh);
+    // CHECK:  sycl::local_accessor<TemplateClass<T2, int>, 1> a_acc_ct1(sycl::range<1>(10), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -56,7 +56,7 @@ template<class T1, class T2, size_t S> void template_host() {
     // CHECK-NEXT:    });
     template_kernel2<T2><<<1,1>>>();
 
-    // CHECK:  sycl::accessor<TemplateClass<T1, T1>, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(S), cgh);
+    // CHECK:  sycl::local_accessor<TemplateClass<T1, T1>, 1> a_acc_ct1(sycl::range<1>(S), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -65,7 +65,7 @@ template<class T1, class T2, size_t S> void template_host() {
     // CHECK-NEXT:    });
     template_kernel3<T1, S><<<1,1>>>();
 
-    // CHECK:  sycl::accessor<TemplateClass<T2, float>, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(3), cgh);
+    // CHECK:  sycl::local_accessor<TemplateClass<T2, float>, 1> a_acc_ct1(sycl::range<1>(3), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -77,7 +77,7 @@ template<class T1, class T2, size_t S> void template_host() {
 
 int main() {
 
-    // CHECK:  sycl::accessor<TemplateClass<sycl::float4, int>, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(10), cgh);
+    // CHECK:  sycl::local_accessor<TemplateClass<sycl::float4, int>, 1> a_acc_ct1(sycl::range<1>(10), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -86,7 +86,7 @@ int main() {
     // CHECK-NEXT:    });
     template_kernel1<float4, int><<<1,1>>>();
 
-    // CHECK:  sycl::accessor<TemplateClass<sycl::float2, int>, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(10), cgh);
+    // CHECK:  sycl::local_accessor<TemplateClass<sycl::float2, int>, 1> a_acc_ct1(sycl::range<1>(10), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -95,7 +95,7 @@ int main() {
     // CHECK-NEXT:    });
     template_kernel2<float2><<<1,1>>>();
 
-    // CHECK:  sycl::accessor<TemplateClass<sycl::float2, sycl::float2>, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(3), cgh);
+    // CHECK:  sycl::local_accessor<TemplateClass<sycl::float2, sycl::float2>, 1> a_acc_ct1(sycl::range<1>(3), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -104,7 +104,7 @@ int main() {
     // CHECK-NEXT:    });
     template_kernel3<float2, 3><<<1,1>>>();
 
-    // CHECK:  sycl::accessor<TemplateClass<sycl::float2, float>, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(3), cgh);
+    // CHECK:  sycl::local_accessor<TemplateClass<sycl::float2, float>, 1> a_acc_ct1(sycl::range<1>(3), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -135,8 +135,8 @@ void foo() {
   // CHECK-NEXT: sycl::queue &q_ct1 = dev_ct1.default_queue();
   // CHECK: q_ct1.submit(
   // CHECK-NEXT:   [&](sycl::handler &cgh) {
-  // CHECK-NEXT:     sycl::accessor<int, 0, sycl::access_mode::read_write, sycl::access::target::local> v1_acc_ct1(cgh);
-  // CHECK-NEXT:     sycl::accessor<double, 0, sycl::access_mode::read_write, sycl::access::target::local> v2_acc_ct1(cgh);
+  // CHECK-NEXT:     sycl::local_accessor<int, 0> v1_acc_ct1(cgh);
+  // CHECK-NEXT:     sycl::local_accessor<double, 0> v2_acc_ct1(cgh);
   // CHECK-EMPTY:
   // CHECK-NEXT:     cgh.parallel_for(
   // CHECK-NEXT:       sycl::nd_range<3>(sycl::range<3>(1, 1, 16) * sycl::range<3>(1, 1, 32), sycl::range<3>(1, 1, 32)),
@@ -147,8 +147,8 @@ void foo() {
   k<<<16, 32>>>(1, 2.3);
   // CHECK: q_ct1.submit(
   // CHECK-NEXT:   [&](sycl::handler &cgh) {
-  // CHECK-NEXT:     sycl::accessor<int, 0, sycl::access_mode::read_write, sycl::access::target::local> v1_acc_ct1(cgh);
-  // CHECK-NEXT:     sycl::accessor<double, 0, sycl::access_mode::read_write, sycl::access::target::local> v2_acc_ct1(cgh);
+  // CHECK-NEXT:     sycl::local_accessor<int, 0> v1_acc_ct1(cgh);
+  // CHECK-NEXT:     sycl::local_accessor<double, 0> v2_acc_ct1(cgh);
   // CHECK-EMPTY:
   // CHECK-NEXT:     cgh.parallel_for(
   // CHECK-NEXT:       sycl::nd_range<3>(sycl::range<3>(1, 1, 16) * sycl::range<3>(1, 1, 32), sycl::range<3>(1, 1, 32)),
@@ -159,8 +159,8 @@ void foo() {
   k<int><<<16, 32>>>(1, 2.3);
   // CHECK: q_ct1.submit(
   // CHECK-NEXT:   [&](sycl::handler &cgh) {
-  // CHECK-NEXT:     sycl::accessor<int, 0, sycl::access_mode::read_write, sycl::access::target::local> v1_acc_ct1(cgh);
-  // CHECK-NEXT:     sycl::accessor<float, 0, sycl::access_mode::read_write, sycl::access::target::local> v2_acc_ct1(cgh);
+  // CHECK-NEXT:     sycl::local_accessor<int, 0> v1_acc_ct1(cgh);
+  // CHECK-NEXT:     sycl::local_accessor<float, 0> v2_acc_ct1(cgh);
   // CHECK-EMPTY:
   // CHECK-NEXT:     cgh.parallel_for(
   // CHECK-NEXT:       sycl::nd_range<3>(sycl::range<3>(1, 1, 16) * sycl::range<3>(1, 1, 32), sycl::range<3>(1, 1, 32)),
@@ -172,8 +172,8 @@ void foo() {
 
   // CHECK: q_ct1.submit(
   // CHECK-NEXT:   [&](sycl::handler &cgh) {
-  // CHECK-NEXT:     sycl::accessor<T3, 0, sycl::access_mode::read_write, sycl::access::target::local> v1_acc_ct1(cgh);
-  // CHECK-NEXT:     sycl::accessor<double, 0, sycl::access_mode::read_write, sycl::access::target::local> v2_acc_ct1(cgh);
+  // CHECK-NEXT:     sycl::local_accessor<T3, 0> v1_acc_ct1(cgh);
+  // CHECK-NEXT:     sycl::local_accessor<double, 0> v2_acc_ct1(cgh);
   // CHECK-EMPTY:
   // CHECK-NEXT:     cgh.parallel_for(
   // CHECK-NEXT:       sycl::nd_range<3>(sycl::range<3>(1, 1, 16) * sycl::range<3>(1, 1, 32), sycl::range<3>(1, 1, 32)),
@@ -184,8 +184,8 @@ void foo() {
   k<T3><<<16, 32>>>(1, 2.3);
   // CHECK: q_ct1.submit(
   // CHECK-NEXT:   [&](sycl::handler &cgh) {
-  // CHECK-NEXT:     sycl::accessor<T3, 0, sycl::access_mode::read_write, sycl::access::target::local> v1_acc_ct1(cgh);
-  // CHECK-NEXT:     sycl::accessor<T4, 0, sycl::access_mode::read_write, sycl::access::target::local> v2_acc_ct1(cgh);
+  // CHECK-NEXT:     sycl::local_accessor<T3, 0> v1_acc_ct1(cgh);
+  // CHECK-NEXT:     sycl::local_accessor<T4, 0> v2_acc_ct1(cgh);
   // CHECK-EMPTY:
   // CHECK-NEXT:     cgh.parallel_for(
   // CHECK-NEXT:       sycl::nd_range<3>(sycl::range<3>(1, 1, 16) * sycl::range<3>(1, 1, 32), sycl::range<3>(1, 1, 32)),
@@ -220,7 +220,7 @@ template<class T1, class T2, size_t S> void implicit_host() {
     typedef_1 *d_c;
     using_1 *d_d;
 
-    // CHECK:  sycl::accessor<T1, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(10), cgh);
+    // CHECK:  sycl::local_accessor<T1, 1> a_acc_ct1(sycl::range<1>(10), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -228,7 +228,7 @@ template<class T1, class T2, size_t S> void implicit_host() {
     // CHECK-NEXT:      kernel_ptr(d_a, (T1 *)a_acc_ct1.get_pointer());
     // CHECK-NEXT:    });
     kernel_ptr<<<1,1>>>(d_a);
-    // CHECK:  sycl::accessor<int, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(10), cgh);
+    // CHECK:  sycl::local_accessor<int, 1> a_acc_ct1(sycl::range<1>(10), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -236,7 +236,7 @@ template<class T1, class T2, size_t S> void implicit_host() {
     // CHECK-NEXT:      kernel_ptr(d_b, (int *)a_acc_ct1.get_pointer());
     // CHECK-NEXT:    });
     kernel_ptr<<<1,1>>>(d_b);
-    // CHECK:  sycl::accessor<typedef_1, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(10), cgh);
+    // CHECK:  sycl::local_accessor<typedef_1, 1> a_acc_ct1(sycl::range<1>(10), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -244,7 +244,7 @@ template<class T1, class T2, size_t S> void implicit_host() {
     // CHECK-NEXT:      kernel_ptr(d_c, (typedef_1 *)a_acc_ct1.get_pointer());
     // CHECK-NEXT:    });
     kernel_ptr<<<1,1>>>(d_c);
-    // CHECK:  sycl::accessor<using_1, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(10), cgh);
+    // CHECK:  sycl::local_accessor<using_1, 1> a_acc_ct1(sycl::range<1>(10), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -258,7 +258,7 @@ template<class T1, class T2, size_t S> void implicit_host() {
     typedef_1 r_c;
     using_1 r_d;
 
-    // CHECK:  sycl::accessor<T1, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(10), cgh);
+    // CHECK:  sycl::local_accessor<T1, 1> a_acc_ct1(sycl::range<1>(10), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -266,7 +266,7 @@ template<class T1, class T2, size_t S> void implicit_host() {
     // CHECK-NEXT:      kernel_ref(r_a, (T1 *)a_acc_ct1.get_pointer());
     // CHECK-NEXT:    });
     kernel_ref<<<1,1>>>(r_a);
-    // CHECK:  sycl::accessor<int, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(10), cgh);
+    // CHECK:  sycl::local_accessor<int, 1> a_acc_ct1(sycl::range<1>(10), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -274,7 +274,7 @@ template<class T1, class T2, size_t S> void implicit_host() {
     // CHECK-NEXT:      kernel_ref(r_b, (int *)a_acc_ct1.get_pointer());
     // CHECK-NEXT:    });
     kernel_ref<<<1,1>>>(r_b);
-    // CHECK:  sycl::accessor<typedef_1, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(10), cgh);
+    // CHECK:  sycl::local_accessor<typedef_1, 1> a_acc_ct1(sycl::range<1>(10), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -282,7 +282,7 @@ template<class T1, class T2, size_t S> void implicit_host() {
     // CHECK-NEXT:      kernel_ref(r_c, (typedef_1 *)a_acc_ct1.get_pointer());
     // CHECK-NEXT:    });
     kernel_ref<<<1,1>>>(r_c);
-    // CHECK:  sycl::accessor<using_1, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(10), cgh);
+    // CHECK:  sycl::local_accessor<using_1, 1> a_acc_ct1(sycl::range<1>(10), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -295,7 +295,7 @@ template<class T1, class T2, size_t S> void implicit_host() {
     int a_b[10][20];
     typedef_1 a_c[10][20];
     using_1 a_d[10][20];
-    // CHECK:  sycl::accessor<T1, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(20), cgh);
+    // CHECK:  sycl::local_accessor<T1, 1> a_acc_ct1(sycl::range<1>(20), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -303,7 +303,7 @@ template<class T1, class T2, size_t S> void implicit_host() {
     // CHECK-NEXT:      kernel_array(a_a, (T1 *)a_acc_ct1.get_pointer());
     // CHECK-NEXT:    });
     kernel_array<<<1,1>>>(a_a);
-    // CHECK:  sycl::accessor<int, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(20), cgh);
+    // CHECK:  sycl::local_accessor<int, 1> a_acc_ct1(sycl::range<1>(20), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -311,7 +311,7 @@ template<class T1, class T2, size_t S> void implicit_host() {
     // CHECK-NEXT:      kernel_array(a_b, (int *)a_acc_ct1.get_pointer());
     // CHECK-NEXT:    });
     kernel_array<<<1,1>>>(a_b);
-    // CHECK:  sycl::accessor<typedef_1, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(20), cgh);
+    // CHECK:  sycl::local_accessor<typedef_1, 1> a_acc_ct1(sycl::range<1>(20), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -319,7 +319,7 @@ template<class T1, class T2, size_t S> void implicit_host() {
     // CHECK-NEXT:      kernel_array(a_c, (typedef_1 *)a_acc_ct1.get_pointer());
     // CHECK-NEXT:    });
     kernel_array<<<1,1>>>(a_c);
-    // CHECK:  sycl::accessor<using_1, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(20), cgh);
+    // CHECK:  sycl::local_accessor<using_1, 1> a_acc_ct1(sycl::range<1>(20), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -335,8 +335,8 @@ template<class T1, class T2, size_t S> void implicit_host() {
     TemplateClass<int, T2> c_d;
     TemplateClass<int, double> c_e;
 
-    // CHECK:  sycl::accessor<T1, 1, sycl::access_mode::read_write, sycl::access::target::local> a1_acc_ct1(sycl::range<1>(10), cgh);
-    // CHECK-NEXT:  sycl::accessor<T2, 1, sycl::access_mode::read_write, sycl::access::target::local> a2_acc_ct1(sycl::range<1>(10), cgh);
+    // CHECK:  sycl::local_accessor<T1, 1> a1_acc_ct1(sycl::range<1>(10), cgh);
+    // CHECK-NEXT:  sycl::local_accessor<T2, 1> a2_acc_ct1(sycl::range<1>(10), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -344,8 +344,8 @@ template<class T1, class T2, size_t S> void implicit_host() {
     // CHECK-NEXT:      kernel_class(c_a, (T1 *)a1_acc_ct1.get_pointer(), (T2 *)a2_acc_ct1.get_pointer());
     // CHECK-NEXT:    });
     kernel_class<<<1,1>>>(c_a);
-    // CHECK:  sycl::accessor<T1, 1, sycl::access_mode::read_write, sycl::access::target::local> a1_acc_ct1(sycl::range<1>(10), cgh);
-    // CHECK-NEXT:  sycl::accessor<T2, 1, sycl::access_mode::read_write, sycl::access::target::local> a2_acc_ct1(sycl::range<1>(10), cgh);
+    // CHECK:  sycl::local_accessor<T1, 1> a1_acc_ct1(sycl::range<1>(10), cgh);
+    // CHECK-NEXT:  sycl::local_accessor<T2, 1> a2_acc_ct1(sycl::range<1>(10), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -353,8 +353,8 @@ template<class T1, class T2, size_t S> void implicit_host() {
     // CHECK-NEXT:      kernel_class(c_b, (T1 *)a1_acc_ct1.get_pointer(), (T2 *)a2_acc_ct1.get_pointer());
     // CHECK-NEXT:    });
     kernel_class<<<1,1>>>(c_b);
-    // CHECK:  sycl::accessor<T1, 1, sycl::access_mode::read_write, sycl::access::target::local> a1_acc_ct1(sycl::range<1>(10), cgh);
-    // CHECK-NEXT:  sycl::accessor<int, 1, sycl::access_mode::read_write, sycl::access::target::local> a2_acc_ct1(sycl::range<1>(10), cgh);
+    // CHECK:  sycl::local_accessor<T1, 1> a1_acc_ct1(sycl::range<1>(10), cgh);
+    // CHECK-NEXT:  sycl::local_accessor<int, 1> a2_acc_ct1(sycl::range<1>(10), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -362,8 +362,8 @@ template<class T1, class T2, size_t S> void implicit_host() {
     // CHECK-NEXT:      kernel_class(c_c, (T1 *)a1_acc_ct1.get_pointer(), (int *)a2_acc_ct1.get_pointer());
     // CHECK-NEXT:    });
     kernel_class<<<1,1>>>(c_c);
-    // CHECK:  sycl::accessor<int, 1, sycl::access_mode::read_write, sycl::access::target::local> a1_acc_ct1(sycl::range<1>(10), cgh);
-    // CHECK-NEXT:  sycl::accessor<T2, 1, sycl::access_mode::read_write, sycl::access::target::local> a2_acc_ct1(sycl::range<1>(10), cgh);
+    // CHECK:  sycl::local_accessor<int, 1> a1_acc_ct1(sycl::range<1>(10), cgh);
+    // CHECK-NEXT:  sycl::local_accessor<T2, 1> a2_acc_ct1(sycl::range<1>(10), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -371,8 +371,8 @@ template<class T1, class T2, size_t S> void implicit_host() {
     // CHECK-NEXT:      kernel_class(c_d, (int *)a1_acc_ct1.get_pointer(), (T2 *)a2_acc_ct1.get_pointer());
     // CHECK-NEXT:    });
     kernel_class<<<1,1>>>(c_d);
-    // CHECK:  sycl::accessor<int, 1, sycl::access_mode::read_write, sycl::access::target::local> a1_acc_ct1(sycl::range<1>(10), cgh);
-    // CHECK-NEXT:  sycl::accessor<double, 1, sycl::access_mode::read_write, sycl::access::target::local> a2_acc_ct1(sycl::range<1>(10), cgh);
+    // CHECK:  sycl::local_accessor<int, 1> a1_acc_ct1(sycl::range<1>(10), cgh);
+    // CHECK-NEXT:  sycl::local_accessor<double, 1> a2_acc_ct1(sycl::range<1>(10), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -384,7 +384,7 @@ template<class T1, class T2, size_t S> void implicit_host() {
     using typedef_2 = std::complex<double>;
     std::complex<int> *h_cpx;
     typedef_2 *h_cpx_2;
-    // CHECK:  sycl::accessor<std::complex<int>, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(10), cgh);
+    // CHECK:  sycl::local_accessor<std::complex<int>, 1> a_acc_ct1(sycl::range<1>(10), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -392,7 +392,7 @@ template<class T1, class T2, size_t S> void implicit_host() {
     // CHECK-NEXT:      kernel_dependent(h_cpx, (std::complex<int> *)a_acc_ct1.get_pointer());
     // CHECK-NEXT:    });
     kernel_dependent<<<1,1>>>(h_cpx);
-    // CHECK:  sycl::accessor<std::complex<double>, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(10), cgh);
+    // CHECK:  sycl::local_accessor<std::complex<double>, 1> a_acc_ct1(sycl::range<1>(10), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),

--- a/clang/test/dpct/template-deduce_windows.cu
+++ b/clang/test/dpct/template-deduce_windows.cu
@@ -36,7 +36,7 @@ template<class T> __global__ void template_kernel4() {
 
 template<class T1, class T2, size_t S> void template_host() {
 
-    // CHECK:  sycl::accessor<TemplateClass<T2, T1>, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(10), cgh);
+    // CHECK:  sycl::local_accessor<TemplateClass<T2, T1>, 1> a_acc_ct1(sycl::range<1>(10), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -45,7 +45,7 @@ template<class T1, class T2, size_t S> void template_host() {
     // CHECK-NEXT:    });
     template_kernel1<T2, T1><<<1,1>>>();
 
-    // CHECK:  sycl::accessor<TemplateClass<T2, int>, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(10), cgh);
+    // CHECK:  sycl::local_accessor<TemplateClass<T2, int>, 1> a_acc_ct1(sycl::range<1>(10), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -54,7 +54,7 @@ template<class T1, class T2, size_t S> void template_host() {
     // CHECK-NEXT:    });
     template_kernel2<T2><<<1,1>>>();
 
-    // CHECK:  sycl::accessor<TemplateClass<T1, T1>, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(S), cgh);
+    // CHECK:  sycl::local_accessor<TemplateClass<T1, T1>, 1> a_acc_ct1(sycl::range<1>(S), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -63,7 +63,7 @@ template<class T1, class T2, size_t S> void template_host() {
     // CHECK-NEXT:    });
     template_kernel3<T1, S><<<1,1>>>();
 
-    // CHECK:  sycl::accessor<TemplateClass<T2, float>, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(3), cgh);
+    // CHECK:  sycl::local_accessor<TemplateClass<T2, float>, 1> a_acc_ct1(sycl::range<1>(3), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -75,7 +75,7 @@ template<class T1, class T2, size_t S> void template_host() {
 
 int main() {
 
-    // CHECK:  sycl::accessor<TemplateClass<sycl::float4, int>, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(10), cgh);
+    // CHECK:  sycl::local_accessor<TemplateClass<sycl::float4, int>, 1> a_acc_ct1(sycl::range<1>(10), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -84,7 +84,7 @@ int main() {
     // CHECK-NEXT:    });
     template_kernel1<float4, int><<<1,1>>>();
 
-    // CHECK:  sycl::accessor<TemplateClass<sycl::float2, int>, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(10), cgh);
+    // CHECK:  sycl::local_accessor<TemplateClass<sycl::float2, int>, 1> a_acc_ct1(sycl::range<1>(10), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -93,7 +93,7 @@ int main() {
     // CHECK-NEXT:    });
     template_kernel2<float2><<<1,1>>>();
 
-    // CHECK:  sycl::accessor<TemplateClass<sycl::float2, sycl::float2>, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(3), cgh);
+    // CHECK:  sycl::local_accessor<TemplateClass<sycl::float2, sycl::float2>, 1> a_acc_ct1(sycl::range<1>(3), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -102,7 +102,7 @@ int main() {
     // CHECK-NEXT:    });
     template_kernel3<float2, 3><<<1,1>>>();
 
-    // CHECK:  sycl::accessor<TemplateClass<sycl::float2, float>, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(3), cgh);
+    // CHECK:  sycl::local_accessor<TemplateClass<sycl::float2, float>, 1> a_acc_ct1(sycl::range<1>(3), cgh);
     // CHECK-EMPTY:
     // CHECK-NEXT:  cgh.parallel_for(
     // CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),

--- a/clang/test/dpct/template-instantiation.cu
+++ b/clang/test/dpct/template-instantiation.cu
@@ -69,7 +69,7 @@ int main() {
 
 // CHECK:      q_ct1.submit(
 // CHECK-NEXT:   [&](sycl::handler &cgh) {
-// CHECK-NEXT:     sycl::accessor<sycl::float2, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(10), cgh);
+// CHECK-NEXT:     sycl::local_accessor<sycl::float2, 1> a_acc_ct1(sycl::range<1>(10), cgh);
 // CHECK-EMPTY:
 // CHECK-NEXT:     cgh.parallel_for(
 // CHECK-NEXT:       sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -81,7 +81,7 @@ int main() {
 
 // CHECK:      q_ct1.submit(
 // CHECK-NEXT:   [&](sycl::handler &cgh) {
-// CHECK-NEXT:     sycl::accessor<sycl::int4, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(10), cgh);
+// CHECK-NEXT:     sycl::local_accessor<sycl::int4, 1> a_acc_ct1(sycl::range<1>(10), cgh);
 // CHECK-EMPTY:
 // CHECK-NEXT:     cgh.parallel_for(
 // CHECK-NEXT:       sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -93,7 +93,7 @@ int main() {
     
 // CHECK:      q_ct1.submit(
 // CHECK-NEXT:   [&](sycl::handler &cgh) {
-// CHECK-NEXT:     sycl::accessor<int, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(10), cgh);
+// CHECK-NEXT:     sycl::local_accessor<int, 1> a_acc_ct1(sycl::range<1>(10), cgh);
 // CHECK-EMPTY:     
 // CHECK-NEXT:     cgh.parallel_for(
 // CHECK-NEXT:       sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -105,8 +105,8 @@ int main() {
     
 // CHECK:      q_ct1.submit(
 // CHECK-NEXT:   [&](sycl::handler &cgh) {
-// CHECK-NEXT:     sycl::accessor<int, 1, sycl::access_mode::read_write, sycl::access::target::local> a1_acc_ct1(sycl::range<1>(10), cgh);
-// CHECK-NEXT:     sycl::accessor<sycl::float2, 1, sycl::access_mode::read_write, sycl::access::target::local> a2_acc_ct1(sycl::range<1>(10), cgh);
+// CHECK-NEXT:     sycl::local_accessor<int, 1> a1_acc_ct1(sycl::range<1>(10), cgh);
+// CHECK-NEXT:     sycl::local_accessor<sycl::float2, 1> a2_acc_ct1(sycl::range<1>(10), cgh);
 // CHECK-EMPTY:     
 // CHECK-NEXT:     cgh.parallel_for(
 // CHECK-NEXT:       sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -118,7 +118,7 @@ int main() {
     
 // CHECK:      q_ct1.submit(
 // CHECK-NEXT:   [&](sycl::handler &cgh) {
-// CHECK-NEXT:     sycl::accessor<int, 1, sycl::access_mode::read_write, sycl::access::target::local> a_acc_ct1(sycl::range<1>(20), cgh);
+// CHECK-NEXT:     sycl::local_accessor<int, 1> a_acc_ct1(sycl::range<1>(20), cgh);
 // CHECK-EMPTY:     
 // CHECK-NEXT:     cgh.parallel_for(
 // CHECK-NEXT:       sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),

--- a/clang/test/dpct/template-kernel-call.cu
+++ b/clang/test/dpct/template-kernel-call.cu
@@ -271,7 +271,7 @@ int main() {
 
 // CHECK:template<typename T>
 // CHECK-NEXT:void convert_kernel(T b, sycl::nd_item<3> item_ct1, int *aaa,
-// CHECK-NEXT:                    sycl::accessor<double, 2, sycl::access_mode::read_write, sycl::access::target::local> bbb){
+// CHECK-NEXT:                    sycl::local_accessor<double, 2> bbb){
 // CHECK:  T a = item_ct1.get_local_range(2) * item_ct1.get_group(2) + item_ct1.get_local_id(2);
 // CHECK-NEXT:}
 template<typename T>
@@ -287,8 +287,8 @@ __global__ void convert_kernel(T b){
 // CHECK-NEXT:  T b;
 // CHECK-NEXT:  dpct::get_default_queue().submit(
 // CHECK-NEXT:    [&](sycl::handler &cgh) {
-// CHECK-NEXT:      sycl::accessor<int, 1, sycl::access_mode::read_write, sycl::access::target::local> aaa_acc_ct1(sycl::range<1>(0), cgh);
-// CHECK-NEXT:      sycl::accessor<double, 2, sycl::access_mode::read_write, sycl::access::target::local> bbb_acc_ct1(sycl::range<2>(8, 0), cgh);
+// CHECK-NEXT:      sycl::local_accessor<int, 1> aaa_acc_ct1(sycl::range<1>(0), cgh);
+// CHECK-NEXT:      sycl::local_accessor<double, 2> bbb_acc_ct1(sycl::range<2>(8, 0), cgh);
 // CHECK-EMPTY:
 // CHECK-NEXT:      cgh.parallel_for<dpct_kernel_name<class convert_kernel_{{[a-f0-9]+}}, T>>(
 // CHECK-NEXT:        sycl::nd_range<3>(sycl::range<3>(1, 1, 128) * sycl::range<3>(1, 1, 128), sycl::range<3>(1, 1, 128)),

--- a/clang/test/dpct/thrust-complex-usmnone.cu
+++ b/clang/test/dpct/thrust-complex-usmnone.cu
@@ -103,7 +103,7 @@ int main() {
   bar(reinterpret_cast<thrust::complex<double> *>(cdp));
 // CHECK:   q_ct1.submit(
 // CHECK-NEXT:     [&](sycl::handler &cgh) {
-// CHECK-NEXT:       sycl::accessor<std::complex<sycl::double2>, 1, sycl::access_mode::read_write, sycl::access::target::local> s_acc_ct1(sycl::range<1>(10), cgh);
+// CHECK-NEXT:       sycl::local_accessor<std::complex<sycl::double2>, 1> s_acc_ct1(sycl::range<1>(10), cgh);
 // CHECK-NEXT:       dpct::access_wrapper<std::complex<double> *> cdp_acc_ct0(reinterpret_cast<std::complex<double> *>(cdp), cgh);
 // CHECK-NEXT:       dpct::access_wrapper<std::complex<double> *> thrust_raw_pointer_cast_dc_ptr_acc_ct2(dpct::get_raw_pointer(dc_ptr), cgh);
 // CHECK-EMPTY:
@@ -120,7 +120,7 @@ int main() {
   int *d_i;
 // CHECK:   q_ct1.submit(
 // CHECK-NEXT:     [&](sycl::handler &cgh) {
-// CHECK-NEXT:       sycl::accessor<std::complex<int>, 1, sycl::access_mode::read_write, sycl::access::target::local> s_acc_ct1(sycl::range<1>(10), cgh);
+// CHECK-NEXT:       sycl::local_accessor<std::complex<int>, 1> s_acc_ct1(sycl::range<1>(10), cgh);
 // CHECK-EMPTY:
 // CHECK-NEXT:       cgh.parallel_for(
 // CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, 256), sycl::range<3>(1, 1, 256)),

--- a/clang/test/dpct/thrust-complex.cu
+++ b/clang/test/dpct/thrust-complex.cu
@@ -100,7 +100,7 @@ int main() {
   bar(reinterpret_cast<thrust::complex<double> *>(cdp));
 // CHECK:   q_ct1.submit(
 // CHECK-NEXT:     [&](sycl::handler &cgh) {
-// CHECK-NEXT:       sycl::accessor<std::complex<sycl::double2>, 1, sycl::access_mode::read_write, sycl::access::target::local> s_acc_ct1(sycl::range<1>(10), cgh);
+// CHECK-NEXT:       sycl::local_accessor<std::complex<sycl::double2>, 1> s_acc_ct1(sycl::range<1>(10), cgh);
 // CHECK-EMPTY:
 // CHECK-NEXT:       auto static_cast_thrust_complex_double_cdp_ct1 = static_cast<std::complex<double>>(*cdp);
 // CHECK-NEXT:       auto thrust_raw_pointer_cast_dc_ptr_ct2 = dpct::get_raw_pointer(dc_ptr);
@@ -116,7 +116,7 @@ int main() {
   int *d_i;
 // CHECK:   q_ct1.submit(
 // CHECK-NEXT:     [&](sycl::handler &cgh) {
-// CHECK-NEXT:       sycl::accessor<std::complex<int>, 1, sycl::access_mode::read_write, sycl::access::target::local> s_acc_ct1(sycl::range<1>(10), cgh);
+// CHECK-NEXT:       sycl::local_accessor<std::complex<int>, 1> s_acc_ct1(sycl::range<1>(10), cgh);
 // CHECK-EMPTY:
 // CHECK-NEXT:       cgh.parallel_for(
 // CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, 256), sycl::range<3>(1, 1, 256)),

--- a/clang/test/dpct/warp_api_outside_inroot/src/kernel_warp.cu
+++ b/clang/test/dpct/warp_api_outside_inroot/src/kernel_warp.cu
@@ -28,7 +28,7 @@ void foo() {
   float *input = NULL;
   //CHECK:dpct::get_default_queue().submit(
   //CHECK-NEXT:  [&](sycl::handler &cgh) {
-  //CHECK-NEXT:    sycl::accessor<float, 1, sycl::access_mode::read_write, sycl::access::target::local> smem_acc_ct1(sycl::range<1>(128), cgh);
+  //CHECK-NEXT:    sycl::local_accessor<float, 1> smem_acc_ct1(sycl::range<1>(128), cgh);
   //CHECK-NEXT:    dpct::access_wrapper<float *> input_acc_ct0(input, cgh);
   //CHECK-EMPTY:
   //CHECK-NEXT:    cgh.parallel_for(


### PR DESCRIPTION
sycl::access::address_space::constant_space ==> remove
sycl::access::target::local ==> sycl::local_accessor
sycl::default_selector{} ==> sycl::default_selector_v

Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>