### PR TITLE
[SYCLomatic] Re-implement cub::DeviceSegmentedReduce::(Reduce/Sum/Max/Min) with rewriter

### DIFF
--- a/clang/lib/DPCT/APINamesCUB.inc
+++ b/clang/lib/DPCT/APINamesCUB.inc
@@ -479,8 +479,9 @@ CONDITIONAL_FACTORY_ENTRY(
                                      "device::segmented_reduce",
                                  LITERAL("128")),
                              STREAM(9), ARG(2), ARG(3), ARG(4), ARG(5), ARG(6),
-                             CALL(TEMPLATED_CALLEE(MapNames::getClNamespace() +
-                                                   "ext::oneapi::plus")),
+                             CALL(TEMPLATED_CALLEE_WITH_ARGS(
+                                 MapNames::getClNamespace() + "plus",
+                                 LITERAL(""))),
                              ZERO_INITIALIZER(TYPENAME(STATIC_MEMBER_EXPR(
                                  TEMPLATED_NAME("std::iterator_traits",
                                                 CALL("decltype", ARG(2))),
@@ -492,8 +493,9 @@ CONDITIONAL_FACTORY_ENTRY(
                                      "device::segmented_reduce",
                                  LITERAL("128")),
                              QUEUESTR, ARG(2), ARG(3), ARG(4), ARG(5), ARG(6),
-                             CALL(TEMPLATED_CALLEE(MapNames::getClNamespace() +
-                                                   "ext::oneapi::plus")),
+                             CALL(TEMPLATED_CALLEE_WITH_ARGS(
+                                 MapNames::getClNamespace() + "plus",
+                                 LITERAL(""))),
                              ZERO_INITIALIZER(TYPENAME(STATIC_MEMBER_EXPR(
                                  TEMPLATED_NAME("std::iterator_traits",
                                                 CALL("decltype", ARG(2))),
@@ -524,8 +526,9 @@ CONDITIONAL_FACTORY_ENTRY(
                                      LITERAL("128")),
                                  STREAM(9), ARG(2), ARG(3), ARG(4), ARG(5),
                                  ARG(6),
-                                 CALL(TEMPLATED_CALLEE(
-                                     MapNames::getClNamespace() + "ext::oneapi::minimum")),
+                                 CALL(TEMPLATED_CALLEE_WITH_ARGS(
+                                     MapNames::getClNamespace() + "minimum",
+                                     LITERAL(""))),
                                  CALL(STATIC_MEMBER_EXPR(
                                      TEMPLATED_NAME(
                                          "std::numeric_limits",
@@ -543,8 +546,9 @@ CONDITIONAL_FACTORY_ENTRY(
                                      LITERAL("128")),
                                  QUEUESTR, ARG(2), ARG(3), ARG(4), ARG(5),
                                  ARG(6),
-                                 CALL(TEMPLATED_CALLEE(
-                                     MapNames::getClNamespace() + "ext::oneapi::minimum")),
+                                 CALL(TEMPLATED_CALLEE_WITH_ARGS(
+                                     MapNames::getClNamespace() + "minimum",
+                                     LITERAL(""))),
                                  CALL(STATIC_MEMBER_EXPR(
                                      TEMPLATED_NAME(
                                          "std::numeric_limits",
@@ -580,8 +584,9 @@ CONDITIONAL_FACTORY_ENTRY(
                                      LITERAL("128")),
                                  STREAM(9), ARG(2), ARG(3), ARG(4), ARG(5),
                                  ARG(6),
-                                 CALL(TEMPLATED_CALLEE(
-                                     MapNames::getClNamespace() + "ext::oneapi::maximum")),
+                                 CALL(TEMPLATED_CALLEE_WITH_ARGS(
+                                     MapNames::getClNamespace() + "maximum",
+                                     LITERAL(""))),
                                  CALL(STATIC_MEMBER_EXPR(
                                      TEMPLATED_NAME(
                                          "std::numeric_limits",
@@ -599,8 +604,9 @@ CONDITIONAL_FACTORY_ENTRY(
                                      LITERAL("128")),
                                  QUEUESTR, ARG(2), ARG(3), ARG(4), ARG(5),
                                  ARG(6),
-                                 CALL(TEMPLATED_CALLEE(
-                                     MapNames::getClNamespace() + "ext::oneapi::minimum")),
+                                 CALL(TEMPLATED_CALLEE_WITH_ARGS(
+                                     MapNames::getClNamespace() + "minimum",
+                                     LITERAL(""))),
                                  CALL(STATIC_MEMBER_EXPR(
                                      TEMPLATED_NAME(
                                          "std::numeric_limits",
@@ -611,4 +617,3 @@ CONDITIONAL_FACTORY_ENTRY(
                                              LITERAL("value_type")))),
                                      LITERAL("max")))))),
                     Diagnostics::REDUCE_PERFORMANCE_TUNE))))))
-

--- a/clang/lib/DPCT/APINamesCUB.inc
+++ b/clang/lib/DPCT/APINamesCUB.inc
@@ -484,7 +484,7 @@ CONDITIONAL_FACTORY_ENTRY(
                                  LITERAL(""))),
                              ZERO_INITIALIZER(TYPENAME(STATIC_MEMBER_EXPR(
                                  TEMPLATED_NAME("std::iterator_traits",
-                                                CALL("decltype", ARG(2))),
+                                                CALL("decltype", ARG(3))),
                                  LITERAL("value_type")))))),
                     CALL_FACTORY_ENTRY(
                         "cub::DeviceSegmentedReduce::Sum",
@@ -498,7 +498,7 @@ CONDITIONAL_FACTORY_ENTRY(
                                  LITERAL(""))),
                              ZERO_INITIALIZER(TYPENAME(STATIC_MEMBER_EXPR(
                                  TEMPLATED_NAME("std::iterator_traits",
-                                                CALL("decltype", ARG(2))),
+                                                CALL("decltype", ARG(3))),
                                  LITERAL("value_type"))))))),
                 Diagnostics::REDUCE_PERFORMANCE_TUNE)))))
 
@@ -535,7 +535,7 @@ CONDITIONAL_FACTORY_ENTRY(
                                          TYPENAME(STATIC_MEMBER_EXPR(
                                              TEMPLATED_NAME(
                                                  "std::iterator_traits",
-                                                 CALL("decltype", ARG(2))),
+                                                 CALL("decltype", ARG(3))),
                                              LITERAL("value_type")))),
                                      LITERAL("max"))))),
                         CALL_FACTORY_ENTRY(
@@ -555,7 +555,7 @@ CONDITIONAL_FACTORY_ENTRY(
                                          TYPENAME(STATIC_MEMBER_EXPR(
                                              TEMPLATED_NAME(
                                                  "std::iterator_traits",
-                                                 CALL("decltype", ARG(2))),
+                                                 CALL("decltype", ARG(3))),
                                              LITERAL("value_type")))),
                                      LITERAL("max")))))),
                     Diagnostics::REDUCE_PERFORMANCE_TUNE))))))
@@ -593,7 +593,7 @@ CONDITIONAL_FACTORY_ENTRY(
                                          TYPENAME(STATIC_MEMBER_EXPR(
                                              TEMPLATED_NAME(
                                                  "std::iterator_traits",
-                                                 CALL("decltype", ARG(2))),
+                                                 CALL("decltype", ARG(3))),
                                              LITERAL("value_type")))),
                                      LITERAL("lowest"))))),
                         CALL_FACTORY_ENTRY(
@@ -605,7 +605,7 @@ CONDITIONAL_FACTORY_ENTRY(
                                  QUEUESTR, ARG(2), ARG(3), ARG(4), ARG(5),
                                  ARG(6),
                                  CALL(TEMPLATED_CALLEE_WITH_ARGS(
-                                     MapNames::getClNamespace() + "minimum",
+                                     MapNames::getClNamespace() + "maximum",
                                      LITERAL(""))),
                                  CALL(STATIC_MEMBER_EXPR(
                                      TEMPLATED_NAME(
@@ -613,7 +613,7 @@ CONDITIONAL_FACTORY_ENTRY(
                                          TYPENAME(STATIC_MEMBER_EXPR(
                                              TEMPLATED_NAME(
                                                  "std::iterator_traits",
-                                                 CALL("decltype", ARG(2))),
+                                                 CALL("decltype", ARG(3))),
                                              LITERAL("value_type")))),
-                                     LITERAL("max")))))),
+                                     LITERAL("lowest")))))),
                     Diagnostics::REDUCE_PERFORMANCE_TUNE))))))

--- a/clang/lib/DPCT/APINamesCUB.inc
+++ b/clang/lib/DPCT/APINamesCUB.inc
@@ -399,3 +399,216 @@ CONDITIONAL_FACTORY_ENTRY(
                                     false, LITERAL("first"))),
                             LITERAL("1")),
                         false, "wait")))))))
