### PR TITLE
[SYCLomatic] Fix dpct::device_vector move semantics bug

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/vector.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/vector.h.inc
@@ -243,9 +243,8 @@ public:
   }
   device_vector &operator=(device_vector &&other) {
     // Move assignment operator:
-    // Swap resource with `other`, so that the old resource owned by `this` will
-    // be deallocated by destructor of `other`.
-    this->swap(other);
+    device_vector dummy(std::move(other));
+    this->swap(dummy);
     return *this;
   }
   size_type size() const { return _size; }
@@ -263,6 +262,7 @@ public:
     std::swap(_size, v._size);
     std::swap(_capacity, v._capacity);
     std::swap(_storage, v._storage);
+    std::swap(_alloc, v._alloc);
   }
   reference operator[](size_type n) { return _storage[n]; }
   const_reference operator[](size_type n) const { return _storage[n]; }

--- a/clang/runtime/dpct-rt/include/dpl_extras/vector.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/vector.h.inc
@@ -151,7 +151,11 @@ public:
   }
   device_vector(device_vector &&other)
       : _alloc(get_default_queue()), _size(other.size()),
-        _capacity(other.capacity()) {}
+        _capacity(other.capacity()), _storage(other._storage) {
+    other._size = 0;
+    other._capacity = _min_capacity();
+    other._storage = nullptr;
+  }
 
   template <typename InputIterator>
   device_vector(InputIterator first,
@@ -239,9 +243,9 @@ public:
   }
   device_vector &operator=(device_vector &&other) {
     // Move assignment operator:
-    this->_size = std::move(other._size);
-    this->_capacity = std::move(other._capacity);
-    this->_storage = std::move(other._storage);
+    // Swap resource with `other`, so that the old resource owned by `this` will
+    // be deallocated by destructor of `other`.
+    this->swap(other);
     return *this;
   }
   size_type size() const { return _size; }
@@ -256,11 +260,9 @@ public:
   T *real_begin() { return _storage; }
   const T *real_begin() const { return _storage; }
   void swap(device_vector &v) {
-    auto temp = std::move(v._storage);
-    v._storage = std::move(this->_storage);
-    this->_storage = std::move(temp);
     std::swap(_size, v._size);
     std::swap(_capacity, v._capacity);
+    std::swap(_storage, v._storage);
   }
   reference operator[](size_type n) { return _storage[n]; }
   const_reference operator[](size_type n) const { return _storage[n]; }

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/vector.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/vector.h
@@ -188,9 +188,8 @@ public:
   }
   device_vector &operator=(device_vector &&other) {
     // Move assignment operator:
-    // Swap resource with `other`, so that the old resource owned by `this` will
-    // be deallocated by destructor of `other`.
-    this->swap(other);
+    device_vector dummy(std::move(other));
+    this->swap(dummy);
     return *this;
   }
   size_type size() const { return _size; }
@@ -208,6 +207,7 @@ public:
     std::swap(_size, v._size);
     std::swap(_capacity, v._capacity);
     std::swap(_storage, v._storage);
+    std::swap(_alloc, v._alloc);
   }
   reference operator[](size_type n) { return _storage[n]; }
   const_reference operator[](size_type n) const { return _storage[n]; }

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/vector.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/vector.h
@@ -96,7 +96,11 @@ public:
   }
   device_vector(device_vector &&other)
       : _alloc(get_default_queue()), _size(other.size()),
-        _capacity(other.capacity()) {}
+        _capacity(other.capacity()), _storage(other._storage) {
+    other._size = 0;
+    other._capacity = _min_capacity();
+    other._storage = nullptr;
+  }
 
   template <typename InputIterator>
   device_vector(InputIterator first,
@@ -184,9 +188,9 @@ public:
   }
   device_vector &operator=(device_vector &&other) {
     // Move assignment operator:
-    this->_size = std::move(other._size);
-    this->_capacity = std::move(other._capacity);
-    this->_storage = std::move(other._storage);
+    // Swap resource with `other`, so that the old resource owned by `this` will
+    // be deallocated by destructor of `other`.
+    this->swap(other);
     return *this;
   }
   size_type size() const { return _size; }
@@ -201,11 +205,9 @@ public:
   T *real_begin() { return _storage; }
   const T *real_begin() const { return _storage; }
   void swap(device_vector &v) {
-    auto temp = std::move(v._storage);
-    v._storage = std::move(this->_storage);
-    this->_storage = std::move(temp);
     std::swap(_size, v._size);
     std::swap(_capacity, v._capacity);
+    std::swap(_storage, v._storage);
   }
   reference operator[](size_type n) { return _storage[n]; }
   const_reference operator[](size_type n) const { return _storage[n]; }


### PR DESCRIPTION
The ownership of the raw pointer `_storage` was not properly transferred when move constructor or move assignment operator is called.

Signed-off-by: Yilong Guo <yilong.guo@intel.com>