### PR TITLE
[SYCLomatic] fix link error multiple definition of `clang::dpct::getTemplateArgsList' 

### DIFF
--- a/clang/lib/DPCT/CallExprRewriterCommon.h
+++ b/clang/lib/DPCT/CallExprRewriterCommon.h
@@ -355,8 +355,8 @@ makeLambdaCreator(bool IsCaptureRef,
                         IsCaptureRef, Stmts...);
 }
 
-auto getTemplateArgsList =
-    [](const CallExpr *C) -> std::vector<TemplateArgumentInfo> {
+inline std::vector<TemplateArgumentInfo>
+getTemplateArgsList(const CallExpr *C) {
   ArrayRef<TemplateArgumentLoc> TemplateArgsList;
   std::vector<TemplateArgumentInfo> Ret;
   auto Callee = C->getCallee()->IgnoreImplicitAsWritten();


### PR DESCRIPTION
Signed-off-by: Ni, Wenhui <wenhui.ni@intel.com>