### PR TITLE
[SYCLomatic] Find real path in getInstallPath()

### DIFF
--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -267,6 +267,7 @@ std::string getInstallPath(clang::tooling::ClangTool &Tool,
   }
 
   makeCanonical(InstalledPath);
+  llvm::sys::fs::real_path(InstalledPath, InstalledPath, true);
   StringRef InstalledPathParent(llvm::sys::path::parent_path(InstalledPath));
   // Move up to parent directory of bin directory
   StringRef InstallPath = llvm::sys::path::parent_path(InstalledPathParent);

--- a/clang/test/dpct/symlink/lib.cuh
+++ b/clang/test/dpct/symlink/lib.cuh
@@ -1,0 +1,3 @@
+#include <cuda.h>
+
+__host__ __device__ int add(int x, int y) { return x + y; }

--- a/clang/test/dpct/symlink/symlink.cu
+++ b/clang/test/dpct/symlink/symlink.cu
@@ -1,0 +1,13 @@
+// UNSUPPORTED: -windows-
+// RUN: rm -rf /tmp/%basename_t && mkdir -p /tmp/%basename_t && cd /tmp/%basename_t
+// RUN: ln -s `which dpct` ./dpct
+// RUN: cp %S/symlink.cu ./symlink.cu
+// RUN: cp %S/lib.cuh ./lib.cuh
+// RUN: ./dpct -out-root ./symlink ./symlink.cu --cuda-include-path="%cuda-path/include"
+// RUN: FileCheck --input-file ./symlink/symlink.dp.cpp --match-full-lines %s
+// RUN: rm -rf /tmp/%basename_t
+
+// CHECK: #include "lib.dp.hpp"
+#include "lib.cuh"
+
+int main() { return add(4, -4); }


### PR DESCRIPTION
This PR fixes an issue where the detected installation path is incorrect when the `dpct` binary is linked into another directory.