### PR TITLE
[SYCLomatic] Refine kernel migration that making the lambda function as the argument passed to kernel function directly instead of declaring a variable for lambda function passed to kernel function

### DIFF
--- a/clang/lib/DPCT/ExprAnalysis.cpp
+++ b/clang/lib/DPCT/ExprAnalysis.cpp
@@ -1586,8 +1586,12 @@ void KernelArgumentAnalysis::analyzeExpr(const MemberExpr *ME) {
 void KernelArgumentAnalysis::analyzeExpr(const LambdaExpr *LE) {
   dispatch(LE->getBody());
   Base::RemoveCUDADeviceAttr(LE);
+  // Lambda function can be passed to kernel function directly.
+  // So, not need to redeclare a variable for lambda function passed to kernel
+  // function
   IsRedeclareRequired = false;
 }
+
 
 void KernelArgumentAnalysis::analyzeExpr(const UnaryOperator *UO) {
   if (UO->getOpcode() == UO_Deref) {

--- a/clang/lib/DPCT/ExprAnalysis.cpp
+++ b/clang/lib/DPCT/ExprAnalysis.cpp
@@ -953,7 +953,7 @@ void ExprAnalysis::analyzeExpr(const ReturnStmt *RS) {
 }
 
 
-void ExprAnalysis::RemoveCUDADeviceAttr(const LambdaExpr *LE) {
+void ExprAnalysis::removeCUDADeviceAttr(const LambdaExpr *LE) {
   // E.g.,
   // my_kernel<<<1, 1>>>([=] __device__(int idx) { idx++; });
   // The "__device__" attribute need to be removed.
@@ -967,7 +967,7 @@ void ExprAnalysis::RemoveCUDADeviceAttr(const LambdaExpr *LE) {
 }
 
 void ExprAnalysis::analyzeExpr(const LambdaExpr *LE) {
-  RemoveCUDADeviceAttr(LE);
+  removeCUDADeviceAttr(LE);
   // TODO: Need to handle capture ([=] in lambda) if required in the future
   for (const auto &Param : LE->getCallOperator()->parameters()) {
     analyzeType(Param->getTypeSourceInfo()->getTypeLoc(), LE);
@@ -1584,8 +1584,8 @@ void KernelArgumentAnalysis::analyzeExpr(const MemberExpr *ME) {
 }
 
 void KernelArgumentAnalysis::analyzeExpr(const LambdaExpr *LE) {
-  dispatch(LE->getBody());
-  Base::RemoveCUDADeviceAttr(LE);
+  Base::analyzeExpr(LE);
+  Base::removeCUDADeviceAttr(LE);
   // Lambda function can be passed to kernel function directly.
   // So, not need to redeclare a variable for lambda function passed to kernel
   // function

--- a/clang/lib/DPCT/ExprAnalysis.cpp
+++ b/clang/lib/DPCT/ExprAnalysis.cpp
@@ -1585,7 +1585,6 @@ void KernelArgumentAnalysis::analyzeExpr(const MemberExpr *ME) {
 
 void KernelArgumentAnalysis::analyzeExpr(const LambdaExpr *LE) {
   Base::analyzeExpr(LE);
-  Base::removeCUDADeviceAttr(LE);
   // Lambda function can be passed to kernel function directly.
   // So, not need to redeclare a variable for lambda function passed to kernel
   // function

--- a/clang/lib/DPCT/ExprAnalysis.h
+++ b/clang/lib/DPCT/ExprAnalysis.h
@@ -631,7 +631,7 @@ protected:
   void analyzeExpr(const ConstantExpr *CE);
   void analyzeExpr(const IntegerLiteral *IL);
 
-  void RemoveCUDADeviceAttr(const LambdaExpr *LE);
+  void removeCUDADeviceAttr(const LambdaExpr *LE);
 
   inline void analyzeType(const TypeSourceInfo *TSI,
                           const Expr *CSCE = nullptr) {

--- a/clang/lib/DPCT/ExprAnalysis.h
+++ b/clang/lib/DPCT/ExprAnalysis.h
@@ -631,6 +631,8 @@ protected:
   void analyzeExpr(const ConstantExpr *CE);
   void analyzeExpr(const IntegerLiteral *IL);
 
+  void RemoveCUDADeviceAttr(const LambdaExpr *LE);
+
   inline void analyzeType(const TypeSourceInfo *TSI,
                           const Expr *CSCE = nullptr) {
     analyzeType(TSI->getTypeLoc(), CSCE);
@@ -799,15 +801,18 @@ private:
   inline void analyzeExpr(const MemberExpr *Arg);
   inline void analyzeExpr(const CallExpr *Arg) {
     IsRedeclareRequired = true;
+    printf("KernelArgumentAnalysis 000 ...\n");
     ExprAnalysis::analyzeExpr(Arg);
   }
   inline void analyzeExpr(const ArraySubscriptExpr *Arg) {
     IsRedeclareRequired = true;
+    printf("KernelArgumentAnalysis 111 ...\n");
     ExprAnalysis::analyzeExpr(Arg);
   }
   inline void analyzeExpr(const UnaryOperator *Arg);
   inline void analyzeExpr(const CXXDependentScopeMemberExpr *Arg);
   inline void analyzeExpr(const MaterializeTemporaryExpr *MTE);
+  inline void analyzeExpr(const LambdaExpr *LE);
 
   bool isNullPtr(const Expr *);
 

--- a/clang/lib/DPCT/ExprAnalysis.h
+++ b/clang/lib/DPCT/ExprAnalysis.h
@@ -801,12 +801,10 @@ private:
   inline void analyzeExpr(const MemberExpr *Arg);
   inline void analyzeExpr(const CallExpr *Arg) {
     IsRedeclareRequired = true;
-    printf("KernelArgumentAnalysis 000 ...\n");
     ExprAnalysis::analyzeExpr(Arg);
   }
   inline void analyzeExpr(const ArraySubscriptExpr *Arg) {
     IsRedeclareRequired = true;
-    printf("KernelArgumentAnalysis 111 ...\n");
     ExprAnalysis::analyzeExpr(Arg);
   }
   inline void analyzeExpr(const UnaryOperator *Arg);

--- a/clang/test/dpct/kernel_lambda_arg.cu
+++ b/clang/test/dpct/kernel_lambda_arg.cu
@@ -45,11 +45,11 @@ template <typename Foo> __global__ void my_kernel2(const Foo &foo) {
   foo(&state);
 }
 
-//     CHECK: inline void run_foo2() {
+//     CHECK:inline void run_foo2() {
 //CHECK-NEXT:  dpct::get_default_queue().parallel_for<dpct_kernel_name<class my_kernel2_{{[0-9a-z]+}}, class lambda_{{[0-9a-z]+}}>>(
 //CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)), 
 //CHECK-NEXT:    [=](sycl::nd_item<3> item_ct1) {
-//CHECK-NEXT:      my_kernel2([] (curandStatePhilox4_32_10_t * state) {
+//CHECK-NEXT:      my_kernel2([] (dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> * state) {
 //CHECK-NEXT:    return state->generate<oneapi::mkl::rng::device::uniform<double>, 2>();
 //CHECK-NEXT:  }, item_ct1);
 //CHECK-NEXT:    });

--- a/clang/test/dpct/kernel_lambda_arg.cu
+++ b/clang/test/dpct/kernel_lambda_arg.cu
@@ -44,18 +44,14 @@ template <typename Foo> __global__ void my_kernel2(const Foo &foo) {
   curand_init(std::get<0>(seeds), idx, std::get<1>(seeds), &state);
   foo(&state);
 }
-//     CHECK:inline void run_foo2() {
-//CHECK-NEXT:  dpct::get_default_queue().submit(
-//CHECK-NEXT:    [&](sycl::handler &cgh) {
-//CHECK-NEXT:      auto __device___curandStatePhilox4_32_10_t_state_return_curand_uniform2_double_state_ct0 = [] (dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> * state) {
+
+//     CHECK: inline void run_foo2() {
+//CHECK-NEXT:  dpct::get_default_queue().parallel_for<dpct_kernel_name<class my_kernel2_{{[0-9a-z]+}}, class lambda_{{[0-9a-z]+}}>>(
+//CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)), 
+//CHECK-NEXT:    [=](sycl::nd_item<3> item_ct1) {
+//CHECK-NEXT:      my_kernel2([] (curandStatePhilox4_32_10_t * state) {
 //CHECK-NEXT:    return state->generate<oneapi::mkl::rng::device::uniform<double>, 2>();
-//CHECK-NEXT:  };
-//CHECK-EMPTY:
-//CHECK-NEXT:      cgh.parallel_for<dpct_kernel_name<class my_kernel2_{{[0-9a-z]+}}, class lambda_{{[0-9a-z]+}}>>(
-//CHECK-NEXT:        sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
-//CHECK-NEXT:        [=](sycl::nd_item<3> item_ct1) {
-//CHECK-NEXT:          my_kernel2(__device___curandStatePhilox4_32_10_t_state_return_curand_uniform2_double_state_ct0, item_ct1);
-//CHECK-NEXT:        });
+//CHECK-NEXT:  }, item_ct1);
 //CHECK-NEXT:    });
 //CHECK-NEXT:}
 inline void run_foo2() {


### PR DESCRIPTION

Signed-off-by: chenwei.sun <chenwei.sun@intel.com>