### PR TITLE
[SYCLomatic] Fix incorrect migration of atomicAdd

### DIFF
--- a/clang/lib/DPCT/APINamesMathRewrite.inc
+++ b/clang/lib/DPCT/APINamesMathRewrite.inc
@@ -87,3 +87,14 @@ CONDITIONAL_FACTORY_ENTRY(
                        CALL(MapNames::getClNamespace(false, true) + "clamp<float>",
                             ARG(0), ARG("0.0f"), ARG("1.0f"))),
     NO_REWRITE_FUNCNAME_FACTORY_ENTRY("saturate", "saturate"))
+
+CONDITIONAL_FACTORY_ENTRY(
+    GetUsingGenericSpace,
+    CALL_FACTORY_ENTRY(
+        "atomicAdd",
+        CALL(MapNames::getDpctNamespace() + "atomic_fetch_add", ARG(0), ARG(1))),
+    /* TODO: Handle case where (GetUsingGenericSpace == false) */
+    CALL_FACTORY_ENTRY(
+        "atomicAdd",
+        CALL(MapNames::getDpctNamespace() + "atomic_fetch_add", ARG(0), ARG(1)))
+)

--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -1859,6 +1859,17 @@ void AtomicFunctionRule::MigrateAtomicFunc(
     return;
   };
 
+  const std::string FuncName = CE->getDirectCallee()->getName().str();
+  if (!CallExprRewriterFactoryBase::RewriterMap)
+    return;
+  auto Iter = CallExprRewriterFactoryBase::RewriterMap->find(FuncName);
+  if (Iter != CallExprRewriterFactoryBase::RewriterMap->end()) {
+    ExprAnalysis EA(CE);
+    emplaceTransformation(EA.getReplacement());
+    EA.applyAllSubExprRepl();
+    return;
+  }
+
   // TODO: 1. Investigate are there usages of atomic functions on local address
   //          space
   //       2. If item 1. shows atomic functions on local address space is

