### PR TITLE
[SYCLomatic] Fix missing backslash issue when insert try-catch in a macro

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -1782,14 +1782,27 @@ void ErrorHandlingHostAPIRule::runRule(const MatchFinder::MatchResult &Result) {
 void ErrorHandlingHostAPIRule::insertTryCatch(const FunctionDecl *FD) {
   SourceManager &SM = DpctGlobalInfo::getSourceManager();
   bool IsLambda = false;
+  bool IsInMacro = false;
   if (auto CMD = dyn_cast<CXXMethodDecl>(FD)) {
     if (CMD->getParent()->isLambda()) {
       IsLambda = true;
     }
   }
 
+  auto BodyRange = getDefinitionRange(FD->getBody()->getBeginLoc(),
+                                      FD->getBody()->getEndLoc());
+  auto It = dpct::DpctGlobalInfo::getExpansionRangeToMacroRecord().find(
+      getCombinedStrFromLoc(BodyRange.getEnd()));
+  if (It != dpct::DpctGlobalInfo::getExpansionRangeToMacroRecord().end()) {
+    IsInMacro = true;
+  }
+
   std::string IndentStr = getIndent(FD->getBeginLoc(), SM).str();
   std::string InnerIndentStr = IndentStr + "  ";
+
+  std::string NewLine = getNL();
+  if(IsInMacro)
+    NewLine = "\\" + NewLine;
 
   if (IsLambda) {
     if (auto CSM = dyn_cast<CompoundStmt>(FD->getBody())) {
@@ -1805,17 +1818,17 @@ void ErrorHandlingHostAPIRule::insertTryCatch(const FunctionDecl *FD) {
   }
 
   std::string ReplaceStr =
-      getNL() + IndentStr +
+      NewLine + IndentStr +
       std::string("catch (" + MapNames::getClNamespace(true) +
                   "exception const &exc) {") +
-      getNL() + InnerIndentStr +
+      NewLine + InnerIndentStr +
       std::string("std::cerr << exc.what() << \"Exception caught at file:\" << "
                   "__FILE__ << "
                   "\", line:\" << __LINE__ << std::endl;") +
-      getNL() + InnerIndentStr + std::string("std::exit(1);") + getNL() +
+      NewLine + InnerIndentStr + std::string("std::exit(1);") + NewLine +
       IndentStr + "}";
   if (IsLambda) {
-    ReplaceStr += getNL() + IndentStr + "}";
+    ReplaceStr += NewLine + IndentStr + "}";
   }
   emplaceTransformation(
       new InsertAfterStmt(FD->getBody(), std::move(ReplaceStr)));

--- a/clang/test/dpct/macro_test.cu
+++ b/clang/test/dpct/macro_test.cu
@@ -21,7 +21,7 @@
 
 #include "macro_test.h"
 
-
+#include <cublas_v2.h>
 #include <thrust/inner_product.h>
 #include <thrust/extrema.h>
 #include <thrust/host_vector.h>
@@ -1268,3 +1268,24 @@ void foo34() {
     }
   });
 }
+
+
+//CHECK: #define ReturnErrorFunction                                                    \
+//CHECK-NEXT:   int amax(dpct::queue_ptr handle, const int n, const float *X,                \
+//CHECK-NEXT:            const int incX, int &result) try {                                  \
+//CHECK-NEXT:     return cublasIsamax(handle, n, (const float *)X, incX, &result);           \
+//CHECK-NEXT:   }                                                                            \
+//CHECK-NEXT:   catch (sycl::exception const &exc) {                                         \
+//CHECK-NEXT:     std::cerr << exc.what() << "Exception caught at file:" << __FILE__         \
+//CHECK-NEXT:               << ", line:" << __LINE__ << std::endl;                           \
+//CHECK-NEXT:     std::exit(1);                                                              \
+//CHECK-NEXT:   }
+
+#define ReturnErrorFunction                                                         \
+  cublasStatus_t amax( cublasHandle_t handle,                                       \
+                       const int n, const float* X, const int incX, int& result )   \
+  {                                                                                 \
+    return cublasIsamax(handle, n, (const float*) X, incX, &result);                \
+  }
+
+ReturnErrorFunction


### PR DESCRIPTION

Signed-off-by: Huang, Andy <andy.huang@intel.com>