### PR TITLE
[NFC][SYCLomatic] Clean llvm::Optional<T>::getValue() deprecated warning

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5605,7 +5605,7 @@ class OffloadingActionBuilder final {
               C.getDriver().Diag(clang::diag::err_drv_bad_target_id) << ArchStr;
               continue;
             }
-            auto CanId = getCanonicalTargetID(Arch.getValue(), Features);
+            auto CanId = getCanonicalTargetID(Arch.value(), Features);
             ArchStr = Args.MakeArgStringRef(CanId);
           }
           ParsedArg->claim();

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5605,7 +5605,11 @@ class OffloadingActionBuilder final {
               C.getDriver().Diag(clang::diag::err_drv_bad_target_id) << ArchStr;
               continue;
             }
+#ifdef SYCLomatic_CUSTOMIZATION
             auto CanId = getCanonicalTargetID(Arch.value(), Features);
+#else
+            auto CanId = getCanonicalTargetID(Arch.getValue(), Features);
+#endif
             ArchStr = Args.MakeArgStringRef(CanId);
           }
           ParsedArg->claim();


### PR DESCRIPTION

Signed-off-by: Wang, Yihan <yihan.wang@intel.com>