--- a/clang/lib/DPCT/CallExprRewriter.cpp
+++ b/clang/lib/DPCT/CallExprRewriter.cpp
@@ -2608,6 +2608,9 @@ auto UseLogicalGroup = [](const CallExpr *C) -> bool {
 auto UseCAndCXXStandardLibrariesExt = [](const CallExpr *C) -> bool {
   return DpctGlobalInfo::useCAndCXXStandardLibrariesExt();
 };
+auto GetUsingGenericSpace = [](const CallExpr *C) -> bool {
+  return DpctGlobalInfo::getUsingGenericSpace();
+};
 
 class CheckDerefedTypeBeforeCast {
   unsigned Idx;

--- a/clang/runtime/dpct-rt/include/atomic.hpp.inc
+++ b/clang/runtime/dpct-rt/include/atomic.hpp.inc
@@ -56,14 +56,14 @@ namespace dpct {
 /// \param operand The value to add to the value at \p addr.
 /// \param memoryOrder The memory ordering used.
 /// \returns The value at the \p addr before the call.
-template <typename T,
+template <typename T1, typename T2,
           sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
-inline T atomic_fetch_add(T *addr, T operand) {
+inline T1 atomic_fetch_add(T1 *addr, T2 operand) {
   auto atm =
-      sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
+      sycl::atomic_ref<T1, memoryOrder, memoryScope, addressSpace>(addr[0]);
   return atm.fetch_add(operand);
 }
 
@@ -73,19 +73,19 @@ inline T atomic_fetch_add(T *addr, T operand) {
 /// \param operand The value to add to the value at \p addr.
 /// \param memoryOrder The memory ordering used.
 /// \returns The value at the \p addr before the call.
-template <typename T, sycl::access::address_space addressSpace =
+template <typename T1, typename T2, sycl::access::address_space addressSpace =
                           sycl::access::address_space::global_space>
-inline T atomic_fetch_add(T *addr, T operand,
+inline T1 atomic_fetch_add(T1 *addr, T2 operand,
                           sycl::memory_order memoryOrder) {
   switch (memoryOrder) {
   case sycl::memory_order::relaxed:
-    return atomic_fetch_add<T, addressSpace, sycl::memory_order::relaxed,
+    return atomic_fetch_add<T1, T2, addressSpace, sycl::memory_order::relaxed,
                             sycl::memory_scope::device>(addr, operand);
   case sycl::memory_order::acq_rel:
-    return atomic_fetch_add<T, addressSpace, sycl::memory_order::acq_rel,
+    return atomic_fetch_add<T1, T2, addressSpace, sycl::memory_order::acq_rel,
                             sycl::memory_scope::device>(addr, operand);
   case sycl::memory_order::seq_cst:
-    return atomic_fetch_add<T, addressSpace, sycl::memory_order::seq_cst,
+    return atomic_fetch_add<T1, T2, addressSpace, sycl::memory_order::seq_cst,
                             sycl::memory_scope::device>(addr, operand);
   default:
     assert(false && "Invalid memory_order for atomics. Valid memory_order for "

--- a/clang/test/dpct/atomic_functions.cu
+++ b/clang/test/dpct/atomic_functions.cu
@@ -13,7 +13,7 @@ __global__ void test(T *data) {
   // CHECK: T tid = item_ct1.get_local_id(2);
   T tid = threadIdx.x;
 
-  // CHECK: dpct::atomic_fetch_add<T, sycl::access::address_space::generic_space>(&data[0], tid);
+  // CHECK: dpct::atomic_fetch_add(&data[0], tid);
   atomicAdd(&data[0], tid);
 
   // CHECK: dpct::atomic_fetch_sub<T, sycl::access::address_space::generic_space>(&data[1], tid);
@@ -61,7 +61,7 @@ template <>
 __global__ void test(unsigned long long int* data) {
   unsigned long long int tid = threadIdx.x;
 
-  // CHECK: dpct::atomic_fetch_add<unsigned long long, sycl::access::address_space::generic_space>(&data[0], tid);
+  // CHECK: dpct::atomic_fetch_add(&data[0], tid);
   atomicAdd(&data[0], tid);
 
   // CHECK: dpct::atomic_exchange<unsigned long long, sycl::access::address_space::generic_space>(&data[2], tid);
@@ -75,7 +75,7 @@ template <>
 __global__ void test(float* data) {
   float tid = threadIdx.x;
 
-  // CHECK: dpct::atomic_fetch_add<float, sycl::access::address_space::generic_space>(&data[0], tid);
+  // CHECK: dpct::atomic_fetch_add(&data[0], tid);
   atomicAdd(&data[0], tid);
 
   // CHECK: dpct::atomic_exchange<float, sycl::access::address_space::generic_space>(&data[2], tid);
@@ -86,7 +86,7 @@ template <>
 __global__ void test(double* data) {
   double tid = threadIdx.x;
 
-  // CHECK: dpct::atomic_fetch_add<double, sycl::access::address_space::generic_space>(&data[0], tid);
+  // CHECK: dpct::atomic_fetch_add(&data[0], tid);
   atomicAdd(&data[0], tid);
 }
 
@@ -122,13 +122,13 @@ static __device__ uint32_t d_error[1];
 __device__ void fun(){
   double *a;
   float b;
-  // CHECK: dpct::atomic_fetch_add<double, sycl::access::address_space::generic_space>(a, (double)1);
+  // CHECK: dpct::atomic_fetch_add(a, 1);
   atomicAdd(a, 1);
 
-  // CHECK: dpct::atomic_fetch_add<double, sycl::access::address_space::generic_space>(a, (double)b);
+  // CHECK: dpct::atomic_fetch_add(a, b);
   atomicAdd(a, b);
 
-  // CHECK: dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::generic_space>((uint32_t*)d_error, (uint32_t)1);
+  // CHECK: dpct::atomic_fetch_add(d_error, 1);
   atomicAdd(d_error, 1);
 }
 
@@ -143,11 +143,11 @@ int main() {
 // CHECK: void foo(sycl::nd_item<3> item_ct1, uint8_t *dpct_local, uint32_t &share_v) {
 // CHECK-NEXT:  auto share_array = (uint32_t *)dpct_local;
 // CHECK-NEXT:  for (int b = item_ct1.get_local_id(2); b < 64; b += item_ct1.get_local_range(2)) {
-// CHECK-NEXT:    dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::generic_space>(&share_array[b], (uint32_t)1);
-// CHECK-NEXT:    dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::generic_space>((uint32_t*)share_array, (uint32_t)1);
+// CHECK-NEXT:    dpct::atomic_fetch_add(&share_array[b], 1);
+// CHECK-NEXT:    dpct::atomic_fetch_add(share_array, 1);
 // CHECK-NEXT:  }
 // CHECK-EMPTY:
-// CHECK-NEXT:  dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::generic_space>(&share_v, (uint32_t)1);
+// CHECK-NEXT:  dpct::atomic_fetch_add(&share_v, 1);
 // CHECK-NEXT:}
 __global__ void foo() {
   extern __shared__ uint32_t share_array[];
@@ -165,17 +165,17 @@ __shared__ uint32_t share_v;
 // CHECK-NEXT:    uint32_t *p_1 = &share_array[b];
 // CHECK-NEXT:    uint32_t *p_2 = share_array;
 // CHECK-NEXT:    uint32_t *p_3 = p_2;
-// CHECK-NEXT:    dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::generic_space>(p_1, (uint32_t)1);
-// CHECK-NEXT:    dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::generic_space>(p_2, (uint32_t)1);
-// CHECK-NEXT:    dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::generic_space>(p_3, (uint32_t)1);
+// CHECK-NEXT:    dpct::atomic_fetch_add(p_1, 1);
+// CHECK-NEXT:    dpct::atomic_fetch_add(p_2, 1);
+// CHECK-NEXT:    dpct::atomic_fetch_add(p_3, 1);
 // CHECK-NEXT:  }
 // CHECK-EMPTY:
 // CHECK-NEXT:  uint32_t *p_1 = &share_v;
 // CHECK-NEXT:  uint32_t *p_2 = p_1;
 // CHECK-NEXT:  uint32_t *p_3 = p_2;
-// CHECK-NEXT:  dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::generic_space>(p_1, (uint32_t)1);
-// CHECK-NEXT:  dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::generic_space>(p_2, (uint32_t)1);
-// CHECK-NEXT:  dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::generic_space>(p_3, (uint32_t)1);
+// CHECK-NEXT:  dpct::atomic_fetch_add(p_1, 1);
+// CHECK-NEXT:  dpct::atomic_fetch_add(p_2, 1);
+// CHECK-NEXT:  dpct::atomic_fetch_add(p_3, 1);
 // CHECK-NEXT:}
 __global__ void foo_2() {
   extern __shared__ uint32_t share_array[];
@@ -205,7 +205,7 @@ __shared__ uint32_t share_v;
 // CHECK-NEXT:  p_2 = p_1;
 // CHECK-NEXT:  p_3 = p_2;
 // CHECK-NEXT:  uint32_t *p_4 = p_3;
-// CHECK-NEXT:  dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::generic_space>(p_4, (uint32_t)1);
+// CHECK-NEXT:  dpct::atomic_fetch_add(p_4, 1);
 // CHECK-NEXT:}
 __global__ void foo_3() {
 __shared__ uint32_t share_v;
@@ -229,13 +229,13 @@ __shared__ uint32_t share_v;
 // CHECK-NEXT:  p_2 = p_1;
 // CHECK-NEXT:  p_3 = p_2;
 // CHECK-NEXT:  uint32_t *p_4 = p_3;
-// CHECK-NEXT:  dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::generic_space>(p_4, (uint32_t)1);
+// CHECK-NEXT:  dpct::atomic_fetch_add(p_4, 1);
 // CHECK-NEXT:  p_1 = share;
 // CHECK-NEXT:  p_2 = p_1;
 // CHECK-NEXT:  p_3 = p_2;
 // CHECK-NEXT:  p_3 = dmem;
 // CHECK-NEXT:  uint32_t *p_5 = p_3;
-// CHECK-NEXT:  dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::generic_space>(p_5, (uint32_t)1);
+// CHECK-NEXT:  dpct::atomic_fetch_add(p_5, 1);
 // CHECK-NEXT:}
 __device__ uint32_t dmem[100];
 __global__ void foo_4() {
@@ -270,9 +270,9 @@ __device__ uint32_t* func(uint32_t *in){
 // CHECK-NEXT:  p_3 = p_2;
 // CHECK-NEXT:  uint32_t *p_4;
 // CHECK-NEXT:  p_4= p_4 + 1;
-// CHECK-NEXT:  dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::generic_space>(p_4, (uint32_t)1);
+// CHECK-NEXT:  dpct::atomic_fetch_add(p_4, 1);
 // CHECK-NEXT:  p_4=func(p_3);
-// CHECK-NEXT:  dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::generic_space>(p_4, (uint32_t)1);
+// CHECK-NEXT:  dpct::atomic_fetch_add(p_4, 1);
 // CHECK-NEXT:}
 __global__ void foo_5() {
 extern __shared__ uint32_t share[];
@@ -301,7 +301,7 @@ extern __shared__ uint32_t share[];
 // CHECK-NEXT:  uint32_t *p_4;
 // CHECK-NEXT:  p_4= p_4 + 1;
 // CHECK-NEXT:  p_4=FUNC(p_3);
-// CHECK-NEXT:  dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::generic_space>(p_4, (uint32_t)1);
+// CHECK-NEXT:  dpct::atomic_fetch_add(p_4, 1);
 // CHECK-NEXT:}
 __global__ void foo_6() {
 extern __shared__ uint32_t share[];
@@ -327,7 +327,7 @@ extern __shared__ uint32_t share[];
 // CHECK-NEXT:    p_2 = p_1;
 // CHECK-NEXT:  else
 // CHECK-NEXT:    p_2 = p_3;
-// CHECK-NEXT:  dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::generic_space>(p_2, (uint32_t)1);
+// CHECK-NEXT:  dpct::atomic_fetch_add(p_2, 1);
 // CHECK-NEXT:}
 __global__ void foo_7(int a) {
 extern __shared__ uint32_t share[];
@@ -397,7 +397,7 @@ __global__ void k() {
   float f;
   __shared__ uint32_t u32;
 
-// CHECK:  dpct::atomic_fetch_add<int, sycl::access::address_space::generic_space>(&i, i);
+// CHECK:  dpct::atomic_fetch_add(&i, i);
 // CHECK-NEXT: dpct::atomic_fetch_sub<int, sycl::access::address_space::generic_space>(&i, i);
 // CHECK-NEXT:  dpct::atomic_fetch_and<int, sycl::access::address_space::generic_space>(&i, i);
 // CHECK-NEXT:  dpct::atomic_fetch_or<int, sycl::access::address_space::generic_space>(&i, i);
@@ -412,7 +412,7 @@ __global__ void k() {
   atomicMin(&i, i);
   atomicMax(&i, i);
 
-// CHECK:  dpct::atomic_fetch_add<unsigned int, sycl::access::address_space::generic_space>(&ui, ui);
+// CHECK:  dpct::atomic_fetch_add(&ui, ui);
 // CHECK-NEXT:  dpct::atomic_fetch_sub<unsigned int, sycl::access::address_space::generic_space>(&ui, ui);
 // CHECK-NEXT:  dpct::atomic_fetch_and<unsigned int, sycl::access::address_space::generic_space>(&ui, ui);
 // CHECK-NEXT:  dpct::atomic_fetch_or<unsigned int, sycl::access::address_space::generic_space>(&ui, ui);
@@ -427,7 +427,7 @@ __global__ void k() {
   atomicMin(&ui, ui);
   atomicMax(&ui, ui);
 
-// CHECK:  dpct::atomic_fetch_add<unsigned long long, sycl::access::address_space::generic_space>(&ull, ull);
+// CHECK:  dpct::atomic_fetch_add(&ull, ull);
 // CHECK-NEXT:  dpct::atomic_fetch_and<unsigned long long, sycl::access::address_space::generic_space>(&ull, ull);
 // CHECK-NEXT:  dpct::atomic_fetch_or<unsigned long long, sycl::access::address_space::generic_space>(&ull, ull);
 // CHECK-NEXT:  dpct::atomic_fetch_xor<unsigned long long, sycl::access::address_space::generic_space>(&ull, ull);
@@ -440,16 +440,16 @@ __global__ void k() {
   atomicMin(&ull, ull);
   atomicMax(&ull, ull);
 
-  // CHECK: dpct::atomic_fetch_add<unsigned int, sycl::access::address_space::generic_space>(&ui, (unsigned int)i);
+  // CHECK: dpct::atomic_fetch_add(&ui, i);
   atomicAdd(&ui, i);
 
-  // CHECK: dpct::atomic_fetch_add<unsigned int, sycl::access::address_space::generic_space>(&ui, (unsigned int)(i + i));
+  // CHECK: dpct::atomic_fetch_add(&ui, i + i);
   atomicAdd(&ui, i + i);
 
-  // CHECK: dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::generic_space>(&u32, u32);
+  // CHECK: dpct::atomic_fetch_add(&u32, u32);
   atomicAdd(&u32, u32);
 
-  // CHECK: dpct::atomic_fetch_add<float, sycl::access::address_space::generic_space>(&f, f);
+  // CHECK: dpct::atomic_fetch_add(&f, f);
   atomicAdd(&f, f);
 }
 
@@ -479,11 +479,11 @@ __global__ void mykernel(unsigned int *dev) {
 // CHECK-NEXT:  int i = item_ct1.get_local_id(2) + item_ct1.get_group(2) * item_ct1.get_local_range(2);
 // CHECK-NEXT:  int offset = item_ct1.get_local_range(2) * item_ct1.get_group_range(2);
 // CHECK-NEXT:  while (i < size) {
-// CHECK-NEXT:    dpct::atomic_fetch_add<unsigned int, sycl::access::address_space::generic_space>(&temp[buffer[i]], (unsigned int)1);
+// CHECK-NEXT:    dpct::atomic_fetch_add(&temp[buffer[i]], 1);
 // CHECK-NEXT:    i += offset;
 // CHECK-NEXT:  }
 // CHECK-NEXT:  item_ct1.barrier(sycl::access::fence_space::local_space);
-// CHECK-NEXT:  dpct::atomic_fetch_add<unsigned int, sycl::access::address_space::generic_space>(&(histo[item_ct1.get_local_id(2)]), temp[item_ct1.get_local_id(2)]);
+// CHECK-NEXT:  dpct::atomic_fetch_add(&(histo[item_ct1.get_local_id(2)]), temp[item_ct1.get_local_id(2)]);
 // CHECK-NEXT:}
 __global__ void mykernel_1(unsigned char *buffer, long size,
                              unsigned int *histo) {
@@ -524,7 +524,7 @@ __global__ static void vlc_encode_kernel_sm64huff() {
 }
 
 // CHECK:void addByte(unsigned int *s_WarpHist, unsigned int data) {
-// CHECK-NEXT:  dpct::atomic_fetch_add<unsigned int, sycl::access::address_space::generic_space>(s_WarpHist + data, (unsigned int)1);
+// CHECK-NEXT:  dpct::atomic_fetch_add(s_WarpHist + data, 1);
 // CHECK-NEXT:}
 __device__ void addByte(unsigned int *s_WarpHist, unsigned int data) {
   atomicAdd(s_WarpHist + data, 1);
@@ -540,7 +540,7 @@ __shared__ unsigned int s_Hist[100];
 volatile __device__ int g_mutex = 0;
 
 //CHECK:void __gpu_sync(int blocks_to_synch, volatile int &g_mutex) {
-//CHECK-NEXT:  dpct::atomic_fetch_add<int, sycl::access::address_space::generic_space>((int *)&g_mutex, 1);
+//CHECK-NEXT:  dpct::atomic_fetch_add((int *)&g_mutex, 1);
 //CHECK-NEXT:  while(g_mutex < blocks_to_synch);
 //CHECK-NEXT:}
 __device__ void __gpu_sync(int blocks_to_synch) {

--- a/clang/test/dpct/atomic_user_defined.cu
+++ b/clang/test/dpct/atomic_user_defined.cu
@@ -52,7 +52,7 @@ __global__ void ker4(char *count)
 __global__ void ker5(unsigned int *count)
 {
   int n = 1, x = 0;
-  // CHECK: x = dpct::atomic_fetch_add<unsigned int, sycl::access::address_space::generic_space>(count, (unsigned int)n);
+  // CHECK: x = dpct::atomic_fetch_add(count, n);
   x = atomicAdd(count, n);
 }
 

--- a/clang/test/dpct/helper_files_ref/include/atomic.hpp
+++ b/clang/test/dpct/helper_files_ref/include/atomic.hpp
@@ -19,14 +19,14 @@ namespace dpct {
 /// \param operand The value to add to the value at \p addr.
 /// \param memoryOrder The memory ordering used.
 /// \returns The value at the \p addr before the call.
-template <typename T,
+template <typename T1, typename T2,
           sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
-inline T atomic_fetch_add(T *addr, T operand) {
+inline T1 atomic_fetch_add(T1 *addr, T2 operand) {
   auto atm =
-      sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
+      sycl::atomic_ref<T1, memoryOrder, memoryScope, addressSpace>(addr[0]);
   return atm.fetch_add(operand);
 }
 
@@ -36,19 +36,19 @@ inline T atomic_fetch_add(T *addr, T operand) {
 /// \param operand The value to add to the value at \p addr.
 /// \param memoryOrder The memory ordering used.
 /// \returns The value at the \p addr before the call.
-template <typename T, sycl::access::address_space addressSpace =
+template <typename T1, typename T2, sycl::access::address_space addressSpace =
                           sycl::access::address_space::global_space>
-inline T atomic_fetch_add(T *addr, T operand,
+inline T1 atomic_fetch_add(T1 *addr, T2 operand,
                           sycl::memory_order memoryOrder) {
   switch (memoryOrder) {
   case sycl::memory_order::relaxed:
-    return atomic_fetch_add<T, addressSpace, sycl::memory_order::relaxed,
+    return atomic_fetch_add<T1, T2, addressSpace, sycl::memory_order::relaxed,
                             sycl::memory_scope::device>(addr, operand);
   case sycl::memory_order::acq_rel:
-    return atomic_fetch_add<T, addressSpace, sycl::memory_order::acq_rel,
+    return atomic_fetch_add<T1, T2, addressSpace, sycl::memory_order::acq_rel,
                             sycl::memory_scope::device>(addr, operand);
   case sycl::memory_order::seq_cst:
-    return atomic_fetch_add<T, addressSpace, sycl::memory_order::seq_cst,
+    return atomic_fetch_add<T1, T2, addressSpace, sycl::memory_order::seq_cst,
                             sycl::memory_scope::device>(addr, operand);
   default:
     assert(false && "Invalid memory_order for atomics. Valid memory_order for "

--- a/clang/test/dpct/macro_test.cu
+++ b/clang/test/dpct/macro_test.cu
@@ -510,9 +510,9 @@ __global__ void foo7() {
 //CHECK-NEXT:   #define SLOW(X) X
 //CHECK-NEXT:   double* data;
 //CHECK-NEXT:   unsigned long long int tid;
-//CHECK-NEXT:   SLOW(dpct::atomic_fetch_add(&data[0], (double)tid);
-//CHECK-NEXT:         dpct::atomic_fetch_add(&data[1], (double)(tid + 1));
-//CHECK-NEXT:         dpct::atomic_fetch_add(&data[2], (double)(tid + 2)););
+//CHECK-NEXT:   SLOW(dpct::atomic_fetch_add(&data[0], tid);
+//CHECK-NEXT:         dpct::atomic_fetch_add(&data[1], tid + 1);
+//CHECK-NEXT:         dpct::atomic_fetch_add(&data[2], tid + 2););
 //CHECK-NEXT: }
 __global__ void foo8(){
 #define SLOW(X) X

--- a/clang/test/dpct/replace-dim3.cu
+++ b/clang/test/dpct/replace-dim3.cu
@@ -248,7 +248,7 @@ struct wrap {
 // CHECK: void kernel_foo(float *a, wrap *mt, unsigned int N, sycl::nd_item<3> item_ct1) {
 // CHECK-NEXT:   const unsigned int i = item_ct1.get_group(2)*item_ct1.get_local_range(2)+item_ct1.get_local_id(2);
 // CHECK-NEXT:   if (i<N) {
-// CHECK-NEXT:     dpct::atomic_fetch_add<float, sycl::access::address_space::generic_space>(&mt[i].f3.x(), a[i]);
+// CHECK-NEXT:     dpct::atomic_fetch_add(&mt[i].f3.x(), a[i]);
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 __global__ void kernel_foo(float *a, wrap *mt, unsigned int N) {


### PR DESCRIPTION
This PR fixes a bug that causes `atomicAdd` to not migrate correctly when used inside the definition of a macro. It's currently incomplete.