+
+// cub::DeviceSegmentedReduce::Reduce
+CONDITIONAL_FACTORY_ENTRY(
+    CheckCubRedundantFunctionCall(),
+    REMOVE_API_FACTORY_ENTRY("cub::DeviceSegmentedReduce::Reduce"),
+    REMOVE_CUB_TEMP_STORAGE_FACTORY(FEATURE_REQUEST_FACTORY(
+        HelperFeatureEnum::DplExtrasDpcppExtensions_segmented_reduce,
+        HEADER_INSERT_FACTORY(
+            HeaderType::HT_DPL_Utils,
+            WARNING_FACTORY_ENTRY(
+                "cub::DeviceSegmentedReduce::Reduce",
+                CONDITIONAL_FACTORY_ENTRY(
+                    makeCheckAnd(CheckArgCountGreaterThan(9),
+                                 makeCheckNot(CheckArgIsDefaultCudaStream(9))),
+                    CONDITIONAL_FACTORY_ENTRY(
+                        checkArgCanMappingToSyclNativeBinaryOp(7),
+                        CALL_FACTORY_ENTRY(
+                            "cub::DeviceSegmentedReduce::Reduce",
+                            CALL(TEMPLATED_CALLEE_WITH_ARGS(
+                                     MapNames::getDpctNamespace() +
+                                         "device::segmented_reduce",
+                                     LITERAL("128")),
+                                 STREAM(9), ARG(2), ARG(3), ARG(4), ARG(5),
+                                 ARG(6), ARG(7), ARG(8))),
+                        WARNING_FACTORY_ENTRY(
+                            "cub::DeviceSegmentedReduce::Reduce",
+                            CALL_FACTORY_ENTRY(
+                                "cub::DeviceSegmentedReduce::Reduce",
+                                CALL(TEMPLATED_CALLEE_WITH_ARGS(
+                                         MapNames::getDpctNamespace() +
+                                             "device::segmented_reduce",
+                                         LITERAL("128")),
+                                     STREAM(9), ARG(2), ARG(3), ARG(4), ARG(5),
+                                     ARG(6), LITERAL("dpct_placeholder"),
+                                     ARG(8))),
+                            Diagnostics::UNSUPPORTED_BINARY_OPERATION)),
+                    CONDITIONAL_FACTORY_ENTRY(
+                        checkArgCanMappingToSyclNativeBinaryOp(7),
+                        CALL_FACTORY_ENTRY(
+                            "cub::DeviceSegmentedReduce::Reduce",
+                            CALL(TEMPLATED_CALLEE_WITH_ARGS(
+                                     MapNames::getDpctNamespace() +
+                                         "device::segmented_reduce",
+                                     LITERAL("128")),
+                                 QUEUESTR, ARG(2), ARG(3), ARG(4), ARG(5),
+                                 ARG(6), ARG(7), ARG(8))),
+                        WARNING_FACTORY_ENTRY(
+                            "cub::DeviceSegmentedReduce::Reduce",
+                            CALL_FACTORY_ENTRY(
+                                "cub::DeviceSegmentedReduce::Reduce",
+                                CALL(TEMPLATED_CALLEE_WITH_ARGS(
+                                         MapNames::getDpctNamespace() +
+                                             "device::segmented_reduce",
+                                         LITERAL("128")),
+                                     QUEUESTR, ARG(2), ARG(3), ARG(4), ARG(5),
+                                     ARG(6), LITERAL("dpct_placeholder"),
+                                     ARG(8))),
+                            Diagnostics::UNSUPPORTED_BINARY_OPERATION))),
+                Diagnostics::REDUCE_PERFORMANCE_TUNE)))))
+
+// cub::DeviceSegmentedReduce::Sum
+CONDITIONAL_FACTORY_ENTRY(
+    CheckCubRedundantFunctionCall(),
+    REMOVE_API_FACTORY_ENTRY("cub::DeviceSegmentedReduce::Sum"),
+    REMOVE_CUB_TEMP_STORAGE_FACTORY(FEATURE_REQUEST_FACTORY(
+        HelperFeatureEnum::DplExtrasDpcppExtensions_segmented_reduce,
+        HEADER_INSERT_FACTORY(
+            HeaderType::HT_DPL_Utils,
+            WARNING_FACTORY_ENTRY(
+                "cub::DeviceSegmentedReduce::Sum",
+                CONDITIONAL_FACTORY_ENTRY(
+                    makeCheckAnd(CheckArgCountGreaterThan(9),
+                                 makeCheckNot(CheckArgIsDefaultCudaStream(9))),
+                    CALL_FACTORY_ENTRY(
+                        "cub::DeviceSegmentedReduce::Sum",
+                        CALL(TEMPLATED_CALLEE_WITH_ARGS(
+                                 MapNames::getDpctNamespace() +
+                                     "device::segmented_reduce",
+                                 LITERAL("128")),
+                             STREAM(9), ARG(2), ARG(3), ARG(4), ARG(5), ARG(6),
+                             CALL(TEMPLATED_CALLEE(MapNames::getClNamespace() +
+                                                   "ext::oneapi::plus")),
+                             ZERO_INITIALIZER(TYPENAME(STATIC_MEMBER_EXPR(
+                                 TEMPLATED_NAME("std::iterator_traits",
+                                                CALL("decltype", ARG(2))),
+                                 LITERAL("value_type")))))),
+                    CALL_FACTORY_ENTRY(
+                        "cub::DeviceSegmentedReduce::Sum",
+                        CALL(TEMPLATED_CALLEE_WITH_ARGS(
+                                 MapNames::getDpctNamespace() +
+                                     "device::segmented_reduce",
+                                 LITERAL("128")),
+                             QUEUESTR, ARG(2), ARG(3), ARG(4), ARG(5), ARG(6),
+                             CALL(TEMPLATED_CALLEE(MapNames::getClNamespace() +
+                                                   "ext::oneapi::plus")),
+                             ZERO_INITIALIZER(TYPENAME(STATIC_MEMBER_EXPR(
+                                 TEMPLATED_NAME("std::iterator_traits",
+                                                CALL("decltype", ARG(2))),
+                                 LITERAL("value_type"))))))),
+                Diagnostics::REDUCE_PERFORMANCE_TUNE)))))
+
+// cub::DeviceSegmentedReduce::Min
+CONDITIONAL_FACTORY_ENTRY(
+    CheckCubRedundantFunctionCall(),
+    REMOVE_API_FACTORY_ENTRY("cub::DeviceSegmentedReduce::Min"),
+    REMOVE_CUB_TEMP_STORAGE_FACTORY(FEATURE_REQUEST_FACTORY(
+        HelperFeatureEnum::DplExtrasDpcppExtensions_segmented_reduce,
+        HEADER_INSERT_FACTORY(
+            HeaderType::HT_DPL_Utils,
+            HEADER_INSERT_FACTORY(
+                HeaderType::HT_STD_Numeric_Limits,
+                WARNING_FACTORY_ENTRY(
+                    "cub::DeviceSegmentedReduce::Min",
+                    CONDITIONAL_FACTORY_ENTRY(
+                        makeCheckAnd(
+                            CheckArgCountGreaterThan(9),
+                            makeCheckNot(CheckArgIsDefaultCudaStream(9))),
+                        CALL_FACTORY_ENTRY(
+                            "cub::DeviceSegmentedReduce::Min",
+                            CALL(TEMPLATED_CALLEE_WITH_ARGS(
+                                     MapNames::getDpctNamespace() +
+                                         "device::segmented_reduce",
+                                     LITERAL("128")),
+                                 STREAM(9), ARG(2), ARG(3), ARG(4), ARG(5),
+                                 ARG(6),
+                                 CALL(TEMPLATED_CALLEE(
+                                     MapNames::getClNamespace() + "ext::oneapi::minimum")),
+                                 CALL(STATIC_MEMBER_EXPR(
+                                     TEMPLATED_NAME(
+                                         "std::numeric_limits",
+                                         TYPENAME(STATIC_MEMBER_EXPR(
+                                             TEMPLATED_NAME(
+                                                 "std::iterator_traits",
+                                                 CALL("decltype", ARG(2))),
+                                             LITERAL("value_type")))),
+                                     LITERAL("max"))))),
+                        CALL_FACTORY_ENTRY(
+                            "cub::DeviceSegmentedReduce::Min",
+                            CALL(TEMPLATED_CALLEE_WITH_ARGS(
+                                     MapNames::getDpctNamespace() +
+                                         "device::segmented_reduce",
+                                     LITERAL("128")),
+                                 QUEUESTR, ARG(2), ARG(3), ARG(4), ARG(5),
+                                 ARG(6),
+                                 CALL(TEMPLATED_CALLEE(
+                                     MapNames::getClNamespace() + "ext::oneapi::minimum")),
+                                 CALL(STATIC_MEMBER_EXPR(
+                                     TEMPLATED_NAME(
+                                         "std::numeric_limits",
+                                         TYPENAME(STATIC_MEMBER_EXPR(
+                                             TEMPLATED_NAME(
+                                                 "std::iterator_traits",
+                                                 CALL("decltype", ARG(2))),
+                                             LITERAL("value_type")))),
+                                     LITERAL("max")))))),
+                    Diagnostics::REDUCE_PERFORMANCE_TUNE))))))
+
+// cub::DeviceSegmentedReduce::Max
+CONDITIONAL_FACTORY_ENTRY(
+    CheckCubRedundantFunctionCall(),
+    REMOVE_API_FACTORY_ENTRY("cub::DeviceSegmentedReduce::Max"),
+    REMOVE_CUB_TEMP_STORAGE_FACTORY(FEATURE_REQUEST_FACTORY(
+        HelperFeatureEnum::DplExtrasDpcppExtensions_segmented_reduce,
+        HEADER_INSERT_FACTORY(
+            HeaderType::HT_DPL_Utils,
+            HEADER_INSERT_FACTORY(
+                HeaderType::HT_STD_Numeric_Limits,
+                WARNING_FACTORY_ENTRY(
+                    "cub::DeviceSegmentedReduce::Max",
+                    CONDITIONAL_FACTORY_ENTRY(
+                        makeCheckAnd(
+                            CheckArgCountGreaterThan(9),
+                            makeCheckNot(CheckArgIsDefaultCudaStream(9))),
+                        CALL_FACTORY_ENTRY(
+                            "cub::DeviceSegmentedReduce::Max",
+                            CALL(TEMPLATED_CALLEE_WITH_ARGS(
+                                     MapNames::getDpctNamespace() +
+                                         "device::segmented_reduce",
+                                     LITERAL("128")),
+                                 STREAM(9), ARG(2), ARG(3), ARG(4), ARG(5),
+                                 ARG(6),
+                                 CALL(TEMPLATED_CALLEE(
+                                     MapNames::getClNamespace() + "ext::oneapi::maximum")),
+                                 CALL(STATIC_MEMBER_EXPR(
+                                     TEMPLATED_NAME(
+                                         "std::numeric_limits",
+                                         TYPENAME(STATIC_MEMBER_EXPR(
+                                             TEMPLATED_NAME(
+                                                 "std::iterator_traits",
+                                                 CALL("decltype", ARG(2))),
+                                             LITERAL("value_type")))),
+                                     LITERAL("lowest"))))),
+                        CALL_FACTORY_ENTRY(
+                            "cub::DeviceSegmentedReduce::Max",
+                            CALL(TEMPLATED_CALLEE_WITH_ARGS(
+                                     MapNames::getDpctNamespace() +
+                                         "device::segmented_reduce",
+                                     LITERAL("128")),
+                                 QUEUESTR, ARG(2), ARG(3), ARG(4), ARG(5),
+                                 ARG(6),
+                                 CALL(TEMPLATED_CALLEE(
+                                     MapNames::getClNamespace() + "ext::oneapi::minimum")),
+                                 CALL(STATIC_MEMBER_EXPR(
+                                     TEMPLATED_NAME(
+                                         "std::numeric_limits",
+                                         TYPENAME(STATIC_MEMBER_EXPR(
+                                             TEMPLATED_NAME(
+                                                 "std::iterator_traits",
+                                                 CALL("decltype", ARG(2))),
+                                             LITERAL("value_type")))),
+                                     LITERAL("max")))))),
+                    Diagnostics::REDUCE_PERFORMANCE_TUNE))))))
+

