### PR TITLE
[SYCLomatic] Fix incorrect temp variable name for class args in kernel

### DIFF
--- a/clang/lib/DPCT/AnalysisInfo.h
+++ b/clang/lib/DPCT/AnalysisInfo.h
@@ -4044,6 +4044,7 @@ private:
         IsDoublePointer = S->containsVirtualPointer();
       }
       ArgString = Obj->getName();
+      IdString = ArgString + "_";
       ArgSize = MapNames::KernelArgTypeSizeMap.at(KernelArgType::KAT_Texture);
     }
 

--- a/clang/test/dpct/macro_test.cu
+++ b/clang/test/dpct/macro_test.cu
@@ -1179,25 +1179,27 @@ int foo31(){
   VA_CALL( ([&]{ template_kernel<int><<<1,1,0>>>(10); }) );
 }
 
+class ArgClass{};
 
-//CHECK: #define VACALL4(...) __VA_ARGS__()
-//CHECK-NEXT: #define VACALL3(...) VACALL4(__VA_ARGS__)
-//CHECK-NEXT: #define VACALL2(...) VACALL3(__VA_ARGS__)
-//CHECK-NEXT: #define VACALL(x)                                                              \
-//CHECK-NEXT:   dpct::get_default_queue().submit([&](sycl::handler &cgh) {                   \
-//CHECK-NEXT:     auto i_ct0 = i;                                                            \
-//CHECK-NEXT:                                                                                \
-//CHECK-NEXT:     cgh.parallel_for(                                                          \
-//CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, 2), sycl::range<3>(1, 1, 1)),   \
-//CHECK-NEXT:         [=](sycl::nd_item<3> item_ct1) { foo32(i_ct0); });                     \
-//CHECK-NEXT:   });
+// CHECK: #define VACALL4(...) __VA_ARGS__()
+// CHECK-NEXT: #define VACALL3(...) VACALL4(__VA_ARGS__)
+// CHECK-NEXT: #define VACALL2(...) VACALL3(__VA_ARGS__)
+// CHECK-NEXT: #define VACALL(x)                                                              \
+// CHECK-NEXT:  dpct::get_default_queue().submit([&](sycl::handler &cgh) {                    \
+// CHECK-NEXT:   auto i_ct0 = i;                                                              \
+// CHECK-NEXT:   auto ac_ct0 = ac;                                                            \
+// CHECK:   cgh.parallel_for(                                                            \
+// CHECK-NEXT:       sycl::nd_range<3>(sycl::range<3>(1, 1, 2), sycl::range<3>(1, 1, 1)),     \
+// CHECK-NEXT:       [=](sycl::nd_item<3> item_ct1) { foo32(i_ct0, ac_ct0); });               \
+// CHECK-NEXT:  });
 #define VACALL4(...) __VA_ARGS__()
 #define VACALL3(...) VACALL4(__VA_ARGS__)
 #define VACALL2(...) VACALL3(__VA_ARGS__)
-#define VACALL(x) foo32<<<2,1,0>>>(i)
-__global__ void foo32(int a){}
+#define VACALL(x) foo32<<<2,1,0>>>(i, ac)
+__global__ void foo32(int a, ArgClass ac){}
 
 // CHECK: int foo33(){
+// CHECK-NEXT:   ArgClass ac;
 // CHECK-NEXT:   int i;
 // CHECK-NEXT:   /*
 // CHECK-NEXT:   DPCT1038:{{[0-9]+}}: When the kernel function name is used as a macro argument, the
@@ -1208,6 +1210,7 @@ __global__ void foo32(int a){}
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 int foo33(){
+  ArgClass ac;
   int i;
   VACALL2([&]{VACALL(0);});
 }


### PR DESCRIPTION
Signed-off-by: Huang, Andy <andy.huang@intel.com>