### PR TITLE
[SYCLomatic] Fix the migration of type cufftHandle

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -2875,6 +2875,38 @@ bool TypeInDeclRule::isCapturedByLambda(const TypeLoc *TL) {
   return false;
 }
 
+void TypeInDeclRule::processConstFFTHandleType(const DeclaratorDecl *DD,
+                                               SourceLocation BeginLoc,
+                                               SourceLocation EndLoc,
+                                               bool HasGlobalNSPrefix) {
+  std::string Repl = (HasGlobalNSPrefix ? "::" : "") +
+                     MapNames::getDpctNamespace() + "fft::fft_engine*";
+  requestFeature(HelperFeatureEnum::FftUtils_fft_engine, DD->getBeginLoc());
+  SrcAPIStaticsMap[Repl]++;
+
+  clang::SourceManager &SM = dpct::DpctGlobalInfo::getSourceManager();
+  Token Tok;
+  Lexer::getRawToken(DD->getBeginLoc(), Tok, SM, LangOptions());
+  auto Tok2Ptr = Lexer::findNextToken(DD->getBeginLoc(), SM, LangOptions());
+  if (Tok2Ptr.hasValue()) {
+    auto Tok2 = Tok2Ptr.getValue();
+    if (Tok.getKind() == tok::raw_identifier &&
+        Tok.getRawIdentifier().str() == "const") {
+      emplaceTransformation(
+          new ReplaceText(Tok.getLocation(),
+                          Tok2.getLocation().getRawEncoding() -
+                              Tok.getLocation().getRawEncoding(),
+                          ""));
+      Repl = Repl + " const";
+    }
+  }
+  auto Len =
+      Lexer::MeasureTokenLength(EndLoc, DpctGlobalInfo::getSourceManager(),
+                                DpctGlobalInfo::getContext().getLangOpts());
+  Len +=
+      SM.getDecomposedLoc(EndLoc).second - SM.getDecomposedLoc(BeginLoc).second;
+  emplaceTransformation(new ReplaceText(BeginLoc, Len, std::move(Repl)));
+}
 void TypeInDeclRule::processCudaStreamType(const DeclaratorDecl *DD) {
   auto SD = getAllDecls(DD);
 
@@ -3199,6 +3231,19 @@ void TypeInDeclRule::runRule(const MatchFinder::MatchResult &Result) {
       DD = VarD;
     } else if (FieldD) {
       DD = FieldD;
+    } else if (FD) {
+      DD = FD;
+    }
+
+    if (TypeStr == "cufftHandle" || TypeStr == "::cufftHandle") {
+      if (TL->getType().isConstQualified()) {
+        clang::SourceManager &SM = dpct::DpctGlobalInfo::getSourceManager();
+        if (SM.getDecomposedLoc(EndLoc).second >= SM.getDecomposedLoc(BeginLoc).second) {
+          processConstFFTHandleType(DD, BeginLoc, EndLoc,
+                                    TypeStr == "::cufftHandle");
+          return;
+        }
+      }
     }
 
     if (DD) {

--- a/clang/lib/DPCT/ASTTraversal.h
+++ b/clang/lib/DPCT/ASTTraversal.h
@@ -481,6 +481,10 @@ private:
   // Used to prevent them from being processed multiple times
   std::unordered_set<TypeLoc, TypeLocHash, TypeLocEqual> ProcessedTypeLocs;
 
+  void processConstFFTHandleType(const DeclaratorDecl *DD,
+                                 SourceLocation BeginLoc,
+                                 SourceLocation EndLoc,
+                                 bool HasGlobalNSPrefix);
   void processCudaStreamType(const DeclaratorDecl *DD);
   bool replaceTemplateSpecialization(SourceManager *SM, LangOptions &LOpts,
                                      SourceLocation BeginLoc,

--- a/clang/test/dpct/cufft-type.cu
+++ b/clang/test/dpct/cufft-type.cu
@@ -316,3 +316,21 @@ cufftResult_t foo12(){}
 //CHECK-NEXT:int foo13(){}
 template<typename T>
 cufftResult foo13(){}
+
+//     CHECK:void bar1(dpct::fft::fft_engine* const &aaa) {}
+//CHECK-NEXT:void bar2(dpct::fft::fft_engine* const &aaa) {}
+//CHECK-NEXT:void bar3(dpct::fft::fft_engine* const aaa) {}
+//CHECK-NEXT:void bar4(dpct::fft::fft_engine* const aaa) {}
+void bar1(cufftHandle const &aaa) {}
+void bar2(const cufftHandle &aaa) {}
+void bar3(cufftHandle const aaa) {}
+void bar4(const cufftHandle aaa) {}
+
+class MyStruct {
+//     CHECK: ::dpct::fft::fft_engine* handle;
+//CHECK-NEXT: ::dpct::fft::fft_engine* & foo() { return handle; }
+//CHECK-NEXT: ::dpct::fft::fft_engine* const & foo() const { return handle; }
+  ::cufftHandle handle;
+  ::cufftHandle & foo() { return handle; }
+  const ::cufftHandle & foo() const { return handle; }
+};


### PR DESCRIPTION
Original code:
```
const cufftHandle &
```
Before:
```
const dpct::fft::fft_engine* &
```
Now:
```
dpct::fft::fft_engine* const &
```

Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>