--- a/clang/lib/DPCT/APINamesTemplateType.inc
+++ b/clang/lib/DPCT/APINamesTemplateType.inc
@@ -54,22 +54,19 @@ TYPE_REWRITE_ENTRY("cub::ConstantInputIterator",
                    HEADER_INSERTION_FACTORY(HeaderType::HT_DPL_Utils,
                    TYPE_FACTORY(STR("dpct::constant_iterator"), TEMPLATE_ARG(0))))
 
-TYPE_REWRITE_ENTRY("cub::Sum", TYPE_FACTORY(STR(MapNames::getClNamespace() +
-                                                "ext::oneapi::plus"),
-                                            STR("")))
-
-TYPE_REWRITE_ENTRY("cub::Min", TYPE_FACTORY(STR(MapNames::getClNamespace() +
-                                                "ext::oneapi::minimum"),
-                                            STR("")))
-
-TYPE_REWRITE_ENTRY("cub::Max", TYPE_FACTORY(STR(MapNames::getClNamespace() +
-                                                "ext::oneapi::maximum"),
-                                            STR("")))
-
-TYPE_REWRITE_ENTRY("cub::Equality",
-                   TYPE_FACTORY(STR(MapNames::getClNamespace() +
-                                    "ext::oneapi::equal_to"),
+TYPE_REWRITE_ENTRY("cub::Sum",
+                   TYPE_FACTORY(STR(MapNames::getClNamespace() + "plus"),
                                 STR("")))
+
+TYPE_REWRITE_ENTRY("cub::Min",
+                   TYPE_FACTORY(STR(MapNames::getClNamespace() + "minimum"),
+                                STR("")))
+
+TYPE_REWRITE_ENTRY("cub::Max",
+                   TYPE_FACTORY(STR(MapNames::getClNamespace() + "maximum"),
+                                STR("")))
+
+TYPE_REWRITE_ENTRY("cub::Equality", TYPE_FACTORY(STR("std::equal_to"), STR("")))
 
 FEATURE_REQUEST_FACTORY(
     HelperFeatureEnum::Memory_usm_host_allocator_alias,

--- a/clang/lib/DPCT/APINamesTemplateType.inc
+++ b/clang/lib/DPCT/APINamesTemplateType.inc
@@ -54,6 +54,23 @@ TYPE_REWRITE_ENTRY("cub::ConstantInputIterator",
                    HEADER_INSERTION_FACTORY(HeaderType::HT_DPL_Utils,
                    TYPE_FACTORY(STR("dpct::constant_iterator"), TEMPLATE_ARG(0))))
 
+TYPE_REWRITE_ENTRY("cub::Sum", TYPE_FACTORY(STR(MapNames::getClNamespace() +
+                                                "ext::oneapi::plus"),
+                                            STR("")))
+
+TYPE_REWRITE_ENTRY("cub::Min", TYPE_FACTORY(STR(MapNames::getClNamespace() +
+                                                "ext::oneapi::minimum"),
+                                            STR("")))
+
+TYPE_REWRITE_ENTRY("cub::Max", TYPE_FACTORY(STR(MapNames::getClNamespace() +
+                                                "ext::oneapi::maximum"),
+                                            STR("")))
+
+TYPE_REWRITE_ENTRY("cub::Equality",
+                   TYPE_FACTORY(STR(MapNames::getClNamespace() +
+                                    "ext::oneapi::equal_to"),
+                                STR("")))
+
 FEATURE_REQUEST_FACTORY(
     HelperFeatureEnum::Memory_usm_host_allocator_alias,
     TYPE_REWRITE_ENTRY("thrust::system::cuda::experimental::pinned_allocator",

--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -15388,9 +15388,6 @@ void TemplateSpecializationTypeLocRule::registerMatcher(
     ast_matchers::MatchFinder &MF) {
   auto TargetTypeName = [&]() {
     return hasAnyName("thrust::not_equal_to", "thrust::constant_iterator",
-                      "cub::CountingInputIterator",
-                      "cub::TransformInputIterator",
-                      "cub::ConstantInputIterator",
                       "thrust::system::cuda::experimental::pinned_allocator");
   };
 

--- a/clang/lib/DPCT/CUBAPIMigration.cpp
+++ b/clang/lib/DPCT/CUBAPIMigration.cpp
@@ -40,9 +40,9 @@ using namespace ast_matchers;
 
 namespace {
 auto parentStmt = []() {
-  return anyOf(hasAncestor(compoundStmt()), hasAncestor(forStmt()),
-               hasAncestor(whileStmt()), hasAncestor(doStmt()),
-               hasAncestor(ifStmt()));
+  return anyOf(hasParent(compoundStmt()), hasParent(forStmt()),
+               hasParent(whileStmt()), hasParent(doStmt()),
+               hasParent(ifStmt()));
 };
 } // namespace
 
@@ -98,15 +98,13 @@ bool CubTypeRule::CanMappingToSyclBinaryOp(StringRef OpTypeName) {
 
 void CubDeviceLevelRule::registerMatcher(ast_matchers::MatchFinder &MF) {
   MF.addMatcher(
-      callExpr(
-          allOf(callee(functionDecl(allOf(
-                    hasAnyName(CubDeviceFuncNames),
-                    hasParent(functionTemplateDecl(allOf(
-                        hasAnyName(CubDeviceFuncNames),
-                        hasAncestor(cxxRecordDecl(allOf(
-                            hasAnyName(CubDeviceRecordNames),
-                            hasParent(namespaceDecl(hasName("cub")))))))))))),
-                parentStmt()))
+      callExpr(callee(functionDecl(allOf(
+                   hasAnyName(CubDeviceFuncNames),
+                   hasParent(functionTemplateDecl(allOf(
+                       hasAnyName(CubDeviceFuncNames),
+                       hasAncestor(cxxRecordDecl(allOf(
+                           hasAnyName(CubDeviceRecordNames),
+                           hasParent(namespaceDecl(hasName("cub")))))))))))))
 
           .bind("FuncCall"),
       this);

--- a/clang/lib/DPCT/CUBAPIMigration.cpp
+++ b/clang/lib/DPCT/CUBAPIMigration.cpp
@@ -114,24 +114,11 @@ void CubDeviceLevelRule::registerMatcher(ast_matchers::MatchFinder &MF) {
 
 void CubDeviceLevelRule::runRule(const ast_matchers::MatchFinder::MatchResult &Result) {
   if (const auto *CE = getNodeAsType<CallExpr>(Result, "FuncCall")) {
-    const auto *Fn = CE->getDirectCallee();
-    std::string FuncName;
-    llvm::raw_string_ostream SS(FuncName);
-    Fn->printNestedNameSpecifier(SS, DpctGlobalInfo::getContext().getPrintingPolicy());
-    SS << Fn->getName();
-
-    // Check if the RewriteMap has initialized
-    if (!CallExprRewriterFactoryBase::RewriterMap)
-      return;
-
-    auto Itr = CallExprRewriterFactoryBase::RewriterMap->find(FuncName);
-    if (Itr != CallExprRewriterFactoryBase::RewriterMap->end()) {
       ExprAnalysis EA;
       EA.analyze(CE);
       emplaceTransformation(EA.getReplacement());
       EA.applyAllSubExprRepl();
       return;
-    }
   }
 }
 

--- a/clang/lib/DPCT/CUBAPIMigration.cpp
+++ b/clang/lib/DPCT/CUBAPIMigration.cpp
@@ -105,7 +105,6 @@ void CubDeviceLevelRule::registerMatcher(ast_matchers::MatchFinder &MF) {
                        hasAncestor(cxxRecordDecl(allOf(
                            hasAnyName(CubDeviceRecordNames),
                            hasParent(namespaceDecl(hasName("cub")))))))))))))
-
           .bind("FuncCall"),
       this);
 }

--- a/clang/lib/DPCT/CUBAPIMigration.cpp
+++ b/clang/lib/DPCT/CUBAPIMigration.cpp
@@ -57,11 +57,9 @@ auto isDeviceFuncCallExpr = []() {
   };
   return callExpr(callee(functionDecl(
       allOf(hasDeviceFuncName(),
-            hasParent(functionTemplateDecl(
-                allOf(hasDeviceFuncName(),
-                      hasAncestor(cxxRecordDecl(allOf(
-                          hasDeviceRecordName(),
-                          hasParent(namespaceDecl(hasName("cub")))))))))))));
+            hasDeclContext(cxxRecordDecl(
+                allOf(hasDeviceRecordName(),
+                      hasDeclContext(namespaceDecl(hasName("cub"))))))))));
 };
 
 } // namespace

