### PR TITLE
[SYCLomatic] Disable the template specialization dpct::malloc_device when USM switched-off.

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/memory.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/memory.h.inc
@@ -736,9 +736,11 @@ template <typename T>
 device_pointer<T> malloc_device(const std::size_t num_elements) {
   return device_pointer<T>(num_elements * sizeof(T));
 }
+#ifndef DPCT_USM_LEVEL_NONE
 static inline device_pointer<void> malloc_device(const std::size_t num_bytes) {
   return device_pointer<void>(num_bytes);
 }
+#endif
 // DPCT_LABEL_END
 // DPCT_LABEL_BEGIN|device_new|dpct
 // DPCT_DEPENDENCY_BEGIN

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/memory.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/memory.h
@@ -650,9 +650,11 @@ template <typename T>
 device_pointer<T> malloc_device(const std::size_t num_elements) {
   return device_pointer<T>(num_elements * sizeof(T));
 }
+#ifndef DPCT_USM_LEVEL_NONE
 static inline device_pointer<void> malloc_device(const std::size_t num_bytes) {
   return device_pointer<void>(num_bytes);
 }
+#endif
 template <typename T>
 device_pointer<T> device_new(device_pointer<T> p, const T &value,
                              const std::size_t count = 1) {


### PR DESCRIPTION
Signed-off-by: Chen, Sheng S <sheng.s.chen@intel.com>
