### PR TITLE
[SYCLomatic] migrate __constant__ variables to static

### DIFF
--- a/clang/lib/DPCT/AnalysisInfo.cpp
+++ b/clang/lib/DPCT/AnalysisInfo.cpp
@@ -3031,7 +3031,8 @@ MemVarInfo::MemVarInfo(unsigned Offset, const std::string &FilePath,
   }
   if (Var->hasInit())
     setInitList(Var->getInit(), Var);
-  if (Var->getStorageClass() == SC_Static) {
+  if (Var->getStorageClass() == SC_Static ||
+      getAddressAttr(Var)==Constant) {
     IsStatic = true;
   }
 

--- a/clang/test/dpct/change_file_in_incrementa_migration/migrate_ref1.txt
+++ b/clang/test/dpct/change_file_in_incrementa_migration/migrate_ref1.txt
@@ -2,7 +2,7 @@
 // CHECK-NEXT: #include <dpct/dpct.hpp>
 // CHECK-NEXT: #include "test.cuh"
 // CHECK-NEXT: #ifdef AAA
-// CHECK-NEXT: dpct::constant_memory<const float, 0> bbb(1.0);
+// CHECK-NEXT: static dpct::constant_memory<const float, 0> bbb(1.0);
 // CHECK-NEXT: #else
 // CHECK-NEXT: __constant__ const float ccc = 1.0;
 // CHECK-NEXT: #endif

--- a/clang/test/dpct/change_file_in_incrementa_migration/migrate_ref2.txt
+++ b/clang/test/dpct/change_file_in_incrementa_migration/migrate_ref2.txt
@@ -4,7 +4,7 @@
 // CHECK-NEXT: #ifdef AAA
 // CHECK-NEXT: __constant__ const float bbb = 1.0;
 // CHECK-NEXT: #else
-// CHECK-NEXT: dpct::constant_memory<const float, 0> ccc(1.0);
+// CHECK-NEXT: static dpct::constant_memory<const float, 0> ccc(1.0);
 // CHECK-NEXT: #endif
 // CHECK-NEXT: int main() {
 // CHECK-NEXT:   return 0;

--- a/clang/test/dpct/change_file_in_incrementa_migration/migrate_ref3.txt
+++ b/clang/test/dpct/change_file_in_incrementa_migration/migrate_ref3.txt
@@ -2,9 +2,9 @@
 // CHECK-NEXT: #include <dpct/dpct.hpp>
 // CHECK-NEXT: #include "test.cuh"
 // CHECK-NEXT: #ifdef AAA
-// CHECK-NEXT: dpct::constant_memory<const float, 0> bbb(1.0);
+// CHECK-NEXT: static dpct::constant_memory<const float, 0> bbb(1.0);
 // CHECK-NEXT: #else
-// CHECK-NEXT: dpct::constant_memory<const float, 0> ccc(1.0);
+// CHECK-NEXT: static dpct::constant_memory<const float, 0> ccc(1.0);
 // CHECK-NEXT: #endif
 // CHECK-NEXT: int main() {
 // CHECK-NEXT:   return 0;

--- a/clang/test/dpct/compilation_database/db_not_correct/case_in_db.c
+++ b/clang/test/dpct/compilation_database/db_not_correct/case_in_db.c
@@ -10,7 +10,7 @@
 // CHECK-NEXT: #include <dpct/dpct.hpp>
 #include <cuda_runtime.h>
 
-// CHECK: dpct::constant_memory<float, 1> const_angle(230);
+// CHECK: static dpct::constant_memory<float, 1> const_angle(230);
 #ifdef TEST
 __constant__ float const_angle[360];
 __global__ void simple_kernel(float *d_array) {

--- a/clang/test/dpct/compilation_database/input_not_in_db/case_in_db.c
+++ b/clang/test/dpct/compilation_database/input_not_in_db/case_in_db.c
@@ -4,7 +4,7 @@
 #include <cuda_runtime.h>
 
 
-// CHECK: dpct::constant_memory<float, 1> const_angle(360);
+// CHECK: static dpct::constant_memory<float, 1> const_angle(360);
 // CHECK-NEXT: void simple_kernel(float *d_array, float *const_angle) {
 // CHECK-NEXT:  d_array[0] = const_angle[0];
 // CHECK-NEXT:  return;

--- a/clang/test/dpct/compilation_database/input_not_in_db/case_not_in_db.c
+++ b/clang/test/dpct/compilation_database/input_not_in_db/case_not_in_db.c
@@ -12,7 +12,7 @@
 // CHECK-NEXT: #include <dpct/dpct.hpp>
 #include <cuda_runtime.h>
 
-// CHECK: dpct::constant_memory<float, 1> const_angle(240);
+// CHECK: static dpct::constant_memory<float, 1> const_angle(240);
 #ifdef TEST
 __constant__ float const_angle[360];
 __global__ void simple_kernel(float *d_array) {

--- a/clang/test/dpct/compile_by_nvcc_lin.c
+++ b/clang/test/dpct/compile_by_nvcc_lin.c
@@ -21,7 +21,7 @@
 #include <cuda_runtime.h>
 
 // CHECK: int a = 0;
-// CHECK-NEXT: dpct::constant_memory<float, 1> const_angle(360);
+// CHECK-NEXT: static dpct::constant_memory<float, 1> const_angle(360);
 // CHECK-NEXT: void simple_kernel(float *d_array, float *const_angle) {
 // CHECK-NEXT:   d_array[0] = const_angle[0];
 // CHECK-NEXT:   return;

--- a/clang/test/dpct/cuda-math-intrinsics.cu
+++ b/clang/test/dpct/cuda-math-intrinsics.cu
@@ -19,8 +19,8 @@ using namespace std;
 // CHECK: using sycl::max;
 using ::max;
 
-// CHECK: dpct::constant_memory<double, 0> d;
-// CHECK-NEXT: dpct::constant_memory<double, 0> d2;
+// CHECK: static dpct::constant_memory<double, 0> d;
+// CHECK-NEXT: static dpct::constant_memory<double, 0> d2;
 __constant__ double d;
 __constant__ double d2;
 
@@ -45,7 +45,7 @@ __device__ double test3(double d4, double d5) {
   return max(d4, d5);
 }
 
-// CHECK: dpct::constant_memory<float, 0> C;
+// CHECK: static dpct::constant_memory<float, 0> C;
 // CHECK-NEXT:  int foo(int n, float C) {
 // CHECK-NEXT:   return n == 1 ? C : 0;
 // CHECK-NEXT: }

--- a/clang/test/dpct/cuda_const.cu
+++ b/clang/test/dpct/cuda_const.cu
@@ -11,7 +11,7 @@ public:
   __device__ void test() {}
 };
 
-// CHECK: dpct::constant_memory<TestStruct, 0> t1;
+// CHECK: static dpct::constant_memory<TestStruct, 0> t1;
 __constant__ TestStruct t1;
 
 // CHECK: void member_acc(TestStruct t1) {
@@ -20,18 +20,18 @@ __constant__ TestStruct t1;
 __global__ void member_acc() {
   t1.test();
 }
-// CHECK: dpct::constant_memory<float, 1> const_angle(360);
-// CHECK: dpct::constant_memory<float, 2> const_float(NUM_ELEMENTS, num_elements * 2);
+// CHECK: static dpct::constant_memory<float, 1> const_angle(360);
+// CHECK: static dpct::constant_memory<float, 2> const_float(NUM_ELEMENTS, num_elements * 2);
 __constant__ float const_angle[360], const_float[NUM_ELEMENTS][num_elements * 2];
-// CHECK: dpct::constant_memory<sycl::double2, 0> vec_d;
+// CHECK: static dpct::constant_memory<sycl::double2, 0> vec_d;
 __constant__ double2 vec_d;
 
-// CHECK: dpct::global_memory<int, 1> const_ptr;
+// CHECK: static dpct::global_memory<int, 1> const_ptr;
 __constant__ int *const_ptr;
 
-// CHECK: dpct::constant_memory<int, 1> const_init(sycl::range<1>(5), {1, 2, 3, 7, 8});
+// CHECK: static dpct::constant_memory<int, 1> const_init(sycl::range<1>(5), {1, 2, 3, 7, 8});
 __constant__ int const_init[5] = {1, 2, 3, 7, 8};
-// CHECK: dpct::constant_memory<int, 2> const_init_2d(sycl::range<2>(5, 5), {{[{][{]}}1, 2, 3, 7, 8}, {2, 4, 5, 8, 2}, {4, 7, 8, 0}, {1, 3}, {4, 0, 56}});
+// CHECK: static dpct::constant_memory<int, 2> const_init_2d(sycl::range<2>(5, 5), {{[{][{]}}1, 2, 3, 7, 8}, {2, 4, 5, 8, 2}, {4, 7, 8, 0}, {1, 3}, {4, 0, 56}});
 __constant__ int const_init_2d[5][5] = {{1, 2, 3, 7, 8}, {2, 4, 5, 8, 2}, {4, 7, 8, 0}, {1, 3}, {4, 0, 56}};
 
 // CHECK: struct FuncObj {
@@ -67,7 +67,7 @@ __global__ void simple_kernel(float *d_array) {
   return;
 }
 
-// CHECK: dpct::constant_memory<float, 0> const_one;
+// CHECK: static dpct::constant_memory<float, 0> const_one;
 __device__ __constant__ float const_one;
 
 // CHECK:void simple_kernel_one(float *d_array, sycl::nd_item<3> [[ITEM:item_ct1]],
@@ -221,7 +221,7 @@ int main(int argc, char **argv) {
 }
 
 
-// CHECK: dpct::constant_memory<float, 0> C;
+// CHECK: static dpct::constant_memory<float, 0> C;
 __constant__ float C;
 
 // CHECK: void foo(float d, float y, float C){
@@ -233,9 +233,9 @@ __global__ void foo(float d, float y){
   float maxtemp = fmaxf(temp=(y*d)<(y==1?C:0) ? -(3*y) :-10, -10);
 }
 
-// CHECK: dpct::constant_memory<int, 0> d_a0(1);
-// CHECK-NEXT: dpct::constant_memory<int, 0> d_a1(2);
-// CHECK-NEXT: dpct::constant_memory<int, 1> const_array(10);
+// CHECK: static dpct::constant_memory<int, 0> d_a0(1);
+// CHECK-NEXT: static dpct::constant_memory<int, 0> d_a1(2);
+// CHECK-NEXT: static dpct::constant_memory<int, 1> const_array(10);
 __constant__ int d_a0 = 1;
 __constant__ int d_a1 = 2;
 __device__ __constant__ int const_array[10];

--- a/clang/test/dpct/cuda_const_usm.cu
+++ b/clang/test/dpct/cuda_const_usm.cu
@@ -11,7 +11,7 @@ public:
   __device__ void test() {}
 };
 
-// CHECK: dpct::constant_memory<TestStruct, 0> t1;
+// CHECK: static dpct::constant_memory<TestStruct, 0> t1;
 __constant__ TestStruct t1;
 
 // CHECK: void member_acc(TestStruct t1) {
@@ -20,18 +20,18 @@ __constant__ TestStruct t1;
 __global__ void member_acc() {
   t1.test();
 }
-// CHECK: dpct::constant_memory<float, 1> const_angle(360);
-// CHECK: dpct::constant_memory<float, 2> const_float(NUM_ELEMENTS, num_elements * 2);
+// CHECK: static dpct::constant_memory<float, 1> const_angle(360);
+// CHECK: static dpct::constant_memory<float, 2> const_float(NUM_ELEMENTS, num_elements * 2);
 __constant__ float const_angle[360], const_float[NUM_ELEMENTS][num_elements * 2];
-// CHECK: dpct::constant_memory<sycl::double2, 0> vec_d;
+// CHECK: static dpct::constant_memory<sycl::double2, 0> vec_d;
 __constant__ double2 vec_d;
 
-// CHECK: dpct::constant_memory<int *, 0> const_ptr;
+// CHECK: static dpct::constant_memory<int *, 0> const_ptr;
 __constant__ int *const_ptr;
 
-// CHECK: dpct::constant_memory<int, 1> const_init(sycl::range<1>(5), {1, 2, 3, 7, 8});
+// CHECK: static dpct::constant_memory<int, 1> const_init(sycl::range<1>(5), {1, 2, 3, 7, 8});
 __constant__ int const_init[5] = {1, 2, 3, 7, 8};
-// CHECK: dpct::constant_memory<int, 2> const_init_2d(sycl::range<2>(5, 5), {{[{][{]}}1, 2, 3, 7, 8}, {2, 4, 5, 8, 2}, {4, 7, 8, 0}, {1, 3}, {4, 0, 56}});
+// CHECK: static dpct::constant_memory<int, 2> const_init_2d(sycl::range<2>(5, 5), {{[{][{]}}1, 2, 3, 7, 8}, {2, 4, 5, 8, 2}, {4, 7, 8, 0}, {1, 3}, {4, 0, 56}});
 __constant__ int const_init_2d[5][5] = {{1, 2, 3, 7, 8}, {2, 4, 5, 8, 2}, {4, 7, 8, 0}, {1, 3}, {4, 0, 56}};
 
 
@@ -68,7 +68,7 @@ __global__ void simple_kernel(float *d_array) {
   return;
 }
 
-// CHECK: dpct::constant_memory<float, 0> const_one;
+// CHECK: static dpct::constant_memory<float, 0> const_one;
 __device__ __constant__ float const_one;
 
 // CHECK:void simple_kernel_one(float *d_array, sycl::nd_item<3> [[ITEM:item_ct1]],

--- a/clang/test/dpct/device_var_in_header/common.cuh
+++ b/clang/test/dpct/device_var_in_header/common.cuh
@@ -1,4 +1,4 @@
-//CHECK: inline dpct::constant_memory<int, 1> arr2(sycl::range<1>(2), {1, 2});
+//CHECK: static dpct::constant_memory<int, 1> arr2(sycl::range<1>(2), {1, 2});
 __device__ __constant__ int arr2[2] = {1, 2};
 //CHECK: static dpct::constant_memory<int, 1> arr3(sycl::range<1>(2), {1, 2});
 static __device__ __constant__ int arr3[2] = {1, 2};

--- a/clang/test/dpct/device_var_in_header/common.h
+++ b/clang/test/dpct/device_var_in_header/common.h
@@ -1,4 +1,4 @@
-//CHECK: inline dpct::constant_memory<int, 1> arr(sycl::range<1>(2), {1, 2});
+//CHECK: static dpct::constant_memory<int, 1> arr(sycl::range<1>(2), {1, 2});
 __device__ __constant__ int arr[2] = {1, 2};
 //CHECK: static dpct::constant_memory<int, 1> arr1(sycl::range<1>(2), {1, 2});
 static __device__ __constant__ int arr1[2] = {1, 2};

--- a/clang/test/dpct/device_var_in_header/f.cu
+++ b/clang/test/dpct/device_var_in_header/f.cu
@@ -4,7 +4,7 @@
 #include "common.cuh"
 #include <cstdio>
 
-//CHECK: dpct::constant_memory<int, 1> arr4(sycl::range<1>(2), {1, 2});
+//CHECK: static dpct::constant_memory<int, 1> arr4(sycl::range<1>(2), {1, 2});
 __device__ __constant__ int arr4[2] = {1, 2};
 //CHECK: static dpct::constant_memory<int, 1> arr5(sycl::range<1>(2), {1, 2});
 static __device__ __constant__ int arr5[2] = {1, 2};

--- a/clang/test/dpct/device_var_in_header/main.cu
+++ b/clang/test/dpct/device_var_in_header/main.cu
@@ -1,3 +1,6 @@
+// Repeated testing with llvm-lit will fail due to YAML files left in output directory
+// Delete to ensure YAML files to ensure test can be re-run
+// RUN: rm -f %T/*.yaml
 // RUN: dpct --process-all -in-root %S -out-root %T --cuda-include-path="%cuda-path/include"
 // RUN: FileCheck --input-file %T/common.dp.hpp --match-full-lines %S/common.cuh
 // RUN: FileCheck --input-file %T/f.dp.cpp --match-full-lines %S/f.cu
@@ -6,7 +9,7 @@
 #include "common.h"
 #include "common.cuh"
 
-//CHECK: dpct::constant_memory<int, 1> arr6(sycl::range<1>(2), {1, 2});
+//CHECK: static dpct::constant_memory<int, 1> arr6(sycl::range<1>(2), {1, 2});
 __device__ __constant__ int arr6[2] = {1, 2};
 //CHECK: static dpct::constant_memory<int, 1> arr7(sycl::range<1>(2), {1, 2});
 static __device__ __constant__ int arr7[2] = {1, 2};

--- a/clang/test/dpct/global_var_definition.cuh
+++ b/clang/test/dpct/global_var_definition.cuh
@@ -1,7 +1,7 @@
 #ifndef GLOBAL_VAR_DEFINITION_CUH
 #define GLOBAL_VAR_DEFINITION_CUH
 
-//CHECK:inline dpct::constant_memory<float, 1> c_clusters(34);
+//CHECK:static dpct::constant_memory<float, 1> c_clusters(34);
 __constant__ float c_clusters[34];
 
 #endif

--- a/clang/test/dpct/mf-kernel.cu
+++ b/clang/test/dpct/mf-kernel.cu
@@ -31,17 +31,17 @@ __global__ void local_foo_2() { }
 
 
 
-// CHECK: dpct::constant_memory<float, 0> A1_ct;
-// CHECK-NEXT: dpct::constant_memory<float, 0> A2;
+// CHECK: static dpct::constant_memory<float, 0> A1_ct;
+// CHECK-NEXT: static dpct::constant_memory<float, 0> A2;
 __constant__ float A1, A2;
 
-// CHECK: dpct::constant_memory<float, 0> A4_ct;
-// CHECK-NEXT: dpct::constant_memory<float, 0> A5_ct;
+// CHECK: static dpct::constant_memory<float, 0> A4_ct;
+// CHECK-NEXT: static dpct::constant_memory<float, 0> A5_ct;
 __constant__ float A4, A5;
 
-// CHECK: dpct::constant_memory<float, 1> A_ct(sycl::range<1>(3 * 3), {0.0625f, 0.125f,  0.0625f, 0.1250f, 0.250f,
+// CHECK: static dpct::constant_memory<float, 1> A_ct(sycl::range<1>(3 * 3), {0.0625f, 0.125f,  0.0625f, 0.1250f, 0.250f,
 // CHECK-NEXT:                                0.1250f, 0.0625f, 0.125f,  0.0625f});
-// CHECK-NEXT: dpct::constant_memory<float, 0> A3;
+// CHECK-NEXT: static dpct::constant_memory<float, 0> A3;
 __constant__ float A[3 * 3] = {0.0625f, 0.125f,  0.0625f, 0.1250f, 0.250f,
                                0.1250f, 0.0625f, 0.125f,  0.0625f}, A3;
 

--- a/clang/test/dpct/sharedmem-dim-noUSM.cu
+++ b/clang/test/dpct/sharedmem-dim-noUSM.cu
@@ -20,7 +20,7 @@ __managed__ int man_mem[10][10][10][10];
 // CHECK: /*
 // CHECK-NEXT: DPCT1060:{{[0-9]+}}: SYCL range can only be a 1D, 2D or 3D vector. Adjust the code.
 // CHECK-NEXT: */
-// CHECK-NEXT: dpct::constant_memory<int, 4> con_mem(10, 10, 10, 10);
+// CHECK-NEXT: static dpct::constant_memory<int, 4> con_mem(10, 10, 10, 10);
 __constant__ int con_mem[10][10][10][10];
 
 __global__ void staticReverse()

--- a/clang/test/dpct/sharedmem-dim.cu
+++ b/clang/test/dpct/sharedmem-dim.cu
@@ -22,7 +22,7 @@ __managed__ int man_mem[10][10][10][10];
 
 // CHECK-NOT: DPCT1060:{{[0-9]+}}: SYCL range can only be a 1D, 2D or 3D vector. Adjust the code.
 
-// CHECK: dpct::constant_memory<int, 4> con_mem(10, 10, 10, 10);
+// CHECK: static dpct::constant_memory<int, 4> con_mem(10, 10, 10, 10);
 __constant__ int con_mem[10][10][10][10];
 
 __global__ void staticReverse()

--- a/clang/test/dpct/withoutexplicitxcuda.c
+++ b/clang/test/dpct/withoutexplicitxcuda.c
@@ -7,7 +7,7 @@
 // CHECK-NEXT: #include <dpct/dpct.hpp>
 #include <cuda_runtime.h>
 
-// CHECK: dpct::constant_memory<float, 1> const_angle(360);
+// CHECK: static dpct::constant_memory<float, 1> const_angle(360);
 // CHECK-NEXT: void simple_kernel(float *d_array, float *const_angle) {
 // CHECK-NEXT:   d_array[0] = const_angle[0];
 // CHECK-NEXT:   return;

--- a/clang/test/dpct/withoutxcuda.c
+++ b/clang/test/dpct/withoutxcuda.c
@@ -7,7 +7,7 @@
 // CHECK-NEXT: #include <dpct/dpct.hpp>
 #include <cuda_runtime.h>
 
-// CHECK: dpct::constant_memory<float, 1> const_angle(360);
+// CHECK: static dpct::constant_memory<float, 1> const_angle(360);
 // CHECK-NEXT: void simple_kernel(float *d_array, float *const_angle) {
 // CHECK-NEXT:   d_array[0] = const_angle[0];
 // CHECK-NEXT:   return;


### PR DESCRIPTION
CUDA __constant__ variables are implicitly static.  Migrate to a static variable.
Signed-off-by: Lu, John <john.lu@intel.com>