### PR TITLE
[SYCLomatic][DPCT] io_iterator_pair and associated sort APIs

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -49,6 +49,7 @@
 // DPCT_LABEL_END
 #include "functional.h"
 #include "iterators.h"
+#include "vector.h"
 
 namespace dpct {
 
@@ -1166,23 +1167,27 @@ partition(Policy &&policy, Iter1 first, Iter1 last, Iter2 mask, Pred p) {
 // DPCT_CODE
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
           typename value_t, typename value_out_t>
-void sort_pairs(
-    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
+inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value && 
+                   dpct::internal::is_iterator<key_out_t>::value &&
+                   dpct::internal::is_iterator<value_t>::value &&
+                   dpct::internal::is_iterator<value_out_t>::value>
+sort_pairs(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
     value_t values_in, value_out_t values_out, int64_t n,
     bool descending = false, int begin_bit = 0,
-    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
-                  8);
+           int end_bit =
+               sizeof(typename ::std::iterator_traits<key_t>::value_type) * 8);
 // DPCT_LABEL_END
 
 // DPCT_LABEL_BEGIN|sort_keys_forward_decl|dpct
 // DPCT_DEPENDENCY_EMPTY
 // DPCT_CODE
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t>
-inline void sort_keys(
-    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out, int64_t n,
-    bool descending = false, int begin_bit = 0,
-    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
-                  8);
+inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value && 
+                          dpct::internal::is_iterator<key_out_t>::value>
+sort_keys(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
+          int64_t n, bool descending = false, int begin_bit = 0,
+          int end_bit =
+              sizeof(typename ::std::iterator_traits<key_t>::value_type) * 8);
 // DPCT_LABEL_END
 
 namespace internal {
@@ -1601,7 +1606,11 @@ inline void segmented_sort_pairs_by_two_pair_sorts(
 // DPCT_CODE
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
           typename value_t, typename value_out_t>
-void sort_pairs(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
+inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value && 
+                        dpct::internal::is_iterator<key_out_t>::value &&
+                        dpct::internal::is_iterator<value_t>::value &&
+                        dpct::internal::is_iterator<value_out_t>::value> 
+sort_pairs(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
                 value_t values_in, value_out_t values_out, int64_t n,
                 bool descending, int begin_bit, int end_bit) {
   internal::sort_pairs_impl(std::forward<_ExecutionPolicy>(policy), keys_in,
@@ -1636,9 +1645,10 @@ inline void sort_pairs(
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t>
-inline void sort_keys(_ExecutionPolicy &&policy, key_t keys_in,
-                      key_out_t keys_out, int64_t n, bool descending,
-                      int begin_bit, int end_bit) {
+inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value && 
+                        dpct::internal::is_iterator<key_out_t>::value>
+sort_keys(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
+          int64_t n, bool descending, int begin_bit, int end_bit) {
   using key_t_value_t = typename ::std::iterator_traits<key_t>::value_type;
 
   int clipped_begin_bit = ::std::max(begin_bit, 0);
@@ -1678,7 +1688,7 @@ inline void sort_keys(_ExecutionPolicy &&policy, key_t keys_in,
 template <typename _ExecutionPolicy, typename key_t>
 inline void sort_keys(
     _ExecutionPolicy &&policy, io_iterator_pair<key_t> &keys, int64_t n,
-    bool descending, int begin_bit = 0,
+    bool descending = false, int begin_bit = 0,
     int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
                   8) {
   sort_keys(std::forward<_ExecutionPolicy>(policy), keys.input(), keys.output(),
@@ -1746,14 +1756,16 @@ inline void segmented_sort_pairs(
 template <typename _ExecutionPolicy, typename key_t, typename value_t,
           typename OffsetIteratorT>
 inline void segmented_sort_pairs(
-    _ExecutionPolicy &&policy, io_iterator_pair<key_t> &keys, io_iterator_pair<value_t> &values,
-    int64_t n, int64_t nsegments,
+    _ExecutionPolicy &&policy, io_iterator_pair<key_t> &keys,
+    io_iterator_pair<value_t> &values, int64_t n, int64_t nsegments,
     OffsetIteratorT begin_offsets, OffsetIteratorT end_offsets,
     bool descending = false, int begin_bit = 0,
     int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
                   8) {
-  segmented_sort_pairs(std::forward<_ExecutionPolicy>(policy), keys.input(), keys.output(),
-            values.input(), values.output(), n, nsegments, begin_offsets, end_offsets, descending, begin_bit, end_bit);
+  segmented_sort_pairs(std::forward<_ExecutionPolicy>(policy), keys.input(),
+                       keys.output(), values.input(), values.output(), n,
+                       nsegments, begin_offsets, end_offsets, descending,
+                       begin_bit, end_bit);
 }
 // DPCT_LABEL_END
 

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -1163,7 +1163,9 @@ partition(Policy &&policy, Iter1 first, Iter1 last, Iter2 mask, Pred p) {
 // DPCT_LABEL_END
 
 // DPCT_LABEL_BEGIN|sort_pairs_forward_decl|dpct
-// DPCT_DEPENDENCY_EMPTY
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasVector|is_iterator
+// DPCT_DEPENDENCY_END
 // DPCT_CODE
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
           typename value_t, typename value_out_t>
@@ -1179,7 +1181,9 @@ sort_pairs(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
 // DPCT_LABEL_END
 
 // DPCT_LABEL_BEGIN|sort_keys_forward_decl|dpct
-// DPCT_DEPENDENCY_EMPTY
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasVector|is_iterator
+// DPCT_DEPENDENCY_END
 // DPCT_CODE
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t>
 inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value && 
@@ -1602,6 +1606,7 @@ inline void segmented_sort_pairs_by_two_pair_sorts(
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasAlgorithm|sort_pairs_impl
 // DplExtrasAlgorithm|sort_pairs_forward_decl
+// DplExtrasVector|is_iterator
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
@@ -1642,6 +1647,7 @@ inline void sort_pairs(
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasAlgorithm|transform_and_sort
 // DplExtrasAlgorithm|sort_keys_forward_decl
+// DplExtrasVector|is_iterator
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t>

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -1610,6 +1610,25 @@ void sort_pairs(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
 }
 // DPCT_LABEL_END
 
+// DPCT_LABEL_BEGIN|sort_pairs_io_iterator_pair|dpct
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasAlgorithm|sort_pairs
+// DplExtrasIterators|io_iterator_pair
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+template <typename _ExecutionPolicy, typename key_t, typename value_t>
+inline void sort_pairs(
+    _ExecutionPolicy &&policy, io_iterator_pair<key_t> &keys,
+    io_iterator_pair<value_t> &values, int64_t n, bool descending,
+    int begin_bit = 0,
+    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
+                  8) {
+  sort_pairs(::std::forward<_ExecutionPolicy>(policy), keys.input(),
+             keys.output(), values.input(), values.output(), n, descending,
+             begin_bit, end_bit);
+}
+// DPCT_LABEL_END
+
 // DPCT_LABEL_BEGIN|sort_keys|dpct
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasAlgorithm|transform_and_sort
@@ -1698,6 +1717,23 @@ inline void segmented_sort_pairs(
         values_out, n, nsegments, begin_offsets, end_offsets, descending,
         begin_bit, end_bit);
   }
+}
+// DPCT_LABEL_END
+
+// DPCT_LABEL_BEGIN|sort_keys_io_iterator_pair|dpct
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasAlgorithm|sort_keys
+// DplExtrasIterators|io_iterator_pair
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+template <typename _ExecutionPolicy, typename key_t>
+inline void sort_keys(
+    _ExecutionPolicy &&policy, io_iterator_pair<key_t> &keys, int64_t n,
+    bool descending, int begin_bit = 0,
+    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
+                  8) {
+  sort_keys(std::forward<_ExecutionPolicy>(policy), keys.input(), keys.output(),
+            n, descending, begin_bit, end_bit);
 }
 // DPCT_LABEL_END
 

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -1669,6 +1669,23 @@ inline void sort_keys(_ExecutionPolicy &&policy, key_t keys_in,
 }
 // DPCT_LABEL_END
 
+// DPCT_LABEL_BEGIN|sort_keys_io_iterator_pair|dpct
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasAlgorithm|sort_keys
+// DplExtrasIterators|io_iterator_pair
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+template <typename _ExecutionPolicy, typename key_t>
+inline void sort_keys(
+    _ExecutionPolicy &&policy, io_iterator_pair<key_t> &keys, int64_t n,
+    bool descending, int begin_bit = 0,
+    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
+                  8) {
+  sort_keys(std::forward<_ExecutionPolicy>(policy), keys.input(), keys.output(),
+            n, descending, begin_bit, end_bit);
+}
+// DPCT_LABEL_END
+
 // DPCT_LABEL_BEGIN|segmented_sort_pairs|dpct
 // DPCT_DEPENDENCY_BEGIN 
 // DplExtrasAlgorithm|segmented_sort_pairs_by_parallel_sorts
@@ -1717,23 +1734,6 @@ inline void segmented_sort_pairs(
         values_out, n, nsegments, begin_offsets, end_offsets, descending,
         begin_bit, end_bit);
   }
-}
-// DPCT_LABEL_END
-
-// DPCT_LABEL_BEGIN|sort_keys_io_iterator_pair|dpct
-// DPCT_DEPENDENCY_BEGIN
-// DplExtrasAlgorithm|sort_keys
-// DplExtrasIterators|io_iterator_pair
-// DPCT_DEPENDENCY_END
-// DPCT_CODE
-template <typename _ExecutionPolicy, typename key_t>
-inline void sort_keys(
-    _ExecutionPolicy &&policy, io_iterator_pair<key_t> &keys, int64_t n,
-    bool descending, int begin_bit = 0,
-    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
-                  8) {
-  sort_keys(std::forward<_ExecutionPolicy>(policy), keys.input(), keys.output(),
-            n, descending, begin_bit, end_bit);
 }
 // DPCT_LABEL_END
 

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -1737,6 +1737,26 @@ inline void segmented_sort_pairs(
 }
 // DPCT_LABEL_END
 
+// DPCT_LABEL_BEGIN|segmented_sort_pairs_io_iterator_pair|dpct
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasAlgorithm|segmented_sort_pairs
+// DplExtrasIterators|io_iterator_pair
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+template <typename _ExecutionPolicy, typename key_t, typename value_t,
+          typename OffsetIteratorT>
+inline void segmented_sort_pairs(
+    _ExecutionPolicy &&policy, io_iterator_pair<key_t> &keys, io_iterator_pair<value_t> &values,
+    int64_t n, int64_t nsegments,
+    OffsetIteratorT begin_offsets, OffsetIteratorT end_offsets,
+    bool descending = false, int begin_bit = 0,
+    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
+                  8) {
+  segmented_sort_pairs(std::forward<_ExecutionPolicy>(policy), keys.input(), keys.output(),
+            values.input(), values.output(), n, nsegments, begin_offsets, end_offsets, descending, begin_bit, end_bit);
+}
+// DPCT_LABEL_END
+
 } // end namespace dpct
 
 #endif

--- a/clang/runtime/dpct-rt/include/dpl_extras/iterators.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/iterators.h.inc
@@ -329,23 +329,23 @@ public:
 // DPCT_DEPENDENCY_EMPTY
 // DPCT_CODE
 template <typename IterT> struct io_iterator_pair {
-  inline io_iterator_pair() : __selector(false) {}
+  inline io_iterator_pair() : selector(false) {}
 
   inline io_iterator_pair(const IterT &first_input, const IterT &first_output)
-      : __selector(false) {
-    __iter[0] = first_input;
-    __iter[1] = first_output;
+      : selector(false) {
+    iter[0] = first_input;
+    iter[1] = first_output;
   }
 
-  inline IterT input() const { return __selector ? __iter[1] : __iter[0]; }
+  inline IterT input() const { return selector ? iter[1] : iter[0]; }
 
-  inline IterT output() const { return __selector ? __iter[0] : __iter[1]; }
+  inline IterT output() const { return selector ? iter[0] : iter[1]; }
 
-  inline void swap() { __selector = !__selector; }
+  inline void swap() { selector = !selector; }
 
-  bool __selector;
+  bool selector;
 
-  IterT __iter[2];
+  IterT iter[2];
 };
 // DPCT_LABEL_END
 

--- a/clang/runtime/dpct-rt/include/dpl_extras/iterators.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/iterators.h.inc
@@ -325,6 +325,30 @@ public:
 };
 // DPCT_LABEL_END
 
+// DPCT_LABEL_BEGIN|io_iterator_pair|dpct
+// DPCT_DEPENDENCY_EMPTY
+// DPCT_CODE
+template <typename IterT> struct io_iterator_pair {
+  inline io_iterator_pair() : __selector(false) {}
+
+  inline io_iterator_pair(const IterT &first_input, const IterT &first_output)
+      : __selector(false) {
+    __iter[0] = first_input;
+    __iter[1] = first_output;
+  }
+
+  inline IterT input() const { return __selector ? __iter[1] : __iter[0]; }
+
+  inline IterT output() const { return __selector ? __iter[0] : __iter[1]; }
+
+  inline void swap() { __selector = !__selector; }
+
+  bool __selector;
+
+  IterT __iter[2];
+};
+// DPCT_LABEL_END
+
 } // end namespace dpct
 
 #endif

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -978,21 +978,19 @@ inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
                    dpct::internal::is_iterator<key_out_t>::value &&
                    dpct::internal::is_iterator<value_t>::value &&
                    dpct::internal::is_iterator<value_out_t>::value>
-sort_pairs(
-    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
+sort_pairs(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
     value_t values_in, value_out_t values_out, int64_t n,
     bool descending = false, int begin_bit = 0,
-    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
-                  8);
+           int end_bit =
+               sizeof(typename ::std::iterator_traits<key_t>::value_type) * 8);
 
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t>
 inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value && 
                           dpct::internal::is_iterator<key_out_t>::value>
-sort_keys(
-    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out, int64_t n,
-    bool descending = false, int begin_bit = 0,
-    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
-                  8);
+sort_keys(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
+          int64_t n, bool descending = false, int begin_bit = 0,
+          int end_bit =
+              sizeof(typename ::std::iterator_traits<key_t>::value_type) * 8);
 
 namespace internal {
 
@@ -1386,9 +1384,8 @@ inline void sort_pairs(
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t>
 inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value && 
                         dpct::internal::is_iterator<key_out_t>::value>
-sort_keys(_ExecutionPolicy &&policy, key_t keys_in,
-                      key_out_t keys_out, int64_t n, bool descending,
-                      int begin_bit, int end_bit) {
+sort_keys(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
+          int64_t n, bool descending, int begin_bit, int end_bit) {
   using key_t_value_t = typename ::std::iterator_traits<key_t>::value_type;
 
   int clipped_begin_bit = ::std::max(begin_bit, 0);
@@ -1474,14 +1471,16 @@ inline void segmented_sort_pairs(
 template <typename _ExecutionPolicy, typename key_t, typename value_t,
           typename OffsetIteratorT>
 inline void segmented_sort_pairs(
-    _ExecutionPolicy &&policy, io_iterator_pair<key_t> &keys, io_iterator_pair<value_t> &values,
-    int64_t n, int64_t nsegments,
+    _ExecutionPolicy &&policy, io_iterator_pair<key_t> &keys,
+    io_iterator_pair<value_t> &values, int64_t n, int64_t nsegments,
     OffsetIteratorT begin_offsets, OffsetIteratorT end_offsets,
     bool descending = false, int begin_bit = 0,
     int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
                   8) {
-  segmented_sort_pairs(std::forward<_ExecutionPolicy>(policy), keys.input(), keys.output(),
-            values.input(), values.output(), n, nsegments, begin_offsets, end_offsets, descending, begin_bit, end_bit);
+  segmented_sort_pairs(std::forward<_ExecutionPolicy>(policy), keys.input(),
+                       keys.output(), values.input(), values.output(), n,
+                       nsegments, begin_offsets, end_offsets, descending,
+                       begin_bit, end_bit);
 }
 
 } // end namespace dpct

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -15,6 +15,7 @@
 
 #include "functional.h"
 #include "iterators.h"
+#include "vector.h"
 
 namespace dpct {
 
@@ -973,7 +974,11 @@ partition(Policy &&policy, Iter1 first, Iter1 last, Iter2 mask, Pred p) {
 
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
           typename value_t, typename value_out_t>
-void sort_pairs(
+inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value && 
+                   dpct::internal::is_iterator<key_out_t>::value &&
+                   dpct::internal::is_iterator<value_t>::value &&
+                   dpct::internal::is_iterator<value_out_t>::value>
+sort_pairs(
     _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
     value_t values_in, value_out_t values_out, int64_t n,
     bool descending = false, int begin_bit = 0,
@@ -981,7 +986,9 @@ void sort_pairs(
                   8);
 
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t>
-inline void sort_keys(
+inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value && 
+                          dpct::internal::is_iterator<key_out_t>::value>
+sort_keys(
     _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out, int64_t n,
     bool descending = false, int begin_bit = 0,
     int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
@@ -1352,7 +1359,11 @@ inline void segmented_sort_pairs_by_two_pair_sorts(
 
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
           typename value_t, typename value_out_t>
-void sort_pairs(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
+inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value && 
+                        dpct::internal::is_iterator<key_out_t>::value &&
+                        dpct::internal::is_iterator<value_t>::value &&
+                        dpct::internal::is_iterator<value_out_t>::value> 
+sort_pairs(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
                 value_t values_in, value_out_t values_out, int64_t n,
                 bool descending, int begin_bit, int end_bit) {
   internal::sort_pairs_impl(std::forward<_ExecutionPolicy>(policy), keys_in,
@@ -1373,7 +1384,9 @@ inline void sort_pairs(
 }
 
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t>
-inline void sort_keys(_ExecutionPolicy &&policy, key_t keys_in,
+inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value && 
+                        dpct::internal::is_iterator<key_out_t>::value>
+sort_keys(_ExecutionPolicy &&policy, key_t keys_in,
                       key_out_t keys_out, int64_t n, bool descending,
                       int begin_bit, int end_bit) {
   using key_t_value_t = typename ::std::iterator_traits<key_t>::value_type;

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1408,7 +1408,7 @@ inline void sort_keys(_ExecutionPolicy &&policy, key_t keys_in,
 template <typename _ExecutionPolicy, typename key_t>
 inline void sort_keys(
     _ExecutionPolicy &&policy, io_iterator_pair<key_t> &keys, int64_t n,
-    bool descending, int begin_bit = 0,
+    bool descending = false, int begin_bit = 0,
     int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
                   8) {
   sort_keys(std::forward<_ExecutionPolicy>(policy), keys.input(), keys.output(),

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1458,6 +1458,19 @@ inline void segmented_sort_pairs(
   }
 }
 
+template <typename _ExecutionPolicy, typename key_t, typename value_t,
+          typename OffsetIteratorT>
+inline void segmented_sort_pairs(
+    _ExecutionPolicy &&policy, io_iterator_pair<key_t> &keys, io_iterator_pair<value_t> &values,
+    int64_t n, int64_t nsegments,
+    OffsetIteratorT begin_offsets, OffsetIteratorT end_offsets,
+    bool descending = false, int begin_bit = 0,
+    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
+                  8) {
+  segmented_sort_pairs(std::forward<_ExecutionPolicy>(policy), keys.input(), keys.output(),
+            values.input(), values.output(), n, nsegments, begin_offsets, end_offsets, descending, begin_bit, end_bit);
+}
+
 } // end namespace dpct
 
 #endif

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1360,6 +1360,18 @@ void sort_pairs(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
                             begin_bit, end_bit);
 }
 
+template <typename _ExecutionPolicy, typename key_t, typename value_t>
+inline void sort_pairs(
+    _ExecutionPolicy &&policy, io_iterator_pair<key_t> &keys,
+    io_iterator_pair<value_t> &values, int64_t n, bool descending,
+    int begin_bit = 0,
+    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
+                  8) {
+  sort_pairs(::std::forward<_ExecutionPolicy>(policy), keys.input(),
+             keys.output(), values.input(), values.output(), n, descending,
+             begin_bit, end_bit);
+}
+
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t>
 inline void sort_keys(_ExecutionPolicy &&policy, key_t keys_in,
                       key_out_t keys_out, int64_t n, bool descending,
@@ -1434,6 +1446,16 @@ inline void segmented_sort_pairs(
         values_out, n, nsegments, begin_offsets, end_offsets, descending,
         begin_bit, end_bit);
   }
+}
+
+template <typename _ExecutionPolicy, typename key_t>
+inline void sort_keys(
+    _ExecutionPolicy &&policy, io_iterator_pair<key_t> &keys, int64_t n,
+    bool descending, int begin_bit = 0,
+    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
+                  8) {
+  sort_keys(std::forward<_ExecutionPolicy>(policy), keys.input(), keys.output(),
+            n, descending, begin_bit, end_bit);
 }
 
 } // end namespace dpct

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1405,6 +1405,16 @@ inline void sort_keys(_ExecutionPolicy &&policy, key_t keys_in,
   }
 }
 
+template <typename _ExecutionPolicy, typename key_t>
+inline void sort_keys(
+    _ExecutionPolicy &&policy, io_iterator_pair<key_t> &keys, int64_t n,
+    bool descending, int begin_bit = 0,
+    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
+                  8) {
+  sort_keys(std::forward<_ExecutionPolicy>(policy), keys.input(), keys.output(),
+            n, descending, begin_bit, end_bit);
+}
+
 template <typename _ExecutionPolicy, typename key_t, typename value_t,
           typename OffsetIteratorT>
 inline void segmented_sort_pairs(
@@ -1446,16 +1456,6 @@ inline void segmented_sort_pairs(
         values_out, n, nsegments, begin_offsets, end_offsets, descending,
         begin_bit, end_bit);
   }
-}
-
-template <typename _ExecutionPolicy, typename key_t>
-inline void sort_keys(
-    _ExecutionPolicy &&policy, io_iterator_pair<key_t> &keys, int64_t n,
-    bool descending, int begin_bit = 0,
-    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
-                  8) {
-  sort_keys(std::forward<_ExecutionPolicy>(policy), keys.input(), keys.output(),
-            n, descending, begin_bit, end_bit);
 }
 
 } // end namespace dpct

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/iterators.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/iterators.h
@@ -253,23 +253,23 @@ public:
 };
 
 template <typename IterT> struct io_iterator_pair {
-  inline io_iterator_pair() : __selector(false) {}
+  inline io_iterator_pair() : selector(false) {}
 
   inline io_iterator_pair(const IterT &first_input, const IterT &first_output)
-      : __selector(false) {
-    __iter[0] = first_input;
-    __iter[1] = first_output;
+      : selector(false) {
+    iter[0] = first_input;
+    iter[1] = first_output;
   }
 
-  inline IterT input() const { return __selector ? __iter[1] : __iter[0]; }
+  inline IterT input() const { return selector ? iter[1] : iter[0]; }
 
-  inline IterT output() const { return __selector ? __iter[0] : __iter[1]; }
+  inline IterT output() const { return selector ? iter[0] : iter[1]; }
 
-  inline void swap() { __selector = !__selector; }
+  inline void swap() { selector = !selector; }
 
-  bool __selector;
+  bool selector;
 
-  IterT __iter[2];
+  IterT iter[2];
 };
 
 } // end namespace dpct

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/iterators.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/iterators.h
@@ -252,6 +252,26 @@ public:
   }
 };
 
+template <typename IterT> struct io_iterator_pair {
+  inline io_iterator_pair() : __selector(false) {}
+
+  inline io_iterator_pair(const IterT &first_input, const IterT &first_output)
+      : __selector(false) {
+    __iter[0] = first_input;
+    __iter[1] = first_output;
+  }
+
+  inline IterT input() const { return __selector ? __iter[1] : __iter[0]; }
+
+  inline IterT output() const { return __selector ? __iter[0] : __iter[1]; }
+
+  inline void swap() { __selector = !__selector; }
+
+  bool __selector;
+
+  IterT __iter[2];
+};
+
 } // end namespace dpct
 
 #endif

--- a/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test13.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test13.cu
@@ -5,7 +5,7 @@
 // RUN: FileCheck --input-file %T/DplExtrasAlgorithm/api_test13/count.txt --match-full-lines %s
 // RUN: rm -rf %T/DplExtrasAlgorithm/api_test13
 
-// CHECK: 24
+// CHECK: 25
 // TEST_FEATURE: DplExtrasAlgorithm_sort_keys
 
 #include <cub/cub.cuh>

--- a/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test14.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test14.cu
@@ -5,7 +5,7 @@
 // RUN: FileCheck --input-file %T/DplExtrasAlgorithm/api_test14/count.txt --match-full-lines %s
 // RUN: rm -rf %T/DplExtrasAlgorithm/api_test14
 
-// CHECK: 26
+// CHECK: 27
 // TEST_FEATURE: DplExtrasAlgorithm_sort_pairs
 
 #include <cub/cub.cuh>

--- a/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test15.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test15.cu
@@ -5,7 +5,7 @@
 // RUN: FileCheck --input-file %T/DplExtrasAlgorithm/api_test15/count.txt --match-full-lines %s
 // RUN: rm -rf %T/DplExtrasAlgorithm/api_test15
 
-// CHECK: 30
+// CHECK: 31
 // TEST_FEATURE: DplExtrasAlgorithm_segmented_sort_pairs
 
 #include <cub/cub.cuh>


### PR DESCRIPTION
This add the struct io_iterator_pair to the dpct header, and and adds associated APIs for sort_keys, sort_pairs, and segmented_sort_pairs.  

Signed-off-by: Dan Hoeflinger <dan.hoeflinger@intel.com>