### PR TITLE
[SYCLomatic] check for filesystem precisely

### DIFF
--- a/clang/runtime/dpct-rt/include/kernel.hpp.inc
+++ b/clang/runtime/dpct-rt/include/kernel.hpp.inc
@@ -46,10 +46,10 @@
 #include <dlfcn.h>
 #endif
 
-#if (__GNUC__ < 8) && !defined(__llvm__)
-#include <experimental/filesystem>
-#else
+#if defined(__has_include) && __has_include(<filesystem>)
 #include <filesystem>
+#else
+#include <experimental/filesystem>
 #endif
 
 #include <random>
@@ -109,10 +109,10 @@ static kernel_function_info get_kernel_function_info(const void *function) {
 
 namespace detail {
 
-#if (__GNUC__ < 8) && !defined(__llvm__)
-namespace fs = std::experimental::filesystem;
-#else
+#if defined(__has_include) && __has_include(<filesystem>)
 namespace fs = std::filesystem;
+#else
+namespace fs = std::experimental::filesystem;
 #endif
 
  /// Write data to temporary file and return absolute path to temporary file.

--- a/clang/test/dpct/helper_files_ref/include/kernel.hpp
+++ b/clang/test/dpct/helper_files_ref/include/kernel.hpp
@@ -17,10 +17,10 @@
 #include <dlfcn.h>
 #endif
 
-#if (__GNUC__ < 8) && !defined(__llvm__)
-#include <experimental/filesystem>
-#else
+#if defined(__has_include) && __has_include(<filesystem>)
 #include <filesystem>
+#else
+#include <experimental/filesystem>
 #endif
 
 #include <random>
@@ -54,10 +54,10 @@ static kernel_function_info get_kernel_function_info(const void *function) {
 
 namespace detail {
 
-#if (__GNUC__ < 8) && !defined(__llvm__)
-namespace fs = std::experimental::filesystem;
-#else
+#if defined(__has_include) && __has_include(<filesystem>)
 namespace fs = std::filesystem;
+#else
+namespace fs = std::experimental::filesystem;
 #endif
 
  /// Write data to temporary file and return absolute path to temporary file.


### PR DESCRIPTION
Check for filesystem precisely.  Previous check did not work for gcc 7.5.0 invoked through icpx.  Precise check tested with
icpx , icpx-gcc 9.4.0, MSVC which uses filesystem.
icpx-gcc 7.5.0 which uses experimental/filesystem.

Signed-off-by: Lu, John <john.lu@intel.com>