### PR TITLE
[SYCLomatic] Fix comparsion two APInt value with different bit width in isDefalutStream

### DIFF
--- a/clang/lib/DPCT/Utility.cpp
+++ b/clang/lib/DPCT/Utility.cpp
@@ -3096,7 +3096,7 @@ bool isDefaultStream(const Expr *StreamArg) {
       StreamArg->EvaluateAsInt(Result, dpct::DpctGlobalInfo::getContext())) {
     // 0 or 1 (cudaStreamLegacy) or 2 (cudaStreamPerThread)
     // all migrated to default queue;
-    return Result.Val.getInt() < APSInt::get(3);
+    return Result.Val.getInt().getZExtValue() < 3;
   }
   return false;
 }


### PR DESCRIPTION
Signed-off-by: Ni, Wenhui <wenhui.ni@intel.com>