--- a/clang/lib/DPCT/CUBAPIMigration.h
+++ b/clang/lib/DPCT/CUBAPIMigration.h
@@ -14,6 +14,20 @@
 namespace clang {
 namespace dpct {
 
+class CubTypeRule : public NamedMigrationRule<CubTypeRule> {
+public:
+  void registerMatcher(ast_matchers::MatchFinder &MF) override;
+  void runRule(const ast_matchers::MatchFinder::MatchResult &Result);
+
+  static bool CanMappingToSyclNativeBinaryOp(StringRef OpTypeName);
+};
+
+class CubDeviceLevelRule : public NamedMigrationRule<CubDeviceLevelRule> {
+public:
+  void registerMatcher(ast_matchers::MatchFinder &MF) override;
+  void runRule(const ast_matchers::MatchFinder::MatchResult &Result);
+};
+
 class CubRule : public NamedMigrationRule<CubRule> {
 public:
   void registerMatcher(ast_matchers::MatchFinder &MF) override;

--- a/clang/lib/DPCT/CUBAPIMigration.h
+++ b/clang/lib/DPCT/CUBAPIMigration.h
@@ -22,7 +22,6 @@ public:
 
   static bool CanMappingToSyclNativeBinaryOp(StringRef OpTypeName);
   static bool CanMappingToSyclBinaryOp(StringRef OpTypeName);
-  static Optional<StringRef> GetMappingToSyclBinaryOp(StringRef OpTypeName);
 };
 
 class CubDeviceLevelRule : public NamedMigrationRule<CubDeviceLevelRule> {

--- a/clang/lib/DPCT/CUBAPIMigration.h
+++ b/clang/lib/DPCT/CUBAPIMigration.h
@@ -1,4 +1,4 @@
-//===--------------- CUBAPIMigration.h --------------------------------------------===//
+//===--------------- CUBAPIMigration.h-------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -28,44 +28,7 @@ class CubDeviceLevelRule : public NamedMigrationRule<CubDeviceLevelRule> {
 public:
   void registerMatcher(ast_matchers::MatchFinder &MF) override;
   void runRule(const ast_matchers::MatchFinder::MatchResult &Result);
-};
 
-class CubRule : public NamedMigrationRule<CubRule> {
-public:
-  void registerMatcher(ast_matchers::MatchFinder &MF) override;
-  void runRule(const ast_matchers::MatchFinder::MatchResult &Result);
-
-private:
-  struct ParamAssembler {
-    std::string &ParamListRef;
-    ParamAssembler(std::string &List) : ParamListRef(List){};
-    ParamAssembler &operator<<(std::string Param) {
-      if (Param.empty()) {
-        return *this;
-      }
-      if (ParamListRef.empty()) {
-        ParamListRef = Param;
-      } else {
-        ParamListRef += ", " + Param;
-      }
-      return *this;
-    };
-  };
-  static int PlaceholderIndex;
-  std::string getOpRepl(const Expr *Operator);
-  void processCubDeclStmt(const DeclStmt *DS);
-  void processCubTypeDef(const TypedefDecl *TD);
-  void processCubFuncCall(const CallExpr *CE, bool FuncCallUsed = false);
-  void processCubMemberCall(const CXXMemberCallExpr *MC);
-  void processTypeLoc(const TypeLoc *TL);
-
-  void processDeviceLevelFuncCall(const CallExpr *CE, bool FuncCallUsed);
-  void processThreadLevelFuncCall(const CallExpr *CE, bool FuncCallUsed);
-  void processWarpLevelFuncCall(const CallExpr *CE, bool FuncCallUsed);
-  void processBlockLevelMemberCall(const CXXMemberCallExpr *MC);
-  void processWarpLevelMemberCall(const CXXMemberCallExpr *MC);
-
-public:
   /// Pseudo code:
   /// loop_1 {
   ///   ...
@@ -109,6 +72,42 @@ public:
   /// (2) No modified reference in loop_j or deeper loop.
   /// The redundant callexpr can be remove safely.
   static void removeRedundantTempVar(const CallExpr *CE);
+};
+
+class CubRule : public NamedMigrationRule<CubRule> {
+public:
+  void registerMatcher(ast_matchers::MatchFinder &MF) override;
+  void runRule(const ast_matchers::MatchFinder::MatchResult &Result);
+
+private:
+  struct ParamAssembler {
+    std::string &ParamListRef;
+    ParamAssembler(std::string &List) : ParamListRef(List){};
+    ParamAssembler &operator<<(std::string Param) {
+      if (Param.empty()) {
+        return *this;
+      }
+      if (ParamListRef.empty()) {
+        ParamListRef = Param;
+      } else {
+        ParamListRef += ", " + Param;
+      }
+      return *this;
+    };
+  };
+  static int PlaceholderIndex;
+  std::string getOpRepl(const Expr *Operator);
+  void processCubDeclStmt(const DeclStmt *DS);
+  void processCubTypeDef(const TypedefDecl *TD);
+  void processCubFuncCall(const CallExpr *CE, bool FuncCallUsed = false);
+  void processCubMemberCall(const CXXMemberCallExpr *MC);
+  void processTypeLoc(const TypeLoc *TL);
+
+  void processDeviceLevelFuncCall(const CallExpr *CE, bool FuncCallUsed);
+  void processThreadLevelFuncCall(const CallExpr *CE, bool FuncCallUsed);
+  void processWarpLevelFuncCall(const CallExpr *CE, bool FuncCallUsed);
+  void processBlockLevelMemberCall(const CXXMemberCallExpr *MC);
+  void processWarpLevelMemberCall(const CXXMemberCallExpr *MC);
 };
 
 } // namespace dpct

--- a/clang/lib/DPCT/CUBAPIMigration.h
+++ b/clang/lib/DPCT/CUBAPIMigration.h
@@ -10,6 +10,7 @@
 #define CLANG_DPCT_CUBAPIMIGRATION_H
 
 #include "ASTTraversal.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace clang {
 namespace dpct {
@@ -20,6 +21,8 @@ public:
   void runRule(const ast_matchers::MatchFinder::MatchResult &Result);
 
   static bool CanMappingToSyclNativeBinaryOp(StringRef OpTypeName);
+  static bool CanMappingToSyclBinaryOp(StringRef OpTypeName);
+  static Optional<StringRef> GetMappingToSyclBinaryOp(StringRef OpTypeName);
 };
 
 class CubDeviceLevelRule : public NamedMigrationRule<CubDeviceLevelRule> {

--- a/clang/lib/DPCT/CallExprRewriter.cpp
+++ b/clang/lib/DPCT/CallExprRewriter.cpp
@@ -2830,7 +2830,7 @@ public:
 class CheckCubRedundantFunctionCall {
 public:
   bool operator()(const CallExpr *C) {
-    return CubRule::isRedundantCallExpr(C);
+    return CubDeviceLevelRule::isRedundantCallExpr(C);
   }
 };
 
@@ -2845,7 +2845,7 @@ public:
 
 std::shared_ptr<CallExprRewriter>
 RemoveCubTempStorageFactory::create(const CallExpr *C) const {
-  CubRule::removeRedundantTempVar(C);
+  CubDeviceLevelRule::removeRedundantTempVar(C);
   return Inner->create(C);
 }
 

--- a/clang/lib/DPCT/CallExprRewriter.cpp
+++ b/clang/lib/DPCT/CallExprRewriter.cpp
@@ -2000,8 +2000,8 @@ std::function<bool(const CallExpr *)>
 checkArgCanMappingToSyclNativeBinaryOp(size_t ArgIdx) {
   return [=](const CallExpr *C) -> bool {
     const Expr *Arg = C->getArg(ArgIdx);
-    QualType CanTy = Arg->getType().getCanonicalType();
-    std::string TypeName = CanTy.getAsString();
+    std::string TypeName = DpctGlobalInfo::getUnqualifiedTypeName(
+        Arg->getType().getCanonicalType());
     return CubTypeRule::CanMappingToSyclNativeBinaryOp(TypeName);
   };
 }

--- a/clang/lib/DPCT/CallExprRewriter.cpp
+++ b/clang/lib/DPCT/CallExprRewriter.cpp
@@ -16,8 +16,10 @@
 #include "CUBAPIMigration.h"
 #include "clang/AST/Attr.h"
 #include "clang/AST/Expr.h"
+#include "clang/AST/Type.h"
 #include "clang/Basic/LangOptions.h"
 #include <cstdarg>
+#include <cstddef>
 
 namespace clang {
 namespace dpct {
@@ -1991,6 +1993,16 @@ std::function<bool(const CallExpr *C)> checkIsArgIntegerLiteral(size_t index) {
       }
     }
     return Arg2Expr->getStmtClass() == Stmt::IntegerLiteralClass;
+  };
+}
+
+std::function<bool(const CallExpr *)>
+checkArgCanMappingToSyclNativeBinaryOp(size_t ArgIdx) {
+  return [=](const CallExpr *C) -> bool {
+    const Expr *Arg = C->getArg(ArgIdx);
+    QualType CanTy = Arg->getType().getCanonicalType();
+    std::string TypeName = CanTy.getAsString();
+    return CubTypeRule::CanMappingToSyclNativeBinaryOp(TypeName);
   };
 }
 

--- a/clang/lib/DPCT/ExprAnalysis.cpp
+++ b/clang/lib/DPCT/ExprAnalysis.cpp
@@ -639,7 +639,7 @@ void ExprAnalysis::analyzeExpr(const CXXTemporaryObjectExpr *Temp) {
     return;
   }
 
-  analyzeExpr(dyn_cast<CXXConstructExpr>(Temp));
+  analyzeExpr(static_cast<const CXXConstructExpr *>(Temp));
 }
 
 void ExprAnalysis::analyzeExpr(const CXXConstructExpr *Ctor) {

--- a/clang/lib/DPCT/ExprAnalysis.cpp
+++ b/clang/lib/DPCT/ExprAnalysis.cpp
@@ -10,6 +10,7 @@
 
 #include "ASTTraversal.h"
 #include "AnalysisInfo.h"
+#include "CUBAPIMigration.h"
 #include "CallExprRewriter.h"
 #include "DNNAPIMigration.h"
 #include "TypeLocRewriters.h"
@@ -647,6 +648,11 @@ void ExprAnalysis::analyzeExpr(const CXXConstructExpr *Ctor) {
       addReplacement(Ctor, TypeLen, Replacement);
     }
   }
