### PR TITLE
[SYCLomatic] Support migration of 4 cub::DeviceRadixSort::* API

### DIFF
--- a/clang/lib/DPCT/APINamesCUB.inc
+++ b/clang/lib/DPCT/APINamesCUB.inc
@@ -15,7 +15,7 @@ CONDITIONAL_FACTORY_ENTRY(
         HEADER_INSERT_FACTORY(
             HeaderType::HT_DPL_Algorithm,
             REMOVE_CUB_TEMP_STORAGE_FACTORY(CONDITIONAL_FACTORY_ENTRY(
-                makeCheckAnd(CheckArgCountGreaterThan(5),
+                makeCheckAnd(CheckArgCount(6, std::greater_equal<>(), /* IncludeDefaultArg */false),
                              makeCheckNot(CheckArgIsDefaultCudaStream(5))),
                 MEMBER_CALL_FACTORY_ENTRY(
                     "cub::DeviceReduce::Sum",
@@ -57,7 +57,7 @@ CONDITIONAL_FACTORY_ENTRY(
         HEADER_INSERT_FACTORY(
             HeaderType::HT_DPL_Algorithm,
             REMOVE_CUB_TEMP_STORAGE_FACTORY(CONDITIONAL_FACTORY_ENTRY(
-                makeCheckAnd(CheckArgCountGreaterThan(7),
+                makeCheckAnd(CheckArgCount(8, std::greater_equal<>(), /* IncludeDefaultArg */false),
                              makeCheckNot(CheckArgIsDefaultCudaStream(7))),
                 MEMBER_CALL_FACTORY_ENTRY(
                     "cub::DeviceReduce::Reduce",
@@ -93,7 +93,7 @@ CONDITIONAL_FACTORY_ENTRY(
         HEADER_INSERT_FACTORY(
             HeaderType::HT_DPL_Algorithm,
             REMOVE_CUB_TEMP_STORAGE_FACTORY(CONDITIONAL_FACTORY_ENTRY(
-                makeCheckAnd(CheckArgCountGreaterThan(9),
+                makeCheckAnd(CheckArgCount(10, std::greater_equal<>(), /* IncludeDefaultArg */false),
                              makeCheckNot(CheckArgIsDefaultCudaStream(9))),
                 MEMBER_CALL_FACTORY_ENTRY(
                     "cub::DeviceReduce::ReduceByKey",
@@ -159,7 +159,7 @@ CONDITIONAL_FACTORY_ENTRY(
         HEADER_INSERT_FACTORY(
             HeaderType::HT_DPL_Algorithm,
             REMOVE_CUB_TEMP_STORAGE_FACTORY(CONDITIONAL_FACTORY_ENTRY(
-                makeCheckAnd(CheckArgCountGreaterThan(5),
+                makeCheckAnd(CheckArgCount(6, std::greater_equal<>(), /* IncludeDefaultArg */false),
                              makeCheckNot(CheckArgIsDefaultCudaStream(5))),
                 CALL_FACTORY_ENTRY(
                     "cub::DeviceScan::ExclusiveSum",
@@ -193,7 +193,7 @@ CONDITIONAL_FACTORY_ENTRY(
         HEADER_INSERT_FACTORY(
             HeaderType::HT_DPL_Algorithm,
             REMOVE_CUB_TEMP_STORAGE_FACTORY(CONDITIONAL_FACTORY_ENTRY(
-                makeCheckAnd(CheckArgCountGreaterThan(5),
+                makeCheckAnd(CheckArgCount(6, std::greater_equal<>(), /* IncludeDefaultArg */false),
                              makeCheckNot(CheckArgIsDefaultCudaStream(5))),
                 CALL_FACTORY_ENTRY(
                     "cub::DeviceScan::InclusiveSum",
@@ -219,7 +219,7 @@ CONDITIONAL_FACTORY_ENTRY(
         HEADER_INSERT_FACTORY(
             HeaderType::HT_DPL_Algorithm,
             REMOVE_CUB_TEMP_STORAGE_FACTORY(CONDITIONAL_FACTORY_ENTRY(
-                makeCheckAnd(CheckArgCountGreaterThan(7),
+                makeCheckAnd(CheckArgCount(8, std::greater_equal<>(), /* IncludeDefaultArg */false),
                              makeCheckNot(CheckArgIsDefaultCudaStream(7))),
                 CALL_FACTORY_ENTRY(
                     "cub::DeviceScan::ExclusiveScan",
@@ -245,7 +245,7 @@ CONDITIONAL_FACTORY_ENTRY(
         HEADER_INSERT_FACTORY(
             HeaderType::HT_DPL_Algorithm,
             REMOVE_CUB_TEMP_STORAGE_FACTORY(CONDITIONAL_FACTORY_ENTRY(
-                makeCheckAnd(CheckArgCountGreaterThan(6),
+                makeCheckAnd(CheckArgCount(7, std::greater_equal<>(), /* IncludeDefaultArg */false),
                              makeCheckNot(CheckArgIsDefaultCudaStream(6))),
                 CALL_FACTORY_ENTRY(
                     "cub::DeviceScan::InclusiveScan",
@@ -269,7 +269,7 @@ CONDITIONAL_FACTORY_ENTRY(
     HEADER_INSERT_FACTORY(
         HeaderType::HT_DPL_Utils,
         REMOVE_CUB_TEMP_STORAGE_FACTORY(CONDITIONAL_FACTORY_ENTRY(
-            makeCheckAnd(CheckArgCountGreaterThan(7),
+            makeCheckAnd(CheckArgCount(8, std::greater_equal<>(), /* IncludeDefaultArg */false),
                          makeCheckNot(CheckArgIsDefaultCudaStream(7))),
             MEMBER_CALL_FACTORY_ENTRY(
                 "cub::DeviceSelect::Flagged",
@@ -311,7 +311,7 @@ CONDITIONAL_FACTORY_ENTRY(
         HEADER_INSERT_FACTORY(
             HeaderType::HT_DPL_Algorithm,
             REMOVE_CUB_TEMP_STORAGE_FACTORY(CONDITIONAL_FACTORY_ENTRY(
-                makeCheckAnd(CheckArgCountGreaterThan(6),
+                makeCheckAnd(CheckArgCount(7, std::greater_equal<>(), /* IncludeDefaultArg */false),
                              makeCheckNot(CheckArgIsDefaultCudaStream(6))),
                 MEMBER_CALL_FACTORY_ENTRY(
                     "cub::DeviceSelect::Unique",
@@ -353,7 +353,7 @@ CONDITIONAL_FACTORY_ENTRY(
             HEADER_INSERT_FACTORY(
                 HeaderType::HT_DPL_Algorithm,
                 REMOVE_CUB_TEMP_STORAGE_FACTORY(CONDITIONAL_FACTORY_ENTRY(
-                    makeCheckAnd(CheckArgCountGreaterThan(7),
+                    makeCheckAnd(CheckArgCount(8, std::greater_equal<>(), /* IncludeDefaultArg */false),
                                  makeCheckNot(CheckArgIsDefaultCudaStream(7))),
                     MEMBER_CALL_FACTORY_ENTRY(
                         "cub::DeviceRunLengthEncode::Encode",
@@ -411,7 +411,7 @@ CONDITIONAL_FACTORY_ENTRY(
             WARNING_FACTORY_ENTRY(
                 "cub::DeviceSegmentedReduce::Reduce",
                 CONDITIONAL_FACTORY_ENTRY(
-                    makeCheckAnd(CheckArgCountGreaterThan(9),
+                    makeCheckAnd(CheckArgCount(10, std::greater_equal<>(), /* IncludeDefaultArg */false),
                                  makeCheckNot(CheckArgIsDefaultCudaStream(9))),
                     CONDITIONAL_FACTORY_ENTRY(
                         checkArgCanMappingToSyclNativeBinaryOp(7),
@@ -470,7 +470,7 @@ CONDITIONAL_FACTORY_ENTRY(
             WARNING_FACTORY_ENTRY(
                 "cub::DeviceSegmentedReduce::Sum",
                 CONDITIONAL_FACTORY_ENTRY(
-                    makeCheckAnd(CheckArgCountGreaterThan(9),
+                    makeCheckAnd(CheckArgCount(10, std::greater_equal<>(), /* IncludeDefaultArg */false),
                                  makeCheckNot(CheckArgIsDefaultCudaStream(9))),
                     CALL_FACTORY_ENTRY(
                         "cub::DeviceSegmentedReduce::Sum",
@@ -516,7 +516,7 @@ CONDITIONAL_FACTORY_ENTRY(
                     "cub::DeviceSegmentedReduce::Min",
                     CONDITIONAL_FACTORY_ENTRY(
                         makeCheckAnd(
-                            CheckArgCountGreaterThan(9),
+                            CheckArgCount(10, std::greater_equal<>(), /* IncludeDefaultArg */false),
                             makeCheckNot(CheckArgIsDefaultCudaStream(9))),
                         CALL_FACTORY_ENTRY(
                             "cub::DeviceSegmentedReduce::Min",
@@ -574,7 +574,7 @@ CONDITIONAL_FACTORY_ENTRY(
                     "cub::DeviceSegmentedReduce::Max",
                     CONDITIONAL_FACTORY_ENTRY(
                         makeCheckAnd(
-                            CheckArgCountGreaterThan(9),
+                            CheckArgCount(10, std::greater_equal<>(), /* IncludeDefaultArg */false),
                             makeCheckNot(CheckArgIsDefaultCudaStream(9))),
                         CALL_FACTORY_ENTRY(
                             "cub::DeviceSegmentedReduce::Max",
@@ -617,3 +617,187 @@ CONDITIONAL_FACTORY_ENTRY(
                                              LITERAL("value_type")))),
                                      LITERAL("lowest")))))),
                     Diagnostics::REDUCE_PERFORMANCE_TUNE))))))
+
+CONDITIONAL_FACTORY_ENTRY(
+    CheckCubRedundantFunctionCall(),
+    REMOVE_API_FACTORY_ENTRY("cub::DeviceRadixSort::SortKeys"),
+    REMOVE_CUB_TEMP_STORAGE_FACTORY(FEATURE_REQUEST_FACTORY(
+        HelperFeatureEnum::DplExtrasAlgorithm_sort_keys,
+        HEADER_INSERT_FACTORY(
+            HeaderType::HT_DPL_Utils,
+            REMOVE_CUB_TEMP_STORAGE_FACTORY(CONDITIONAL_FACTORY_ENTRY(
+                makeCheckAnd(CheckArgCount(8, std::greater_equal<>(),
+                                           /* IncludeDefaultArg */ false),
+                             makeCheckNot(CheckArgIsDefaultCudaStream(7))),
+                CALL_FACTORY_ENTRY(
+                    "cub::DeviceRadixSort::SortKeys",
+                    CALL("dpct::sort_keys",
+                         CALL("oneapi::dpl::execution::device_policy",
+                              STREAM(7)),
+                         ARG(2), ARG(3), ARG(4), LITERAL("false"), ARG(5),
+                         ARG(6))),
+                CONDITIONAL_FACTORY_ENTRY(
+                    CheckArgCount(7, std::greater_equal<>(),
+                                  /* IncludeDefaultArg */ false),
+                    CALL_FACTORY_ENTRY(
+                        "cub::DeviceRadixSort::SortKeys",
+                        CALL("dpct::sort_keys",
+                             CALL("oneapi::dpl::execution::device_policy",
+                                  QUEUESTR),
+                             ARG(2), ARG(3), ARG(4), LITERAL("false"), ARG(5),
+                             ARG(6))),
+                    CONDITIONAL_FACTORY_ENTRY(
+                        CheckArgCount(6, std::greater_equal<>(),
+                                      /* IncludeDefaultArg */ false),
+                        CALL_FACTORY_ENTRY(
+                            "cub::DeviceRadixSort::SortKeys",
+                            CALL("dpct::sort_keys",
+                                 CALL("oneapi::dpl::execution::device_policy",
+                                      QUEUESTR),
+                                 ARG(2), ARG(3), ARG(4), LITERAL("false"),
+                                 ARG(5))),
+                        CALL_FACTORY_ENTRY(
+                            "cub::DeviceRadixSort::SortKeys",
+                            CALL("dpct::sort_keys",
+                                 CALL("oneapi::dpl::execution::device_policy",
+                                      QUEUESTR),
+                                 ARG(2), ARG(3), ARG(4),
+                                 LITERAL("false")))))))))))
+
+CONDITIONAL_FACTORY_ENTRY(
+    CheckCubRedundantFunctionCall(),
+    REMOVE_API_FACTORY_ENTRY("cub::DeviceRadixSort::SortKeysDescending"),
+    REMOVE_CUB_TEMP_STORAGE_FACTORY(FEATURE_REQUEST_FACTORY(
+        HelperFeatureEnum::DplExtrasAlgorithm_sort_keys,
+        HEADER_INSERT_FACTORY(
+            HeaderType::HT_DPL_Utils,
+            REMOVE_CUB_TEMP_STORAGE_FACTORY(CONDITIONAL_FACTORY_ENTRY(
+                makeCheckAnd(CheckArgCount(8, std::greater_equal<>(),
+                                           /* IncludeDefaultArg */ false),
+                             makeCheckNot(CheckArgIsDefaultCudaStream(7))),
+                CALL_FACTORY_ENTRY(
+                    "cub::DeviceRadixSort::SortKeysDescending",
+                    CALL("dpct::sort_keys",
+                         CALL("oneapi::dpl::execution::device_policy",
+                              STREAM(7)),
+                         ARG(2), ARG(3), ARG(4), LITERAL("true"), ARG(5),
+                         ARG(6))),
+                CONDITIONAL_FACTORY_ENTRY(
+                    CheckArgCount(7, std::greater_equal<>(),
+                                  /* IncludeDefaultArg */ false),
+                    CALL_FACTORY_ENTRY(
+                        "cub::DeviceRadixSort::SortKeysDescending",
+                        CALL("dpct::sort_keys",
+                             CALL("oneapi::dpl::execution::device_policy",
+                                  QUEUESTR),
+                             ARG(2), ARG(3), ARG(4), LITERAL("true"), ARG(5),
+                             ARG(6))),
+                    CONDITIONAL_FACTORY_ENTRY(
+                        CheckArgCount(6, std::greater_equal<>(),
+                                      /* IncludeDefaultArg */ false),
+                        CALL_FACTORY_ENTRY(
+                            "cub::DeviceRadixSort::SortKeysDescending",
+                            CALL("dpct::sort_keys",
+                                 CALL("oneapi::dpl::execution::device_policy",
+                                      QUEUESTR),
+                                 ARG(2), ARG(3), ARG(4), LITERAL("true"),
+                                 ARG(5))),
+                        CALL_FACTORY_ENTRY(
+                            "cub::DeviceRadixSort::SortKeysDescending",
+                            CALL("dpct::sort_keys",
+                                 CALL("oneapi::dpl::execution::device_policy",
+                                      QUEUESTR),
+                                 ARG(2), ARG(3), ARG(4),
+                                 LITERAL("true")))))))))))
+
+CONDITIONAL_FACTORY_ENTRY(
+    CheckCubRedundantFunctionCall(),
+    REMOVE_API_FACTORY_ENTRY("cub::DeviceRadixSort::SortPairs"),
+    REMOVE_CUB_TEMP_STORAGE_FACTORY(FEATURE_REQUEST_FACTORY(
+        HelperFeatureEnum::DplExtrasAlgorithm_sort_pairs,
+        HEADER_INSERT_FACTORY(
+            HeaderType::HT_DPL_Utils,
+            REMOVE_CUB_TEMP_STORAGE_FACTORY(CONDITIONAL_FACTORY_ENTRY(
+                makeCheckAnd(CheckArgCount(10, std::greater_equal<>(),
+                                           /* IncludeDefaultArg */ false),
+                             makeCheckNot(CheckArgIsDefaultCudaStream(9))),
+                CALL_FACTORY_ENTRY(
+                    "cub::DeviceRadixSort::SortPairs",
+                    CALL("dpct::sort_pairs",
+                         CALL("oneapi::dpl::execution::device_policy",
+                              STREAM(9)),
+                         ARG(2), ARG(3), ARG(4), ARG(5), ARG(6),
+                         LITERAL("false"), ARG(7), ARG(8))),
+                CONDITIONAL_FACTORY_ENTRY(
+                    CheckArgCount(9, std::greater_equal<>(),
+                                  /* IncludeDefaultArg */ false),
+                    CALL_FACTORY_ENTRY(
+                        "cub::DeviceRadixSort::SortPairs",
+                        CALL("dpct::sort_pairs",
+                             CALL("oneapi::dpl::execution::device_policy",
+                                  QUEUESTR),
+                             ARG(2), ARG(3), ARG(4), ARG(5), ARG(6),
+                             LITERAL("false"), ARG(7), ARG(8))),
+                    CONDITIONAL_FACTORY_ENTRY(
+                        CheckArgCount(8, std::greater_equal<>(),
+                                      /* IncludeDefaultArg */ false),
+                        CALL_FACTORY_ENTRY(
+                            "cub::DeviceRadixSort::SortPairs",
+                            CALL("dpct::sort_pairs",
+                                 CALL("oneapi::dpl::execution::device_policy",
+                                      QUEUESTR),
+                                 ARG(2), ARG(3), ARG(4), ARG(5), ARG(6),
+                                 LITERAL("false"), ARG(7))),
+                        CALL_FACTORY_ENTRY(
+                            "cub::DeviceRadixSort::SortPairs",
+                            CALL("dpct::sort_pairs",
+                                 CALL("oneapi::dpl::execution::device_policy",
+                                      QUEUESTR),
+                                 ARG(2), ARG(3), ARG(4), ARG(5), ARG(6),
+                                 LITERAL("false")))))))))))
+
+CONDITIONAL_FACTORY_ENTRY(
+    CheckCubRedundantFunctionCall(),
+    REMOVE_API_FACTORY_ENTRY("cub::DeviceRadixSort::SortPairsDescending"),
+    REMOVE_CUB_TEMP_STORAGE_FACTORY(FEATURE_REQUEST_FACTORY(
+        HelperFeatureEnum::DplExtrasAlgorithm_sort_pairs,
+        HEADER_INSERT_FACTORY(
+            HeaderType::HT_DPL_Utils,
+            REMOVE_CUB_TEMP_STORAGE_FACTORY(CONDITIONAL_FACTORY_ENTRY(
+                makeCheckAnd(CheckArgCount(10, std::greater_equal<>(),
+                                           /* IncludeDefaultArg */ false),
+                             makeCheckNot(CheckArgIsDefaultCudaStream(9))),
+                CALL_FACTORY_ENTRY(
+                    "cub::DeviceRadixSort::SortPairsDescending",
+                    CALL("dpct::sort_pairs",
+                         CALL("oneapi::dpl::execution::device_policy",
+                              STREAM(9)),
+                         ARG(2), ARG(3), ARG(4), ARG(5), ARG(6),
+                         LITERAL("true"), ARG(7), ARG(8))),
+                CONDITIONAL_FACTORY_ENTRY(
+                    CheckArgCount(9, std::greater_equal<>(),
+                                  /* IncludeDefaultArg */ false),
+                    CALL_FACTORY_ENTRY(
+                        "cub::DeviceRadixSort::SortPairsDescending",
+                        CALL("dpct::sort_pairs",
+                             CALL("oneapi::dpl::execution::device_policy",
+                                  QUEUESTR),
+                             ARG(2), ARG(3), ARG(4), ARG(5), ARG(6),
+                             LITERAL("true"), ARG(7), ARG(8))),
+                    CONDITIONAL_FACTORY_ENTRY(
+                        CheckArgCount(8, std::greater_equal<>(),
+                                      /* IncludeDefaultArg */ false),
+                        CALL_FACTORY_ENTRY(
+                            "cub::DeviceRadixSort::SortPairsDescending",
+                            CALL("dpct::sort_pairs",
+                                 CALL("oneapi::dpl::execution::device_policy",
+                                      QUEUESTR),
+                                 ARG(2), ARG(3), ARG(4), ARG(5), ARG(6),
+                                 LITERAL("true"), ARG(7))),
+                        CALL_FACTORY_ENTRY(
+                            "cub::DeviceRadixSort::SortPairsDescending",
+                            CALL("dpct::sort_pairs",
+                                 CALL("oneapi::dpl::execution::device_policy",
+                                      QUEUESTR),
+                                 ARG(2), ARG(3), ARG(4), ARG(5), ARG(6),
+                                 LITERAL("true")))))))))))

--- a/clang/lib/DPCT/CUBAPIMigration.cpp
+++ b/clang/lib/DPCT/CUBAPIMigration.cpp
@@ -49,11 +49,14 @@ auto isDeviceFuncCallExpr = []() {
   auto hasDeviceFuncName = []() {
     return hasAnyName("Sum", "Min", "Max", "Reduce", "ReduceByKey",
                       "ExclusiveSum", "InclusiveSum", "InclusiveScan",
-                      "ExclusiveScan", "Flagged", "Unique", "Encode");
+                      "ExclusiveScan", "Flagged", "Unique", "Encode",
+                      "SortKeys", "SortKeysDescending", "SortPairs",
+                      "SortPairsDescending");
   };
   auto hasDeviceRecordName = []() {
     return hasAnyName("DeviceSegmentedReduce", "DeviceReduce", "DeviceScan",
-                      "DeviceSelect", "DeviceRunLengthEncode");
+                      "DeviceSelect", "DeviceRunLengthEncode",
+                      "DeviceRadixSort");
   };
   return callExpr(callee(functionDecl(
       allOf(hasDeviceFuncName(),

--- a/clang/test/dpct/cub/devicelevel/device_radix_sort.cu
+++ b/clang/test/dpct/cub/devicelevel/device_radix_sort.cu
@@ -1,0 +1,240 @@
+// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.2, cuda-11.4
+// UNSUPPORTED: v8.0, v9.0, v9.1, v9.2, v10.0, v10.1, v10.2
+// RUN: dpct --format-range=none -in-root %S -out-root %T/devicelevel/device_radix_sort %S/device_radix_sort.cu --cuda-include-path="%cuda-path/include" -- -std=c++14 -x cuda --cuda-host-only
+// RUN: FileCheck --input-file %T/devicelevel/device_radix_sort/device_radix_sort.dp.cpp %s
+
+#include <cub/cub.cuh>
+
+int n, *d_keys_in, *d_keys_out, *d_values_in, *d_values_out;
+
+void test1(void) {
+  void *temp_storage;
+  size_t temp_storage_size;
+  cub::DeviceRadixSort::SortKeys(nullptr, temp_storage_size, d_keys_in, d_keys_out, n);
+  cudaMalloc(&temp_storage, temp_storage_size);
+  cub::DeviceRadixSort::SortKeys(temp_storage, temp_storage_size, d_keys_in, d_keys_out, n);
+// CHECK: void test1(void)
+// CHECK-NOT: void *temp_storage;
+// CHECK-NOT: size_t temp_storage_size;
+// CHECK-NOT: cudaMalloc(&temp_storage, temp_storage_size);
+// CHECK: DPCT1026:{{.*}}
+// CHECK: dpct::sort_keys(oneapi::dpl::execution::device_policy(q_ct1), d_keys_in, d_keys_out, n, false);
+}
+
+void test2(void) {
+  void *temp_storage;
+  size_t temp_storage_size;
+  cub::DeviceRadixSort::SortKeys(nullptr, temp_storage_size, d_keys_in, d_keys_out, n, 1);
+  cudaMalloc(&temp_storage, temp_storage_size);
+  cub::DeviceRadixSort::SortKeys(temp_storage, temp_storage_size, d_keys_in, d_keys_out, n, 1);
+// CHECK: void test2(void)
+// CHECK-NOT: void *temp_storage;
+// CHECK-NOT: size_t temp_storage_size;
+// CHECK-NOT: cudaMalloc(&temp_storage, temp_storage_size);
+// CHECK: DPCT1026:{{.*}}
+// CHECK: dpct::sort_keys(oneapi::dpl::execution::device_policy(q_ct1), d_keys_in, d_keys_out, n, false, 1);
+}
+
+void test3(void) {
+  void *temp_storage;
+  size_t temp_storage_size;
+  cub::DeviceRadixSort::SortKeys(nullptr, temp_storage_size, d_keys_in, d_keys_out, n, 1, 4);
+  cudaMalloc(&temp_storage, temp_storage_size);
+  cub::DeviceRadixSort::SortKeys(temp_storage, temp_storage_size, d_keys_in, d_keys_out, n, 1, 4);
+// CHECK: void test3(void)
+// CHECK-NOT: void *temp_storage;
+// CHECK-NOT: size_t temp_storage_size;
+// CHECK-NOT: cudaMalloc(&temp_storage, temp_storage_size);
+// CHECK: DPCT1026:{{.*}}
+// CHECK: dpct::sort_keys(oneapi::dpl::execution::device_policy(q_ct1), d_keys_in, d_keys_out, n, false, 1, 4);
+}
+
+void test4(void) {
+  void *temp_storage;
+  size_t temp_storage_size;
+  cudaStream_t s = (cudaStream_t)(uintptr_t)0x80;
+  cub::DeviceRadixSort::SortKeys(nullptr, temp_storage_size, d_keys_in, d_keys_out, n, 1, 4, s);
+  cudaMalloc(&temp_storage, temp_storage_size);
+  cub::DeviceRadixSort::SortKeys(temp_storage, temp_storage_size, d_keys_in, d_keys_out, n, 1, 4, s);
+// CHECK: void test4(void)
+// CHECK-NOT: void *temp_storage;
+// CHECK-NOT: size_t temp_storage_size;
+// CHECK-NOT: cudaMalloc(&temp_storage, temp_storage_size);
+// CHECK: dpct::queue_ptr s = (dpct::queue_ptr)(uintptr_t)0x80;
+// CHECK: DPCT1026:{{.*}}
+// CHECK: dpct::sort_keys(oneapi::dpl::execution::device_policy(*s), d_keys_in, d_keys_out, n, false, 1, 4);
+}
+
+void test5(void) {
+  void *temp_storage;
+  size_t temp_storage_size;
+  cub::DeviceRadixSort::SortKeysDescending(nullptr, temp_storage_size, d_keys_in, d_keys_out, n);
+  cudaMalloc(&temp_storage, temp_storage_size);
+  cub::DeviceRadixSort::SortKeysDescending(temp_storage, temp_storage_size, d_keys_in, d_keys_out, n);
+// CHECK: void test5(void)
+// CHECK-NOT: void *temp_storage;
+// CHECK-NOT: size_t temp_storage_size;
+// CHECK-NOT: cudaMalloc(&temp_storage, temp_storage_size);
+// CHECK: DPCT1026:{{.*}}
+// CHECK: dpct::sort_keys(oneapi::dpl::execution::device_policy(q_ct1), d_keys_in, d_keys_out, n, true);
+}
+
+void test6(void) {
+  void *temp_storage;
+  size_t temp_storage_size;
+  cub::DeviceRadixSort::SortKeysDescending(nullptr, temp_storage_size, d_keys_in, d_keys_out, n, 1);
+  cudaMalloc(&temp_storage, temp_storage_size);
+  cub::DeviceRadixSort::SortKeysDescending(temp_storage, temp_storage_size, d_keys_in, d_keys_out, n, 1);
+// CHECK: void test6(void)
+// CHECK-NOT: void *temp_storage;
+// CHECK-NOT: size_t temp_storage_size;
+// CHECK-NOT: cudaMalloc(&temp_storage, temp_storage_size);
+// CHECK: DPCT1026:{{.*}}
+// CHECK: dpct::sort_keys(oneapi::dpl::execution::device_policy(q_ct1), d_keys_in, d_keys_out, n, true, 1);
+}
+
+void test7(void) {
+  void *temp_storage;
+  size_t temp_storage_size;
+  cub::DeviceRadixSort::SortKeysDescending(nullptr, temp_storage_size, d_keys_in, d_keys_out, n, 1, 4);
+  cudaMalloc(&temp_storage, temp_storage_size);
+  cub::DeviceRadixSort::SortKeysDescending(temp_storage, temp_storage_size, d_keys_in, d_keys_out, n, 1, 4);
+// CHECK: void test7(void)
+// CHECK-NOT: void *temp_storage;
+// CHECK-NOT: size_t temp_storage_size;
+// CHECK-NOT: cudaMalloc(&temp_storage, temp_storage_size);
+// CHECK: DPCT1026:{{.*}}
+// CHECK: dpct::sort_keys(oneapi::dpl::execution::device_policy(q_ct1), d_keys_in, d_keys_out, n, true, 1, 4);
+}
+
+void test8(void) {
+  void *temp_storage;
+  size_t temp_storage_size;
+  cudaStream_t s = (cudaStream_t)(uintptr_t)0x80;
+  cub::DeviceRadixSort::SortKeysDescending(nullptr, temp_storage_size, d_keys_in, d_keys_out, n, 1, 4, s);
+  cudaMalloc(&temp_storage, temp_storage_size);
+  cub::DeviceRadixSort::SortKeysDescending(temp_storage, temp_storage_size, d_keys_in, d_keys_out, n, 1, 4, s);
+// CHECK: void test8(void)
+// CHECK-NOT: void *temp_storage;
+// CHECK-NOT: size_t temp_storage_size;
+// CHECK-NOT: cudaMalloc(&temp_storage, temp_storage_size);
+// CHECK: dpct::queue_ptr s = (dpct::queue_ptr)(uintptr_t)0x80;
+// CHECK: DPCT1026:{{.*}}
+// CHECK: dpct::sort_keys(oneapi::dpl::execution::device_policy(*s), d_keys_in, d_keys_out, n, true, 1, 4);
+}
+
+void test9(void) {
+  void *temp_storage;
+  size_t temp_storage_size;
+  cub::DeviceRadixSort::SortPairs(nullptr, temp_storage_size, d_keys_in, d_keys_out, d_values_in, d_values_out, n);
+  cudaMalloc(&temp_storage, temp_storage_size);
+  cub::DeviceRadixSort::SortPairs(temp_storage, temp_storage_size, d_keys_in, d_keys_out, d_values_in, d_values_out, n);
+// CHECK: void test9(void)
+// CHECK-NOT: void *temp_storage;
+// CHECK-NOT: size_t temp_storage_size;
+// CHECK-NOT: cudaMalloc(&temp_storage, temp_storage_size);
+// CHECK: DPCT1026:{{.*}}
+// CHECK: dpct::sort_pairs(oneapi::dpl::execution::device_policy(q_ct1), d_keys_in, d_keys_out, d_values_in, d_values_out, n, false);
+}
+
+void test10(void) {
+  void *temp_storage;
+  size_t temp_storage_size;
+  cub::DeviceRadixSort::SortPairs(nullptr, temp_storage_size, d_keys_in, d_keys_out, d_values_in, d_values_out, n, 1);
+  cudaMalloc(&temp_storage, temp_storage_size);
+  cub::DeviceRadixSort::SortPairs(temp_storage, temp_storage_size, d_keys_in, d_keys_out, d_values_in, d_values_out, n, 1);
+// CHECK: void test10(void)
+// CHECK-NOT: void *temp_storage;
+// CHECK-NOT: size_t temp_storage_size;
+// CHECK-NOT: cudaMalloc(&temp_storage, temp_storage_size);
+// CHECK: DPCT1026:{{.*}}
+// CHECK: dpct::sort_pairs(oneapi::dpl::execution::device_policy(q_ct1), d_keys_in, d_keys_out, d_values_in, d_values_out, n, false, 1);
+}
+
+void test11(void) {
+  void *temp_storage;
+  size_t temp_storage_size;
+  cub::DeviceRadixSort::SortPairs(nullptr, temp_storage_size, d_keys_in, d_keys_out, d_values_in, d_values_out, n, 1, 4);
+  cudaMalloc(&temp_storage, temp_storage_size);
+  cub::DeviceRadixSort::SortPairs(temp_storage, temp_storage_size, d_keys_in, d_keys_out, d_values_in, d_values_out, n, 1, 4);
+// CHECK: void test11(void)
+// CHECK-NOT: void *temp_storage;
+// CHECK-NOT: size_t temp_storage_size;
+// CHECK-NOT: cudaMalloc(&temp_storage, temp_storage_size);
+// CHECK: DPCT1026:{{.*}}
+// CHECK: dpct::sort_pairs(oneapi::dpl::execution::device_policy(q_ct1), d_keys_in, d_keys_out, d_values_in, d_values_out, n, false, 1, 4);
+}
+
+void test12(void) {
+  void *temp_storage;
+  size_t temp_storage_size;
+  cudaStream_t s = (cudaStream_t)(uintptr_t)0x80;
+  cub::DeviceRadixSort::SortPairs(nullptr, temp_storage_size, d_keys_in, d_keys_out, d_values_in, d_values_out, n, 1, 4, s);
+  cudaMalloc(&temp_storage, temp_storage_size);
+  cub::DeviceRadixSort::SortPairs(temp_storage, temp_storage_size, d_keys_in, d_keys_out, d_values_in, d_values_out, n, 1, 4, s);
+// CHECK: void test12(void)
+// CHECK-NOT: void *temp_storage;
+// CHECK-NOT: size_t temp_storage_size;
+// CHECK-NOT: cudaMalloc(&temp_storage, temp_storage_size);
+// CHECK: dpct::queue_ptr s = (dpct::queue_ptr)(uintptr_t)0x80;
+// CHECK: DPCT1026:{{.*}}
+// CHECK: dpct::sort_pairs(oneapi::dpl::execution::device_policy(*s), d_keys_in, d_keys_out, d_values_in, d_values_out, n, false, 1, 4);
+}
+
+void test13(void) {
+  void *temp_storage;
+  size_t temp_storage_size;
+  cub::DeviceRadixSort::SortPairsDescending(nullptr, temp_storage_size, d_keys_in, d_keys_out, d_values_in, d_values_out, n);
+  cudaMalloc(&temp_storage, temp_storage_size);
+  cub::DeviceRadixSort::SortPairsDescending(temp_storage, temp_storage_size, d_keys_in, d_keys_out, d_values_in, d_values_out, n);
+// CHECK: void test13(void)
+// CHECK-NOT: void *temp_storage;
+// CHECK-NOT: size_t temp_storage_size;
+// CHECK-NOT: cudaMalloc(&temp_storage, temp_storage_size);
+// CHECK: DPCT1026:{{.*}}
+// CHECK: dpct::sort_pairs(oneapi::dpl::execution::device_policy(q_ct1), d_keys_in, d_keys_out, d_values_in, d_values_out, n, true);
+}
+
+void test14(void) {
+  void *temp_storage;
+  size_t temp_storage_size;
+  cub::DeviceRadixSort::SortPairsDescending(nullptr, temp_storage_size, d_keys_in, d_keys_out, d_values_in, d_values_out, n, 1);
+  cudaMalloc(&temp_storage, temp_storage_size);
+  cub::DeviceRadixSort::SortPairsDescending(temp_storage, temp_storage_size, d_keys_in, d_keys_out, d_values_in, d_values_out, n, 1);
+// CHECK: void test14(void)
+// CHECK-NOT: void *temp_storage;
+// CHECK-NOT: size_t temp_storage_size;
+// CHECK-NOT: cudaMalloc(&temp_storage, temp_storage_size);
+// CHECK: DPCT1026:{{.*}}
+// CHECK: dpct::sort_pairs(oneapi::dpl::execution::device_policy(q_ct1), d_keys_in, d_keys_out, d_values_in, d_values_out, n, true, 1);
+}
+
+void test15(void) {
+  void *temp_storage;
+  size_t temp_storage_size;
+  cub::DeviceRadixSort::SortPairsDescending(nullptr, temp_storage_size, d_keys_in, d_keys_out, d_values_in, d_values_out, n, 1, 4);
+  cudaMalloc(&temp_storage, temp_storage_size);
+  cub::DeviceRadixSort::SortPairsDescending(temp_storage, temp_storage_size, d_keys_in, d_keys_out, d_values_in, d_values_out, n, 1, 4);
+// CHECK: void test15(void)
+// CHECK-NOT: void *temp_storage;
+// CHECK-NOT: size_t temp_storage_size;
+// CHECK-NOT: cudaMalloc(&temp_storage, temp_storage_size);
+// CHECK: DPCT1026:{{.*}}
+// CHECK: dpct::sort_pairs(oneapi::dpl::execution::device_policy(q_ct1), d_keys_in, d_keys_out, d_values_in, d_values_out, n, true, 1, 4);
+}
+
+void test16(void) {
+  void *temp_storage;
+  size_t temp_storage_size;
+  cudaStream_t s = (cudaStream_t)(uintptr_t)0x80;
+  cub::DeviceRadixSort::SortPairsDescending(nullptr, temp_storage_size, d_keys_in, d_keys_out, d_values_in, d_values_out, n, 1, 4, s);
+  cudaMalloc(&temp_storage, temp_storage_size);
+  cub::DeviceRadixSort::SortPairsDescending(temp_storage, temp_storage_size, d_keys_in, d_keys_out, d_values_in, d_values_out, n, 1, 4, s);
+// CHECK: void test16(void)
+// CHECK-NOT: void *temp_storage;
+// CHECK-NOT: size_t temp_storage_size;
+// CHECK-NOT: cudaMalloc(&temp_storage, temp_storage_size);
+// CHECK: dpct::queue_ptr s = (dpct::queue_ptr)(uintptr_t)0x80;
+// CHECK: DPCT1026:{{.*}}
+// CHECK: dpct::sort_pairs(oneapi::dpl::execution::device_policy(*s), d_keys_in, d_keys_out, d_values_in, d_values_out, n, true, 1, 4);
+}

--- a/clang/test/dpct/cub/devicelevel/device_radix_sort.cu
+++ b/clang/test/dpct/cub/devicelevel/device_radix_sort.cu
@@ -1,5 +1,5 @@
 // UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.2, cuda-11.4
-// UNSUPPORTED: v8.0, v9.0, v9.1, v9.2, v10.0, v10.1, v10.2
+// UNSUPPORTED: v8.0, v9.0, v9.1, v9.2, v10.0, v10.1, v10.2, v11.0, v11.2, v11.4
 // RUN: dpct --format-range=none -in-root %S -out-root %T/devicelevel/device_radix_sort %S/device_radix_sort.cu --cuda-include-path="%cuda-path/include" -- -std=c++14 -x cuda --cuda-host-only
 // RUN: FileCheck --input-file %T/devicelevel/device_radix_sort/device_radix_sort.dp.cpp %s
 

--- a/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test13.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test13.cu
@@ -1,0 +1,19 @@
+// UNSUPPORTED: cuda-8.0
+// UNSUPPORTED: v8.0
+// RUN: dpct --format-range=none  --usm-level=none  --use-custom-helper=api -out-root %T/DplExtrasAlgorithm/api_test13 %s --cuda-include-path="%cuda-path/include" -- -x cuda --cuda-host-only -std=c++17
+// RUN: grep "IsCalled" %T/DplExtrasAlgorithm/api_test13/MainSourceFiles.yaml | wc -l > %T/DplExtrasAlgorithm/api_test13/count.txt
+// RUN: FileCheck --input-file %T/DplExtrasAlgorithm/api_test13/count.txt --match-full-lines %s
+// RUN: rm -rf %T/DplExtrasAlgorithm/api_test13
+
+// CHECK: 21
+// TEST_FEATURE: DplExtrasAlgorithm_sort_keys
+
+#include <cub/cub.cuh>
+
+int main() {
+  void *temp_storage;
+  size_t temp_storage_size;
+  int n, *d_keys_in, *d_keys_out;
+  cub::DeviceRadixSort::SortKeys(temp_storage, temp_storage_size, d_keys_in, d_keys_out, n);
+  return 0;
+}

--- a/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test13.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test13.cu
@@ -1,5 +1,5 @@
-// UNSUPPORTED: cuda-8.0
-// UNSUPPORTED: v8.0
+// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.2, cuda-11.4
+// UNSUPPORTED: v8.0, v9.0, v9.1, v9.2, v10.0, v10.1, v10.2, v11.0, v11.2, v11.4s
 // RUN: dpct --format-range=none  --usm-level=none  --use-custom-helper=api -out-root %T/DplExtrasAlgorithm/api_test13 %s --cuda-include-path="%cuda-path/include" -- -x cuda --cuda-host-only -std=c++17
 // RUN: grep "IsCalled" %T/DplExtrasAlgorithm/api_test13/MainSourceFiles.yaml | wc -l > %T/DplExtrasAlgorithm/api_test13/count.txt
 // RUN: FileCheck --input-file %T/DplExtrasAlgorithm/api_test13/count.txt --match-full-lines %s

--- a/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test13.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test13.cu
@@ -1,5 +1,5 @@
 // UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.2, cuda-11.4
-// UNSUPPORTED: v8.0, v9.0, v9.1, v9.2, v10.0, v10.1, v10.2, v11.0, v11.2, v11.4s
+// UNSUPPORTED: v8.0, v9.0, v9.1, v9.2, v10.0, v10.1, v10.2, v11.0, v11.2, v11.4
 // RUN: dpct --format-range=none  --usm-level=none  --use-custom-helper=api -out-root %T/DplExtrasAlgorithm/api_test13 %s --cuda-include-path="%cuda-path/include" -- -x cuda --cuda-host-only -std=c++17
 // RUN: grep "IsCalled" %T/DplExtrasAlgorithm/api_test13/MainSourceFiles.yaml | wc -l > %T/DplExtrasAlgorithm/api_test13/count.txt
 // RUN: FileCheck --input-file %T/DplExtrasAlgorithm/api_test13/count.txt --match-full-lines %s

--- a/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test14.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test14.cu
@@ -1,0 +1,19 @@
+// UNSUPPORTED: cuda-8.0
+// UNSUPPORTED: v8.0
+// RUN: dpct --format-range=none  --usm-level=none  --use-custom-helper=api -out-root %T/DplExtrasAlgorithm/api_test14 %s --cuda-include-path="%cuda-path/include" -- -x cuda --cuda-host-only -std=c++17
+// RUN: grep "IsCalled" %T/DplExtrasAlgorithm/api_test14/MainSourceFiles.yaml | wc -l > %T/DplExtrasAlgorithm/api_test14/count.txt
+// RUN: FileCheck --input-file %T/DplExtrasAlgorithm/api_test14/count.txt --match-full-lines %s
+// RUN: rm -rf %T/DplExtrasAlgorithm/api_test14
+
+// CHECK: 23
+// TEST_FEATURE: DplExtrasAlgorithm_sort_pairs
+
+#include <cub/cub.cuh>
+
+int main() {
+   void *temp_storage;
+  size_t temp_storage_size;
+  int n, *d_keys_in, *d_keys_out, *d_values_in, *d_values_out;
+  cub::DeviceRadixSort::SortPairs(temp_storage, temp_storage_size, d_keys_in, d_keys_out, d_values_in, d_values_out, n);
+  return 0;
+}

--- a/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test14.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test14.cu
@@ -1,5 +1,5 @@
-// UNSUPPORTED: cuda-8.0
-// UNSUPPORTED: v8.0
+// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.2, cuda-11.4
+// UNSUPPORTED: v8.0, v9.0, v9.1, v9.2, v10.0, v10.1, v10.2, v11.0, v11.2, v11.4
 // RUN: dpct --format-range=none  --usm-level=none  --use-custom-helper=api -out-root %T/DplExtrasAlgorithm/api_test14 %s --cuda-include-path="%cuda-path/include" -- -x cuda --cuda-host-only -std=c++17
 // RUN: grep "IsCalled" %T/DplExtrasAlgorithm/api_test14/MainSourceFiles.yaml | wc -l > %T/DplExtrasAlgorithm/api_test14/count.txt
 // RUN: FileCheck --input-file %T/DplExtrasAlgorithm/api_test14/count.txt --match-full-lines %s


### PR DESCRIPTION
Support migration of:
- cub::DeviceRadixSort::SortKeys
- cub::DeviceRadixSort::SortKeysDescending
- cub::DeviceRadixSort::SortPairs
- cub::DeviceRadixSort::SortPairsDescending

Signed-off-by: Wang, Yihan <yihan.wang@intel.com>