### PR TITLE
[SYCLomatic] Fix dependency annotations for kernel library header.

### DIFF
--- a/clang/lib/DPCT/MapNames.cpp
+++ b/clang/lib/DPCT/MapNames.cpp
@@ -96,10 +96,11 @@ void MapNames::setExplicitNamespaceMap() {
       {"cudaError", std::make_shared<TypeNameRule>("int")},
       {"CUresult", std::make_shared<TypeNameRule>("int")},
       {"CUcontext", std::make_shared<TypeNameRule>("int")},
-      {"CUmodule", std::make_shared<TypeNameRule>(getDpctNamespace() + "kernel_library")},
+      {"CUmodule", std::make_shared<TypeNameRule>(getDpctNamespace() + "kernel_library",
+                         HelperFeatureEnum::Kernel_kernel_library)},
       {"CUfunction", std::make_shared<TypeNameRule>(
                          getDpctNamespace() + "kernel_function",
-                         HelperFeatureEnum::Kernel_kernel_functor)},
+                         HelperFeatureEnum::Kernel_kernel_library)},
       {"cudaPointerAttributes",
        std::make_shared<TypeNameRule>(getDpctNamespace() + "pointer_attributes",
                                   HelperFeatureEnum::Memory_pointer_attributes)},

--- a/clang/test/dpct/test_api_level/Kernel/api_test3.cu
+++ b/clang/test/dpct/test_api_level/Kernel/api_test3.cu
@@ -3,7 +3,7 @@
 // RUN: FileCheck --input-file %T/Kernel/api_test3_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/Kernel/api_test3_out
 
-// CHECK: 2
+// CHECK: 3
 // TEST_FEATURE: Kernel_kernel_functor
 
 int main() {


### PR DESCRIPTION
Signed-off-by: Lu, John <john.lu@intel.com>

Fix/add annotations for kernel library header.