### PR TITLE
[SYCLomatic] Replace the default RNG to mcg59<1> and correct mrg32k3a parameters

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -5533,7 +5533,7 @@ void DeviceRandomFunctionCallRule::runRule(
 
     std::string Factor = "8";
     if (GeneratorType == "dpct::rng::device::rng_generator<oneapi::"
-                         "mkl::rng::device::philox4x32x10<4>>" &&
+                         "mkl::rng::device::philox4x32x10<1>>" &&
         (DRefArg3Type == "curandStatePhilox4_32_10_t" ||
          DRefArg3Type == "curandStatePhilox4_32_10")) {
       Factor = "4";

--- a/clang/lib/DPCT/MapNames.cpp
+++ b/clang/lib/DPCT/MapNames.cpp
@@ -3809,8 +3809,8 @@ const std::map<std::string, MapNames::SOLVERFuncReplInfo>
 
 // Random Engine Type mapping
 const MapNames::MapTy MapNames::RandomEngineTypeMap{
-    {"CURAND_RNG_PSEUDO_DEFAULT", "oneapi::mkl::rng::philox4x32x10"},
-    {"CURAND_RNG_PSEUDO_XORWOW", "oneapi::mkl::rng::philox4x32x10"},
+    {"CURAND_RNG_PSEUDO_DEFAULT", "oneapi::mkl::rng::mcg59"},
+    {"CURAND_RNG_PSEUDO_XORWOW", "oneapi::mkl::rng::mcg59"},
     {"CURAND_RNG_PSEUDO_MRG32K3A", "oneapi::mkl::rng::mrg32k3a"},
     {"CURAND_RNG_PSEUDO_MTGP32", "oneapi::mkl::rng::mt2203"},
     {"CURAND_RNG_PSEUDO_MT19937", "oneapi::mkl::rng::mt19937"},
@@ -3825,22 +3825,22 @@ const MapNames::MapTy MapNames::RandomEngineTypeMap{
 // Device Random Generator Type mapping
 const MapNames::MapTy MapNames::DeviceRandomGeneratorTypeMap{
     {"curandStateXORWOW_t", "dpct::rng::device::rng_generator<oneapi::"
-                            "mkl::rng::device::philox4x32x10<4>>"},
+                            "mkl::rng::device::mcg59<1>>"},
     {"curandStateXORWOW", "dpct::rng::device::rng_generator<oneapi::"
-                          "mkl::rng::device::philox4x32x10<4>>"},
+                          "mkl::rng::device::mcg59<1>>"},
     {"curandState_t", "dpct::rng::device::rng_generator<oneapi::mkl::"
-                      "rng::device::philox4x32x10<4>>"},
+                      "rng::device::mcg59<1>>"},
     {"curandState", "dpct::rng::device::rng_generator<oneapi::mkl::"
-                    "rng::device::philox4x32x10<4>>"},
+                    "rng::device::mcg59<1>>"},
     {"curandStatePhilox4_32_10_t",
      "dpct::rng::device::rng_generator<oneapi::mkl::rng::device::"
-     "philox4x32x10<4>>"},
+     "philox4x32x10<1>>"},
     {"curandStatePhilox4_32_10", "dpct::rng::device::rng_generator<"
-                                 "oneapi::mkl::rng::device::philox4x32x10<4>>"},
+                                 "oneapi::mkl::rng::device::philox4x32x10<1>>"},
     {"curandStateMRG32k3a_t", "dpct::rng::device::rng_generator<"
-                              "oneapi::mkl::rng::device::mrg32k3a<4>>"},
+                              "oneapi::mkl::rng::device::mrg32k3a<1>>"},
     {"curandStateMRG32k3a", "dpct::rng::device::rng_generator<oneapi::"
-                            "mkl::rng::device::mrg32k3a<4>>"},
+                            "mkl::rng::device::mrg32k3a<1>>"},
 };
 
 const std::map<std::string, MapNames::RandomGenerateFuncReplInfo>

