### PR TITLE
[SYCLomatic] Adding metafunction to correct type used in buffer_allocator when device_pointer value type is void

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/memory.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/memory.h.inc
@@ -50,13 +50,31 @@
 // DPCT_LABEL_END
 namespace dpct {
 namespace detail {
-// DPCT_LABEL_BEGIN|__buffer_allocator|dpct::detail
+template <typename T>
+// DPCT_LABEL_BEGIN|make_allocatable|dpct::detail
 // DPCT_DEPENDENCY_EMPTY
+// DPCT_CODE
+struct make_allocatable
+{
+  using type = T;
+};
+
+template <>
+struct make_allocatable<void>
+{
+  using type = dpct::byte_t;
+};
+// DPCT_LABEL_END
+
+// DPCT_LABEL_BEGIN|__buffer_allocator|dpct::detail
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasMemory|make_allocatable
+// DPCT_DEPENDENCY_END
 // DPCT_CODE
 template <typename _DataT>
 using __buffer_allocator =
 #if __LIBSYCL_VERSION >= 50707
-    sycl::buffer_allocator<_DataT>;
+    sycl::buffer_allocator<typename make_allocatable<_DataT>::type>;
 #else
     sycl::buffer_allocator;
 #endif

--- a/clang/runtime/dpct-rt/include/dpl_extras/memory.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/memory.h.inc
@@ -52,7 +52,9 @@ namespace dpct {
 namespace detail {
 template <typename T>
 // DPCT_LABEL_BEGIN|make_allocatable|dpct::detail
-// DPCT_DEPENDENCY_EMPTY
+// DPCT_DEPENDENCY_BEGIN
+// Memory|typedef_byte_t
+// DPCT_DEPENDENCY_END
 // DPCT_CODE
 struct make_allocatable
 {

--- a/clang/runtime/dpct-rt/include/dpl_extras/memory.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/memory.h.inc
@@ -50,12 +50,12 @@
 // DPCT_LABEL_END
 namespace dpct {
 namespace detail {
-template <typename T>
 // DPCT_LABEL_BEGIN|make_allocatable|dpct::detail
 // DPCT_DEPENDENCY_BEGIN
 // Memory|typedef_byte_t
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+template <typename T>
 struct make_allocatable
 {
   using type = T;

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/memory.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/memory.h
@@ -16,10 +16,22 @@
 // device_new, free_device, device_delete
 namespace dpct {
 namespace detail {
+template <typename T>
+struct make_allocatable
+{
+  using type = T;
+};
+
+template <>
+struct make_allocatable<void>
+{
+  using type = dpct::byte_t;
+};
+
 template <typename _DataT>
 using __buffer_allocator =
 #if __LIBSYCL_VERSION >= 50707
-    sycl::buffer_allocator<_DataT>;
+    sycl::buffer_allocator<typename make_allocatable<_DataT>::type>;
 #else
     sycl::buffer_allocator;
 #endif

--- a/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test1.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test1.cu
@@ -5,7 +5,7 @@
 // RUN: FileCheck --input-file %T/DplExtrasAlgorithm/api_test1_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/DplExtrasAlgorithm/api_test1_out
 
-// CHECK: 33
+// CHECK: 34
 // TEST_FEATURE: DplExtrasAlgorithm_replace_if
 
 #include <thrust/replace.h>

--- a/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test2.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test2.cu
@@ -5,7 +5,7 @@
 // RUN: FileCheck --input-file %T/DplExtrasAlgorithm/api_test2_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/DplExtrasAlgorithm/api_test2_out
 
-// CHECK: 36
+// CHECK: 37
 // TEST_FEATURE: DplExtrasAlgorithm_remove_if
 
 #include <thrust/remove.h>

--- a/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test3.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test3.cu
@@ -5,7 +5,7 @@
 // RUN: FileCheck --input-file %T/DplExtrasAlgorithm/api_test3_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/DplExtrasAlgorithm/api_test3_out
 
-// CHECK: 33
+// CHECK: 34
 // TEST_FEATURE: DplExtrasAlgorithm_remove_copy_if
 
 #include <thrust/remove.h>

--- a/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test6.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test6.cu
@@ -5,7 +5,7 @@
 // RUN: FileCheck --input-file %T/DplExtrasAlgorithm/api_test6_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/DplExtrasAlgorithm/api_test6_out
 
-// CHECK: 34
+// CHECK: 35
 // TEST_FEATURE: DplExtrasAlgorithm_stable_sort
 
 #include <thrust/sort.h>

--- a/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test7.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test7.cu
@@ -5,7 +5,7 @@
 // RUN: FileCheck --input-file %T/DplExtrasAlgorithm/api_test7_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/DplExtrasAlgorithm/api_test7_out
 
-// CHECK: 38
+// CHECK: 39
 // TEST_FEATURE: DplExtrasAlgorithm_gather
 
 #include <thrust/gather.h>

--- a/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test8.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test8.cu
@@ -5,7 +5,7 @@
 // RUN: FileCheck --input-file %T/DplExtrasAlgorithm/api_test8_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/DplExtrasAlgorithm/api_test8_out
 
-// CHECK: 38
+// CHECK: 39
 // TEST_FEATURE: DplExtrasAlgorithm_scatter
 
 #include <thrust/scatter.h>

--- a/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test9.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test9.cu
@@ -5,7 +5,7 @@
 // RUN: FileCheck --input-file %T/DplExtrasAlgorithm/api_test9_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/DplExtrasAlgorithm/api_test9_out
 
-// CHECK: 33
+// CHECK: 34
 // TEST_FEATURE: DplExtrasAlgorithm_unique_copy
 
 #include <thrust/unique.h>

--- a/clang/test/dpct/test_api_level/DplExtrasMemory/api_test1.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasMemory/api_test1.cu
@@ -5,7 +5,7 @@
 // RUN: FileCheck --input-file %T/DplExtrasMemory/api_test1_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/DplExtrasMemory/api_test1_out
 
-// CHECK: 14
+// CHECK: 15
 // TEST_FEATURE: DplExtrasMemory_device_ptr
 
 #include <thrust/device_ptr.h>

--- a/clang/test/dpct/test_api_level/DplExtrasMemory/api_test10.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasMemory/api_test10.cu
@@ -5,7 +5,7 @@
 // RUN: FileCheck --input-file %T/DplExtrasMemory/api_test10_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/DplExtrasMemory/api_test10_out
 
-// CHECK: 24
+// CHECK: 25
 // TEST_FEATURE: DplExtrasMemory_get_device_pointer
 
 #include <thrust/device_ptr.h>

--- a/clang/test/dpct/test_api_level/DplExtrasMemory/api_test2.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasMemory/api_test2.cu
@@ -5,7 +5,7 @@
 // RUN: FileCheck --input-file %T/DplExtrasMemory/api_test2_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/DplExtrasMemory/api_test2_out
 
-// CHECK: 23
+// CHECK: 24
 // TEST_FEATURE: DplExtrasMemory_device_ptr
 // TEST_FEATURE: DplExtrasMemory_device_pointer_forward_decl
 

--- a/clang/test/dpct/test_api_level/DplExtrasMemory/api_test3.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasMemory/api_test3.cu
@@ -5,7 +5,7 @@
 // RUN: FileCheck --input-file %T/DplExtrasMemory/api_test3_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/DplExtrasMemory/api_test3_out
 
-// CHECK: 15
+// CHECK: 16
 // TEST_FEATURE: DplExtrasMemory_free_device
 
 #include <thrust/device_ptr.h>

--- a/clang/test/dpct/test_api_level/DplExtrasMemory/api_test4.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasMemory/api_test4.cu
@@ -5,7 +5,7 @@
 // RUN: FileCheck --input-file %T/DplExtrasMemory/api_test4_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/DplExtrasMemory/api_test4_out
 
-// CHECK: 24
+// CHECK: 25
 // TEST_FEATURE: DplExtrasMemory_free_device
 
 #include <thrust/device_ptr.h>

--- a/clang/test/dpct/test_api_level/DplExtrasMemory/api_test5.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasMemory/api_test5.cu
@@ -5,7 +5,7 @@
 // RUN: FileCheck --input-file %T/DplExtrasMemory/api_test5_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/DplExtrasMemory/api_test5_out
 
-// CHECK: 15
+// CHECK: 16
 // TEST_FEATURE: DplExtrasMemory_malloc_device
 
 #include <thrust/device_ptr.h>

--- a/clang/test/dpct/test_api_level/DplExtrasMemory/api_test6.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasMemory/api_test6.cu
@@ -5,7 +5,7 @@
 // RUN: FileCheck --input-file %T/DplExtrasMemory/api_test6_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/DplExtrasMemory/api_test6_out
 
-// CHECK: 24
+// CHECK: 25
 // TEST_FEATURE: DplExtrasMemory_malloc_device
 
 #include <thrust/device_ptr.h>

--- a/clang/test/dpct/test_api_level/DplExtrasMemory/api_test7.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasMemory/api_test7.cu
@@ -5,7 +5,7 @@
 // RUN: FileCheck --input-file %T/DplExtrasMemory/api_test7_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/DplExtrasMemory/api_test7_out
 
-// CHECK: 15
+// CHECK: 16
 // TEST_FEATURE: DplExtrasMemory_get_raw_pointer
 
 #include <thrust/device_ptr.h>

--- a/clang/test/dpct/test_api_level/DplExtrasMemory/api_test8.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasMemory/api_test8.cu
@@ -5,7 +5,7 @@
 // RUN: FileCheck --input-file %T/DplExtrasMemory/api_test8_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/DplExtrasMemory/api_test8_out
 
-// CHECK: 24
+// CHECK: 25
 // TEST_FEATURE: DplExtrasMemory_get_raw_pointer
 
 #include <thrust/device_ptr.h>

--- a/clang/test/dpct/test_api_level/DplExtrasMemory/api_test9.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasMemory/api_test9.cu
@@ -5,7 +5,7 @@
 // RUN: FileCheck --input-file %T/DplExtrasMemory/api_test9_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/DplExtrasMemory/api_test9_out
 
-// CHECK: 15
+// CHECK: 16
 // TEST_FEATURE: DplExtrasMemory_get_device_pointer
 
 #include <thrust/device_ptr.h>

--- a/clang/test/dpct/test_api_level/DplExtrasVector/api_test1.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasVector/api_test1.cu
@@ -5,7 +5,7 @@
 // RUN: FileCheck --input-file %T/DplExtrasVector/api_test1_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/DplExtrasVector/api_test1_out
 
-// CHECK: 37
+// CHECK: 38
 // TEST_FEATURE: DplExtrasVector_device_vector
 
 #include <thrust/device_vector.h>

--- a/clang/test/dpct/test_api_level/DplExtrasVector/api_test2.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasVector/api_test2.cu
@@ -5,7 +5,7 @@
 // RUN: FileCheck --input-file %T/DplExtrasVector/api_test2_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/DplExtrasVector/api_test2_out
 
-// CHECK: 29
+// CHECK: 30
 // TEST_FEATURE: DplExtrasVector_device_vector
 
 #include <thrust/device_vector.h>


### PR DESCRIPTION
Signed-off-by: Zhiwei Jiang <zhiwei.jiang@intel.com>