### PR TITLE
[SYCLomatic] Fix incorrect migration of dim3 ctor in kernel

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -3509,13 +3509,19 @@ void ReplaceDim3CtorRule::registerMatcher(MatchFinder &MF) {
 ReplaceDim3Ctor *ReplaceDim3CtorRule::getReplaceDim3Modification(
     const MatchFinder::MatchResult &Result) {
   if (auto Ctor = getNodeAsType<CXXConstructExpr>(Result, "dim3CtorDecl")) {
+    if(auto Kernel = getParentKernelCall(Ctor))
+      return nullptr;
     // dim3 a; or dim3 a(1);
     return new ReplaceDim3Ctor(Ctor, true /*isDecl*/);
   } else if (auto Ctor =
                  getNodeAsType<CXXConstructExpr>(Result, "dim3CtorNoDecl")) {
+    if(auto Kernel = getParentKernelCall(Ctor))
+      return nullptr;
     // deflt = dim3(3);
     return new ReplaceDim3Ctor(Ctor, false /*isDecl*/);
   } else if (auto Ctor = getNodeAsType<CXXConstructExpr>(Result, "dim3Top")) {
+    if(auto Kernel = getParentKernelCall(Ctor))
+      return nullptr;
     // dim3 d3_6_3 = dim3(ceil(test.x + NUM), NUM + test.y, NUM + test.z + NUM);
     if (auto A = ReplaceDim3Ctor::getConstructExpr(Ctor->getArg(0))) {
       // strip the top CXXConstructExpr, if there's a CXXConstructExpr further

--- a/clang/lib/DPCT/Utility.cpp
+++ b/clang/lib/DPCT/Utility.cpp
@@ -419,6 +419,22 @@ const clang::FunctionDecl *getImmediateOuterFuncDecl(const clang::Stmt *S) {
   return nullptr;
 }
 
+const clang::CUDAKernelCallExpr *getParentKernelCall(const clang::Expr *E) {
+  if (!E)
+    return nullptr;
+
+  auto &Context = dpct::DpctGlobalInfo::getContext();
+  auto Parents = Context.getParents(*E);
+  while (Parents.size() == 1) {
+    if (auto KC = Parents[0].get<clang::CUDAKernelCallExpr>())
+      return KC;
+
+    Parents = Context.getParents(Parents[0]);
+  }
+
+  return nullptr;
+}
+
 bool callingFuncHasDeviceAttr(const CallExpr *CE) {
   auto FD = getImmediateOuterFuncDecl(CE);
   return FD && FD->hasAttr<CUDADeviceAttr>();

--- a/clang/lib/DPCT/Utility.h
+++ b/clang/lib/DPCT/Utility.h
@@ -327,6 +327,7 @@ const clang::CompoundStmt *findImmediateBlock(const clang::Stmt *S);
 const clang::CompoundStmt *findImmediateBlock(const clang::ValueDecl *D);
 bool callingFuncHasDeviceAttr(const clang::CallExpr *CE);
 const clang::FunctionDecl *getImmediateOuterFuncDecl(const clang::Stmt *S);
+const clang::CUDAKernelCallExpr *getParentKernelCall(const clang::Expr *E);
 bool isInSameScope(const clang::Stmt *S, const clang::ValueDecl *D);
 const clang::DeclRefExpr *getInnerValueDecl(const clang::Expr *Arg);
 const clang::Stmt *getParentStmt(clang::DynTypedNode Node);

--- a/clang/test/dpct/macro_test.cu
+++ b/clang/test/dpct/macro_test.cu
@@ -241,7 +241,7 @@ MACRO_KC
 //CHECK-NEXT: migration result may be incorrect. You need to verify the definition of the
 //CHECK-NEXT: macro.
 //CHECK-NEXT: */
-//CHECK-NEXT: HARD_KC(foo3, sycl::range<3>(1, 1, 3), sycl::range<3>(1, 1, 2), 1, 0)
+//CHECK-NEXT: HARD_KC(foo3, 3, 2, 1, 0)
 #define HARD_KC(NAME,a,b,c,d) NAME<<<a,b,0>>>(c,d);
 HARD_KC(foo3,3,2,1,0)
 
@@ -262,13 +262,10 @@ dim3 threaddim = 32;
 // CHECK: MACRO_KC2(griddim,threaddim,1,0)
 MACRO_KC2(griddim,threaddim,1,0)
 
-// [Note] Since 3 and 2 are migrated to sycl::range<3>, if they are used in macro as native numbers,
-// there might be some issues in the migrated code.
-// Since this is a corner case, not to emit warning message here.
-// CHECK: MACRO_KC2(sycl::range<3>(1, 1, 3), sycl::range<3>(1, 1, 2), 1, 0)
+// CHECK: MACRO_KC2(3,2,1,0)
 MACRO_KC2(3,2,1,0)
 
-// CHECK: MACRO_KC2(sycl::range<3>(3, 4, 5), sycl::range<3>(1, 1, 2), 1, 0)
+// CHECK: MACRO_KC2(sycl::range<3>(5, 4, 3), 2, 1, 0)
 MACRO_KC2(dim3(5,4,3),2,1,0)
 
 int *a;
@@ -562,7 +559,7 @@ __global__ void templatefoo(){
   int y = b;
 }
 //CHECK: #define AAA 15 + 3
-//CHECK-NEXT: #define CCC <<<sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)>>>()
+//CHECK-NEXT: #define CCC <<<1,1>>>()
 //CHECK-NEXT: #define KERNEL(A, B)                                                           \
 //CHECK-NEXT:   dpct::get_default_queue().parallel_for(                                      \
 //CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),   \
@@ -1201,7 +1198,7 @@ int foo31(){
 
 class ArgClass{};
 
-
+//CHECK: #define SIZE 256
 #define SIZE 256
 //CHECK: #define VACALL4(...) __VA_ARGS__()
 //CHECK-NEXT: #define VACALL3(...) VACALL4(__VA_ARGS__)


### PR DESCRIPTION
Since KernelCallExpr::buildExecutionConfig() takes care of the dim3 ctor in kernel config, ignore the rule migration of dim3 ctors in kernel call.

Signed-off-by: Huang, Andy <andy.huang@intel.com>