### PR TITLE
[SYCLomatic] Improve dpct::device::segmented_reduce

### DIFF
--- a/clang/lib/DPCT/CUBAPIMigration.cpp
+++ b/clang/lib/DPCT/CUBAPIMigration.cpp
@@ -790,8 +790,8 @@ void CubRule::processDeviceLevelFuncCall(const CallExpr *CE,
 
   CubParamAs << QueueRepl << InputEA.getReplacedString()
              << OutputEA.getReplacedString() << SegmentNumEA.getReplacedString()
-             << ("(unsigned int *)(" + OffsetBegEA.getReplacedString() + ")")
-             << ("(unsigned int *)(" + OffsetEndEA.getReplacedString() + ")")
+             << OffsetBegEA.getReplacedString()
+             << OffsetEndEA.getReplacedString()
              << OpRepl << InitRepl;
   if (FuncCallUsed) {
     Repl = "(" + MapNames::getDpctNamespace() + "device::segmented_reduce<" +

--- a/clang/lib/DPCT/Utility.cpp
+++ b/clang/lib/DPCT/Utility.cpp
@@ -3096,7 +3096,7 @@ bool isDefaultStream(const Expr *StreamArg) {
       StreamArg->EvaluateAsInt(Result, dpct::DpctGlobalInfo::getContext())) {
     // 0 or 1 (cudaStreamLegacy) or 2 (cudaStreamPerThread)
     // all migrated to default queue;
-    return Result.Val.getInt() < APSInt::get(3);
+    return Result.Val.getInt().getZExtValue() < APSInt::get(3);
   }
   return false;
 }

--- a/clang/runtime/dpct-rt/include/dpl_extras/dpcpp_extensions.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/dpcpp_extensions.h.inc
@@ -677,20 +677,20 @@ template <typename... _Args> constexpr auto __joint_reduce(_Args... __args) {
 /// that are one past the last element in each segment \param binary_op functor
 /// that implements the binary operation used to perform the scan. \param init
 /// initial value of the reduction for each segment.
-template <int GROUP_SIZE, typename T, class BinaryOperation>
+template <int GROUP_SIZE, typename T, typename Ptr, class BinaryOperation>
 void segmented_reduce(sycl::queue queue, T *inputs, T *outputs,
-                      size_t segment_count, uint32_t *begin_offsets,
-                      uint32_t *end_offsets, BinaryOperation binary_op,
-                      T init) {
+                      size_t segment_count, Ptr begin_offsets, Ptr end_offsets,
+                      BinaryOperation binary_op, T init) {
 
   sycl::range<1> global_size(segment_count * GROUP_SIZE);
   sycl::range<1> local_size(GROUP_SIZE);
+  typedef std::remove_pointer_t<Ptr> OffsetT;
 
   queue.submit([&](sycl::handler &cgh) {
     cgh.parallel_for(
         sycl::nd_range<1>(global_size, local_size), [=](sycl::nd_item<1> item) {
-          uint32_t segment_begin = begin_offsets[item.get_group_linear_id()];
-          uint32_t segment_end = end_offsets[item.get_group_linear_id()];
+          OffsetT segment_begin = begin_offsets[item.get_group_linear_id()];
+          OffsetT segment_end = end_offsets[item.get_group_linear_id()];
           if (segment_begin == segment_end) {
             if (item.get_local_linear_id() == 0) {
               outputs[item.get_group_linear_id()] = init;

--- a/clang/test/dpct/cub/devicelevel/devicesegmentedreduce.cu
+++ b/clang/test/dpct/cub/devicelevel/devicesegmentedreduce.cu
@@ -82,7 +82,7 @@ struct UserMin
 //CHECK:    /*
 //CHECK:    DPCT1092:{{[0-9]+}}: Consider replacing work-group size 128 with differnt value for specific hardware for better performance.
 //CHECK:    */
-//CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), dpct_placeholder, initial_value);
+//CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, device_offsets, device_offsets + 1, dpct_placeholder, initial_value);
 
 
 //CHECK:    dev_ct1.queues_wait_and_throw();
@@ -156,7 +156,7 @@ bool test_reduce_1(){
 //CHECK:    /*
 //CHECK:    DPCT1092:{{[0-9]+}}: Consider replacing work-group size 128 with differnt value for specific hardware for better performance.
 //CHECK:    */
-//CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::ext::oneapi::minimum<>(), initial_value);
+//CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, device_offsets, device_offsets + 1, sycl::ext::oneapi::minimum<>(), initial_value);
 
 //CHECK:    dev_ct1.queues_wait_and_throw();
 
@@ -233,7 +233,7 @@ bool test_reduce_3(){
   // CHECK:   /*
   // CHECK:   DPCT1092:{{[0-9]+}}: Consider replacing work-group size 128 with differnt value for specific hardware for better performance.
   // CHECK:   */
-  // CHECK:   dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::ext::oneapi::minimum<>(), initial_value);
+  // CHECK:   dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, device_offsets, device_offsets + 1, sycl::ext::oneapi::minimum<>(), initial_value);
   // CHECK:   temp_storage = (void *)sycl::malloc_device(temp_storage_size, q_ct1);
   // CHECK: }
   for(int i = 0; i < 10; i++) {
@@ -249,7 +249,7 @@ bool test_reduce_3(){
   // CHECK:    /*
   // CHECK:    DPCT1092:{{[0-9]+}}: Consider replacing work-group size 128 with differnt value for specific hardware for better performance.
   // CHECK:    */
-  // CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::ext::oneapi::minimum<>(), initial_value);
+  // CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, device_offsets, device_offsets + 1, sycl::ext::oneapi::minimum<>(), initial_value);
   // CHECK:  }
   for(int i = 0; i < 10; i++) {
     temp_storage = nullptr;
@@ -269,12 +269,12 @@ bool test_reduce_3(){
   // CHECK:    /*
   // CHECK:    DPCT1092:{{[0-9]+}}: Consider replacing work-group size 128 with differnt value for specific hardware for better performance.
   // CHECK:    */
-  // CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::ext::oneapi::minimum<>(), initial_value);
+  // CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, device_offsets, device_offsets + 1, sycl::ext::oneapi::minimum<>(), initial_value);
   // CHECK:    temp_storage = (void *)sycl::malloc_device(temp_storage_size, q_ct1);
   // CHECK:    /*
   // CHECK:    DPCT1092:{{[0-9]+}}: Consider replacing work-group size 128 with differnt value for specific hardware for better performance.
   // CHECK:    */
-  // CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::ext::oneapi::minimum<>(), initial_value);
+  // CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, device_offsets, device_offsets + 1, sycl::ext::oneapi::minimum<>(), initial_value);
   // CHECK:  }
   for(int i = 0; i < 10; i++) {
     temp_storage = nullptr;
@@ -293,7 +293,7 @@ bool test_reduce_3(){
   // CHECK: /*
   // CHECK: DPCT1092:{{[0-9]+}}: Consider replacing work-group size 128 with differnt value for specific hardware for better performance.
   // CHECK: */
-  // CHECK: dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::ext::oneapi::minimum<>(), initial_value);
+  // CHECK: dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, device_offsets, device_offsets + 1, sycl::ext::oneapi::minimum<>(), initial_value);
 
   cudaMalloc(&temp_storage, temp_storage_size);
 
@@ -334,7 +334,7 @@ bool test_reduce_3(){
 //CHECK:      /*
 //CHECK:      DPCT1092:{{[0-9]+}}: Consider replacing work-group size 128 with differnt value for specific hardware for better performance.
 //CHECK:      */
-//CHECK:      dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::ext::oneapi::plus<>(), 0);
+//CHECK:      dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, device_offsets, device_offsets + 1, sycl::ext::oneapi::plus<>(), 0);
 
 //CHECK:      dev_ct1.queues_wait_and_throw();
 
@@ -407,7 +407,7 @@ bool test_sum_1(){
 //CHECK:    /*
 //CHECK:    DPCT1092:{{[0-9]+}}: Consider replacing work-group size 128 with differnt value for specific hardware for better performance.
 //CHECK:    */
-//CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::ext::oneapi::plus<>(), 0);
+//CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, device_offsets, device_offsets + 1, sycl::ext::oneapi::plus<>(), 0);
 
 //CHECK:    dev_ct1.queues_wait_and_throw();
 
@@ -479,7 +479,7 @@ bool test_sum_2(){
 //CHECK:    /*
 //CHECK:    DPCT1092:{{[0-9]+}}: Consider replacing work-group size 128 with differnt value for specific hardware for better performance.
 //CHECK:    */
-//CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::ext::oneapi::minimum<>(), std::numeric_limits<int>::max());
+//CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, device_offsets, device_offsets + 1, sycl::ext::oneapi::minimum<>(), std::numeric_limits<int>::max());
 
 //CHECK:    dev_ct1.queues_wait_and_throw();
 
@@ -551,7 +551,7 @@ bool test_min(){
 //CHECK:    /*
 //CHECK:    DPCT1092:{{[0-9]+}}: Consider replacing work-group size 128 with differnt value for specific hardware for better performance.
 //CHECK:    */
-//CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::ext::oneapi::maximum<>(), std::numeric_limits<int>::lowest());
+//CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, device_offsets, device_offsets + 1, sycl::ext::oneapi::maximum<>(), std::numeric_limits<int>::lowest());
 
 //CHECK:    dev_ct1.queues_wait_and_throw();
 


### PR DESCRIPTION
- Use template arg instead of uint32_t as offset type in dpct::device::segment_reduce
- Refine the migration of cub::DeviceSegmentedReduce::(Reduce/Sum/Min/Max), remove redundant c-style type cast

Signed-off-by: Wang, Yihan <yihan.wang@intel.com>