### PR TITLE
[SYCLomatic] Ensure wrappers are only generated under C language linkage and for __global__ functions

### DIFF
--- a/clang/lib/DPCT/AnalysisInfo.cpp
+++ b/clang/lib/DPCT/AnalysisInfo.cpp
@@ -2448,7 +2448,7 @@ inline void DeviceFunctionDecl::emplaceReplacement() {
 
 inline void DeviceFunctionDeclInModule::emplaceReplacement() {
   DeviceFunctionDecl::emplaceReplacement();
-  if(GenerateWrapper) { insertWrapper(); }
+  insertWrapper();
 }
 
 void DeviceFunctionDeclInModule::buildParameterInfo(const FunctionDecl *FD) {
@@ -2459,9 +2459,6 @@ void DeviceFunctionDeclInModule::buildParameterInfo(const FunctionDecl *FD) {
 }
 
 void DeviceFunctionDeclInModule::buildWrapperInfo(const FunctionDecl *FD) {
-  GenerateWrapper =
-    (FD->getLanguageLinkage() == CLanguageLinkage
-     && FD->hasAttr<CUDAGlobalAttr>());
   auto &SM = DpctGlobalInfo::getSourceManager();
   const FunctionDecl *Def;
   HasBody = FD->hasBody(Def);
@@ -2491,12 +2488,12 @@ void DeviceFunctionDeclInModule::buildCallInfo(const FunctionDecl *FD) {
 
 bool isModuleFunction(const FunctionDecl *FD) {
   auto &SM = DpctGlobalInfo::getSourceManager();
-  if (DpctGlobalInfo::getModuleFiles().find(
+  return
+    FD->getLanguageLinkage() == CLanguageLinkage
+    && FD->hasAttr<CUDAGlobalAttr>()
+    && DpctGlobalInfo::getModuleFiles().find(
           DpctGlobalInfo::getLocInfo(SM.getExpansionLoc(FD->getBeginLoc()))
-              .first) != DpctGlobalInfo::getModuleFiles().end()) {
-    return true;
-  }
-  return false;
+              .first) != DpctGlobalInfo::getModuleFiles().end();
 }
 
 DeviceFunctionDecl::DeviceFunctionDecl(unsigned Offset,

--- a/clang/lib/DPCT/AnalysisInfo.cpp
+++ b/clang/lib/DPCT/AnalysisInfo.cpp
@@ -2448,7 +2448,7 @@ inline void DeviceFunctionDecl::emplaceReplacement() {
 
 inline void DeviceFunctionDeclInModule::emplaceReplacement() {
   DeviceFunctionDecl::emplaceReplacement();
-  insertWrapper();
+  if(GenerateWrapper) { insertWrapper(); }
 }
 
 void DeviceFunctionDeclInModule::buildParameterInfo(const FunctionDecl *FD) {
@@ -2459,6 +2459,9 @@ void DeviceFunctionDeclInModule::buildParameterInfo(const FunctionDecl *FD) {
 }
 
 void DeviceFunctionDeclInModule::buildWrapperInfo(const FunctionDecl *FD) {
+  GenerateWrapper =
+    (FD->getLanguageLinkage() == CLanguageLinkage
+     && FD->hasAttr<CUDAGlobalAttr>());
   auto &SM = DpctGlobalInfo::getSourceManager();
   const FunctionDecl *Def;
   HasBody = FD->hasBody(Def);

--- a/clang/lib/DPCT/AnalysisInfo.h
+++ b/clang/lib/DPCT/AnalysisInfo.h
@@ -3720,6 +3720,7 @@ private:
 class DeviceFunctionDeclInModule : public DeviceFunctionDecl {
   void insertWrapper();
   bool HasBody = false;
+  bool GenerateWrapper;
   size_t DeclEnd;
   std::string FuncName;
   std::vector<std::pair<std::string, std::string>> ParametersInfo;

--- a/clang/lib/DPCT/AnalysisInfo.h
+++ b/clang/lib/DPCT/AnalysisInfo.h
@@ -3720,7 +3720,6 @@ private:
 class DeviceFunctionDeclInModule : public DeviceFunctionDecl {
   void insertWrapper();
   bool HasBody = false;
-  bool GenerateWrapper;
   size_t DeclEnd;
   std::string FuncName;
   std::vector<std::pair<std::string, std::string>> ParametersInfo;

--- a/clang/test/dpct/module_kernel.cu
+++ b/clang/test/dpct/module_kernel.cu
@@ -5,13 +5,13 @@
 //CHECK: dpct::image_wrapper_base_p tex;
 CUtexref tex;
 
-//CHECK: void foo(float* k, float* y, sycl::nd_item<3> item_ct1, uint8_t *dpct_local,
-//CHECK-NEXT:     unsigned int *const_data);
+//CHECK: extern "C" void foo(float* k, float* y, sycl::nd_item<3> item_ct1,
+//CHECK-NEXT:     uint8_t *dpct_local, unsigned int *const_data);
 
 //CHECK:extern "C" {
 //CHECK-NEXT:void foo_wrapper(sycl::queue &queue, const sycl::nd_range<3> &nr, unsigned int localMemSize, void **kernelParams, void **extra);
 //CHECK-NEXT:}
-__global__ void foo(float* k, float* y);
+extern "C" __global__ void foo(float* k, float* y);
 
 
 __constant__ unsigned int const_data[3] = {1, 2, 3};

--- a/clang/test/dpct/module_kernel_win.cu
+++ b/clang/test/dpct/module_kernel_win.cu
@@ -5,7 +5,8 @@
 //CHECK: dpct::image_wrapper_base_p tex;
 CUtexref tex;
 
-//CHECK: extern "C" void foo(float* k, float* y, sycl::nd_item<3> item_ct1, uint8_t *dpct_local);
+//CHECK: extern "C" void foo(float* k, float* y, sycl::nd_item<3> item_ct1,
+//CHECK-NEXT: uint8_t *dpct_local);
 
 //CHECK: extern "C" {
 //CHECK-NEXT: __declspec(dllexport) void foo_wrapper(sycl::queue &queue, const sycl::nd_range<3> &nr, unsigned int localMemSize, void **kernelParams, void **extra);

--- a/clang/test/dpct/module_kernel_win.cu
+++ b/clang/test/dpct/module_kernel_win.cu
@@ -5,12 +5,12 @@
 //CHECK: dpct::image_wrapper_base_p tex;
 CUtexref tex;
 
-//CHECK: void foo(float* k, float* y, sycl::nd_item<3> item_ct1, uint8_t *dpct_local);
+//CHECK: extern "C" void foo(float* k, float* y, sycl::nd_item<3> item_ct1, uint8_t *dpct_local);
 
 //CHECK: extern "C" {
 //CHECK-NEXT: __declspec(dllexport) void foo_wrapper(sycl::queue &queue, const sycl::nd_range<3> &nr, unsigned int localMemSize, void **kernelParams, void **extra);
 //CHECK-NEXT: }
-__global__ void foo(float* k, float* y);
+extern "C" __global__ void foo(float* k, float* y);
 
 
 //CHECK: void foo(float* k, float* y, sycl::nd_item<3> item_ct1, uint8_t *dpct_local){

--- a/clang/test/dpct/module_wrapper_gen.cu
+++ b/clang/test/dpct/module_wrapper_gen.cu
@@ -11,6 +11,10 @@ __device__ float2 operator+(float2 a, float2 b) {
 
 extern "C" __device__ void externCNonKernel() {}
 
+__device__ void deviceFun() {}
+
+__global__ void nonExternCKernel() {}
+
 extern "C" __global__ void exampleKernel() {
   float2 x;
   float2 y;

--- a/clang/test/dpct/module_wrapper_gen.cu
+++ b/clang/test/dpct/module_wrapper_gen.cu
@@ -1,0 +1,24 @@
+// RUN: dpct --extra-arg="--ptx" --out-root=%T/module_wrapper_gen %s
+// RUN: FileCheck %s --input-file=%T/module_wrapper_gen/module_wrapper_gen.dp.cpp
+
+// START
+
+__device__ float2 operator+(float2 a, float2 b) {
+  return float2{a.x - b.x, a.y - b.y};
+}
+
+extern "C" __device__ void externCNonKernel() {}
+
+extern "C" __global__ void exampleKernel() {
+  float2 x;
+  float2 y;
+  float2 z = x + y;
+}
+
+// END
+
+// Only one _wrapper should be generated.
+// CHECK:     // START
+// CHECK:     _wrapper
+// CHECK-NOT: _wrapper
+// CHECK:     // END

--- a/clang/test/dpct/module_wrapper_gen.cu
+++ b/clang/test/dpct/module_wrapper_gen.cu
@@ -1,4 +1,6 @@
-// RUN: dpct --extra-arg="--ptx" --out-root=%T/module_wrapper_gen %s
+// RUN: dpct --extra-arg="--ptx" \
+// RUN:      --out-root=%T/module_wrapper_gen \
+// RUN:      --cuda-include-path="%cuda-path/include" %s
 // RUN: FileCheck %s --input-file=%T/module_wrapper_gen/module_wrapper_gen.dp.cpp
 
 // START


### PR DESCRIPTION


Signed-off-by: Cai, Justin <justin.cai@intel.com>