+
+  if (StringRef(CtorClassName).startswith("cub::") &&
+      CubTypeRule::CanMappingToSyclBinaryOp(CtorClassName))
+    addReplacement(Ctor,
+                   CubTypeRule::GetMappingToSyclBinaryOp(CtorClassName)->str());
 
   if (Ctor->getConstructor()->getDeclName().getAsString() == "dim3") {
     std::string ArgsString;

--- a/clang/lib/DPCT/ExprAnalysis.h
+++ b/clang/lib/DPCT/ExprAnalysis.h
@@ -616,6 +616,7 @@ protected:
   }
 
   void analyzeExpr(const CXXConstructExpr *Ctor);
+  void analyzeExpr(const CXXTemporaryObjectExpr *Temp);
   void analyzeExpr(const CXXUnresolvedConstructExpr *Ctor);
   void analyzeExpr(const MemberExpr *ME);
   void analyzeExpr(const UnaryExprOrTypeTraitExpr *UETT);

--- a/clang/runtime/dpct-rt/include/dpl_extras/dpcpp_extensions.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/dpcpp_extensions.h.inc
@@ -677,14 +677,13 @@ template <typename... _Args> constexpr auto __joint_reduce(_Args... __args) {
 /// that are one past the last element in each segment \param binary_op functor
 /// that implements the binary operation used to perform the scan. \param init
 /// initial value of the reduction for each segment.
-template <int GROUP_SIZE, typename T, typename Ptr, class BinaryOperation>
+template <int GROUP_SIZE, typename T, typename OffsetT, class BinaryOperation>
 void segmented_reduce(sycl::queue queue, T *inputs, T *outputs,
-                      size_t segment_count, Ptr begin_offsets, Ptr end_offsets,
-                      BinaryOperation binary_op, T init) {
+                      size_t segment_count, OffsetT *begin_offsets,
+                      OffsetT *end_offsets, BinaryOperation binary_op, T init) {
 
   sycl::range<1> global_size(segment_count * GROUP_SIZE);
   sycl::range<1> local_size(GROUP_SIZE);
-  typedef std::remove_pointer_t<Ptr> OffsetT;
 
   queue.submit([&](sycl::handler &cgh) {
     cgh.parallel_for(

--- a/clang/runtime/dpct-rt/include/dpl_extras/dpcpp_extensions.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/dpcpp_extensions.h.inc
@@ -677,20 +677,20 @@ template <typename... _Args> constexpr auto __joint_reduce(_Args... __args) {
 /// that are one past the last element in each segment \param binary_op functor
 /// that implements the binary operation used to perform the scan. \param init
 /// initial value of the reduction for each segment.
-template <int GROUP_SIZE, typename T, class BinaryOperation>
+template <int GROUP_SIZE, typename T, typename Ptr, class BinaryOperation>
 void segmented_reduce(sycl::queue queue, T *inputs, T *outputs,
-                      size_t segment_count, uint32_t *begin_offsets,
-                      uint32_t *end_offsets, BinaryOperation binary_op,
-                      T init) {
+                      size_t segment_count, Ptr begin_offsets, Ptr end_offsets,
+                      BinaryOperation binary_op, T init) {
 
   sycl::range<1> global_size(segment_count * GROUP_SIZE);
   sycl::range<1> local_size(GROUP_SIZE);
+  typedef std::remove_pointer_t<Ptr> OffsetT;
 
   queue.submit([&](sycl::handler &cgh) {
     cgh.parallel_for(
         sycl::nd_range<1>(global_size, local_size), [=](sycl::nd_item<1> item) {
-          uint32_t segment_begin = begin_offsets[item.get_group_linear_id()];
-          uint32_t segment_end = end_offsets[item.get_group_linear_id()];
+          OffsetT segment_begin = begin_offsets[item.get_group_linear_id()];
+          OffsetT segment_end = end_offsets[item.get_group_linear_id()];
           if (segment_begin == segment_end) {
             if (item.get_local_linear_id() == 0) {
               outputs[item.get_group_linear_id()] = init;

--- a/clang/test/dpct/cub/blocklevel/blockreduce.cu
+++ b/clang/test/dpct/cub/blocklevel/blockreduce.cu
@@ -31,7 +31,7 @@ void print_data(int* data, int num) {
 //CHECK-EMPTY:
 //CHECK-NEXT:  int input = data[threadid];
 //CHECK-NEXT:  int output = 0;
-//CHECK-NEXT:  output = sycl::reduce_over_group(item_ct1.get_group(), input, sycl::ext::oneapi::plus<>());
+//CHECK-NEXT:  output = sycl::reduce_over_group(item_ct1.get_group(), input, sycl::plus<>());
 //CHECK-NEXT:  data[threadid] = output;
 //CHECK-NEXT:}
 __global__ void SumKernel(int* data) {
@@ -54,7 +54,7 @@ __global__ void SumKernel(int* data) {
 //CHECK-EMPTY:
 //CHECK-NEXT:  int input = data[threadid];
 //CHECK-NEXT:  int output = 0;
-//CHECK-NEXT:  output = sycl::reduce_over_group(item_ct1.get_group(), input, sycl::ext::oneapi::plus<>());
+//CHECK-NEXT:  output = sycl::reduce_over_group(item_ct1.get_group(), input, sycl::plus<>());
 //CHECK-NEXT:  data[threadid] = output;
 //CHECK-NEXT:}
 __global__ void ReduceKernel(int* data) {

--- a/clang/test/dpct/cub/blocklevel/blockreduce_p2.cu
+++ b/clang/test/dpct/cub/blocklevel/blockreduce_p2.cu
@@ -49,7 +49,7 @@ void print_data(T* data, int num) {
 //CHECK:    input[2] = data[4 * threadid + 2];
 //CHECK:    input[3] = data[4 * threadid + 3];
 //CHECK:    int output = 0;
-//CHECK:    output = dpct::group::reduce(item_ct1, input, sycl::ext::oneapi::plus<>());
+//CHECK:    output = dpct::group::reduce(item_ct1, input, sycl::plus<>());
 //CHECK:    data[4 * threadid] = output;
 //CHECK:    data[4 * threadid + 1] = 0;
 //CHECK:    data[4 * threadid + 2] = 0;
@@ -92,7 +92,7 @@ __global__ void SumKernel(int* data) {
 //CHECK:    input[2] = data[4 * threadid + 2];
 //CHECK:    input[3] = data[4 * threadid + 3];
 //CHECK:    int output = 0;
-//CHECK:    output = dpct::group::reduce(item_ct1, input, sycl::ext::oneapi::plus<>());
+//CHECK:    output = dpct::group::reduce(item_ct1, input, sycl::plus<>());
 //CHECK:    data[4 * threadid] = output;
 //CHECK:    data[4 * threadid + 1] = 0;
 //CHECK:    data[4 * threadid + 2] = 0;

--- a/clang/test/dpct/cub/blocklevel/blockscan.cu
+++ b/clang/test/dpct/cub/blocklevel/blockscan.cu
@@ -31,7 +31,7 @@ void print_data(int* data, int num) {
 //CHECK-EMPTY:
 //CHECK-NEXT:  int input = data[threadid];
 //CHECK-NEXT:  int output = 0;
-//CHECK-NEXT:  output = sycl::exclusive_scan_over_group(item_ct1.get_group(), input, 0, sycl::ext::oneapi::plus<>());
+//CHECK-NEXT:  output = sycl::exclusive_scan_over_group(item_ct1.get_group(), input, 0, sycl::plus<>());
 //CHECK-NEXT:  data[threadid] = output;
 //CHECK-NEXT:}
 __global__ void ExclusiveScanKernel(int* data) {
@@ -54,7 +54,7 @@ __global__ void ExclusiveScanKernel(int* data) {
 //CHECK-EMPTY:
 //CHECK-NEXT:  int input = data[threadid];
 //CHECK-NEXT:  int output = 0;
-//CHECK-NEXT:  output = sycl::exclusive_scan_over_group(item_ct1.get_group(), input, 0, sycl::ext::oneapi::plus<>());
+//CHECK-NEXT:  output = sycl::exclusive_scan_over_group(item_ct1.get_group(), input, 0, sycl::plus<>());
 //CHECK-NEXT:  data[threadid] = output;
 //CHECK-NEXT:}
 __global__ void ExclusiveSumKernel(int* data) {
@@ -77,7 +77,7 @@ __global__ void ExclusiveSumKernel(int* data) {
 //CHECK-EMPTY:
 //CHECK-NEXT:  int input = data[threadid];
 //CHECK-NEXT:  int output = 0;
-//CHECK-NEXT:  output = sycl::inclusive_scan_over_group(item_ct1.get_group(), input, sycl::ext::oneapi::plus<>());
+//CHECK-NEXT:  output = sycl::inclusive_scan_over_group(item_ct1.get_group(), input, sycl::plus<>());
 //CHECK-NEXT:  data[threadid] = output;
 //CHECK-NEXT:}
 __global__ void InclusiveScanKernel(int* data) {
@@ -100,7 +100,7 @@ __global__ void InclusiveScanKernel(int* data) {
 //CHECK-EMPTY:
 //CHECK-NEXT:  int input = data[threadid];
 //CHECK-NEXT:  int output = 0;
-//CHECK-NEXT:  output = sycl::inclusive_scan_over_group(item_ct1.get_group(), input, sycl::ext::oneapi::plus<>());
+//CHECK-NEXT:  output = sycl::inclusive_scan_over_group(item_ct1.get_group(), input, sycl::plus<>());
 //CHECK-NEXT:  data[threadid] = output;
 //CHECK-NEXT:}
 __global__ void InclusiveSumKernel(int* data) {

--- a/clang/test/dpct/cub/blocklevel/blockscan_p2.cu
+++ b/clang/test/dpct/cub/blocklevel/blockscan_p2.cu
@@ -47,7 +47,7 @@ void print_data(T* data, int num) {
 //CHECK:    int output = 0;
 //CHECK:    int agg = 0;
 
-//CHECK:    output = dpct::group::exclusive_scan(item_ct1, input, 0, sycl::ext::oneapi::plus<>(), agg);
+//CHECK:    output = dpct::group::exclusive_scan(item_ct1, input, 0, sycl::plus<>(), agg);
 
 //CHECK:    data[threadid] = output;
 //CHECK:    aggregate[threadid] = agg;
@@ -92,7 +92,7 @@ __global__ void ExclusiveSumKernel1(int* data, int* aggregate) {
 //CHECK:      int input = data[threadid];
 //CHECK:      int output = 0;
 
-//CHECK:      output = dpct::group::exclusive_scan(item_ct1, input, sycl::ext::oneapi::plus<>(), CB);
+//CHECK:      output = dpct::group::exclusive_scan(item_ct1, input, sycl::plus<>(), CB);
 
 //CHECK:      data[threadid] = output;
 //CHECK:  }
@@ -139,7 +139,7 @@ __global__ void ExclusiveSumKernel2(int* data) {
 //CHECK:    input[3] = data[4 * threadid + 3];
 //CHECK:    int output[4];
 
-//CHECK:    dpct::group::exclusive_scan(item_ct1, input, output, 0, sycl::ext::oneapi::plus<>());
+//CHECK:    dpct::group::exclusive_scan(item_ct1, input, output, 0, sycl::plus<>());
 
 //CHECK:    data[4 * threadid] = output[0];
 //CHECK:    data[4 * threadid + 1] = output[1];
@@ -177,7 +177,7 @@ __global__ void ExclusiveSumKernel3(int* data) {
 //CHECK:  int output = 0;
 //CHECK:  int agg = 0;
 
-//CHECK:  output = dpct::group::exclusive_scan(item_ct1, input, 0, sycl::ext::oneapi::plus<>(), agg);
+//CHECK:  output = dpct::group::exclusive_scan(item_ct1, input, 0, sycl::plus<>(), agg);
 
 //CHECK:  data[threadid] = output;
 //CHECK:  aggregate[threadid] = agg;
@@ -222,7 +222,7 @@ __global__ void ExclusiveScanKernel1(int* data, int* aggregate) {
 //CHECK:      int input = data[threadid];
 //CHECK:      int output = 0;
 
-//CHECK:      output = dpct::group::exclusive_scan(item_ct1, input, sycl::ext::oneapi::plus<>(), CB);
+//CHECK:      output = dpct::group::exclusive_scan(item_ct1, input, sycl::plus<>(), CB);
 
 //CHECK:      data[threadid] = output;
 //CHECK:  }
@@ -268,7 +268,7 @@ __global__ void ExclusiveScanKernel2(int* data) {
 //CHECK:    input[3] = data[4 * threadid + 3];
 //CHECK:    int output[4];
 
-//CHECK:    dpct::group::exclusive_scan(item_ct1, input, output, 0, sycl::ext::oneapi::plus<>());
+//CHECK:    dpct::group::exclusive_scan(item_ct1, input, output, 0, sycl::plus<>());
 
 //CHECK:    data[4 * threadid] = output[0];
 //CHECK:    data[4 * threadid + 1] = output[1];
@@ -307,7 +307,7 @@ __global__ void ExclusiveScanKernel3(int* data) {
 //CHECK:  int output = 0;
 //CHECK:  int agg = 0;
 
-//CHECK:  output = dpct::group::inclusive_scan(item_ct1, input, sycl::ext::oneapi::plus<>(), agg);
+//CHECK:  output = dpct::group::inclusive_scan(item_ct1, input, sycl::plus<>(), agg);
 
 //CHECK:  data[threadid] = output;
 //CHECK:  aggregate[threadid] = agg;
@@ -354,7 +354,7 @@ __global__ void InclusiveSumKernel1(int* data, int* aggregate) {
 //CHECK:      int input = data[threadid];
 //CHECK:      int output = 0;
 
-//CHECK:      output = dpct::group::inclusive_scan(item_ct1, input, sycl::ext::oneapi::plus<>(), CB);
+//CHECK:      output = dpct::group::inclusive_scan(item_ct1, input, sycl::plus<>(), CB);
 
 //CHECK:      data[threadid] = output;
 //CHECK:  }
@@ -402,7 +402,7 @@ __global__ void InclusiveSumKernel2(int* data) {
 //CHECK:    input[3] = data[4 * threadid + 3];
 //CHECK:    int output[4];
 
-//CHECK:    dpct::group::inclusive_scan(item_ct1, input, output, sycl::ext::oneapi::plus<>());
+//CHECK:    dpct::group::inclusive_scan(item_ct1, input, output, sycl::plus<>());
 
 //CHECK:    data[4 * threadid] = output[0];
 //CHECK:    data[4 * threadid + 1] = output[1];
@@ -442,7 +442,7 @@ __global__ void InclusiveSumKernel3(int* data) {
 //CHECK:  int output = 0;
 //CHECK:  int agg = 0;
 
-//CHECK:  output = dpct::group::inclusive_scan(item_ct1, input, sycl::ext::oneapi::plus<>(), agg);
+//CHECK:  output = dpct::group::inclusive_scan(item_ct1, input, sycl::plus<>(), agg);
 
 //CHECK:  data[threadid] = output;
 //CHECK:  aggregate[threadid] = agg;
@@ -489,7 +489,7 @@ __global__ void InclusiveScanKernel1(int* data, int* aggregate) {
 //CHECK:      int input = data[threadid];
 //CHECK:      int output = 0;
 
-//CHECK:      output = dpct::group::inclusive_scan(item_ct1, input, sycl::ext::oneapi::plus<>(), CB);
+//CHECK:      output = dpct::group::inclusive_scan(item_ct1, input, sycl::plus<>(), CB);
 
 //CHECK:      data[threadid] = output;
 //CHECK:  }
@@ -537,7 +537,7 @@ __global__ void InclusiveScanKernel2(int* data) {
 //CHECK:    input[3] = data[4 * threadid + 3];
 //CHECK:    int output[4];
 
-//CHECK:    dpct::group::inclusive_scan(item_ct1, input, output, sycl::ext::oneapi::plus<>());
+//CHECK:    dpct::group::inclusive_scan(item_ct1, input, output, sycl::plus<>());
 
 //CHECK:    data[4 * threadid] = output[0];
 //CHECK:    data[4 * threadid + 1] = output[1];

--- a/clang/test/dpct/cub/devicelevel/devicesegmentedreduce.cu
+++ b/clang/test/dpct/cub/devicelevel/devicesegmentedreduce.cu
@@ -156,7 +156,7 @@ bool test_reduce_1(){
 //CHECK:    /*
 //CHECK:    DPCT1092:{{[0-9]+}}: Consider replacing work-group size 128 with differnt value for specific hardware for better performance.
 //CHECK:    */
-//CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::ext::oneapi::minimum<>(), initial_value);
+//CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::minimum<>(), initial_value);
 
 //CHECK:    dev_ct1.queues_wait_and_throw();
 
@@ -233,7 +233,7 @@ bool test_reduce_3(){
   // CHECK:   /*
   // CHECK:   DPCT1092:{{[0-9]+}}: Consider replacing work-group size 128 with differnt value for specific hardware for better performance.
   // CHECK:   */
-  // CHECK:   dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::ext::oneapi::minimum<>(), initial_value);
+  // CHECK:   dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::minimum<>(), initial_value);
   // CHECK:   temp_storage = (void *)sycl::malloc_device(temp_storage_size, q_ct1);
   // CHECK: }
   for(int i = 0; i < 10; i++) {
@@ -249,7 +249,7 @@ bool test_reduce_3(){
   // CHECK:    /*
   // CHECK:    DPCT1092:{{[0-9]+}}: Consider replacing work-group size 128 with differnt value for specific hardware for better performance.
   // CHECK:    */
-  // CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::ext::oneapi::minimum<>(), initial_value);
+  // CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::minimum<>(), initial_value);
   // CHECK:  }
   for(int i = 0; i < 10; i++) {
     temp_storage = nullptr;
@@ -269,12 +269,12 @@ bool test_reduce_3(){
   // CHECK:    /*
   // CHECK:    DPCT1092:{{[0-9]+}}: Consider replacing work-group size 128 with differnt value for specific hardware for better performance.
   // CHECK:    */
-  // CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::ext::oneapi::minimum<>(), initial_value);
+  // CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::minimum<>(), initial_value);
   // CHECK:    temp_storage = (void *)sycl::malloc_device(temp_storage_size, q_ct1);
   // CHECK:    /*
   // CHECK:    DPCT1092:{{[0-9]+}}: Consider replacing work-group size 128 with differnt value for specific hardware for better performance.
   // CHECK:    */
-  // CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::ext::oneapi::minimum<>(), initial_value);
+  // CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::minimum<>(), initial_value);
   // CHECK:  }
   for(int i = 0; i < 10; i++) {
     temp_storage = nullptr;
@@ -293,7 +293,7 @@ bool test_reduce_3(){
   // CHECK: /*
   // CHECK: DPCT1092:{{[0-9]+}}: Consider replacing work-group size 128 with differnt value for specific hardware for better performance.
   // CHECK: */
-  // CHECK: dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::ext::oneapi::minimum<>(), initial_value);
+  // CHECK: dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::minimum<>(), initial_value);
 
   cudaMalloc(&temp_storage, temp_storage_size);
 
@@ -334,7 +334,7 @@ bool test_reduce_3(){
 //CHECK:      /*
 //CHECK:      DPCT1092:{{[0-9]+}}: Consider replacing work-group size 128 with differnt value for specific hardware for better performance.
 //CHECK:      */
-//CHECK:      dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::ext::oneapi::plus<>(), 0);
+//CHECK:      dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::plus<>(), 0);
 
 //CHECK:      dev_ct1.queues_wait_and_throw();
 
@@ -407,7 +407,7 @@ bool test_sum_1(){
 //CHECK:    /*
 //CHECK:    DPCT1092:{{[0-9]+}}: Consider replacing work-group size 128 with differnt value for specific hardware for better performance.
 //CHECK:    */
-//CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::ext::oneapi::plus<>(), 0);
+//CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::plus<>(), 0);
 
 //CHECK:    dev_ct1.queues_wait_and_throw();
 
@@ -479,7 +479,7 @@ bool test_sum_2(){
 //CHECK:    /*
 //CHECK:    DPCT1092:{{[0-9]+}}: Consider replacing work-group size 128 with differnt value for specific hardware for better performance.
 //CHECK:    */
-//CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::ext::oneapi::minimum<>(), std::numeric_limits<int>::max());
+//CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::minimum<>(), std::numeric_limits<int>::max());
 
 //CHECK:    dev_ct1.queues_wait_and_throw();
 
@@ -551,7 +551,7 @@ bool test_min(){
 //CHECK:    /*
 //CHECK:    DPCT1092:{{[0-9]+}}: Consider replacing work-group size 128 with differnt value for specific hardware for better performance.
 //CHECK:    */
-//CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::ext::oneapi::maximum<>(), std::numeric_limits<int>::lowest());
+//CHECK:    dpct::device::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, (unsigned int *)(device_offsets), (unsigned int *)(device_offsets + 1), sycl::maximum<>(), std::numeric_limits<int>::lowest());
 
 //CHECK:    dev_ct1.queues_wait_and_throw();
 

--- a/clang/test/dpct/cub/type/binop.cu
+++ b/clang/test/dpct/cub/type/binop.cu
@@ -1,0 +1,47 @@
+// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2
+// UNSUPPORTED: v8.0, v9.0, v9.1, v9.2, v10.0, v10.1, v10.2
+// RUN: dpct --format-range=none -in-root %S -out-root %T/type/binop %S/binop.cu --cuda-include-path="%cuda-path/include" -- -std=c++17 -x cuda --cuda-host-only
+// RUN: FileCheck --input-file %T/type/binop/binop.dp.cpp %s
+
+// CHECK: #include <sycl/sycl.hpp>
+// CHECK-NEXT: #include <dpct/dpct.hpp>
+#include <cub/cub.cuh>
+
+// CHECK: void foo(sycl::plus<> sum) {}
+__global__ void foo(cub::Sum sum) {}
+
+template<typename BinOp>
+void foo1(BinOp op) {
+  BinOp op2 = op;
+}
+
+int main() {
+  // CHECK: sycl::plus<> sum;
+  cub::Sum sum;
+
+  // CHECK: sycl::maximum<> max;
+  cub::Max max;
+
+  // CHECK: sycl::minimum<> min;
+  cub::Min min;
+
+  // CHECK: std::equal_to<> eq;
+  cub::Equality eq;
+
+  // CHECK: dpct::get_default_queue().parallel_for(
+  // CHECK:   sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)), 
+  // CHECK:   [=](sycl::nd_item<3> item_ct1) {
+  // CHECK:     foo(sycl::plus<>());
+  // CHECK:   });
+  foo<<<1, 1>>>(cub::Sum());
+
+  // CHECK: foo1<sycl::maximum<>>(max);
+  foo1<cub::Max>(max);
+
+  // CHECK: foo1<sycl::minimum<>>(min);
+  foo1<cub::Min>(min);
+
+  // CHECK: foo1<std::equal_to<>>(eq);
+  foo1<cub::Equality>(eq);
+  return 0;
+}

--- a/clang/test/dpct/cub/type/constant_iterator.cu
+++ b/clang/test/dpct/cub/type/constant_iterator.cu
@@ -1,7 +1,7 @@
 // UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2
 // UNSUPPORTED: v8.0, v9.0, v9.1, v9.2, v10.0, v10.1, v10.2
-// RUN: dpct --format-range=none -in-root %S -out-root %T/iterator/constant_iterator %S/constant_iterator.cu --cuda-include-path="%cuda-path/include" -- -std=c++14 -x cuda --cuda-host-only
-// RUN: FileCheck --input-file %T/iterator/constant_iterator/constant_iterator.dp.cpp %s
+// RUN: dpct --format-range=none -in-root %S -out-root %T/type/constant_iterator %S/constant_iterator.cu --cuda-include-path="%cuda-path/include" -- -std=c++14 -x cuda --cuda-host-only
+// RUN: FileCheck --input-file %T/type/constant_iterator/constant_iterator.dp.cpp %s
 
 // CHECK: #include <dpct/dpl_utils.hpp>
 #include <cub/cub.cuh>

--- a/clang/test/dpct/cub/type/counting_iterator.cu
+++ b/clang/test/dpct/cub/type/counting_iterator.cu
@@ -1,7 +1,7 @@
 // UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2
 // UNSUPPORTED: v8.0, v9.0, v9.1, v9.2, v10.0, v10.1, v10.2
-// RUN: dpct --format-range=none -in-root %S -out-root %T/iterator/counting_iterator %S/counting_iterator.cu --cuda-include-path="%cuda-path/include" -- -std=c++14 -x cuda --cuda-host-only
-// RUN: FileCheck --input-file %T/iterator/counting_iterator/counting_iterator.dp.cpp --match-full-lines %s
+// RUN: dpct --format-range=none -in-root %S -out-root %T/type/counting_iterator %S/counting_iterator.cu --cuda-include-path="%cuda-path/include" -- -std=c++14 -x cuda --cuda-host-only
+// RUN: FileCheck --input-file %T/type/counting_iterator/counting_iterator.dp.cpp --match-full-lines %s
 
 // CHECK:#include <oneapi/dpl/iterator>
 #include <cub/cub.cuh>

--- a/clang/test/dpct/cub/type/transform_iterator.cu
+++ b/clang/test/dpct/cub/type/transform_iterator.cu
@@ -1,7 +1,7 @@
 // UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2
 // UNSUPPORTED: v8.0, v9.0, v9.1, v9.2, v10.0, v10.1, v10.2
-// RUN: dpct --format-range=none -in-root %S -out-root %T/iterator/transform_iterator %S/transform_iterator.cu --cuda-include-path="%cuda-path/include" -- -std=c++14 -x cuda --cuda-host-only
-// RUN: FileCheck --input-file %T/iterator/transform_iterator/transform_iterator.dp.cpp --match-full-lines %s
+// RUN: dpct --format-range=none -in-root %S -out-root %T/type/transform_iterator %S/transform_iterator.cu --cuda-include-path="%cuda-path/include" -- -std=c++14 -x cuda --cuda-host-only
+// RUN: FileCheck --input-file %T/type/transform_iterator/transform_iterator.dp.cpp --match-full-lines %s
 
 // CHECK:#include <oneapi/dpl/iterator>
 #include <cub/cub.cuh>

--- a/clang/test/dpct/cub/warplevel/warpreduce.cu
+++ b/clang/test/dpct/cub/warplevel/warpreduce.cu
@@ -32,7 +32,7 @@ void print_data(int* data, int num) {
 //CHECK-EMPTY:
 //CHECK-NEXT:  int input = data[threadid];
 //CHECK-NEXT:  int output = 0;
-//CHECK-NEXT:  output = sycl::reduce_over_group(item_ct1.get_sub_group(), input, sycl::ext::oneapi::plus<>());
+//CHECK-NEXT:  output = sycl::reduce_over_group(item_ct1.get_sub_group(), input, sycl::plus<>());
 //CHECK-NEXT:  data[threadid] = output;
 //CHECK-NEXT:}
 __global__ void SumKernel(int* data) {
@@ -55,7 +55,7 @@ __global__ void SumKernel(int* data) {
 //CHECK-EMPTY:
 //CHECK-NEXT:  int input = data[threadid];
 //CHECK-NEXT:  int output = 0;
-//CHECK-NEXT:  output = sycl::reduce_over_group(item_ct1.get_sub_group(), input, sycl::ext::oneapi::plus<>());
+//CHECK-NEXT:  output = sycl::reduce_over_group(item_ct1.get_sub_group(), input, sycl::plus<>());
 //CHECK-NEXT:  data[threadid] = output;
 //CHECK-NEXT:}
 __global__ void ReduceKernel(int* data) {

--- a/clang/test/dpct/cub/warplevel/warpscan.cu
+++ b/clang/test/dpct/cub/warplevel/warpscan.cu
@@ -32,7 +32,7 @@ void print_data(int* data, int num) {
 //CHECK-EMPTY:
 //CHECK-NEXT: int input = data[threadid];
 //CHECK-NEXT: int output = 0;
-//CHECK-NEXT: output = sycl::exclusive_scan_over_group(item_ct1.get_sub_group(), input, sycl::ext::oneapi::plus<>());
+//CHECK-NEXT: output = sycl::exclusive_scan_over_group(item_ct1.get_sub_group(), input, sycl::plus<>());
 //CHECK-NEXT: data[threadid] = output;
 //CHECK-NEXT: }
 __global__ void ExclusiveScanKernel1(int* data) {
@@ -55,7 +55,7 @@ __global__ void ExclusiveScanKernel1(int* data) {
 //CHECK-EMPTY:
 //CHECK-NEXT: int input = data[threadid];
 //CHECK-NEXT: int output = 0;
-//CHECK-NEXT: output = sycl::exclusive_scan_over_group(item_ct1.get_sub_group(), input, 0, sycl::ext::oneapi::plus<>());
+//CHECK-NEXT: output = sycl::exclusive_scan_over_group(item_ct1.get_sub_group(), input, 0, sycl::plus<>());
 //CHECK-NEXT: data[threadid] = output;
 //CHECK-NEXT: }
 __global__ void ExclusiveScanKernel2(int* data) {
@@ -78,7 +78,7 @@ __global__ void ExclusiveScanKernel2(int* data) {
 //CHECK-EMPTY:
 //CHECK-NEXT: int input = data[threadid];
 //CHECK-NEXT: int output = 0;
-//CHECK-NEXT: output = sycl::inclusive_scan_over_group(item_ct1.get_sub_group(), input, sycl::ext::oneapi::plus<>());
+//CHECK-NEXT: output = sycl::inclusive_scan_over_group(item_ct1.get_sub_group(), input, sycl::plus<>());
 //CHECK-NEXT: data[threadid] = output;
 //CHECK-NEXT: }
 __global__ void InclusiveScanKernel(int* data) {
@@ -101,7 +101,7 @@ __global__ void InclusiveScanKernel(int* data) {
 //CHECK-EMPTY:
 //CHECK-NEXT: int input = data[threadid];
 //CHECK-NEXT: int output = 0;
-//CHECK-NEXT: output = sycl::exclusive_scan_over_group(item_ct1.get_sub_group(), input, sycl::ext::oneapi::plus<>());
+//CHECK-NEXT: output = sycl::exclusive_scan_over_group(item_ct1.get_sub_group(), input, sycl::plus<>());
 //CHECK-NEXT: data[threadid] = output;
 //CHECK-NEXT: }
 __global__ void ExclusiveSumKernel(int* data) {
@@ -124,7 +124,7 @@ __global__ void ExclusiveSumKernel(int* data) {
 //CHECK-EMPTY:
 //CHECK-NEXT: int input = data[threadid];
 //CHECK-NEXT: int output = 0;
-//CHECK-NEXT: output = sycl::inclusive_scan_over_group(item_ct1.get_sub_group(), input, sycl::ext::oneapi::plus<>());
+//CHECK-NEXT: output = sycl::inclusive_scan_over_group(item_ct1.get_sub_group(), input, sycl::plus<>());
 //CHECK-NEXT: data[threadid] = output;
 //CHECK-NEXT: }
 __global__ void InclusiveSumKernel(int* data) {
@@ -170,13 +170,13 @@ __global__ void BroadcastKernel(int* data) {
 //CHECK-EMPTY:
 //CHECK-NEXT:  int input = data[threadid];
 //CHECK-NEXT:  int output = 0;
-//CHECK-NEXT:  output = sycl::inclusive_scan_over_group(item_ct1.get_sub_group(), input, sycl::ext::oneapi::plus<>());
+//CHECK-NEXT:  output = sycl::inclusive_scan_over_group(item_ct1.get_sub_group(), input, sycl::plus<>());
 //CHECK-NEXT:  data[threadid] = output;
 //CHECK-EMPTY:
 //CHECK-NEXT:  /*
 //CHECK-NEXT:  DPCT1085:{{[0-9]+}}: The function inclusive_scan_over_group requires sub-group size to be 16, while other sub-group functions in the same SYCL kernel require a different sub-group size. You may need to adjust the code.
 //CHECK-NEXT:  */
-//CHECK-NEXT:  output = sycl::inclusive_scan_over_group(item_ct1.get_sub_group(), input, sycl::ext::oneapi::plus<>());
+//CHECK-NEXT:  output = sycl::inclusive_scan_over_group(item_ct1.get_sub_group(), input, sycl::plus<>());
 //CHECK-NEXT:  data[threadid] = output + data[threadid];
 //CHECK-NEXT:}
 __global__ void WarningTestKernel1(int* data) {
@@ -204,7 +204,7 @@ __global__ void WarningTestKernel1(int* data) {
 //CHECK-NEXT:  /*
 //CHECK-NEXT:  DPCT1085:{{[0-9]+}}: The function inclusive_scan_over_group requires sub-group size to be 32, while other sub-group functions in the same SYCL kernel require a different sub-group size. You may need to adjust the code.
 //CHECK-NEXT:  */
-//CHECK-NEXT:  data = sycl::inclusive_scan_over_group(item_ct1.get_sub_group(), data, sycl::ext::oneapi::plus<>());
+//CHECK-NEXT:  data = sycl::inclusive_scan_over_group(item_ct1.get_sub_group(), data, sycl::plus<>());
 //CHECK-NEXT:}
 __device__ void WarpScanTest(){
   typedef cub::WarpScan<int> WarpScan;
@@ -219,7 +219,7 @@ __device__ void WarpScanTest(){
 //CHECK-NEXT:  /*
 //CHECK-NEXT:  DPCT1085:{{[0-9]+}}: The function reduce_over_group requires sub-group size to be 16, while other sub-group functions in the same SYCL kernel require a different sub-group size. You may need to adjust the code.
 //CHECK-NEXT:  */
-//CHECK-NEXT:  data = sycl::reduce_over_group(item_ct1.get_sub_group(), data, sycl::ext::oneapi::plus<>());
+//CHECK-NEXT:  data = sycl::reduce_over_group(item_ct1.get_sub_group(), data, sycl::plus<>());
 //CHECK-NEXT:}
 __device__ void WarpReduceTest(){
   typedef cub::WarpReduce<int, 16> WarpReduce;
@@ -235,7 +235,7 @@ __device__ void WarpReduceTest(){
 //CHECK-EMPTY:
 //CHECK-NEXT: int input = data[threadid];
 //CHECK-NEXT: int output = 0;
-//CHECK-NEXT: output = sycl::inclusive_scan_over_group(item_ct1.get_sub_group(), input, sycl::ext::oneapi::plus<>());
+//CHECK-NEXT: output = sycl::inclusive_scan_over_group(item_ct1.get_sub_group(), input, sycl::plus<>());
 //CHECK-NEXT: data[threadid] = output;
 //CHECK-EMPTY:
 //CHECK-NEXT: WarpScanTest(item_ct1);
@@ -262,7 +262,7 @@ __global__ void WarningTestKernel2(int* data) {
 //CHECK: template<typename ScanTy, typename DataTy>
 //CHECK-NEXT: void Scan1(ScanTy &s) {
 //CHECK-NEXT:  DataTy d;
-//CHECK-NEXT:  d = sycl::inclusive_scan_over_group(s, d, sycl::ext::oneapi::plus<>());
+//CHECK-NEXT:  d = sycl::inclusive_scan_over_group(s, d, sycl::plus<>());
 //CHECK-NEXT: }
 template<typename ScanTy, typename DataTy>
 __device__ void Scan1(ScanTy &s) {
@@ -304,7 +304,7 @@ __global__ void ScanKernel(int* data) {
 // CHECK: /*
 // CHECK-NEXT: DPCT1007:{{[0-9]+}}: Migration of cub::WarpScan.Scan is not supported.
 // CHECK-NEXT: */
-// CHECK-NEXT: WarpScan(temp1).Scan(input, output1, output2, cub::Sum());
+// CHECK-NEXT: WarpScan(temp1).Scan(input, output1, output2, sycl::plus<>());
   WarpScan(temp1).Scan(input, output1, output2, cub::Sum());
   data[threadid] = output1 + output2;
 }

--- a/clang/test/dpct/cub/warplevel/warpscan1d.cu
+++ b/clang/test/dpct/cub/warplevel/warpscan1d.cu
@@ -28,7 +28,7 @@ void print_data(int* data, int num) {
 //CHECK: template<typename ScanTy, typename DataTy>
 //CHECK-NEXT: void Scan1(ScanTy &s) {
 //CHECK-NEXT:  DataTy d;
-//CHECK-NEXT:  d = sycl::inclusive_scan_over_group(s, d, sycl::ext::oneapi::plus<>());
+//CHECK-NEXT:  d = sycl::inclusive_scan_over_group(s, d, sycl::plus<>());
 //CHECK-NEXT: }
 template<typename ScanTy, typename DataTy>
 __device__ void Scan1(ScanTy &s) {

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/dpcpp_extensions.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/dpcpp_extensions.h
@@ -608,14 +608,13 @@ template <typename... _Args> constexpr auto __joint_reduce(_Args... __args) {
 /// that are one past the last element in each segment \param binary_op functor
 /// that implements the binary operation used to perform the scan. \param init
 /// initial value of the reduction for each segment.
-template <int GROUP_SIZE, typename T, typename Ptr, class BinaryOperation>
+template <int GROUP_SIZE, typename T, typename OffsetT, class BinaryOperation>
 void segmented_reduce(sycl::queue queue, T *inputs, T *outputs,
-                      size_t segment_count, Ptr begin_offsets, Ptr end_offsets,
-                      BinaryOperation binary_op, T init) {
+                      size_t segment_count, OffsetT *begin_offsets,
+                      OffsetT *end_offsets, BinaryOperation binary_op, T init) {
 
   sycl::range<1> global_size(segment_count * GROUP_SIZE);
   sycl::range<1> local_size(GROUP_SIZE);
-  typedef std::remove_pointer_t<Ptr> OffsetT;
 
   queue.submit([&](sycl::handler &cgh) {
     cgh.parallel_for(


### PR DESCRIPTION
- Re-implement cub::DeviceSegmentedReduce::(Reduce/Sum/Max/Min) with rewriter
- Support migration of 4 CUB binary operator(cub::Sum/cub::Min/cub::Max/cub::Equality)
- Improve dpct::device::segmented_reduce help function