### PR TITLE
[SYCLomatic] [DPCT] adding arg_index_input_iterator and key_value_pair to dpct headers

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/iterators.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/iterators.h.inc
@@ -175,6 +175,8 @@ constant_iterator<_Tp> make_constant_iterator(_Tp __value) {
 // DPCT_LABEL_BEGIN|key_value_pair|dpct
 // DPCT_DEPENDENCY_EMPTY
 // DPCT_CODE
+// key_value_pair class to represent a key and value, specifically a
+// dereferenced arg_index_input_iterator
 template <typename _KeyTp, typename _ValueTp> class key_value_pair {
 public:
   key_value_pair(const _KeyTp &_key, const _ValueTp &_value)
@@ -211,7 +213,6 @@ template <typename KeyTp, typename _ValueTp> struct make_key_value_pair {
 // DPCT_LABEL_END
 
 } // end namespace detail
-
 
 // DPCT_LABEL_BEGIN|arg_index_input_iterator|dpct
 // DPCT_DEPENDENCY_BEGIN

--- a/clang/runtime/dpct-rt/include/dpl_extras/iterators.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/iterators.h.inc
@@ -195,7 +195,7 @@ public:
 
 namespace detail {
 
-// DPCT_LABEL_BEGIN|make_key_value_pair|dpct
+// DPCT_LABEL_BEGIN|make_key_value_pair|dpct::detail
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasIterators|key_value_pair
 // DPCT_DEPENDENCY_END

--- a/clang/runtime/dpct-rt/include/dpl_extras/iterators.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/iterators.h.inc
@@ -80,7 +80,8 @@ public:
   typedef std::ptrdiff_t difference_type;
   typedef _Tp value_type;
   typedef _Tp *pointer;
-  // There is no storage behind the iterator, so we return a value instead of reference.
+  // There is no storage behind the iterator, so we return a value instead of
+  // reference.
   typedef const _Tp reference;
   typedef const _Tp const_reference;
   typedef std::random_access_iterator_tag iterator_category;
@@ -169,6 +170,158 @@ template <typename _Tp>
 constant_iterator<_Tp> make_constant_iterator(_Tp __value) {
   return constant_iterator<_Tp>(__value);
 }
+// DPCT_LABEL_END
+
+// DPCT_LABEL_BEGIN|key_value_pair|dpct
+// DPCT_DEPENDENCY_EMPTY
+// DPCT_CODE
+template <typename _KeyTp, typename _ValueTp> class key_value_pair {
+public:
+  key_value_pair(const _KeyTp &_key, const _ValueTp &_value)
+      : key(_key), value(_value) {}
+
+  bool operator==(const key_value_pair<_KeyTp, _ValueTp> &_kvp) const {
+    return (key == _kvp.key) && (value == _kvp.value);
+  }
+
+  bool operator!=(const key_value_pair<_KeyTp, _ValueTp> &_kvp) const {
+    return (key != _kvp.key) || (value != _kvp.value);
+  }
+
+  _KeyTp key;
+  _ValueTp value;
+};
+// DPCT_LABEL_END
+
+namespace detail {
+
+// DPCT_LABEL_BEGIN|make_key_value_pair|dpct
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasIterators|key_value_pair
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+template <typename KeyTp, typename _ValueTp> struct make_key_value_pair {
+  template <typename ValRefTp>
+  key_value_pair<KeyTp, _ValueTp>
+  operator()(const oneapi::dpl::__internal::tuple<KeyTp, ValRefTp> &tup) const {
+    return ::dpct::key_value_pair<KeyTp, _ValueTp>(::std::get<0>(tup),
+                                                   ::std::get<1>(tup));
+  }
+};
+// DPCT_LABEL_END
+
+} // end namespace detail
+
+
+// DPCT_LABEL_BEGIN|arg_index_input_iterator|dpct
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasIterators|make_key_value_pair
+// DplExtrasIterators|key_value_pair
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+// arg_index_input_iterator is an iterator over a input iterator, with a index.
+// When dereferenced, it returns a key_value_pair, which can be interrogated for
+// the index key or the value from the input iterator
+template <typename InputIteratorT, typename OffsetT = ptrdiff_t,
+          typename OutputValueT =
+              typename ::std::iterator_traits<InputIteratorT>::value_type>
+class arg_index_input_iterator
+    : public oneapi::dpl::transform_iterator<
+          oneapi::dpl::zip_iterator<oneapi::dpl::counting_iterator<OffsetT>,
+                                    InputIteratorT>,
+          detail::make_key_value_pair<OffsetT, OutputValueT>> {
+  using arg_index_input_iterator_wrap = oneapi::dpl::transform_iterator<
+      oneapi::dpl::zip_iterator<oneapi::dpl::counting_iterator<OffsetT>,
+                                InputIteratorT>,
+      detail::make_key_value_pair<OffsetT, OutputValueT>>;
+
+public:
+  typedef OffsetT difference_type;
+
+  // signal to __get_sycl_range that this iterator is as a direct pass iterator
+  using is_zip = ::std::true_type;
+
+  arg_index_input_iterator(const arg_index_input_iterator_wrap &__arg_wrap)
+      : arg_index_input_iterator_wrap(__arg_wrap) {}
+  arg_index_input_iterator(InputIteratorT __iter)
+      : arg_index_input_iterator_wrap(
+            oneapi::dpl::make_zip_iterator(
+                oneapi::dpl::counting_iterator(OffsetT(0)), __iter),
+            detail::make_key_value_pair<OffsetT, OutputValueT>()) {}
+
+  arg_index_input_iterator &operator=(const arg_index_input_iterator &__input) {
+    arg_index_input_iterator_wrap::operator=(__input);
+    return *this;
+  }
+  arg_index_input_iterator &operator++() {
+    arg_index_input_iterator_wrap::operator++();
+    return *this;
+  }
+  arg_index_input_iterator &operator--() {
+    arg_index_input_iterator_wrap::operator--();
+    return *this;
+  }
+  arg_index_input_iterator operator++(int) {
+    arg_index_input_iterator __it(*this);
+    ++(*this);
+    return __it;
+  }
+  arg_index_input_iterator operator--(int) {
+    arg_index_input_iterator __it(*this);
+    --(*this);
+    return __it;
+  }
+  arg_index_input_iterator operator+(difference_type __forward) const {
+    return arg_index_input_iterator(
+        arg_index_input_iterator_wrap::operator+(__forward));
+  }
+  arg_index_input_iterator operator-(difference_type __backward) const {
+    return arg_index_input_iterator(
+        arg_index_input_iterator_wrap::operator-(__backward));
+  }
+  arg_index_input_iterator &operator+=(difference_type __forward) {
+    arg_index_input_iterator_wrap::operator+=(__forward);
+    return *this;
+  }
+  arg_index_input_iterator &operator-=(difference_type __backward) {
+    arg_index_input_iterator_wrap::operator-=(__backward);
+    return *this;
+  }
+
+  friend arg_index_input_iterator
+  operator+(difference_type __forward, const arg_index_input_iterator &__it) {
+    return __it + __forward;
+  }
+
+  difference_type operator-(const arg_index_input_iterator &__it) const {
+    return arg_index_input_iterator_wrap::operator-(__it);
+  }
+  bool operator==(const arg_index_input_iterator &__it) const {
+    return arg_index_input_iterator_wrap::operator==(__it);
+  }
+  bool operator!=(const arg_index_input_iterator &__it) const {
+    return !(*this == __it);
+  }
+  bool operator<(const arg_index_input_iterator &__it) const {
+    return *this - __it < 0;
+  }
+  bool operator>(const arg_index_input_iterator &__it) const {
+    return __it < *this;
+  }
+  bool operator<=(const arg_index_input_iterator &__it) const {
+    return !(*this > __it);
+  }
+  bool operator>=(const arg_index_input_iterator &__it) const {
+    return !(*this < __it);
+  }
+
+  // returns an arg_index_input_iterator with the same iter position, but a
+  // count reset to 0
+  arg_index_input_iterator create_normalized() {
+    return arg_index_input_iterator(
+        ::std::get<1>(arg_index_input_iterator_wrap::base().base()));
+  }
+};
 // DPCT_LABEL_END
 
 } // end namespace dpct

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/iterators.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/iterators.h
@@ -31,7 +31,8 @@ public:
   typedef std::ptrdiff_t difference_type;
   typedef _Tp value_type;
   typedef _Tp *pointer;
-  // There is no storage behind the iterator, so we return a value instead of reference.
+  // There is no storage behind the iterator, so we return a value instead of
+  // reference.
   typedef const _Tp reference;
   typedef const _Tp const_reference;
   typedef std::random_access_iterator_tag iterator_category;
@@ -114,6 +115,142 @@ template <typename _Tp>
 constant_iterator<_Tp> make_constant_iterator(_Tp __value) {
   return constant_iterator<_Tp>(__value);
 }
+
+// key_value_pair class to represent a key and value, specifically a
+// dereferenced arg_index_input_iterator
+template <typename _KeyTp, typename _ValueTp> class key_value_pair {
+public:
+  key_value_pair(const _KeyTp &_key, const _ValueTp &_value)
+      : key(_key), value(_value) {}
+
+  bool operator==(const key_value_pair<_KeyTp, _ValueTp> &_kvp) const {
+    return (key == _kvp.key) && (value == _kvp.value);
+  }
+
+  bool operator!=(const key_value_pair<_KeyTp, _ValueTp> &_kvp) const {
+    return (key != _kvp.key) || (value != _kvp.value);
+  }
+
+  _KeyTp key;
+  _ValueTp value;
+};
+
+namespace detail {
+
+template <typename KeyTp, typename _ValueTp> struct make_key_value_pair {
+  template <typename ValRefTp>
+  key_value_pair<KeyTp, _ValueTp>
+  operator()(const oneapi::dpl::__internal::tuple<KeyTp, ValRefTp> &tup) const {
+    return ::dpct::key_value_pair<KeyTp, _ValueTp>(::std::get<0>(tup),
+                                                   ::std::get<1>(tup));
+  }
+};
+
+} // namespace detail
+
+// arg_index_input_iterator is an iterator over a input iterator, with a index.
+// When dereferenced, it returns a key_value_pair, which can be interrogated for
+// the index key or the value from the input iterator
+template <typename InputIteratorT, typename OffsetT = ptrdiff_t,
+          typename OutputValueT =
+              typename ::std::iterator_traits<InputIteratorT>::value_type>
+class arg_index_input_iterator
+    : public oneapi::dpl::transform_iterator<
+          oneapi::dpl::zip_iterator<oneapi::dpl::counting_iterator<OffsetT>,
+                                    InputIteratorT>,
+          detail::make_key_value_pair<OffsetT, OutputValueT>> {
+  using arg_index_input_iterator_wrap = oneapi::dpl::transform_iterator<
+      oneapi::dpl::zip_iterator<oneapi::dpl::counting_iterator<OffsetT>,
+                                InputIteratorT>,
+      detail::make_key_value_pair<OffsetT, OutputValueT>>;
+
+public:
+  typedef OffsetT difference_type;
+
+  // signal to __get_sycl_range that this iterator is as a direct pass iterator
+  using is_zip = ::std::true_type;
+
+  arg_index_input_iterator(const arg_index_input_iterator_wrap &__arg_wrap)
+      : arg_index_input_iterator_wrap(__arg_wrap) {}
+  arg_index_input_iterator(InputIteratorT __iter)
+      : arg_index_input_iterator_wrap(
+            oneapi::dpl::make_zip_iterator(
+                oneapi::dpl::counting_iterator(OffsetT(0)), __iter),
+            detail::make_key_value_pair<OffsetT, OutputValueT>()) {}
+
+  arg_index_input_iterator &operator=(const arg_index_input_iterator &__input) {
+    arg_index_input_iterator_wrap::operator=(__input);
+    return *this;
+  }
+  arg_index_input_iterator &operator++() {
+    arg_index_input_iterator_wrap::operator++();
+    return *this;
+  }
+  arg_index_input_iterator &operator--() {
+    arg_index_input_iterator_wrap::operator--();
+    return *this;
+  }
+  arg_index_input_iterator operator++(int) {
+    arg_index_input_iterator __it(*this);
+    ++(*this);
+    return __it;
+  }
+  arg_index_input_iterator operator--(int) {
+    arg_index_input_iterator __it(*this);
+    --(*this);
+    return __it;
+  }
+  arg_index_input_iterator operator+(difference_type __forward) const {
+    return arg_index_input_iterator(
+        arg_index_input_iterator_wrap::operator+(__forward));
+  }
+  arg_index_input_iterator operator-(difference_type __backward) const {
+    return arg_index_input_iterator(
+        arg_index_input_iterator_wrap::operator-(__backward));
+  }
+  arg_index_input_iterator &operator+=(difference_type __forward) {
+    arg_index_input_iterator_wrap::operator+=(__forward);
+    return *this;
+  }
+  arg_index_input_iterator &operator-=(difference_type __backward) {
+    arg_index_input_iterator_wrap::operator-=(__backward);
+    return *this;
+  }
+
+  friend arg_index_input_iterator
+  operator+(difference_type __forward, const arg_index_input_iterator &__it) {
+    return __it + __forward;
+  }
+
+  difference_type operator-(const arg_index_input_iterator &__it) const {
+    return arg_index_input_iterator_wrap::operator-(__it);
+  }
+  bool operator==(const arg_index_input_iterator &__it) const {
+    return arg_index_input_iterator_wrap::operator==(__it);
+  }
+  bool operator!=(const arg_index_input_iterator &__it) const {
+    return !(*this == __it);
+  }
+  bool operator<(const arg_index_input_iterator &__it) const {
+    return *this - __it < 0;
+  }
+  bool operator>(const arg_index_input_iterator &__it) const {
+    return __it < *this;
+  }
+  bool operator<=(const arg_index_input_iterator &__it) const {
+    return !(*this > __it);
+  }
+  bool operator>=(const arg_index_input_iterator &__it) const {
+    return !(*this < __it);
+  }
+
+  // returns an arg_index_input_iterator with the same iter position, but a
+  // count reset to 0
+  arg_index_input_iterator create_normalized() {
+    return arg_index_input_iterator(
+        ::std::get<1>(arg_index_input_iterator_wrap::base().base()));
+  }
+};
 
 } // end namespace dpct
 

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/iterators.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/iterators.h
@@ -146,7 +146,7 @@ template <typename KeyTp, typename _ValueTp> struct make_key_value_pair {
   }
 };
 
-} // namespace detail
+} // end namespace detail
 
 // arg_index_input_iterator is an iterator over a input iterator, with a index.
 // When dereferenced, it returns a key_value_pair, which can be interrogated for


### PR DESCRIPTION
Adding dpct helpers for arg_index_input_iterator and key_value_pair to dpct headers.

Associated tests can be found in the SYCLomatic-test PR:
https://github.com/oneapi-src/SYCLomatic-test/pull/137