### PR TITLE
[SYCLomatic] Use llvm::Optional::value_or() instead of llvm::Optional::getValueOr, because getValurOr is deprecated

### DIFF
--- a/clang/lib/DPCT/AnalysisInfo.cpp
+++ b/clang/lib/DPCT/AnalysisInfo.cpp
@@ -344,7 +344,7 @@ void DpctFileInfo::buildLinesInfo() {
   }
   auto RawBuffer =
       Content.getBufferOrNone(SM.getDiagnostics(), SM.getFileManager())
-          .getValueOr(llvm::MemoryBufferRef())
+          .value_or(llvm::MemoryBufferRef())
           .getBuffer();
   if (RawBuffer.empty())
     return;


### PR DESCRIPTION
Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>