### PR TITLE
[SYCLomatic]The 'host_unified_memory' was deprecated in SYCL 2020, us…

### DIFF
--- a/clang/runtime/dpct-rt/include/device.hpp.inc
+++ b/clang/runtime/dpct-rt/include/device.hpp.inc
@@ -586,9 +586,9 @@ public:
         get_info<sycl::info::device::max_work_item_sizes<3>>());
 #endif
     prop.set_host_unified_memory(
-        get_current_device().has(sycl::aspect::usm_host_allocations) ||
-        get_current_device().has(sycl::aspect::usm_shared_allocations) ||
-        get_current_device().has(sycl::aspect::usm_system_allocations));
+        this->has(sycl::aspect::usm_host_allocations) ||
+        this->has(sycl::aspect::usm_shared_allocations) ||
+        this->has(sycl::aspect::usm_system_allocations));
 
     // max_clock_frequency parameter is not supported on host device
     if (is_host()) {

--- a/clang/runtime/dpct-rt/include/device.hpp.inc
+++ b/clang/runtime/dpct-rt/include/device.hpp.inc
@@ -586,7 +586,9 @@ public:
         get_info<sycl::info::device::max_work_item_sizes<3>>());
 #endif
     prop.set_host_unified_memory(
-        get_info<sycl::info::device::host_unified_memory>());
+        get_current_device().has(sycl::aspect::usm_host_allocations) ||
+        get_current_device().has(sycl::aspect::usm_shared_allocations) ||
+        get_current_device().has(sycl::aspect::usm_system_allocations));
 
     // max_clock_frequency parameter is not supported on host device
     if (is_host()) {

--- a/clang/runtime/dpct-rt/include/device.hpp.inc
+++ b/clang/runtime/dpct-rt/include/device.hpp.inc
@@ -586,9 +586,7 @@ public:
         get_info<sycl::info::device::max_work_item_sizes<3>>());
 #endif
     prop.set_host_unified_memory(
-        this->has(sycl::aspect::usm_host_allocations) ||
-        this->has(sycl::aspect::usm_shared_allocations) ||
-        this->has(sycl::aspect::usm_system_allocations));
+        this->has(sycl::aspect::usm_host_allocations));
 
     // max_clock_frequency parameter is not supported on host device
     if (is_host()) {

--- a/clang/test/dpct/helper_files_ref/include/device.hpp
+++ b/clang/test/dpct/helper_files_ref/include/device.hpp
@@ -247,7 +247,9 @@ public:
         get_info<sycl::info::device::max_work_item_sizes<3>>());
 #endif
     prop.set_host_unified_memory(
-        get_info<sycl::info::device::host_unified_memory>());
+        get_current_device().has(sycl::aspect::usm_host_allocations) ||
+        get_current_device().has(sycl::aspect::usm_shared_allocations) ||
+        get_current_device().has(sycl::aspect::usm_system_allocations));
 
     // max_clock_frequency parameter is not supported on host device
     if (is_host()) {

--- a/clang/test/dpct/helper_files_ref/include/device.hpp
+++ b/clang/test/dpct/helper_files_ref/include/device.hpp
@@ -247,9 +247,7 @@ public:
         get_info<sycl::info::device::max_work_item_sizes<3>>());
 #endif
     prop.set_host_unified_memory(
-        this->has(sycl::aspect::usm_host_allocations) ||
-        this->has(sycl::aspect::usm_shared_allocations) ||
-        this->has(sycl::aspect::usm_system_allocations));
+        this->has(sycl::aspect::usm_host_allocations));
 
     // max_clock_frequency parameter is not supported on host device
     if (is_host()) {

--- a/clang/test/dpct/helper_files_ref/include/device.hpp
+++ b/clang/test/dpct/helper_files_ref/include/device.hpp
@@ -247,9 +247,9 @@ public:
         get_info<sycl::info::device::max_work_item_sizes<3>>());
 #endif
     prop.set_host_unified_memory(
-        get_current_device().has(sycl::aspect::usm_host_allocations) ||
-        get_current_device().has(sycl::aspect::usm_shared_allocations) ||
-        get_current_device().has(sycl::aspect::usm_system_allocations));
+        this->has(sycl::aspect::usm_host_allocations) ||
+        this->has(sycl::aspect::usm_shared_allocations) ||
+        this->has(sycl::aspect::usm_system_allocations));
 
     // max_clock_frequency parameter is not supported on host device
     if (is_host()) {


### PR DESCRIPTION
…e device::has() with one of the aspect::usm_* aspects instead.

Signed-off-by: Chen, Sheng S <sheng.s.chen@intel.com>