### PR TITLE
[SYCLomatic] Adding segmented_sort_pairs

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -1384,9 +1384,12 @@ sort_pairs_impl(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
 // DPCT_CODE
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
           typename value_t, typename value_out_t>
-void sort_pairs(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
-                value_t values_in, value_out_t values_out, int64_t n,
-                bool descending, int begin_bit, int end_bit) {
+void sort_pairs(
+    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
+    value_t values_in, value_out_t values_out, int64_t n, bool descending,
+    int begin_bit = 0,
+    int end_bit = sizeof(typename std::iterator_traits<key_t>::value_type) *
+                  8) {
   internal::sort_pairs_impl(std::forward<_ExecutionPolicy>(policy), keys_in,
                             keys_out, values_in, values_out, n, descending,
                             begin_bit, end_bit);
@@ -1399,9 +1402,11 @@ void sort_pairs(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t>
-inline void sort_keys(_ExecutionPolicy &&policy, key_t keys_in,
-                      key_out_t keys_out, int64_t n, bool descending,
-                      int begin_bit, int end_bit) {
+inline void sort_keys(
+    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out, int64_t n,
+    bool descending, int begin_bit = 0,
+    int end_bit = sizeof(typename std::iterator_traits<key_t>::value_type) *
+                  8) {
   using key_t_value_t = typename ::std::iterator_traits<key_t>::value_type;
 
   int clipped_begin_bit = ::std::max(begin_bit, 0);

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -1491,36 +1491,80 @@ inline void segmented_sort_pairs_by_two_pair_sorts(
                   8) {
   using key_t_value_t = typename ::std::iterator_traits<key_t>::value_type;
   using value_t_value_t = typename ::std::iterator_traits<value_t>::value_type;
-  int *segments = sycl::malloc_device<int>(n, policy.queue());
-  int *segments_sorted = sycl::malloc_device<int>(n, policy.queue());
+  ::std::size_t *segments =
+      sycl::malloc_device<::std::size_t>(n, policy.queue());
+  ::std::size_t *segments_sorted =
+      sycl::malloc_device<::std::size_t>(n, policy.queue());
   auto keys_temp = sycl::malloc_device<key_t_value_t>(n, policy.queue());
   auto values_temp = sycl::malloc_device<value_t_value_t>(n, policy.queue());
 
-  // create a list of segment indexes
-  if (nsegments > n / nsegments) {
+  ::std::size_t work_group_size =
+      policy.queue()
+          .get_device()
+          .template get_info<sycl::info::device::max_work_group_size>();
+
+  auto sg_sizes = policy.queue()
+                      .get_device()
+                      .template get_info<sycl::info::device::sub_group_sizes>();
+  ::std::size_t subgroup_size = sg_sizes.empty() ? 0 : sg_sizes.back();
+
+  float avg_seg_size = (float)n / (float)nsegments;
+  if (avg_seg_size > work_group_size) {
+    // If average segment size is larger than workgroup, use workgroup to
+    // coordinate to mark segments
     policy.queue()
         .submit([&](sycl::handler &h) {
-          h.parallel_for(nsegments, ([=](sycl::id<1> seg) {
-                           for (int i = begin_offsets[seg];
-                                i < end_offsets[seg]; i++) {
-                             segments[i] = seg;
+          h.parallel_for(work_group_size, ([=](sycl::id<1> id) {
+                           for (::std::size_t seg = 0; seg < nsegments; seg++) {
+                             ::std::size_t i = begin_offsets[seg];
+                             ::std::size_t end = end_offsets[seg];
+                             while (i + id < end) {
+                               segments[i + id] = seg;
+                               i += work_group_size;
+                             }
+                           }
+                         }));
+        })
+        .wait();
+  } else if (sub_group_size > 0 && avg_seg_size > sub_group_size / 2) {
+    // If average segment size is larger than half a subgroup, use subgroup to
+    // coordinate to mark segments
+    policy.queue()
+        .submit([&](sycl::handler &h) {
+          h.parallel_for(sycl::nd_range<1>{work_group_size, work_group_size},
+                         ([=](sycl::nd_item<1> __item) {
+                           auto __sub_group = __item.get_sub_group();
+                           ::std::size_t __num_subgroups =
+                               __sub_group.get_group_range().size();
+                           ::std::size_t __local_size =
+                               __sub_group.get_local_range().size();
+
+                           ::std::size_t __sub_group_id =
+                               __sub_group.get_group_id();
+                           while (__sub_group_id < nsegments) {
+                             ::std::size_t __subgroup_local_id =
+                                 __sub_group.get_local_id();
+                             std::size_t i = begin_offsets[__sub_group_id];
+                             std::size_t end = end_offsets[__sub_group_id];
+                             while (i + __subgroup_local_id < end) {
+                               segments[i + __subgroup_local_id] =
+                                   __sub_group_id;
+                               i += __local_size;
+                             }
+                             __sub_group_id += __num_subgroups;
                            }
                          }));
         })
         .wait();
   } else {
-    // probably better off setting block size based on characteristics of device
-    int block_size = n / nsegments;
+    // If average segment size is small as compared to subgroup, use single
+    // work item to mark each segment
     policy.queue()
         .submit([&](sycl::handler &h) {
-          h.parallel_for(block_size, ([=](sycl::id<1> id) {
-                           for (int seg = 0; seg < nsegments; seg++) {
-                             int i = begin_offsets[seg];
-                             int end = end_offsets[seg];
-                             while (i + id < end) {
-                               segments[i + id] = seg;
-                               i += block_size;
-                             }
+          h.parallel_for(nsegments, ([=](sycl::id<1> seg) {
+                           for (std::size_t i = begin_offsets[seg];
+                                i < end_offsets[seg]; i++) {
+                             segments[i] = seg;
                            }
                          }));
         })
@@ -1530,13 +1574,13 @@ inline void segmented_sort_pairs_by_two_pair_sorts(
   auto zip_seg_vals = oneapi::dpl::make_zip_iterator(segments, values_in);
   auto zip_seg_vals_out =
       oneapi::dpl::make_zip_iterator(segments_sorted, values_temp);
-  // first sort by keys keeping track of which segment were in...
+  // Part 1: Sort by keys keeping track of which segment were in
   dpct::sort_pairs(::std::forward<_ExecutionPolicy>(policy), keys_in, keys_temp,
                    zip_seg_vals, zip_seg_vals_out, n, descending);
 
   auto zip_keys_vals = oneapi::dpl::make_zip_iterator(keys_temp, values_temp);
   auto zip_keys_vals_out = oneapi::dpl::make_zip_iterator(keys_out, values_out);
-  // then sort the segments with a stable sort to get back sorted segments.
+  // Part 2: Sort the segments with a stable sort to get back sorted segments.
   dpct::sort_pairs(::std::forward<_ExecutionPolicy>(policy), segments_sorted,
                    segments, zip_keys_vals, zip_keys_vals_out, n, false);
 
@@ -1630,23 +1674,24 @@ inline void segmented_sort_pairs(
                       .get_device()
                       .template get_info<sycl::info::device::sub_group_sizes>();
   int subgroup_size = sg_sizes.empty() ? 1 : sg_sizes.back();
-  int compute_unit_threads =
-      policy.queue().get_device().is_gpu() ? subgroup_size : 1;
   // parallel for of serial sorts when we have sufficient number of segments for
-  // load balance
-  if (nsegments > compute_units * compute_unit_threads) {
+  // load balance when number of segments is large as compared to our target
+  // compute capability
+  if (nsegments >
+      compute_units *
+          (policy.queue().get_device().is_gpu() ? subgroup_size : 1)) {
     dpct::internal::segmented_sort_pairs_by_parallel_for_of_sorts(
         ::std::forward<_ExecutionPolicy>(policy), keys_in, keys_out, values_in,
         values_out, n, nsegments, begin_offsets, end_offsets, descending,
         begin_bit, end_bit);
-  } else if (nsegments < 500) // for loop of parallel sorts when we have a small
+  } else if (nsegments < 512) // for loop of parallel sorts when we have a small
                               // number of total sorts to limit total overhead
   {
     dpct::internal::segmented_sort_pairs_by_parallel_sorts(
         ::std::forward<_ExecutionPolicy>(policy), keys_in, keys_out, values_in,
         values_out, n, nsegments, begin_offsets, end_offsets, descending,
         begin_bit, end_bit);
-  } else // decent catch using 2 full sorts
+  } else // decent catch all using 2 full sorts
   {
     dpct::internal::segmented_sort_pairs_by_two_pair_sorts(
         ::std::forward<_ExecutionPolicy>(policy), keys_in, keys_out, values_in,

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -1160,6 +1160,35 @@ partition(Policy &&policy, Iter1 first, Iter1 last, Iter2 mask, Pred p) {
   return stable_partition(std::forward<Policy>(policy), first, last, mask, p);
 }
 // DPCT_LABEL_END
+
+// DPCT_LABEL_BEGIN|sort_pairs|dpct
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasAlgorithm|sort_pairs_impl
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
+          typename value_t, typename value_out_t>
+void sort_pairs(
+    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
+    value_t values_in, value_out_t values_out, int64_t n,
+    bool descending = false, int begin_bit = 0,
+    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
+                  8);
+// DPCT_LABEL_END
+
+// DPCT_LABEL_BEGIN|sort_keys|dpct
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasAlgorithm|transform_and_sort
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+template <typename _ExecutionPolicy, typename key_t, typename key_out_t>
+inline void sort_keys(
+    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out, int64_t n,
+    bool descending = false, int begin_bit = 0,
+    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
+                  8);
+// DPCT_LABEL_END
+
 namespace internal {
 
 // DPCT_LABEL_BEGIN|transform_and_sort|dpct::internal
@@ -1375,6 +1404,153 @@ sort_pairs_impl(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
 }
 // DPCT_LABEL_END
 
+// DPCT_LABEL_BEGIN|segmented_sort_pairs_by_parallel_sorts|dpct::internal
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasAlgorithm|sort_pairs
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+template <typename _ExecutionPolicy, typename key_t, typename value_t,
+          typename OffsetIteratorT>
+inline void segmented_sort_pairs_by_parallel_sorts(
+    _ExecutionPolicy &&policy, key_t keys_in, key_t keys_out, value_t values_in,
+    value_t values_out, int64_t n, int64_t nsegments,
+    OffsetIteratorT begin_offsets, OffsetIteratorT end_offsets,
+    bool descending = false, int begin_bit = 0,
+    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
+                  8) {
+  using offset_type =
+      typename ::std::iterator_traits<OffsetIteratorT>::value_type;
+  auto host_accessible_offset_starts =
+      sycl::malloc_shared<offset_type>(nsegments, policy.queue());
+  auto host_accessible_offset_ends =
+      sycl::malloc_shared<offset_type>(nsegments, policy.queue());
+  // make offsets accessible on host
+  ::std::copy(::std::forward<_ExecutionPolicy>(policy), begin_offsets,
+              begin_offsets + nsegments, host_accessible_offset_starts);
+  ::std::copy(::std::forward<_ExecutionPolicy>(policy), end_offsets,
+              end_offsets + nsegments, host_accessible_offset_ends);
+
+  for (int i = 0; i < nsegments; i++) {
+    uint64_t segment_begin = host_accessible_offset_starts[i];
+    uint64_t segment_end =
+        ::std::min(n, (int64_t)host_accessible_offset_ends[i]);
+    if (segment_begin < segment_end) {
+      ::dpct::sort_pairs(::std::forward<_ExecutionPolicy>(policy),
+                         keys_in + segment_begin, keys_out + segment_begin,
+                         values_in + segment_begin, values_out + segment_begin,
+                         segment_end - segment_begin, descending, begin_bit,
+                         end_bit);
+    }
+  }
+  sycl::free(host_accessible_offset_starts, policy.queue());
+  sycl::free(host_accessible_offset_ends, policy.queue());
+}
+// DPCT_LABEL_END
+
+// DPCT_LABEL_BEGIN|segmented_sort_pairs_by_parallel_for_of_sorts|dpct::internal
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasAlgorithm|sort_pairs
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+template <typename _ExecutionPolicy, typename key_t, typename value_t,
+          typename OffsetIteratorT>
+inline void segmented_sort_pairs_by_parallel_for_of_sorts(
+    _ExecutionPolicy &&policy, key_t keys_in, key_t keys_out, value_t values_in,
+    value_t values_out, int64_t n, int64_t nsegments,
+    OffsetIteratorT begin_offsets, OffsetIteratorT end_offsets,
+    bool descending = false, int begin_bit = 0,
+    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
+                  8) {
+  policy.queue().submit([&](sycl::handler &cgh) {
+    cgh.parallel_for(nsegments, [=](sycl::id<1> i) {
+      uint64_t segment_begin = begin_offsets[(int)i];
+      uint64_t segment_end = ::std::min(n, (int64_t)end_offsets[(int)i]);
+      if (segment_begin == segment_end) {
+        return;
+      }
+      ::dpct::sort_pairs(::std::execution::seq, keys_in + segment_begin,
+                         keys_out + segment_begin, values_in + segment_begin,
+                         values_out + segment_begin,
+                         segment_end - segment_begin, descending, begin_bit,
+                         end_bit);
+    });
+  });
+  policy.queue().wait();
+}
+// DPCT_LABEL_END
+
+// DPCT_LABEL_BEGIN|segmented_sort_pairs_by_two_pair_sorts|dpct::internal
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasAlgorithm|sort_pairs
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+template <typename _ExecutionPolicy, typename key_t, typename value_t,
+          typename OffsetIteratorT>
+inline void segmented_sort_pairs_by_two_pair_sorts(
+    _ExecutionPolicy &&policy, key_t keys_in, key_t keys_out, value_t values_in,
+    value_t values_out, int64_t n, int64_t nsegments,
+    OffsetIteratorT begin_offsets, OffsetIteratorT end_offsets,
+    bool descending = false, int begin_bit = 0,
+    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
+                  8) {
+  using key_t_value_t = typename ::std::iterator_traits<key_t>::value_type;
+  using value_t_value_t = typename ::std::iterator_traits<value_t>::value_type;
+  int *segments = sycl::malloc_device<int>(n, policy.queue());
+  int *segments_sorted = sycl::malloc_device<int>(n, policy.queue());
+  auto keys_temp = sycl::malloc_device<key_t_value_t>(n, policy.queue());
+  auto values_temp = sycl::malloc_device<value_t_value_t>(n, policy.queue());
+
+  // create a list of segment indexes
+  if (nsegments > n / nsegments) {
+    policy.queue()
+        .submit([&](sycl::handler &h) {
+          h.parallel_for(nsegments, ([=](sycl::id<1> seg) {
+                           for (int i = begin_offsets[seg];
+                                i < end_offsets[seg]; i++) {
+                             segments[i] = seg;
+                           }
+                         }));
+        })
+        .wait();
+  } else {
+    // probably better off setting block size based on characteristics of device
+    int block_size = n / nsegments;
+    policy.queue()
+        .submit([&](sycl::handler &h) {
+          h.parallel_for(block_size, ([=](sycl::id<1> id) {
+                           for (int seg = 0; seg < nsegments; seg++) {
+                             int i = begin_offsets[seg];
+                             int end = end_offsets[seg];
+                             while (i + id < end) {
+                               segments[i + id] = seg;
+                               i += block_size;
+                             }
+                           }
+                         }));
+        })
+        .wait();
+  }
+
+  auto zip_seg_vals = oneapi::dpl::make_zip_iterator(segments, values_in);
+  auto zip_seg_vals_out =
+      oneapi::dpl::make_zip_iterator(segments_sorted, values_temp);
+  // first sort by keys keeping track of which segment were in...
+  dpct::sort_pairs(::std::forward<_ExecutionPolicy>(policy), keys_in, keys_temp,
+                   zip_seg_vals, zip_seg_vals_out, n, descending);
+
+  auto zip_keys_vals = oneapi::dpl::make_zip_iterator(keys_temp, values_temp);
+  auto zip_keys_vals_out = oneapi::dpl::make_zip_iterator(keys_out, values_out);
+  // then sort the segments with a stable sort to get back sorted segments.
+  dpct::sort_pairs(::std::forward<_ExecutionPolicy>(policy), segments_sorted,
+                   segments, zip_keys_vals, zip_keys_vals_out, n, false);
+
+  sycl::free(segments, policy.queue());
+  sycl::free(segments_sorted, policy.queue());
+  sycl::free(keys_temp, policy.queue());
+  sycl::free(values_temp, policy.queue());
+}
+// DPCT_LABEL_END
+
 } // end namespace internal
 
 // DPCT_LABEL_BEGIN|sort_pairs|dpct
@@ -1384,12 +1560,9 @@ sort_pairs_impl(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
 // DPCT_CODE
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
           typename value_t, typename value_out_t>
-void sort_pairs(
-    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
-    value_t values_in, value_out_t values_out, int64_t n, bool descending,
-    int begin_bit = 0,
-    int end_bit = sizeof(typename std::iterator_traits<key_t>::value_type) *
-                  8) {
+void sort_pairs(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
+                value_t values_in, value_out_t values_out, int64_t n,
+                bool descending, int begin_bit, int end_bit) {
   internal::sort_pairs_impl(std::forward<_ExecutionPolicy>(policy), keys_in,
                             keys_out, values_in, values_out, n, descending,
                             begin_bit, end_bit);
@@ -1402,11 +1575,9 @@ void sort_pairs(
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t>
-inline void sort_keys(
-    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out, int64_t n,
-    bool descending, int begin_bit = 0,
-    int end_bit = sizeof(typename std::iterator_traits<key_t>::value_type) *
-                  8) {
+inline void sort_keys(_ExecutionPolicy &&policy, key_t keys_in,
+                      key_out_t keys_out, int64_t n, bool descending,
+                      int begin_bit, int end_bit) {
   using key_t_value_t = typename ::std::iterator_traits<key_t>::value_type;
 
   int clipped_begin_bit = ::std::max(begin_bit, 0);
@@ -1433,6 +1604,56 @@ inline void sort_keys(
   } else // if (num_bytes <= 8)
   {
     transform_and_sort_f.template operator()<uint64_t>(0);
+  }
+}
+// DPCT_LABEL_END
+
+// DPCT_LABEL_BEGIN|segmented_sort_pairs|dpct
+// DPCT_DEPENDENCY_BEGIN 
+// DplExtrasAlgorithm|segmented_sort_pairs_by_parallel_sorts
+// DplExtrasAlgorithm|segmented_sort_pairs_by_parallel_for_of_sorts
+// DplExtrasAlgorithm|segmented_sort_pairs_by_two_pair_sorts
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+template <typename _ExecutionPolicy, typename key_t, typename value_t,
+          typename OffsetIteratorT>
+inline void segmented_sort_pairs(
+    _ExecutionPolicy &&policy, key_t keys_in, key_t keys_out, value_t values_in,
+    value_t values_out, int64_t n, int64_t nsegments,
+    OffsetIteratorT begin_offsets, OffsetIteratorT end_offsets,
+    bool descending = false, int begin_bit = 0,
+    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
+                  8) {
+  int compute_units =
+      policy.queue()
+          .get_device()
+          .template get_info<sycl::info::device::max_compute_units>();
+  auto sg_sizes = policy.queue()
+                      .get_device()
+                      .template get_info<sycl::info::device::sub_group_sizes>();
+  int subgroup_size = sg_sizes.empty() ? 1 : sg_sizes.back();
+  int compute_unit_threads =
+      policy.queue().get_device().is_gpu() ? subgroup_size : 1;
+  // parallel for of serial sorts when we have sufficient number of segments for
+  // load balance
+  if (nsegments > compute_units * compute_unit_threads) {
+    dpct::internal::segmented_sort_pairs_by_parallel_for_of_sorts(
+        ::std::forward<_ExecutionPolicy>(policy), keys_in, keys_out, values_in,
+        values_out, n, nsegments, begin_offsets, end_offsets, descending,
+        begin_bit, end_bit);
+  } else if (nsegments < 500) // for loop of parallel sorts when we have a small
+                              // number of total sorts to limit total overhead
+  {
+    dpct::internal::segmented_sort_pairs_by_parallel_sorts(
+        ::std::forward<_ExecutionPolicy>(policy), keys_in, keys_out, values_in,
+        values_out, n, nsegments, begin_offsets, end_offsets, descending,
+        begin_bit, end_bit);
+  } else // decent catch using 2 full sorts
+  {
+    dpct::internal::segmented_sort_pairs_by_two_pair_sorts(
+        ::std::forward<_ExecutionPolicy>(policy), keys_in, keys_out, values_in,
+        values_out, n, nsegments, begin_offsets, end_offsets, descending,
+        begin_bit, end_bit);
   }
 }
 // DPCT_LABEL_END

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -1506,7 +1506,7 @@ inline void segmented_sort_pairs_by_two_pair_sorts(
   auto sg_sizes = policy.queue()
                       .get_device()
                       .template get_info<sycl::info::device::sub_group_sizes>();
-  ::std::size_t subgroup_size = sg_sizes.empty() ? 0 : sg_sizes.back();
+  ::std::size_t sub_group_size = sg_sizes.empty() ? 0 : sg_sizes.back();
 
   float avg_seg_size = (float)n / (float)nsegments;
   if (avg_seg_size > work_group_size) {

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -1161,10 +1161,8 @@ partition(Policy &&policy, Iter1 first, Iter1 last, Iter2 mask, Pred p) {
 }
 // DPCT_LABEL_END
 
-// DPCT_LABEL_BEGIN|sort_pairs|dpct
-// DPCT_DEPENDENCY_BEGIN
-// DplExtrasAlgorithm|sort_pairs_impl
-// DPCT_DEPENDENCY_END
+// DPCT_LABEL_BEGIN|sort_pairs_forward_decl|dpct
+// DPCT_DEPENDENCY_EMPTY
 // DPCT_CODE
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
           typename value_t, typename value_out_t>
@@ -1556,6 +1554,7 @@ inline void segmented_sort_pairs_by_two_pair_sorts(
 // DPCT_LABEL_BEGIN|sort_pairs|dpct
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasAlgorithm|sort_pairs_impl
+// DplExtrasAlgorithm|sort_pairs_forward_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t,

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -1384,12 +1384,9 @@ sort_pairs_impl(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
 // DPCT_CODE
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
           typename value_t, typename value_out_t>
-void sort_pairs(
-    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
-    value_t values_in, value_out_t values_out, int64_t n, bool descending,
-    int begin_bit = 0,
-    int end_bit = sizeof(typename std::iterator_traits<key_t>::value_type) *
-                  8) {
+void sort_pairs(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
+                value_t values_in, value_out_t values_out, int64_t n,
+                bool descending, int begin_bit, int end_bit) {
   internal::sort_pairs_impl(std::forward<_ExecutionPolicy>(policy), keys_in,
                             keys_out, values_in, values_out, n, descending,
                             begin_bit, end_bit);
@@ -1402,11 +1399,9 @@ void sort_pairs(
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t>
-inline void sort_keys(
-    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out, int64_t n,
-    bool descending, int begin_bit = 0,
-    int end_bit = sizeof(typename std::iterator_traits<key_t>::value_type) *
-                  8) {
+inline void sort_keys(_ExecutionPolicy &&policy, key_t keys_in,
+                      key_out_t keys_out, int64_t n, bool descending,
+                      int begin_bit, int end_bit) {
   using key_t_value_t = typename ::std::iterator_traits<key_t>::value_type;
 
   int clipped_begin_bit = ::std::max(begin_bit, 0);

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -1532,26 +1532,26 @@ inline void segmented_sort_pairs_by_two_pair_sorts(
     policy.queue()
         .submit([&](sycl::handler &h) {
           h.parallel_for(sycl::nd_range<1>{work_group_size, work_group_size},
-                         ([=](sycl::nd_item<1> __item) {
-                           auto __sub_group = __item.get_sub_group();
-                           ::std::size_t __num_subgroups =
-                               __sub_group.get_group_range().size();
-                           ::std::size_t __local_size =
-                               __sub_group.get_local_range().size();
+                         ([=](sycl::nd_item<1> item) {
+                           auto sub_group = item.get_sub_group();
+                           ::std::size_t num_subgroups =
+                               sub_group.get_group_range().size();
+                           ::std::size_t local_size =
+                               sub_group.get_local_range().size();
 
-                           ::std::size_t __sub_group_id =
-                               __sub_group.get_group_id();
-                           while (__sub_group_id < nsegments) {
-                             ::std::size_t __subgroup_local_id =
-                                 __sub_group.get_local_id();
-                             std::size_t i = begin_offsets[__sub_group_id];
-                             std::size_t end = end_offsets[__sub_group_id];
-                             while (i + __subgroup_local_id < end) {
-                               segments[i + __subgroup_local_id] =
-                                   __sub_group_id;
-                               i += __local_size;
+                           ::std::size_t sub_group_id =
+                               sub_group.get_group_id();
+                           while (sub_group_id < nsegments) {
+                             ::std::size_t subgroup_local_id =
+                                 sub_group.get_local_id();
+                             std::size_t i = begin_offsets[sub_group_id];
+                             std::size_t end = end_offsets[sub_group_id];
+                             while (i + subgroup_local_id < end) {
+                               segments[i + subgroup_local_id] =
+                                   sub_group_id;
+                               i += local_size;
                              }
-                             __sub_group_id += __num_subgroups;
+                             sub_group_id += num_subgroups;
                            }
                          }));
         })

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -1174,10 +1174,8 @@ void sort_pairs(
                   8);
 // DPCT_LABEL_END
 
-// DPCT_LABEL_BEGIN|sort_keys|dpct
-// DPCT_DEPENDENCY_BEGIN
-// DplExtrasAlgorithm|transform_and_sort
-// DPCT_DEPENDENCY_END
+// DPCT_LABEL_BEGIN|sort_keys_forward_decl|dpct
+// DPCT_DEPENDENCY_EMPTY
 // DPCT_CODE
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t>
 inline void sort_keys(
@@ -1571,6 +1569,7 @@ void sort_pairs(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
 // DPCT_LABEL_BEGIN|sort_keys|dpct
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasAlgorithm|transform_and_sort
+// DplExtrasAlgorithm|sort_keys_forward_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t>

--- a/clang/runtime/dpct-rt/include/dpl_extras/functional.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/functional.h.inc
@@ -54,12 +54,6 @@
 // DPCT_CODE
 // DPCT_LABEL_END
 
-#ifdef __NVCC__
-#define CONSTEXPR_IF_NOT_NVCC
-#else // __NVCC__
-#define CONSTEXPR_IF_NOT_NVCC constexpr
-#endif // __NVCC__
-
 namespace dpct {
 
 namespace internal {
@@ -462,12 +456,10 @@ public:
 
   inline OutKeyT operator()(const T &key) const {
     uint_type_t intermediate;
-    if
-      CONSTEXPR_IF_NOT_NVCC(std::is_floating_point<T>::value) {
+    if constexpr (std::is_floating_point<T>::value) {
         // normal case (both -0.0f and 0.0f equal -0.0f)
         if (key != T(-0.0f)) {
-          uint_type_t is_negative =
-              reinterpret_cast<const uint_type_t &>(key) >>
+        uint_type_t is_negative = reinterpret_cast<const uint_type_t &>(key) >>
               (sizeof(uint_type_t) * 8 - 1);
           intermediate = reinterpret_cast<const uint_type_t &>(key) ^
                          ((is_negative * flip_key) | flip_sign);
@@ -476,12 +468,9 @@ public:
           T negzero = T(-0.0f);
           intermediate = reinterpret_cast<const uint_type_t &>(negzero);
         }
-      }
-    else if
-      CONSTEXPR_IF_NOT_NVCC(std::is_signed<T>::value) {
+    } else if constexpr (std::is_signed<T>::value) {
         intermediate = reinterpret_cast<const uint_type_t &>(key) ^ flip_sign;
-      }
-    else {
+    } else {
       intermediate = key;
     }
 

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1162,18 +1162,23 @@ sort_pairs_impl(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
 
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
           typename value_t, typename value_out_t>
-void sort_pairs(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
-                value_t values_in, value_out_t values_out, int64_t n,
-                bool descending, int begin_bit, int end_bit) {
+void sort_pairs(
+    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
+    value_t values_in, value_out_t values_out, int64_t n, bool descending,
+    int begin_bit = 0,
+    int end_bit = sizeof(typename std::iterator_traits<key_t>::value_type) *
+                  8) {
   internal::sort_pairs_impl(std::forward<_ExecutionPolicy>(policy), keys_in,
                             keys_out, values_in, values_out, n, descending,
                             begin_bit, end_bit);
 }
 
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t>
-inline void sort_keys(_ExecutionPolicy &&policy, key_t keys_in,
-                      key_out_t keys_out, int64_t n, bool descending,
-                      int begin_bit, int end_bit) {
+inline void sort_keys(
+    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out, int64_t n,
+    bool descending, int begin_bit = 0,
+    int end_bit = sizeof(typename std::iterator_traits<key_t>::value_type) *
+                  8) {
   using key_t_value_t = typename ::std::iterator_traits<key_t>::value_type;
 
   int clipped_begin_bit = ::std::max(begin_bit, 0);

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1264,7 +1264,7 @@ inline void segmented_sort_pairs_by_two_pair_sorts(
   auto sg_sizes = policy.queue()
                       .get_device()
                       .template get_info<sycl::info::device::sub_group_sizes>();
-  ::std::size_t subgroup_size = sg_sizes.empty() ? 0 : sg_sizes.back();
+  ::std::size_t sub_group_size = sg_sizes.empty() ? 0 : sg_sizes.back();
 
   float avg_seg_size = (float)n / (float)nsegments;
   if (avg_seg_size > work_group_size) {

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1290,26 +1290,26 @@ inline void segmented_sort_pairs_by_two_pair_sorts(
     policy.queue()
         .submit([&](sycl::handler &h) {
           h.parallel_for(sycl::nd_range<1>{work_group_size, work_group_size},
-                         ([=](sycl::nd_item<1> __item) {
-                           auto __sub_group = __item.get_sub_group();
-                           ::std::size_t __num_subgroups =
-                               __sub_group.get_group_range().size();
-                           ::std::size_t __local_size =
-                               __sub_group.get_local_range().size();
+                         ([=](sycl::nd_item<1> item) {
+                           auto sub_group = item.get_sub_group();
+                           ::std::size_t num_subgroups =
+                               sub_group.get_group_range().size();
+                           ::std::size_t local_size =
+                               sub_group.get_local_range().size();
 
-                           ::std::size_t __sub_group_id =
-                               __sub_group.get_group_id();
-                           while (__sub_group_id < nsegments) {
-                             ::std::size_t __subgroup_local_id =
-                                 __sub_group.get_local_id();
-                             std::size_t i = begin_offsets[__sub_group_id];
-                             std::size_t end = end_offsets[__sub_group_id];
-                             while (i + __subgroup_local_id < end) {
-                               segments[i + __subgroup_local_id] =
-                                   __sub_group_id;
-                               i += __local_size;
+                           ::std::size_t sub_group_id =
+                               sub_group.get_group_id();
+                           while (sub_group_id < nsegments) {
+                             ::std::size_t subgroup_local_id =
+                                 sub_group.get_local_id();
+                             std::size_t i = begin_offsets[sub_group_id];
+                             std::size_t end = end_offsets[sub_group_id];
+                             while (i + subgroup_local_id < end) {
+                               segments[i + subgroup_local_id] =
+                                   sub_group_id;
+                               i += local_size;
                              }
-                             __sub_group_id += __num_subgroups;
+                             sub_group_id += num_subgroups;
                            }
                          }));
         })

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1375,7 +1375,7 @@ inline void segmented_sort_pairs(
         ::std::forward<_ExecutionPolicy>(policy), keys_in, keys_out, values_in,
         values_out, n, nsegments, begin_offsets, end_offsets, descending,
         begin_bit, end_bit);
-  } else if (nsegments < 500) // for loop of parallel sorts when we have a small
+  } else if (nsegments < 512) // for loop of parallel sorts when we have a small
                               // number of total sorts to limit total overhead
   {
     dpct::internal::segmented_sort_pairs_by_parallel_sorts(

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1288,13 +1288,13 @@ inline void segmented_sort_pairs_by_two_pair_sorts(
   auto zip_seg_vals = oneapi::dpl::make_zip_iterator(segments, values_in);
   auto zip_seg_vals_out =
       oneapi::dpl::make_zip_iterator(segments_sorted, values_temp);
-  // first sort by keys keeping track of which segment were in...
+  // Part 1: Sort by keys keeping track of which segment were in
   dpct::sort_pairs(::std::forward<_ExecutionPolicy>(policy), keys_in, keys_temp,
                    zip_seg_vals, zip_seg_vals_out, n, descending);
 
   auto zip_keys_vals = oneapi::dpl::make_zip_iterator(keys_temp, values_temp);
   auto zip_keys_vals_out = oneapi::dpl::make_zip_iterator(keys_out, values_out);
-  // then sort the segments with a stable sort to get back sorted segments.
+  // Part 2: Sort the segments with a stable sort to get back sorted segments.
   dpct::sort_pairs(::std::forward<_ExecutionPolicy>(policy), segments_sorted,
                    segments, zip_keys_vals, zip_keys_vals_out, n, false);
 
@@ -1382,7 +1382,7 @@ inline void segmented_sort_pairs(
         ::std::forward<_ExecutionPolicy>(policy), keys_in, keys_out, values_in,
         values_out, n, nsegments, begin_offsets, end_offsets, descending,
         begin_bit, end_bit);
-  } else // decent catch using 2 full sorts
+  } else // decent catch all using 2 full sorts
   {
     dpct::internal::segmented_sort_pairs_by_two_pair_sorts(
         ::std::forward<_ExecutionPolicy>(policy), keys_in, keys_out, values_in,

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -970,6 +970,23 @@ partition(Policy &&policy, Iter1 first, Iter1 last, Iter2 mask, Pred p) {
       "Iterators passed to algorithms must be random-access iterators.");
   return stable_partition(std::forward<Policy>(policy), first, last, mask, p);
 }
+
+template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
+          typename value_t, typename value_out_t>
+void sort_pairs(
+    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
+    value_t values_in, value_out_t values_out, int64_t n,
+    bool descending = false, int begin_bit = 0,
+    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
+                  8);
+
+template <typename _ExecutionPolicy, typename key_t, typename key_out_t>
+inline void sort_keys(
+    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out, int64_t n,
+    bool descending = false, int begin_bit = 0,
+    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
+                  8);
+
 namespace internal {
 
 // Transforms key to a specific bit range and sorts the transformed key
@@ -1158,27 +1175,151 @@ sort_pairs_impl(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
   sycl::free(temp_keys_out, policy.queue());
 }
 
+template <typename _ExecutionPolicy, typename key_t, typename value_t,
+          typename OffsetIteratorT>
+inline void segmented_sort_pairs_by_parallel_sorts(
+    _ExecutionPolicy &&policy, key_t keys_in, key_t keys_out, value_t values_in,
+    value_t values_out, int64_t n, int64_t nsegments,
+    OffsetIteratorT begin_offsets, OffsetIteratorT end_offsets,
+    bool descending = false, int begin_bit = 0,
+    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
+                  8) {
+  using offset_type =
+      typename ::std::iterator_traits<OffsetIteratorT>::value_type;
+  auto host_accessible_offset_starts =
+      sycl::malloc_shared<offset_type>(nsegments, policy.queue());
+  auto host_accessible_offset_ends =
+      sycl::malloc_shared<offset_type>(nsegments, policy.queue());
+  // make offsets accessible on host
+  ::std::copy(::std::forward<_ExecutionPolicy>(policy), begin_offsets,
+              begin_offsets + nsegments, host_accessible_offset_starts);
+  ::std::copy(::std::forward<_ExecutionPolicy>(policy), end_offsets,
+              end_offsets + nsegments, host_accessible_offset_ends);
+
+  for (int i = 0; i < nsegments; i++) {
+    uint64_t segment_begin = host_accessible_offset_starts[i];
+    uint64_t segment_end =
+        ::std::min(n, (int64_t)host_accessible_offset_ends[i]);
+    if (segment_begin < segment_end) {
+      ::dpct::sort_pairs(::std::forward<_ExecutionPolicy>(policy),
+                         keys_in + segment_begin, keys_out + segment_begin,
+                         values_in + segment_begin, values_out + segment_begin,
+                         segment_end - segment_begin, descending, begin_bit,
+                         end_bit);
+    }
+  }
+  sycl::free(host_accessible_offset_starts, policy.queue());
+  sycl::free(host_accessible_offset_ends, policy.queue());
+}
+
+template <typename _ExecutionPolicy, typename key_t, typename value_t,
+          typename OffsetIteratorT>
+inline void segmented_sort_pairs_by_parallel_for_of_sorts(
+    _ExecutionPolicy &&policy, key_t keys_in, key_t keys_out, value_t values_in,
+    value_t values_out, int64_t n, int64_t nsegments,
+    OffsetIteratorT begin_offsets, OffsetIteratorT end_offsets,
+    bool descending = false, int begin_bit = 0,
+    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
+                  8) {
+  policy.queue().submit([&](sycl::handler &cgh) {
+    cgh.parallel_for(nsegments, [=](sycl::id<1> i) {
+      uint64_t segment_begin = begin_offsets[(int)i];
+      uint64_t segment_end = ::std::min(n, (int64_t)end_offsets[(int)i]);
+      if (segment_begin == segment_end) {
+        return;
+      }
+      ::dpct::sort_pairs(::std::execution::seq, keys_in + segment_begin,
+                         keys_out + segment_begin, values_in + segment_begin,
+                         values_out + segment_begin,
+                         segment_end - segment_begin, descending, begin_bit,
+                         end_bit);
+    });
+  });
+  policy.queue().wait();
+}
+
+template <typename _ExecutionPolicy, typename key_t, typename value_t,
+          typename OffsetIteratorT>
+inline void segmented_sort_pairs_by_two_pair_sorts(
+    _ExecutionPolicy &&policy, key_t keys_in, key_t keys_out, value_t values_in,
+    value_t values_out, int64_t n, int64_t nsegments,
+    OffsetIteratorT begin_offsets, OffsetIteratorT end_offsets,
+    bool descending = false, int begin_bit = 0,
+    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
+                  8) {
+  using key_t_value_t = typename ::std::iterator_traits<key_t>::value_type;
+  using value_t_value_t = typename ::std::iterator_traits<value_t>::value_type;
+  int *segments = sycl::malloc_device<int>(n, policy.queue());
+  int *segments_sorted = sycl::malloc_device<int>(n, policy.queue());
+  auto keys_temp = sycl::malloc_device<key_t_value_t>(n, policy.queue());
+  auto values_temp = sycl::malloc_device<value_t_value_t>(n, policy.queue());
+
+  // create a list of segment indexes
+  if (nsegments > n / nsegments) {
+    policy.queue()
+        .submit([&](sycl::handler &h) {
+          h.parallel_for(nsegments, ([=](sycl::id<1> seg) {
+                           for (int i = begin_offsets[seg];
+                                i < end_offsets[seg]; i++) {
+                             segments[i] = seg;
+                           }
+                         }));
+        })
+        .wait();
+  } else {
+    // probably better off setting block size based on characteristics of device
+    int block_size = n / nsegments;
+    policy.queue()
+        .submit([&](sycl::handler &h) {
+          h.parallel_for(block_size, ([=](sycl::id<1> id) {
+                           for (int seg = 0; seg < nsegments; seg++) {
+                             int i = begin_offsets[seg];
+                             int end = end_offsets[seg];
+                             while (i + id < end) {
+                               segments[i + id] = seg;
+                               i += block_size;
+                             }
+                           }
+                         }));
+        })
+        .wait();
+  }
+
+  auto zip_seg_vals = oneapi::dpl::make_zip_iterator(segments, values_in);
+  auto zip_seg_vals_out =
+      oneapi::dpl::make_zip_iterator(segments_sorted, values_temp);
+  // first sort by keys keeping track of which segment were in...
+  dpct::sort_pairs(::std::forward<_ExecutionPolicy>(policy), keys_in, keys_temp,
+                   zip_seg_vals, zip_seg_vals_out, n, descending);
+
+  auto zip_keys_vals = oneapi::dpl::make_zip_iterator(keys_temp, values_temp);
+  auto zip_keys_vals_out = oneapi::dpl::make_zip_iterator(keys_out, values_out);
+  // then sort the segments with a stable sort to get back sorted segments.
+  dpct::sort_pairs(::std::forward<_ExecutionPolicy>(policy), segments_sorted,
+                   segments, zip_keys_vals, zip_keys_vals_out, n, false);
+
+  sycl::free(segments, policy.queue());
+  sycl::free(segments_sorted, policy.queue());
+  sycl::free(keys_temp, policy.queue());
+  sycl::free(values_temp, policy.queue());
+}
+
 } // end namespace internal
 
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
           typename value_t, typename value_out_t>
-void sort_pairs(
-    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
-    value_t values_in, value_out_t values_out, int64_t n, bool descending,
-    int begin_bit = 0,
-    int end_bit = sizeof(typename std::iterator_traits<key_t>::value_type) *
-                  8) {
+void sort_pairs(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
+                value_t values_in, value_out_t values_out, int64_t n,
+                bool descending, int begin_bit, int end_bit) {
   internal::sort_pairs_impl(std::forward<_ExecutionPolicy>(policy), keys_in,
                             keys_out, values_in, values_out, n, descending,
                             begin_bit, end_bit);
 }
 
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t>
-inline void sort_keys(
-    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out, int64_t n,
-    bool descending, int begin_bit = 0,
-    int end_bit = sizeof(typename std::iterator_traits<key_t>::value_type) *
-                  8) {
+inline void sort_keys(_ExecutionPolicy &&policy, key_t keys_in,
+                      key_out_t keys_out, int64_t n, bool descending,
+                      int begin_bit, int end_bit) {
   using key_t_value_t = typename ::std::iterator_traits<key_t>::value_type;
 
   int clipped_begin_bit = ::std::max(begin_bit, 0);
@@ -1205,6 +1346,48 @@ inline void sort_keys(
   } else // if (num_bytes <= 8)
   {
     transform_and_sort_f.template operator()<uint64_t>(0);
+  }
+}
+
+template <typename _ExecutionPolicy, typename key_t, typename value_t,
+          typename OffsetIteratorT>
+inline void segmented_sort_pairs(
+    _ExecutionPolicy &&policy, key_t keys_in, key_t keys_out, value_t values_in,
+    value_t values_out, int64_t n, int64_t nsegments,
+    OffsetIteratorT begin_offsets, OffsetIteratorT end_offsets,
+    bool descending = false, int begin_bit = 0,
+    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
+                  8) {
+  int compute_units =
+      policy.queue()
+          .get_device()
+          .template get_info<sycl::info::device::max_compute_units>();
+  auto sg_sizes = policy.queue()
+                      .get_device()
+                      .template get_info<sycl::info::device::sub_group_sizes>();
+  int subgroup_size = sg_sizes.empty() ? 1 : sg_sizes.back();
+  int compute_unit_threads =
+      policy.queue().get_device().is_gpu() ? subgroup_size : 1;
+  // parallel for of serial sorts when we have sufficient number of segments for
+  // load balance
+  if (nsegments > compute_units * compute_unit_threads) {
+    dpct::internal::segmented_sort_pairs_by_parallel_for_of_sorts(
+        ::std::forward<_ExecutionPolicy>(policy), keys_in, keys_out, values_in,
+        values_out, n, nsegments, begin_offsets, end_offsets, descending,
+        begin_bit, end_bit);
+  } else if (nsegments < 500) // for loop of parallel sorts when we have a small
+                              // number of total sorts to limit total overhead
+  {
+    dpct::internal::segmented_sort_pairs_by_parallel_sorts(
+        ::std::forward<_ExecutionPolicy>(policy), keys_in, keys_out, values_in,
+        values_out, n, nsegments, begin_offsets, end_offsets, descending,
+        begin_bit, end_bit);
+  } else // decent catch using 2 full sorts
+  {
+    dpct::internal::segmented_sort_pairs_by_two_pair_sorts(
+        ::std::forward<_ExecutionPolicy>(policy), keys_in, keys_out, values_in,
+        values_out, n, nsegments, begin_offsets, end_offsets, descending,
+        begin_bit, end_bit);
   }
 }
 

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1366,11 +1366,12 @@ inline void segmented_sort_pairs(
                       .get_device()
                       .template get_info<sycl::info::device::sub_group_sizes>();
   int subgroup_size = sg_sizes.empty() ? 1 : sg_sizes.back();
-  int compute_unit_threads =
-      policy.queue().get_device().is_gpu() ? subgroup_size : 1;
   // parallel for of serial sorts when we have sufficient number of segments for
-  // load balance
-  if (nsegments > compute_units * compute_unit_threads) {
+  // load balance when number of segments is large as compared to our target 
+  // compute capability
+  if (nsegments >
+      compute_units *
+          (policy.queue().get_device().is_gpu() ? subgroup_size : 1)) {
     dpct::internal::segmented_sort_pairs_by_parallel_for_of_sorts(
         ::std::forward<_ExecutionPolicy>(policy), keys_in, keys_out, values_in,
         values_out, n, nsegments, begin_offsets, end_offsets, descending,

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1162,23 +1162,18 @@ sort_pairs_impl(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
 
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
           typename value_t, typename value_out_t>
-void sort_pairs(
-    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
-    value_t values_in, value_out_t values_out, int64_t n, bool descending,
-    int begin_bit = 0,
-    int end_bit = sizeof(typename std::iterator_traits<key_t>::value_type) *
-                  8) {
+void sort_pairs(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
+                value_t values_in, value_out_t values_out, int64_t n,
+                bool descending, int begin_bit, int end_bit) {
   internal::sort_pairs_impl(std::forward<_ExecutionPolicy>(policy), keys_in,
                             keys_out, values_in, values_out, n, descending,
                             begin_bit, end_bit);
 }
 
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t>
-inline void sort_keys(
-    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out, int64_t n,
-    bool descending, int begin_bit = 0,
-    int end_bit = sizeof(typename std::iterator_traits<key_t>::value_type) *
-                  8) {
+inline void sort_keys(_ExecutionPolicy &&policy, key_t keys_in,
+                      key_out_t keys_out, int64_t n, bool descending,
+                      int begin_bit, int end_bit) {
   using key_t_value_t = typename ::std::iterator_traits<key_t>::value_type;
 
   int clipped_begin_bit = ::std::max(begin_bit, 0);

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -9,8 +9,8 @@
 #ifndef __DPCT_ALGORITHM_H__
 #define __DPCT_ALGORITHM_H__
 
-#include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/execution>
+#include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/numeric>
 
 #include "functional.h"

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/functional.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/functional.h
@@ -20,12 +20,6 @@
 #include <tuple>
 #include <utility>
 
-#ifdef __NVCC__
-#define CONSTEXPR_IF_NOT_NVCC
-#else // __NVCC__
-#define CONSTEXPR_IF_NOT_NVCC constexpr
-#endif // __NVCC__
-
 namespace dpct {
 
 namespace internal {
@@ -337,12 +331,10 @@ public:
 
   inline OutKeyT operator()(const T &key) const {
     uint_type_t intermediate;
-    if
-      CONSTEXPR_IF_NOT_NVCC(std::is_floating_point<T>::value) {
+    if constexpr (std::is_floating_point<T>::value) {
         // normal case (both -0.0f and 0.0f equal -0.0f)
         if (key != T(-0.0f)) {
-          uint_type_t is_negative =
-              reinterpret_cast<const uint_type_t &>(key) >>
+        uint_type_t is_negative = reinterpret_cast<const uint_type_t &>(key) >>
               (sizeof(uint_type_t) * 8 - 1);
           intermediate = reinterpret_cast<const uint_type_t &>(key) ^
                          ((is_negative * flip_key) | flip_sign);
@@ -351,12 +343,9 @@ public:
           T negzero = T(-0.0f);
           intermediate = reinterpret_cast<const uint_type_t &>(negzero);
         }
-      }
-    else if
-      CONSTEXPR_IF_NOT_NVCC(std::is_signed<T>::value) {
+    } else if constexpr (std::is_signed<T>::value) {
         intermediate = reinterpret_cast<const uint_type_t &>(key) ^ flip_sign;
-      }
-    else {
+    } else {
       intermediate = key;
     }
 

--- a/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test13.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test13.cu
@@ -5,7 +5,7 @@
 // RUN: FileCheck --input-file %T/DplExtrasAlgorithm/api_test13/count.txt --match-full-lines %s
 // RUN: rm -rf %T/DplExtrasAlgorithm/api_test13
 
-// CHECK: 23
+// CHECK: 24
 // TEST_FEATURE: DplExtrasAlgorithm_sort_keys
 
 #include <cub/cub.cuh>

--- a/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test14.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test14.cu
@@ -5,7 +5,7 @@
 // RUN: FileCheck --input-file %T/DplExtrasAlgorithm/api_test14/count.txt --match-full-lines %s
 // RUN: rm -rf %T/DplExtrasAlgorithm/api_test14
 
-// CHECK: 25
+// CHECK: 26
 // TEST_FEATURE: DplExtrasAlgorithm_sort_pairs
 
 #include <cub/cub.cuh>


### PR DESCRIPTION
Adding segmented_sort_pairs functionality to DPCT headers.  This PR is meant to provide a functional implementation to sort many individual segments of key value pairs marked by predetermined offset values to mark segments.  

Provides three implementations, and chooses which to use by device and segment characteristics.  
Choose between:
 1) a pair of full sorts (stable timing fallback)
 2) a parallel for of serial sorts (best for large number of small segments)
 3) a serial loop of parallel sorts  (best for small number of large segments)

~~Branched off from #341, because it depends upon functionality introduced there.  This PR includes the content of that PR as well.  Once that is merged, we can rebase this PR.~~
UPDATE: #341 has been merged, so this has now been rebased.  It should now reflect only the changes necessary for segmented_sort_pairs.  (NVCC specific macro is being removed here, which came in with #341)

Tests added to SYCLomatic-test to cover this functionality can be found in https://github.com/oneapi-src/SYCLomatic-test/pull/142 .