--- a/clang/runtime/dpct-rt/include/rng_utils.hpp.inc
+++ b/clang/runtime/dpct-rt/include/rng_utils.hpp.inc
@@ -57,14 +57,17 @@ namespace device {
 // DPCT_CODE
 /// The random number generator on device.
 /// \tparam engine_t The device random number generator engine. It can only be
-/// oneapi::mkl::rng::device::mrg32k3a<4> or
-/// oneapi::mkl::rng::device::philox4x32x10<4>.
+/// oneapi::mkl::rng::device::mrg32k3a<1> or
+/// oneapi::mkl::rng::device::mcg59<1> or
+/// oneapi::mkl::rng::device::philox4x32x10<1>.
 template <typename engine_t> class rng_generator {
   static_assert(
-      std::is_same_v<engine_t, oneapi::mkl::rng::device::mrg32k3a<4>> ||
-          std::is_same_v<engine_t, oneapi::mkl::rng::device::philox4x32x10<4>>,
-      "engine_t can only be oneapi::mkl::rng::device::mrg32k3a<4> or "
-      "oneapi::mkl::rng::device::philox4x32x10<4>.");
+      std::is_same_v<engine_t, oneapi::mkl::rng::device::mrg32k3a<1>> ||
+          std::is_same_v<engine_t, oneapi::mkl::rng::device::mcg59<1>> ||
+          std::is_same_v<engine_t, oneapi::mkl::rng::device::philox4x32x10<1>>,
+      "engine_t can only be oneapi::mkl::rng::device::mrg32k3a<1> or "
+      "oneapi::mkl::rng::device::mcg59<1> or "
+      "oneapi::mkl::rng::device::philox4x32x10<1>.");
   static constexpr std::uint64_t default_seed = 0;
   oneapi::mkl::rng::device::bits<std::uint32_t> _distr_bits;
   oneapi::mkl::rng::device::gaussian<float> _distr_gaussian_float;

--- a/clang/test/dpct/cublas_curandInMacro.cu
+++ b/clang/test/dpct/cublas_curandInMacro.cu
@@ -159,8 +159,8 @@ int main() {
 
 
     float * __restrict__ d_data;
-    //CHECK:std::shared_ptr<oneapi::mkl::rng::philox4x32x10> rng;
-    //CHECK-NEXT:curandErrCheck((rng = std::make_shared<oneapi::mkl::rng::philox4x32x10>(dpct::get_default_queue(), 1337ull), 0));
+    //CHECK:std::shared_ptr<oneapi::mkl::rng::mcg59> rng;
+    //CHECK-NEXT:curandErrCheck((rng = std::make_shared<oneapi::mkl::rng::mcg59>(dpct::get_default_queue(), 1337ull), 0));
     //CHECK-NEXT:/*
     //CHECK-NEXT:DPCT1027:{{[0-9]+}}: The call to curandSetPseudoRandomGeneratorSeed was replaced with 0 because this call is redundant in SYCL.
     //CHECK-NEXT:*/

--- a/clang/test/dpct/curand-cross-function.cu
+++ b/clang/test/dpct/curand-cross-function.cu
@@ -5,7 +5,7 @@
 #include <stdio.h>
 #include <curand.h>
 
-//CHECK: void update(float* randvals, std::shared_ptr<oneapi::mkl::rng::mcg59> rng, long long nx, long long ny) {
+//CHECK: void update(float* randvals, std::shared_ptr<oneapi::mkl::rng::philox4x32x10> rng, long long nx, long long ny) {
 //CHECK-NEXT:   oneapi::mkl::rng::uniform<float> distr_ct{{[0-9]+}};
 //CHECK-NEXT:   oneapi::mkl::rng::generate(distr_ct{{[0-9]+}}, *rng, nx*ny/2, randvals);
 //CHECK-NEXT: }

--- a/clang/test/dpct/curand-cross-function.cu
+++ b/clang/test/dpct/curand-cross-function.cu
@@ -5,7 +5,7 @@
 #include <stdio.h>
 #include <curand.h>
 
-//CHECK: void update(float* randvals, std::shared_ptr<oneapi::mkl::rng::philox4x32x10> rng, long long nx, long long ny) {
+//CHECK: void update(float* randvals, std::shared_ptr<oneapi::mkl::rng::mcg59> rng, long long nx, long long ny) {
 //CHECK-NEXT:   oneapi::mkl::rng::uniform<float> distr_ct{{[0-9]+}};
 //CHECK-NEXT:   oneapi::mkl::rng::generate(distr_ct{{[0-9]+}}, *rng, nx*ny/2, randvals);
 //CHECK-NEXT: }

--- a/clang/test/dpct/curand-device-different-vec-size.cu
+++ b/clang/test/dpct/curand-device-different-vec-size.cu
@@ -14,8 +14,8 @@ __global__ void picount(int *totals) {
   __shared__ int counter[WARP_SIZE];
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
 
-  // CHECK: dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng;
-  // CHECK: rng = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>(clock64(), {1234, static_cast<std::uint64_t>(tid * 8)});
+  // CHECK: dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>> rng;
+  // CHECK: rng = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>>(clock64(), {1234, static_cast<std::uint64_t>(tid * 8)});
   curandState_t rng;
   curand_init(clock64(), tid, 1234, &rng);
 
@@ -43,11 +43,11 @@ int main(int argc, char **argv) {
   picount<<<NBLOCKS, WARP_SIZE>>>(dOut);
 
   int size = 10;
-  //CHECK: dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> *RandomStates;
+  //CHECK: dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>> *RandomStates;
   curandState *RandomStates;
-  //CHECK: RandomStates = (dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> *)sycl::malloc_device(size * sizeof(dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>) * 10, q_ct1);
+  //CHECK: RandomStates = (dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>> *)sycl::malloc_device(size * sizeof(dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>>) * 10, q_ct1);
   cudaMalloc((void**)&RandomStates, size * sizeof(curandState) * 10);
-  //CHECK: RandomStates = sycl::malloc_device<dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>>(size, q_ct1);
+  //CHECK: RandomStates = sycl::malloc_device<dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>>>(size, q_ct1);
   cudaMalloc((void**)&RandomStates, size * sizeof(curandState));
 
   return 0;

--- a/clang/test/dpct/curand-device-usm.cu
+++ b/clang/test/dpct/curand-device-usm.cu
@@ -23,8 +23,8 @@ __global__ void picount(int *totals) {
   __shared__ int counter[WARP_SIZE];
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
 
-  //CHECK: dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng;
-  //CHECK: rng = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>(clock64(), {0, static_cast<std::uint64_t>(tid * 8)});
+  //CHECK: dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>> rng;
+  //CHECK: rng = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>>(clock64(), {0, static_cast<std::uint64_t>(tid * 8)});
   curandState_t rng;
   curand_init(clock64(), tid, 0, &rng);
 
@@ -46,7 +46,7 @@ __global__ void picount(int *totals) {
   }
 }
 
-//CHECK: void cuda_kernel_initRND(unsigned long seed, dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> *States,
+//CHECK: void cuda_kernel_initRND(unsigned long seed, dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>> *States,
 //CHECK-NEXT:                     sycl::nd_item<3> item_ct1)
 __global__ void cuda_kernel_initRND(unsigned long seed, curandState *States)
 {
@@ -56,11 +56,11 @@ __global__ void cuda_kernel_initRND(unsigned long seed, curandState *States)
   int id    = bid*32 + tid;
   int pixel = bid*32 + tid;
 
-  //CHECK: States[id] = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>(seed, {0, static_cast<std::uint64_t>(pixel * 8)});
+  //CHECK: States[id] = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>>(seed, {0, static_cast<std::uint64_t>(pixel * 8)});
   curand_init(seed, pixel, 0, &States[id]);
 }
 
-//CHECK: void cuda_kernel_RNDnormalDitribution(double *Image, dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> *States,
+//CHECK: void cuda_kernel_RNDnormalDitribution(double *Image, dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>> *States,
 //CHECK-NEXT:                                  sycl::nd_item<3> item_ct1)
 __global__ void cuda_kernel_RNDnormalDitribution(double *Image, curandState *States)
 {
@@ -91,16 +91,16 @@ int main(int argc, char **argv) {
 
   int size = 10;
   double *Image;
-  //CHECK: dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> *RandomStates;
+  //CHECK: dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>> *RandomStates;
   curandState *RandomStates;
   void *dev;
-  //CHECK: dev = (void *)sycl::malloc_device(size * sizeof(dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>), q_ct1);
+  //CHECK: dev = (void *)sycl::malloc_device(size * sizeof(dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>>), q_ct1);
   cudaMalloc((void**)&dev, size * sizeof(curandState));
-  //CHECK: RandomStates = (dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>*)dev;
+  //CHECK: RandomStates = (dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>>*)dev;
   RandomStates = (curandState*)dev;
-  //CHECK: RandomStates = (dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> *)sycl::malloc_device(size * sizeof(dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>) * 10, q_ct1);
+  //CHECK: RandomStates = (dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>> *)sycl::malloc_device(size * sizeof(dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>>) * 10, q_ct1);
   cudaMalloc((void**)&RandomStates, size * sizeof(curandState) * 10);
-  //CHECK: RandomStates = sycl::malloc_device<dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>>(size, q_ct1);
+  //CHECK: RandomStates = sycl::malloc_device<dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>>>(size, q_ct1);
   cudaMalloc((void**)&RandomStates, size * sizeof(curandState));
 
   cuda_kernel_initRND<<<16,32>>>(1234, RandomStates);
@@ -108,7 +108,7 @@ int main(int argc, char **argv) {
 
   //CHECK: CHECK((dOut = sycl::malloc_device<int>(10, q_ct1), 0));
   CHECK(cudaMalloc((void **)&dOut, sizeof(int) * 10));
-  //CHECK: CHECK((RandomStates = (dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> *)sycl::malloc_device(sizeof(dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>) * 10 * 10, q_ct1), 0));
+  //CHECK: CHECK((RandomStates = (dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>> *)sycl::malloc_device(sizeof(dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>>) * 10 * 10, q_ct1), 0));
   CHECK(cudaMalloc((void **)&RandomStates, sizeof(curandState) * 10 * 10));
   //CHECK: sycl::range<3> grid(1, 1, 10);
   dim3 grid(10, 1);
@@ -123,13 +123,13 @@ __global__ void test() {
   std::tuple<unsigned int, unsigned int> seeds = {1, 2};
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
   curandStatePhilox4_32_10_t state;
-  //CHECK:state = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>(std::get<0>(seeds), {static_cast<std::uint64_t>(std::get<1>(seeds)), static_cast<std::uint64_t>(idx * 4)});
+  //CHECK:state = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>(std::get<0>(seeds), {static_cast<std::uint64_t>(std::get<1>(seeds)), static_cast<std::uint64_t>(idx * 4)});
   curand_init(std::get<0>(seeds), idx, std::get<1>(seeds), &state);
 }
 
 // Test description:
 // This test covers the case when the type of the arg has alias.
-// CHECK: using state_type = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mrg32k3a<4>>;
+// CHECK: using state_type = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mrg32k3a<1>>;
 using state_type = curandStateMRG32k3a;
 struct state_struct_t {
   state_type state;
@@ -139,6 +139,6 @@ __device__ void foo() {
   unsigned long long sequence;
   unsigned long long offset;
   state_struct_t state;
-  // CHECK: state.state = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mrg32k3a<4>>(seed, {static_cast<std::uint64_t>(offset), static_cast<std::uint64_t>(sequence * 8)});
+  // CHECK: state.state = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mrg32k3a<1>>(seed, {static_cast<std::uint64_t>(offset), static_cast<std::uint64_t>(sequence * 8)});
   curand_init(seed, sequence, offset, &state.state);
 }

--- a/clang/test/dpct/curand-device2.cu
+++ b/clang/test/dpct/curand-device2.cu
@@ -14,148 +14,148 @@ __global__ void kernel1() {
   double2 d2;
   double4 d4;
 
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng1;
-  //CHECK-NEXT:rng1 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>(1, {3, 2 * 4});
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>> rng1;
+  //CHECK-NEXT:rng1 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>(1, {3, 2 * 4});
   //CHECK-NEXT:u = rng1.generate<oneapi::mkl::rng::device::bits<std::uint32_t>, 1>();
   curandStatePhilox4_32_10_t rng1;
   curand_init(1, 2, 3, &rng1);
   u = curand(&rng1);
 
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng2;
-  //CHECK-NEXT:rng2 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>(1, {3, 2 * 4});
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>> rng2;
+  //CHECK-NEXT:rng2 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>(1, {3, 2 * 4});
   //CHECK-NEXT:u4 = rng2.generate<oneapi::mkl::rng::device::bits<std::uint32_t>, 4>();
   curandStatePhilox4_32_10_t rng2;
   curand_init(1, 2, 3, &rng2);
   u4 = curand4(&rng2);
 
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng3;
-  //CHECK-NEXT:rng3 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>(1, {3, 2 * 4});
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>> rng3;
+  //CHECK-NEXT:rng3 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>(1, {3, 2 * 4});
   //CHECK-NEXT:f = rng3.generate<oneapi::mkl::rng::device::gaussian<float>, 1>();
   curandStatePhilox4_32_10_t rng3;
   curand_init(1, 2, 3, &rng3);
   f = curand_normal(&rng3);
 
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng4;
-  //CHECK-NEXT:rng4 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>(1, {3, 2 * 4});
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>> rng4;
+  //CHECK-NEXT:rng4 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>(1, {3, 2 * 4});
   //CHECK-NEXT:f2 = rng4.generate<oneapi::mkl::rng::device::gaussian<float>, 2>();
   curandStatePhilox4_32_10_t rng4;
   curand_init(1, 2, 3, &rng4);
   f2 = curand_normal2(&rng4);
 
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng5;
-  //CHECK-NEXT:rng5 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>(1, {3, 2 * 4});
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>> rng5;
+  //CHECK-NEXT:rng5 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>(1, {3, 2 * 4});
   //CHECK-NEXT:d2 = rng5.generate<oneapi::mkl::rng::device::gaussian<double>, 2>();
   curandStatePhilox4_32_10_t rng5;
   curand_init(1, 2, 3, &rng5);
   d2 = curand_normal2_double(&rng5);
 
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng6;
-  //CHECK-NEXT:rng6 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>(1, {3, 2 * 4});
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>> rng6;
+  //CHECK-NEXT:rng6 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>(1, {3, 2 * 4});
   //CHECK-NEXT:f4 = rng6.generate<oneapi::mkl::rng::device::gaussian<float>, 4>();
   curandStatePhilox4_32_10_t rng6;
   curand_init(1, 2, 3, &rng6);
   f4 = curand_normal4(&rng6);
 
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng7;
-  //CHECK-NEXT:rng7 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>(1, {3, 2 * 4});
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>> rng7;
+  //CHECK-NEXT:rng7 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>(1, {3, 2 * 4});
   //CHECK-NEXT:d = rng7.generate<oneapi::mkl::rng::device::gaussian<double>, 1>();
   curandStatePhilox4_32_10_t rng7;
   curand_init(1, 2, 3, &rng7);
   d = curand_normal_double(&rng7);
 
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng8;
-  //CHECK-NEXT:rng8 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>(1, {3, 2 * 4});
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>> rng8;
+  //CHECK-NEXT:rng8 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>(1, {3, 2 * 4});
   //CHECK-NEXT:f = rng8.generate<oneapi::mkl::rng::device::lognormal<float>, 1>(3, 7);
   curandStatePhilox4_32_10_t rng8;
   curand_init(1, 2, 3, &rng8);
   f = curand_log_normal(&rng8, 3, 7);
 
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng9;
-  //CHECK-NEXT:rng9 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>(1, {3, 2 * 4});
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>> rng9;
+  //CHECK-NEXT:rng9 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>(1, {3, 2 * 4});
   //CHECK-NEXT:f2 = rng9.generate<oneapi::mkl::rng::device::lognormal<float>, 2>(3, 7);
   curandStatePhilox4_32_10_t rng9;
   curand_init(1, 2, 3, &rng9);
   f2 = curand_log_normal2(&rng9, 3, 7);
 
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng10;
-  //CHECK-NEXT:rng10 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>(1, {3, 2 * 4});
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>> rng10;
+  //CHECK-NEXT:rng10 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>(1, {3, 2 * 4});
   //CHECK-NEXT:d2 = rng10.generate<oneapi::mkl::rng::device::lognormal<double>, 2>(3, 7);
   curandStatePhilox4_32_10_t rng10;
   curand_init(1, 2, 3, &rng10);
   d2 = curand_log_normal2_double(&rng10, 3, 7);
 
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng11;
-  //CHECK-NEXT:rng11 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>(1, {3, 2 * 4});
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>> rng11;
+  //CHECK-NEXT:rng11 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>(1, {3, 2 * 4});
   //CHECK-NEXT:f4 = rng11.generate<oneapi::mkl::rng::device::lognormal<float>, 4>(3, 7);
   curandStatePhilox4_32_10_t rng11;
   curand_init(1, 2, 3, &rng11);
   f4 = curand_log_normal4(&rng11, 3, 7);
 
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng12;
-  //CHECK-NEXT:rng12 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>(1, {3, 2 * 4});
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>> rng12;
+  //CHECK-NEXT:rng12 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>(1, {3, 2 * 4});
   //CHECK-NEXT:d = rng12.generate<oneapi::mkl::rng::device::lognormal<double>, 1>(3, 7);
   curandStatePhilox4_32_10_t rng12;
   curand_init(1, 2, 3, &rng12);
   d = curand_log_normal_double(&rng12, 3, 7);
 
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng13;
-  //CHECK-NEXT:rng13 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>(1, {3, 2 * 4});
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>> rng13;
+  //CHECK-NEXT:rng13 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>(1, {3, 2 * 4});
   //CHECK-NEXT:f = rng13.generate<oneapi::mkl::rng::device::uniform<float>, 1>();
   curandStatePhilox4_32_10_t rng13;
   curand_init(1, 2, 3, &rng13);
   f = curand_uniform(&rng13);
 
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng14;
-  //CHECK-NEXT:rng14 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>(1, {3, 2 * 4});
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>> rng14;
+  //CHECK-NEXT:rng14 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>(1, {3, 2 * 4});
   //CHECK-NEXT:d2 = rng14.generate<oneapi::mkl::rng::device::uniform<double>, 2>();
   curandStatePhilox4_32_10_t rng14;
   curand_init(1, 2, 3, &rng14);
   d2 = curand_uniform2_double(&rng14);
 
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng15;
-  //CHECK-NEXT:rng15 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>(1, {3, 2 * 4});
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>> rng15;
+  //CHECK-NEXT:rng15 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>(1, {3, 2 * 4});
   //CHECK-NEXT:f4 = rng15.generate<oneapi::mkl::rng::device::uniform<float>, 4>();
   curandStatePhilox4_32_10_t rng15;
   curand_init(1, 2, 3, &rng15);
   f4 = curand_uniform4(&rng15);
 
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng16;
-  //CHECK-NEXT:rng16 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>(1, {3, 2 * 4});
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>> rng16;
+  //CHECK-NEXT:rng16 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>(1, {3, 2 * 4});
   //CHECK-NEXT:d = rng16.generate<oneapi::mkl::rng::device::uniform<double>, 1>();
   curandStatePhilox4_32_10_t rng16;
   curand_init(1, 2, 3, &rng16);
   d = curand_uniform_double(&rng16);
 
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng17;
-  //CHECK-NEXT:rng17 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>(1, {3, 2 * 4});
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>> rng17;
+  //CHECK-NEXT:rng17 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>(1, {3, 2 * 4});
   //CHECK-NEXT:u = rng17.generate<oneapi::mkl::rng::device::poisson<std::uint32_t>, 1>(3);
   curandStatePhilox4_32_10_t rng17;
   curand_init(1, 2, 3, &rng17);
   u = curand_poisson(&rng17, 3);
 
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng18;
-  //CHECK-NEXT:rng18 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>(1, {3, 2 * 4});
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>> rng18;
+  //CHECK-NEXT:rng18 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>(1, {3, 2 * 4});
   //CHECK-NEXT:u4 = rng18.generate<oneapi::mkl::rng::device::poisson<std::uint32_t>, 4>(3);
   curandStatePhilox4_32_10_t rng18;
   curand_init(1, 2, 3, &rng18);
   u4 = curand_poisson4(&rng18, 3);
 
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng19;
-  //CHECK-NEXT:rng19 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>(1, {3, 2 * 4});
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>> rng19;
+  //CHECK-NEXT:rng19 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>(1, {3, 2 * 4});
   //CHECK-NEXT:d4 = rng19.generate<oneapi::mkl::rng::device::uniform<double>, 4>();
   curandStatePhilox4_32_10_t rng19;
   curand_init(1, 2, 3, &rng19);
   d4 = curand_uniform4_double(&rng19);
 
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng20;
-  //CHECK-NEXT:rng20 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>(1, {3, 2 * 4});
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>> rng20;
+  //CHECK-NEXT:rng20 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>(1, {3, 2 * 4});
   //CHECK-NEXT:d4 = rng20.generate<oneapi::mkl::rng::device::gaussian<double>, 4>();
   curandStatePhilox4_32_10_t rng20;
   curand_init(1, 2, 3, &rng20);
   d4 = curand_normal4_double(&rng20);
 
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng21;
-  //CHECK-NEXT:rng21 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>(1, {3, 2 * 4});
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>> rng21;
+  //CHECK-NEXT:rng21 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>(1, {3, 2 * 4});
   //CHECK-NEXT:d4 = rng21.generate<oneapi::mkl::rng::device::lognormal<double>, 4>(3, 7);
   curandStatePhilox4_32_10_t rng21;
   curand_init(1, 2, 3, &rng21);
@@ -163,10 +163,10 @@ __global__ void kernel1() {
 }
 
 __global__ void kernel2() {
-//CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng1;
-//CHECK-NEXT:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng2;
-//CHECK-NEXT:rng1 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>(11, {1234, 1 * 4});
-//CHECK-NEXT:rng2 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>(22, {4321, 2 * 4});
+//CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>> rng1;
+//CHECK-NEXT:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>> rng2;
+//CHECK-NEXT:rng1 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>(11, {1234, 1 * 4});
+//CHECK-NEXT:rng2 = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>(22, {4321, 2 * 4});
 //CHECK-NEXT:float x = rng1.generate<oneapi::mkl::rng::device::uniform<float>, 1>();
 //CHECK-NEXT:sycl::float2 y = rng2.generate<oneapi::mkl::rng::device::gaussian<float>, 2>();
   curandStatePhilox4_32_10_t rng1;
@@ -209,21 +209,21 @@ __global__ void kernel3() {
 }
 
 __global__ void type_test() {
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng1;
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>> rng1;
   curandStateXORWOW_t rng1;
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng2;
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>> rng2;
   curandStateXORWOW rng2;
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng3;
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>> rng3;
   curandState_t rng3;
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng4;
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>> rng4;
   curandState rng4;
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng5;
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>> rng5;
   curandStatePhilox4_32_10_t rng5;
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> rng6;
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>> rng6;
   curandStatePhilox4_32_10 rng6;
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mrg32k3a<4>> rng7;
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mrg32k3a<1>> rng7;
   curandStateMRG32k3a_t rng7;
-  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mrg32k3a<4>> rng8;
+  //CHECK:dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mrg32k3a<1>> rng8;
   curandStateMRG32k3a rng8;
 }
 
@@ -236,7 +236,7 @@ int main() {
 
 __global__ void kernel4() {
   curandStateMRG32k3a_t rng;
-  //CHECK:rng = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mrg32k3a<4>>(1, {4, static_cast<std::uint64_t>((2 + 3) * 8)});
+  //CHECK:rng = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mrg32k3a<1>>(1, {4, static_cast<std::uint64_t>((2 + 3) * 8)});
   //CHECK-NEXT:oneapi::mkl::rng::device::skip_ahead(rng.get_engine(), {0, (2 + 3) * (std::uint64_t(1) << 63)});
   //CHECK-NEXT:oneapi::mkl::rng::device::skip_ahead(rng.get_engine(), {0, static_cast<std::uint64_t>((2 + 3) * 8)});
   curand_init(1, 2 + 3, 4, &rng);

--- a/clang/test/dpct/curand-usm.cu
+++ b/clang/test/dpct/curand-usm.cu
@@ -207,8 +207,8 @@ void bar1(){
 //CHECK:/*
 //CHECK-NEXT:DPCT1032:{{[0-9]+}}: A different random number generator is used. You may need to adjust the code.
 //CHECK-NEXT:*/
-//CHECK-NEXT:std::shared_ptr<oneapi::mkl::rng::philox4x32x10> rng;
-//CHECK-NEXT:rng = std::make_shared<oneapi::mkl::rng::philox4x32x10>(dpct::get_default_queue(), 1337ull);
+//CHECK-NEXT:std::shared_ptr<oneapi::mkl::rng::mcg59> rng;
+//CHECK-NEXT:rng = std::make_shared<oneapi::mkl::rng::mcg59>(dpct::get_default_queue(), 1337ull);
 //CHECK-NEXT:/*
 //CHECK-NEXT:DPCT1026:{{[0-9]+}}: The call to curandSetPseudoRandomGeneratorSeed was removed because this call is redundant in SYCL.
 //CHECK-NEXT:*/

--- a/clang/test/dpct/curand-usm.cu
+++ b/clang/test/dpct/curand-usm.cu
@@ -302,12 +302,12 @@ int bar5(){
 
 void bar6(float *x_gpu, size_t n) {
   //CHECK: oneapi::mkl::rng::uniform<float> distr_ct{{[0-9]+}};
-  //CHECK-NEXT: static std::shared_ptr<oneapi::mkl::rng::philox4x32x10> gen[16];
+  //CHECK-NEXT: static std::shared_ptr<oneapi::mkl::rng::mcg59> gen[16];
   static curandGenerator_t gen[16];
   static int init[16] = {0};
   int i = 0;
   if(!init[i]) {
-    //CHECK: gen[i] = std::make_shared<oneapi::mkl::rng::philox4x32x10>(dpct::get_default_queue(), 1234);
+    //CHECK: gen[i] = std::make_shared<oneapi::mkl::rng::mcg59>(dpct::get_default_queue(), 1234);
     //CHECK-NEXT: /*
     //CHECK-NEXT: DPCT1026:{{[0-9]+}}: The call to curandSetPseudoRandomGeneratorSeed was removed because this call is redundant in SYCL.
     //CHECK-NEXT: */

--- a/clang/test/dpct/curand.cu
+++ b/clang/test/dpct/curand.cu
@@ -233,8 +233,8 @@ void bar1(){
 //CHECK-NEXT:adjust the code.
 //CHECK-NEXT:*/
 //CHECK-NEXT:std::shared_ptr<oneapi::mkl::rng::mcg59> rng;
-//CHECK-NEXT:rng = std::make_shared<oneapi::mkl::rng::mcg59>(
-//CHECK-NEXT:    dpct::get_default_queue(), 1337ull);
+//CHECK-NEXT:rng = std::make_shared<oneapi::mkl::rng::mcg59>(dpct::get_default_queue(),
+//CHECK-NEXT:    1337ull);
 //CHECK-NEXT:/*
 //CHECK-NEXT:DPCT1026:{{[0-9]+}}: The call to curandSetPseudoRandomGeneratorSeed was removed
 //CHECK-NEXT:because this call is redundant in SYCL.

--- a/clang/test/dpct/curand.cu
+++ b/clang/test/dpct/curand.cu
@@ -232,8 +232,8 @@ void bar1(){
 //CHECK-NEXT:DPCT1032:{{[0-9]+}}: A different random number generator is used. You may need to
 //CHECK-NEXT:adjust the code.
 //CHECK-NEXT:*/
-//CHECK-NEXT:std::shared_ptr<oneapi::mkl::rng::philox4x32x10> rng;
-//CHECK-NEXT:rng = std::make_shared<oneapi::mkl::rng::philox4x32x10>(
+//CHECK-NEXT:std::shared_ptr<oneapi::mkl::rng::mcg59> rng;
+//CHECK-NEXT:rng = std::make_shared<oneapi::mkl::rng::mcg59>(
 //CHECK-NEXT:    dpct::get_default_queue(), 1337ull);
 //CHECK-NEXT:/*
 //CHECK-NEXT:DPCT1026:{{[0-9]+}}: The call to curandSetPseudoRandomGeneratorSeed was removed

--- a/clang/test/dpct/helper_files_ref/include/rng_utils.hpp
+++ b/clang/test/dpct/helper_files_ref/include/rng_utils.hpp
@@ -24,7 +24,7 @@ namespace device {
 template <typename engine_t> class rng_generator {
   static_assert(
       std::is_same_v<engine_t, oneapi::mkl::rng::device::mrg32k3a<1>> ||
-          std::is_same_v<engine_t, oneapi::mkl::rng::device::mcg59<1> ||
+          std::is_same_v<engine_t, oneapi::mkl::rng::device::mcg59<1>> ||
           std::is_same_v<engine_t, oneapi::mkl::rng::device::philox4x32x10<1>>,
       "engine_t can only be oneapi::mkl::rng::device::mrg32k3a<1> or "
       "oneapi::mkl::rng::device::mcg59<1> or "

--- a/clang/test/dpct/helper_files_ref/include/rng_utils.hpp
+++ b/clang/test/dpct/helper_files_ref/include/rng_utils.hpp
@@ -18,14 +18,17 @@ namespace rng {
 namespace device {
 /// The random number generator on device.
 /// \tparam engine_t The device random number generator engine. It can only be
-/// oneapi::mkl::rng::device::mrg32k3a<4> or
-/// oneapi::mkl::rng::device::philox4x32x10<4>.
+/// oneapi::mkl::rng::device::mrg32k3a<1> or
+/// oneapi::mkl::rng::device::mcg59<1> or
+/// oneapi::mkl::rng::device::philox4x32x10<1>.
 template <typename engine_t> class rng_generator {
   static_assert(
-      std::is_same_v<engine_t, oneapi::mkl::rng::device::mrg32k3a<4>> ||
-          std::is_same_v<engine_t, oneapi::mkl::rng::device::philox4x32x10<4>>,
-      "engine_t can only be oneapi::mkl::rng::device::mrg32k3a<4> or "
-      "oneapi::mkl::rng::device::philox4x32x10<4>.");
+      std::is_same_v<engine_t, oneapi::mkl::rng::device::mrg32k3a<1>> ||
+          std::is_same_v<engine_t, oneapi::mkl::rng::device::mcg59<1> ||
+          std::is_same_v<engine_t, oneapi::mkl::rng::device::philox4x32x10<1>>,
+      "engine_t can only be oneapi::mkl::rng::device::mrg32k3a<1> or "
+      "oneapi::mkl::rng::device::mcg59<1> or "
+      "oneapi::mkl::rng::device::philox4x32x10<1>.");
   static constexpr std::uint64_t default_seed = 0;
   oneapi::mkl::rng::device::bits<std::uint32_t> _distr_bits;
   oneapi::mkl::rng::device::gaussian<float> _distr_gaussian_float;

--- a/clang/test/dpct/kernel_lambda_arg.cu
+++ b/clang/test/dpct/kernel_lambda_arg.cu
@@ -33,8 +33,8 @@ void run_foo1() {
 //CHECK-NEXT:                                        sycl::nd_item<3> item_ct1) {
 //CHECK-NEXT:  std::tuple<unsigned int, unsigned int> seeds = {1, 2};
 //CHECK-NEXT:  int idx = item_ct1.get_group(2) * item_ct1.get_local_range(2) + item_ct1.get_local_id(2);
-//CHECK-NEXT:  dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> state;
-//CHECK-NEXT:  state = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>>(std::get<0>(seeds), {static_cast<std::uint64_t>(std::get<1>(seeds)), static_cast<std::uint64_t>(idx * 4)});
+//CHECK-NEXT:  dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>> state;
+//CHECK-NEXT:  state = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>(std::get<0>(seeds), {static_cast<std::uint64_t>(std::get<1>(seeds)), static_cast<std::uint64_t>(idx * 4)});
 //CHECK-NEXT:  foo(&state);
 //CHECK-NEXT:}
 template <typename Foo> __global__ void my_kernel2(const Foo &foo) {
@@ -47,9 +47,9 @@ template <typename Foo> __global__ void my_kernel2(const Foo &foo) {
 
 //     CHECK:inline void run_foo2() {
 //CHECK-NEXT:  dpct::get_default_queue().parallel_for<dpct_kernel_name<class my_kernel2_{{[0-9a-z]+}}, class lambda_{{[0-9a-z]+}}>>(
-//CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)), 
+//CHECK-NEXT:    sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
 //CHECK-NEXT:    [=](sycl::nd_item<3> item_ct1) {
-//CHECK-NEXT:      my_kernel2([] (dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> * state) {
+//CHECK-NEXT:      my_kernel2([] (dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>> * state) {
 //CHECK-NEXT:    return state->generate<oneapi::mkl::rng::device::uniform<double>, 2>();
 //CHECK-NEXT:  }, item_ct1);
 //CHECK-NEXT:    });

--- a/clang/test/dpct/types006.cu
+++ b/clang/test/dpct/types006.cu
@@ -4,7 +4,7 @@
 #include <curand_kernel.h>
 
 void foo() {
-// CHECK: dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<4>> bar;
+// CHECK: dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>> bar;
 // CHECK-NEXT: auto lambda = [&bar] () {
 // CHECK-NEXT:   return bar.generate<oneapi::mkl::rng::device::uniform<float>, 1>();
 // CHECK-NEXT: };


### PR DESCRIPTION
Replace the default random generator to mcg59<1> and correct mrg32k3a parameters

Signed-off-by: Fedorov, Andrey <andrey.fedorov@intel.com>