### PR TITLE
[SYCLomatic] Functions in DNNL header must be inline

### DIFF
--- a/clang/runtime/dpct-rt/include/dnnl_utils.hpp.inc
+++ b/clang/runtime/dpct-rt/include/dnnl_utils.hpp.inc
@@ -2121,6 +2121,7 @@ public:
 // DPCT_LABEL_BEGIN|memory_desc_ext_def|dpct::dnnl
 // DPCT_DEPENDENCY_EMPTY
 // DPCT_CODE
+inline
 ::dnnl::memory::data_type
 memory_desc_ext::to_dnnl_data_type(dpct::library_data_t dt) {
   using dnnl_dt = ::dnnl::memory::data_type;
@@ -2148,6 +2149,7 @@ memory_desc_ext::to_dnnl_data_type(dpct::library_data_t dt) {
   }
 }
 
+inline
 dpct::library_data_t
 memory_desc_ext::to_dpct_library_data_t(::dnnl::memory::data_type dt,
                                         unsigned block_size) {
@@ -2182,6 +2184,7 @@ memory_desc_ext::to_dpct_library_data_t(::dnnl::memory::data_type dt,
   }
 }
 
+inline
 ::dnnl::memory::format_tag
 memory_desc_ext::to_dnnl_format_tag(dpct::library_data_t dt,
                                     memory_format_tag tag) {
@@ -2202,12 +2205,14 @@ memory_desc_ext::to_dnnl_format_tag(dpct::library_data_t dt,
   }
 }
 
+inline
 void memory_desc_ext::set(memory_format_tag tag, dpct::library_data_t dt, int n,
                           int c, int h, int w) {
   _desc = ::dnnl::memory::desc({n, c, h, w}, to_dnnl_data_type(dt),
                                to_dnnl_format_tag(dt, tag));
 }
 
+inline
 void memory_desc_ext::set(dpct::library_data_t dt, int n, int c, int h, int w,
                           int n_stride, int c_stride, int h_stride,
                           int w_stride) {
@@ -2215,18 +2220,21 @@ void memory_desc_ext::set(dpct::library_data_t dt, int n, int c, int h, int w,
                                {n_stride, c_stride, h_stride, w_stride});
 }
 
+inline
 void memory_desc_ext::set(dpct::library_data_t dt, int ndims, const int dims[],
                           const int strides[]) {
   _desc = ::dnnl::memory::desc({dims, dims + ndims}, to_dnnl_data_type(dt),
                                {strides, strides + ndims});
 }
 
+inline
 void memory_desc_ext::set(memory_format_tag tag, dpct::library_data_t dt,
                           int ndims, const int dims[]) {
   _desc = ::dnnl::memory::desc({dims, dims + ndims}, to_dnnl_data_type(dt),
                                to_dnnl_format_tag(dt, tag));
 }
 
+inline
 void memory_desc_ext::set(rnn_memory_format_tag tag, dpct::library_data_t dt,
                           int t, int n, int c) {
   if (tag == rnn_memory_format_tag::tnc) {
@@ -2240,6 +2248,7 @@ void memory_desc_ext::set(rnn_memory_format_tag tag, dpct::library_data_t dt,
   }
 }
 
+inline
 void memory_desc_ext::get(dpct::library_data_t *dt, int *n, int *c, int *h,
                           int *w, int *n_stride, int *c_stride, int *h_stride,
                           int *w_stride) const {
@@ -2262,6 +2271,7 @@ void memory_desc_ext::get(dpct::library_data_t *dt, int *n, int *c, int *h,
   *w_stride = strides[3] / block_size;
 }
 
+inline
 void memory_desc_ext::get(dpct::library_data_t *dt, memory_format_tag *tag,
                           int *n, int *c, int *h, int *w) const {
   unsigned block_size = 1;
@@ -2283,6 +2293,7 @@ void memory_desc_ext::get(dpct::library_data_t *dt, memory_format_tag *tag,
   *w = dims[3];
 }
 
+inline
 void memory_desc_ext::get(dpct::library_data_t *dt, rnn_memory_format_tag *tag,
                           int *t, int *n, int *c) const {
   auto dims = _desc.get_dims();
@@ -2300,6 +2311,7 @@ void memory_desc_ext::get(dpct::library_data_t *dt, rnn_memory_format_tag *tag,
   *c = dims[2];
 }
 
+inline
 void memory_desc_ext::get(int requested_ndims, dpct::library_data_t *dt,
                           int *ndims, int dims[], int strides[]) const {
   unsigned block_size = 1;
@@ -2318,6 +2330,7 @@ void memory_desc_ext::get(int requested_ndims, dpct::library_data_t *dt,
   }
 }
 
+inline
 void memory_desc_ext::get(int requested_ndims, dpct::library_data_t *dt,
                           memory_format_tag *tag, int *ndims,
                           int dims[]) const {
@@ -2345,6 +2358,7 @@ void memory_desc_ext::get(int requested_ndims, dpct::library_data_t *dt,
 // DPCT_LABEL_BEGIN|engine_ext_2|dpct::dnnl
 // DPCT_DEPENDENCY_EMPTY
 // DPCT_CODE
+inline
 void engine_ext::get_rnn_configuration(const ::dnnl::memory::desc &desc,
                                        rnn_direction direction, rnn_mode mode,
                                        dpct::library_data_t dt, int hidden_size,
@@ -2387,12 +2401,14 @@ void engine_ext::get_rnn_configuration(const ::dnnl::memory::desc &desc,
   *dnnl_dt = memory_desc_ext::to_dnnl_data_type(dt);
 }
 
+inline
 void *engine_ext::allocate(const memory_desc_ext &data_desc, int count) const {
   size_t mem_size = data_desc.get_size();
   void *mem = sycl::malloc_device(mem_size * count, *_q);
   return mem;
 }
 
+inline
 void engine_ext::transform_no_zero(const memory_desc_ext &desc, void *src, void *dst) {
   ::dnnl::memory::data_type dt = desc.get_desc().get_data_type();
   size_t element_num = desc.get_element_num();
@@ -2417,6 +2433,7 @@ void engine_ext::transform_no_zero(const memory_desc_ext &desc, void *src, void 
   }
 }
 
+inline
 ::dnnl::memory::desc
 engine_ext::get_group_weight_desc(int group_count,
                                   const memory_desc_ext &weight_desc) {
@@ -2459,6 +2476,7 @@ engine_ext::get_group_weight_desc(int group_count,
   return help_weight_desc;
 }
 
+inline
 ::dnnl::memory::desc engine_ext::compress_spatial_dimensions_to_channel(
     const ::dnnl::memory::desc &desc) {
   int ndims = desc.get_ndims();
@@ -2485,6 +2503,7 @@ engine_ext::get_group_weight_desc(int group_count,
   return ::dnnl::memory::desc(compressed_dims, desc.get_data_type(), strides);
 }
 
+inline
 ::dnnl::memory::desc
 engine_ext::get_bn_scale_bias_mean_var_desc(const ::dnnl::memory::desc &desc,
                                             batch_normalization_mode mode) {
@@ -2503,6 +2522,7 @@ engine_ext::get_bn_scale_bias_mean_var_desc(const ::dnnl::memory::desc &desc,
                               ::dnnl::memory::format_tag::a);
 }
 
+inline
 ::dnnl::memory::desc engine_ext::transfer_memory_desc_to_channel_major_format(
     const ::dnnl::memory::desc &desc) {
   if (!desc.get_inner_blks().empty()) {
@@ -2521,6 +2541,7 @@ engine_ext::get_bn_scale_bias_mean_var_desc(const ::dnnl::memory::desc &desc,
 /// If the alpha = 0 and beta = 1, then the destination (dst = alpha * out +
 /// beta * prior_dst) have no change. In this case this function returns true
 /// means the operation can exit directly.
+inline
 bool engine_ext::scale_parameter_preprocess(
     const std::vector<output_argument_info> &args) {
   bool direct_exit = true;
@@ -2536,6 +2557,7 @@ bool engine_ext::scale_parameter_preprocess(
   return direct_exit;
 }
 
+inline
 void engine_ext::derive_batch_normalization_memory_desc(
     memory_desc_ext &scale_bias_desc, memory_desc_ext &mean_var_desc,
     const memory_desc_ext &src_desc, batch_normalization_mode mode) {
@@ -2543,6 +2565,7 @@ void engine_ext::derive_batch_normalization_memory_desc(
     derive_batch_normalization_memory_desc(mean_var_desc, src_desc, mode);
 }
 
+inline
 void engine_ext::derive_batch_normalization_memory_desc(
     memory_desc_ext &desc, const memory_desc_ext &src_desc,
     batch_normalization_mode mode) {
@@ -2636,6 +2659,7 @@ sycl::event engine_ext::execute_primitive(primitive_type *primitive, args_type *
   return e;
 }
 
+inline
 ::dnnl::memory::desc engine_ext::bn_reorder_memory_to_channel_major_format(
     bool is_input, ::dnnl::memory::desc &desc, void *src, void **cache,
     std::vector<void *> &caches) {
@@ -2651,6 +2675,7 @@ sycl::event engine_ext::execute_primitive(primitive_type *primitive, args_type *
   return result;
 }
 
+inline
 sycl::event engine_ext::batch_normalization_backward_internal(
     batch_normalization_mode mode, float epsilon, float alpha_data,
     const memory_desc_ext &src_desc, void *src,
@@ -2815,6 +2840,7 @@ sycl::event engine_ext::batch_normalization_backward_internal(
   return e;
 }
 
+inline
 sycl::event engine_ext::batch_normalization_forward_internal(
     bool is_infer, batch_normalization_mode mode, float epsilon, float factor,
     float alpha, const memory_desc_ext &src_desc, void *src, float beta,
@@ -2946,6 +2972,7 @@ sycl::event engine_ext::batch_normalization_forward_internal(
   return e;
 }
 
+inline
 sycl::event engine_ext::rnn_forward_internal(
     const rnn_desc &desc, ::dnnl::prop_kind kind,
     const memory_desc_ext &src_desc, void *src, const memory_desc_ext &dst_desc,
@@ -3032,6 +3059,7 @@ sycl::event engine_ext::rnn_forward_internal(
   return e;
 }
 
+inline
 sycl::event engine_ext::execute_rnn_forward_primitive(
     rnn_mode mode, ::dnnl::prop_kind kind, ::dnnl::rnn_direction direction,
     rnn_bias_mode bias_mode, ::dnnl::memory::data_type dt,
@@ -3206,6 +3234,7 @@ sycl::event engine_ext::execute_rnn_forward_primitive(
   return e;
 }
 
+inline
 sycl::event engine_ext::execute_rnn_backward_primitive(
     rnn_mode mode, ::dnnl::rnn_direction direction, rnn_bias_mode bias_mode,
     ::dnnl::memory::data_type dt, ::dnnl::memory::format_tag tag,
@@ -3385,25 +3414,30 @@ engine_ext::create_backward_primitive(args_type &&...args) {
       _eng, std::forward<args_type>(args)...));
 }
 
+inline
 void engine_ext::fill(const memory_desc_ext &src_desc, void *src,
                       const void *valuePtr) {
   async_fill(src_desc, src, valuePtr).wait();
 }
 
+inline
 void engine_ext::reorder(float alpha, const memory_desc_ext &src_desc,
                          void *src, float beta, const memory_desc_ext &dst_desc,
                          void *dst) {
   async_reorder(alpha, src_desc, src, beta, dst_desc, dst).wait();
 }
 
+inline
 void engine_ext::scale(float alpha, const memory_desc_ext &src_desc,
                        void *src) {
   async_scale(alpha, src_desc, src).wait();
 }
+inline
 void engine_ext::sum(float alpha, const memory_desc_ext &src_desc, void *src,
                      float beta, const memory_desc_ext &dst_desc, void *dst) {
   async_sum(alpha, src_desc, src, beta, dst_desc, dst).wait();
 }
+inline
 void engine_ext::activation_forward(activation_desc &desc, float alpha,
                                     const memory_desc_ext &src_desc, void *src,
                                     float beta, const memory_desc_ext &dst_desc,
@@ -3411,6 +3445,7 @@ void engine_ext::activation_forward(activation_desc &desc, float alpha,
   async_activation_forward(desc, alpha, src_desc, src, beta, dst_desc, dst)
       .wait();
 }
+inline
 void engine_ext::activation_backward(
     activation_desc &desc, float alpha, const memory_desc_ext &dst_desc,
     void *dst, const memory_desc_ext &diff_dst_desc, void *diff_dst,
@@ -3420,6 +3455,7 @@ void engine_ext::activation_backward(
                             src_desc, src, beta, diff_src_desc, diff_src)
       .wait();
 }
+inline
 void engine_ext::pooling_forward(pooling_desc &desc, float alpha,
                                  const memory_desc_ext &src_desc, void *src,
                                  float beta, const memory_desc_ext &dst_desc,
@@ -3429,6 +3465,7 @@ void engine_ext::pooling_forward(pooling_desc &desc, float alpha,
                         workspace).wait();
 }
 
+inline
 void engine_ext::pooling_backward(
     pooling_desc &desc, float alpha, const memory_desc_ext &dst_desc, void *dst,
     const memory_desc_ext &diff_dst_desc, void *diff_dst,
@@ -3441,6 +3478,7 @@ void engine_ext::pooling_backward(
       .wait();
 }
 
+inline
 void engine_ext::softmax_forward(softmax_algorithm alg, softmax_mode mode,
                                  float alpha, const memory_desc_ext &src_desc,
                                  void *src, float beta,
@@ -3449,6 +3487,7 @@ void engine_ext::softmax_forward(softmax_algorithm alg, softmax_mode mode,
       .wait();
 }
 
+inline
 void engine_ext::softmax_backward(softmax_algorithm alg, softmax_mode mode,
                                   float alpha, const memory_desc_ext &dst_desc,
                                   void *dst,
@@ -3461,6 +3500,7 @@ void engine_ext::softmax_backward(softmax_algorithm alg, softmax_mode mode,
       .wait();
 }
 
+inline
 void engine_ext::lrn_forward(lrn_desc &desc, float alpha,
                              const memory_desc_ext &src_desc, void *src,
                              float beta, const memory_desc_ext &dst_desc,
@@ -3469,6 +3509,7 @@ void engine_ext::lrn_forward(lrn_desc &desc, float alpha,
       .wait();
 }
 
+inline
 void engine_ext::lrn_backward(lrn_desc &desc, float alpha,
                               const memory_desc_ext &dst_desc, void *dst,
                               const memory_desc_ext &diff_dst_desc,
@@ -3488,6 +3529,7 @@ void engine_ext::lrn_backward(lrn_desc &desc, float alpha,
 // DnnlUtils|fill_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event engine_ext::async_fill(const memory_desc_ext &src_desc, void *src,
                              const void *valuePtr) {
   ::dnnl::memory::data_type dt = src_desc.get_desc().get_data_type();
@@ -3514,6 +3556,7 @@ sycl::event engine_ext::async_fill(const memory_desc_ext &src_desc, void *src,
 // DnnlUtils|reorder_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event engine_ext::async_reorder(float alpha, const memory_desc_ext &src_desc,
                                 void *src, float beta,
                                 const memory_desc_ext &dst_desc, void *dst) {
@@ -3536,6 +3579,7 @@ sycl::event engine_ext::async_reorder(float alpha, const memory_desc_ext &src_de
 // DnnlUtils|scale_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event engine_ext::async_scale(float alpha, const memory_desc_ext &src_desc,
                               void *src) {
   if (alpha == 1.f) {
@@ -3562,6 +3606,7 @@ sycl::event engine_ext::async_scale(float alpha, const memory_desc_ext &src_desc
 // DnnlUtils|sum_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event engine_ext::async_sum(float alpha, const memory_desc_ext &src_desc,
                             void *src, float beta,
                             const memory_desc_ext &dst_desc, void *dst) {
@@ -3592,6 +3637,7 @@ sycl::event engine_ext::async_sum(float alpha, const memory_desc_ext &src_desc,
 // DnnlUtils|binary_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event engine_ext::async_binary(binary_op op, float alpha_0,
                                const memory_desc_ext &src_desc_0, void *src_0,
                                float alpha_1, const memory_desc_ext &src_desc_1,
@@ -3700,6 +3746,7 @@ sycl::event engine_ext::async_binary(binary_op op, float alpha_0,
 // DnnlUtils|reduction_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event engine_ext::async_reduction(reduction_op op, float alpha,
                                   const memory_desc_ext &src_desc, void *src,
                                   float beta, const memory_desc_ext &dst_desc,
@@ -3769,6 +3816,7 @@ sycl::event engine_ext::async_reduction(reduction_op op, float alpha,
 // DnnlUtils|activation_forward_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event engine_ext::async_activation_forward(activation_desc &desc, float alpha,
                                            const memory_desc_ext &src_desc,
                                            void *src, float beta,
@@ -3794,6 +3842,7 @@ sycl::event engine_ext::async_activation_forward(activation_desc &desc, float al
 // DnnlUtils|activation_backward_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event engine_ext::async_activation_backward(
     activation_desc &desc, float alpha, const memory_desc_ext &dst_desc,
     void *dst, const memory_desc_ext &diff_dst_desc, void *diff_dst,
@@ -3834,6 +3883,7 @@ sycl::event engine_ext::async_activation_backward(
 // DnnlUtils|pooling_forward_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event engine_ext::async_pooling_forward(pooling_desc &desc, float alpha,
                                         const memory_desc_ext &src_desc,
                                         void *src, float beta,
@@ -3871,6 +3921,7 @@ sycl::event engine_ext::async_pooling_forward(pooling_desc &desc, float alpha,
 // DnnlUtils|pooling_backward_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event engine_ext::async_pooling_backward(
     pooling_desc &desc, float alpha, const memory_desc_ext &dst_desc, void *dst,
     const memory_desc_ext &diff_dst_desc, void *diff_dst,
@@ -3914,6 +3965,7 @@ sycl::event engine_ext::async_pooling_backward(
 // DnnlUtils|softmax_forward_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event engine_ext::async_softmax_forward(softmax_algorithm alg,
                                         softmax_mode mode, float alpha,
                                         const memory_desc_ext &src_desc,
@@ -3952,6 +4004,7 @@ sycl::event engine_ext::async_softmax_forward(softmax_algorithm alg,
 // DnnlUtils|softmax_backward_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event engine_ext::async_softmax_backward(
     softmax_algorithm alg, softmax_mode mode, float alpha,
     const memory_desc_ext &dst_desc, void *dst,
@@ -3997,6 +4050,7 @@ sycl::event engine_ext::async_softmax_backward(
 // DnnlUtils|lrn_forward_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event engine_ext::async_lrn_forward(lrn_desc &desc, float alpha,
                                     const memory_desc_ext &src_desc, void *src,
                                     float beta, const memory_desc_ext &dst_desc,
@@ -4032,6 +4086,7 @@ sycl::event engine_ext::async_lrn_forward(lrn_desc &desc, float alpha,
 // DnnlUtils|lrn_backward_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event
 engine_ext::async_lrn_backward(lrn_desc &desc, float alpha,
                          const memory_desc_ext &dst_desc, void *dst,
@@ -4076,6 +4131,7 @@ engine_ext::async_lrn_backward(lrn_desc &desc, float alpha,
 // DnnlUtils|get_batch_normalization_workspace_size_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 size_t engine_ext::get_batch_normalization_workspace_size(
     batch_normalization_ops ops, const memory_desc_ext &src_desc) {
   if(ops == batch_normalization_ops::none) {
@@ -4090,6 +4146,7 @@ size_t engine_ext::get_batch_normalization_workspace_size(
 // DnnlUtils|batch_normalization_forward_inference_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event engine_ext::async_batch_normalization_forward_inference(
     batch_normalization_mode mode, float epsilon, float alpha,
     const memory_desc_ext &src_desc, void *src, float beta,
@@ -4109,6 +4166,7 @@ sycl::event engine_ext::async_batch_normalization_forward_inference(
 // DnnlUtils|batch_normalization_forward_inference_ex_norm_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event engine_ext::async_batch_normalization_forward_inference(
     batch_normalization_mode mode, batch_normalization_ops ops,
     activation_desc &adesc, float epsilon, float alpha,
@@ -4156,6 +4214,7 @@ sycl::event engine_ext::async_batch_normalization_forward_inference(
 // DnnlUtils|batch_normalization_forward_training_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event engine_ext::async_batch_normalization_forward_training(
     batch_normalization_mode mode, float epsilon, float factor, float alpha,
     const memory_desc_ext &src_desc, void *src, float beta,
@@ -4174,6 +4233,7 @@ sycl::event engine_ext::async_batch_normalization_forward_training(
 // DnnlUtils|batch_normalization_forward_training_ex_2_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event engine_ext::async_batch_normalization_forward_training(
     batch_normalization_mode mode, batch_normalization_ops ops,
     activation_desc &adesc, float epsilon, float factor, float alpha,
@@ -4214,6 +4274,7 @@ sycl::event engine_ext::async_batch_normalization_forward_training(
 // DnnlUtils|batch_normalization_forward_training_ex_1_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event engine_ext::async_batch_normalization_forward_training(
     batch_normalization_mode mode, batch_normalization_ops ops,
     activation_desc &adesc, float epsilon, float factor, float alpha,
@@ -4236,6 +4297,7 @@ sycl::event engine_ext::async_batch_normalization_forward_training(
 // DnnlUtils|batch_normalization_backward_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event engine_ext::async_batch_normalization_backward(
     batch_normalization_mode mode, float epsilon, float alpha_data,
     const memory_desc_ext &src_desc, void *src,
@@ -4258,6 +4320,7 @@ sycl::event engine_ext::async_batch_normalization_backward(
 // DnnlUtils|batch_normalization_backward_ex_2_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event engine_ext::async_batch_normalization_backward(
     batch_normalization_mode mode, batch_normalization_ops ops,
     activation_desc &adesc, float epsilon, float alpha_data,
@@ -4319,6 +4382,7 @@ sycl::event engine_ext::async_batch_normalization_backward(
 // DnnlUtils|batch_normalization_backward_ex_1_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event engine_ext::async_batch_normalization_backward(
     batch_normalization_mode mode, batch_normalization_ops ops,
     activation_desc &adesc, float epsilon, float alpha_data,
@@ -4346,6 +4410,7 @@ sycl::event engine_ext::async_batch_normalization_backward(
 // DnnlUtils|convolution_forward_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event
 engine_ext::async_convolution_forward(convolution_desc &desc, ::dnnl::algorithm alg,
                                 float alpha, const memory_desc_ext &src_desc,
@@ -4377,6 +4442,7 @@ engine_ext::async_convolution_forward(convolution_desc &desc, ::dnnl::algorithm 
 // DnnlUtils|convolution_forward_ex_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event engine_ext::async_convolution_forward(
     convolution_desc &desc, ::dnnl::algorithm alg, activation_desc &adesc,
     float alpha_0, const memory_desc_ext &src_desc, void *src,
@@ -4425,6 +4491,7 @@ sycl::event engine_ext::async_convolution_forward(
 // DnnlUtils|convolution_backward_data_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event engine_ext::async_convolution_backward_data(
     convolution_desc &desc, ::dnnl::algorithm alg, float alpha,
     const memory_desc_ext &weight_desc, void *weight,
@@ -4465,6 +4532,7 @@ sycl::event engine_ext::async_convolution_backward_data(
 // DnnlUtils|convolution_backward_weight_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event engine_ext::async_convolution_backward_weight(
     convolution_desc &desc, ::dnnl::algorithm alg, float alpha,
     const memory_desc_ext &src_desc, void *src,
@@ -4507,6 +4575,7 @@ sycl::event engine_ext::async_convolution_backward_weight(
 // DnnlUtils|convolution_backward_bias_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event engine_ext::async_convolution_backward_bias(
     float alpha, const memory_desc_ext &diff_dst_desc, void *diff_dst,
     float beta, const memory_desc_ext &diff_bias_desc, void *diff_bias) {
@@ -4520,6 +4589,7 @@ sycl::event engine_ext::async_convolution_backward_bias(
 // DnnlUtils|rnn_get_weight_space_size_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 void engine_ext::rnn_get_weight_space_size(const rnn_desc &desc,
                                            size_t *weight_space_size) {
   *weight_space_size = 0;
@@ -4537,6 +4607,7 @@ void engine_ext::rnn_get_weight_space_size(const rnn_desc &desc,
 // DnnlUtils|rnn_get_scratchpad_workspace_size_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 void engine_ext::rnn_get_scratchpad_workspace_size(
     const rnn_desc &desc, ::dnnl::prop_kind kind,
     const memory_desc_ext &src_desc, size_t *scratchpad_size,
@@ -4557,6 +4628,7 @@ void engine_ext::rnn_get_scratchpad_workspace_size(
 // DnnlUtils|async_rnn_forward_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event engine_ext::async_rnn_forward(
     const rnn_desc &desc, ::dnnl::prop_kind kind,
     const memory_desc_ext &src_desc, void *src, const memory_desc_ext &dst_desc,
@@ -4578,6 +4650,7 @@ sycl::event engine_ext::async_rnn_forward(
 // DnnlUtils|async_rnn_backward_decl
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
+inline
 sycl::event engine_ext::async_rnn_backward(
     const rnn_desc &desc, const memory_desc_ext &dst_desc, void *dst,
     void *diff_dst, const memory_desc_ext &src_desc, void *src, void *diff_src,

--- a/clang/test/dpct/helper_files_ref/include/dnnl_utils.hpp
+++ b/clang/test/dpct/helper_files_ref/include/dnnl_utils.hpp
@@ -1759,6 +1759,7 @@ public:
 
 };
 
+inline
 ::dnnl::memory::data_type
 memory_desc_ext::to_dnnl_data_type(dpct::library_data_t dt) {
   using dnnl_dt = ::dnnl::memory::data_type;
@@ -1786,6 +1787,7 @@ memory_desc_ext::to_dnnl_data_type(dpct::library_data_t dt) {
   }
 }
 
+inline
 dpct::library_data_t
 memory_desc_ext::to_dpct_library_data_t(::dnnl::memory::data_type dt,
                                         unsigned block_size) {
@@ -1820,6 +1822,7 @@ memory_desc_ext::to_dpct_library_data_t(::dnnl::memory::data_type dt,
   }
 }
 
+inline
 ::dnnl::memory::format_tag
 memory_desc_ext::to_dnnl_format_tag(dpct::library_data_t dt,
                                     memory_format_tag tag) {
@@ -1840,12 +1843,14 @@ memory_desc_ext::to_dnnl_format_tag(dpct::library_data_t dt,
   }
 }
 
+inline
 void memory_desc_ext::set(memory_format_tag tag, dpct::library_data_t dt, int n,
                           int c, int h, int w) {
   _desc = ::dnnl::memory::desc({n, c, h, w}, to_dnnl_data_type(dt),
                                to_dnnl_format_tag(dt, tag));
 }
 
+inline
 void memory_desc_ext::set(dpct::library_data_t dt, int n, int c, int h, int w,
                           int n_stride, int c_stride, int h_stride,
                           int w_stride) {
@@ -1853,18 +1858,21 @@ void memory_desc_ext::set(dpct::library_data_t dt, int n, int c, int h, int w,
                                {n_stride, c_stride, h_stride, w_stride});
 }
 
+inline
 void memory_desc_ext::set(dpct::library_data_t dt, int ndims, const int dims[],
                           const int strides[]) {
   _desc = ::dnnl::memory::desc({dims, dims + ndims}, to_dnnl_data_type(dt),
                                {strides, strides + ndims});
 }
 
+inline
 void memory_desc_ext::set(memory_format_tag tag, dpct::library_data_t dt,
                           int ndims, const int dims[]) {
   _desc = ::dnnl::memory::desc({dims, dims + ndims}, to_dnnl_data_type(dt),
                                to_dnnl_format_tag(dt, tag));
 }
 
+inline
 void memory_desc_ext::set(rnn_memory_format_tag tag, dpct::library_data_t dt,
                           int t, int n, int c) {
   if (tag == rnn_memory_format_tag::tnc) {
@@ -1878,6 +1886,7 @@ void memory_desc_ext::set(rnn_memory_format_tag tag, dpct::library_data_t dt,
   }
 }
 
+inline
 void memory_desc_ext::get(dpct::library_data_t *dt, int *n, int *c, int *h,
                           int *w, int *n_stride, int *c_stride, int *h_stride,
                           int *w_stride) const {
@@ -1900,6 +1909,7 @@ void memory_desc_ext::get(dpct::library_data_t *dt, int *n, int *c, int *h,
   *w_stride = strides[3] / block_size;
 }
 
+inline
 void memory_desc_ext::get(dpct::library_data_t *dt, memory_format_tag *tag,
                           int *n, int *c, int *h, int *w) const {
   unsigned block_size = 1;
@@ -1921,6 +1931,7 @@ void memory_desc_ext::get(dpct::library_data_t *dt, memory_format_tag *tag,
   *w = dims[3];
 }
 
+inline
 void memory_desc_ext::get(dpct::library_data_t *dt, rnn_memory_format_tag *tag,
                           int *t, int *n, int *c) const {
   auto dims = _desc.get_dims();
@@ -1938,6 +1949,7 @@ void memory_desc_ext::get(dpct::library_data_t *dt, rnn_memory_format_tag *tag,
   *c = dims[2];
 }
 
+inline
 void memory_desc_ext::get(int requested_ndims, dpct::library_data_t *dt,
                           int *ndims, int dims[], int strides[]) const {
   unsigned block_size = 1;
@@ -1956,6 +1968,7 @@ void memory_desc_ext::get(int requested_ndims, dpct::library_data_t *dt,
   }
 }
 
+inline
 void memory_desc_ext::get(int requested_ndims, dpct::library_data_t *dt,
                           memory_format_tag *tag, int *ndims,
                           int dims[]) const {
@@ -1979,6 +1992,7 @@ void memory_desc_ext::get(int requested_ndims, dpct::library_data_t *dt,
   }
 }
 
+inline
 void engine_ext::get_rnn_configuration(const ::dnnl::memory::desc &desc,
                                        rnn_direction direction, rnn_mode mode,
                                        dpct::library_data_t dt, int hidden_size,
@@ -2021,12 +2035,14 @@ void engine_ext::get_rnn_configuration(const ::dnnl::memory::desc &desc,
   *dnnl_dt = memory_desc_ext::to_dnnl_data_type(dt);
 }
 
+inline
 void *engine_ext::allocate(const memory_desc_ext &data_desc, int count) const {
   size_t mem_size = data_desc.get_size();
   void *mem = sycl::malloc_device(mem_size * count, *_q);
   return mem;
 }
 
+inline
 void engine_ext::transform_no_zero(const memory_desc_ext &desc, void *src, void *dst) {
   ::dnnl::memory::data_type dt = desc.get_desc().get_data_type();
   size_t element_num = desc.get_element_num();
@@ -2051,6 +2067,7 @@ void engine_ext::transform_no_zero(const memory_desc_ext &desc, void *src, void 
   }
 }
 
+inline
 ::dnnl::memory::desc
 engine_ext::get_group_weight_desc(int group_count,
                                   const memory_desc_ext &weight_desc) {
@@ -2093,6 +2110,7 @@ engine_ext::get_group_weight_desc(int group_count,
   return help_weight_desc;
 }
 
+inline
 ::dnnl::memory::desc engine_ext::compress_spatial_dimensions_to_channel(
     const ::dnnl::memory::desc &desc) {
   int ndims = desc.get_ndims();
@@ -2119,6 +2137,7 @@ engine_ext::get_group_weight_desc(int group_count,
   return ::dnnl::memory::desc(compressed_dims, desc.get_data_type(), strides);
 }
 
+inline
 ::dnnl::memory::desc
 engine_ext::get_bn_scale_bias_mean_var_desc(const ::dnnl::memory::desc &desc,
                                             batch_normalization_mode mode) {
@@ -2137,6 +2156,7 @@ engine_ext::get_bn_scale_bias_mean_var_desc(const ::dnnl::memory::desc &desc,
                               ::dnnl::memory::format_tag::a);
 }
 
+inline
 ::dnnl::memory::desc engine_ext::transfer_memory_desc_to_channel_major_format(
     const ::dnnl::memory::desc &desc) {
   if (!desc.get_inner_blks().empty()) {
@@ -2155,6 +2175,7 @@ engine_ext::get_bn_scale_bias_mean_var_desc(const ::dnnl::memory::desc &desc,
 /// If the alpha = 0 and beta = 1, then the destination (dst = alpha * out +
 /// beta * prior_dst) have no change. In this case this function returns true
 /// means the operation can exit directly.
+inline
 bool engine_ext::scale_parameter_preprocess(
     const std::vector<output_argument_info> &args) {
   bool direct_exit = true;
@@ -2170,6 +2191,7 @@ bool engine_ext::scale_parameter_preprocess(
   return direct_exit;
 }
 
+inline
 void engine_ext::derive_batch_normalization_memory_desc(
     memory_desc_ext &scale_bias_desc, memory_desc_ext &mean_var_desc,
     const memory_desc_ext &src_desc, batch_normalization_mode mode) {
@@ -2177,6 +2199,7 @@ void engine_ext::derive_batch_normalization_memory_desc(
     derive_batch_normalization_memory_desc(mean_var_desc, src_desc, mode);
 }
 
+inline
 void engine_ext::derive_batch_normalization_memory_desc(
     memory_desc_ext &desc, const memory_desc_ext &src_desc,
     batch_normalization_mode mode) {
@@ -2270,6 +2293,7 @@ sycl::event engine_ext::execute_primitive(primitive_type *primitive, args_type *
   return e;
 }
 
+inline
 ::dnnl::memory::desc engine_ext::bn_reorder_memory_to_channel_major_format(
     bool is_input, ::dnnl::memory::desc &desc, void *src, void **cache,
     std::vector<void *> &caches) {
@@ -2285,6 +2309,7 @@ sycl::event engine_ext::execute_primitive(primitive_type *primitive, args_type *
   return result;
 }
 
+inline
 sycl::event engine_ext::batch_normalization_backward_internal(
     batch_normalization_mode mode, float epsilon, float alpha_data,
     const memory_desc_ext &src_desc, void *src,
@@ -2449,6 +2474,7 @@ sycl::event engine_ext::batch_normalization_backward_internal(
   return e;
 }
 
+inline
 sycl::event engine_ext::batch_normalization_forward_internal(
     bool is_infer, batch_normalization_mode mode, float epsilon, float factor,
     float alpha, const memory_desc_ext &src_desc, void *src, float beta,
@@ -2580,6 +2606,7 @@ sycl::event engine_ext::batch_normalization_forward_internal(
   return e;
 }
 
+inline
 sycl::event engine_ext::rnn_forward_internal(
     const rnn_desc &desc, ::dnnl::prop_kind kind,
     const memory_desc_ext &src_desc, void *src, const memory_desc_ext &dst_desc,
@@ -2666,6 +2693,7 @@ sycl::event engine_ext::rnn_forward_internal(
   return e;
 }
 
+inline
 sycl::event engine_ext::execute_rnn_forward_primitive(
     rnn_mode mode, ::dnnl::prop_kind kind, ::dnnl::rnn_direction direction,
     rnn_bias_mode bias_mode, ::dnnl::memory::data_type dt,
@@ -2840,6 +2868,7 @@ sycl::event engine_ext::execute_rnn_forward_primitive(
   return e;
 }
 
+inline
 sycl::event engine_ext::execute_rnn_backward_primitive(
     rnn_mode mode, ::dnnl::rnn_direction direction, rnn_bias_mode bias_mode,
     ::dnnl::memory::data_type dt, ::dnnl::memory::format_tag tag,
@@ -3019,25 +3048,30 @@ engine_ext::create_backward_primitive(args_type &&...args) {
       _eng, std::forward<args_type>(args)...));
 }
 
+inline
 void engine_ext::fill(const memory_desc_ext &src_desc, void *src,
                       const void *valuePtr) {
   async_fill(src_desc, src, valuePtr).wait();
 }
 
+inline
 void engine_ext::reorder(float alpha, const memory_desc_ext &src_desc,
                          void *src, float beta, const memory_desc_ext &dst_desc,
                          void *dst) {
   async_reorder(alpha, src_desc, src, beta, dst_desc, dst).wait();
 }
 
+inline
 void engine_ext::scale(float alpha, const memory_desc_ext &src_desc,
                        void *src) {
   async_scale(alpha, src_desc, src).wait();
 }
+inline
 void engine_ext::sum(float alpha, const memory_desc_ext &src_desc, void *src,
                      float beta, const memory_desc_ext &dst_desc, void *dst) {
   async_sum(alpha, src_desc, src, beta, dst_desc, dst).wait();
 }
+inline
 void engine_ext::activation_forward(activation_desc &desc, float alpha,
                                     const memory_desc_ext &src_desc, void *src,
                                     float beta, const memory_desc_ext &dst_desc,
@@ -3045,6 +3079,7 @@ void engine_ext::activation_forward(activation_desc &desc, float alpha,
   async_activation_forward(desc, alpha, src_desc, src, beta, dst_desc, dst)
       .wait();
 }
+inline
 void engine_ext::activation_backward(
     activation_desc &desc, float alpha, const memory_desc_ext &dst_desc,
     void *dst, const memory_desc_ext &diff_dst_desc, void *diff_dst,
@@ -3054,6 +3089,7 @@ void engine_ext::activation_backward(
                             src_desc, src, beta, diff_src_desc, diff_src)
       .wait();
 }
+inline
 void engine_ext::pooling_forward(pooling_desc &desc, float alpha,
                                  const memory_desc_ext &src_desc, void *src,
                                  float beta, const memory_desc_ext &dst_desc,
@@ -3063,6 +3099,7 @@ void engine_ext::pooling_forward(pooling_desc &desc, float alpha,
                         workspace).wait();
 }
 
+inline
 void engine_ext::pooling_backward(
     pooling_desc &desc, float alpha, const memory_desc_ext &dst_desc, void *dst,
     const memory_desc_ext &diff_dst_desc, void *diff_dst,
@@ -3075,6 +3112,7 @@ void engine_ext::pooling_backward(
       .wait();
 }
 
+inline
 void engine_ext::softmax_forward(softmax_algorithm alg, softmax_mode mode,
                                  float alpha, const memory_desc_ext &src_desc,
                                  void *src, float beta,
@@ -3083,6 +3121,7 @@ void engine_ext::softmax_forward(softmax_algorithm alg, softmax_mode mode,
       .wait();
 }
 
+inline
 void engine_ext::softmax_backward(softmax_algorithm alg, softmax_mode mode,
                                   float alpha, const memory_desc_ext &dst_desc,
                                   void *dst,
@@ -3095,6 +3134,7 @@ void engine_ext::softmax_backward(softmax_algorithm alg, softmax_mode mode,
       .wait();
 }
 
+inline
 void engine_ext::lrn_forward(lrn_desc &desc, float alpha,
                              const memory_desc_ext &src_desc, void *src,
                              float beta, const memory_desc_ext &dst_desc,
@@ -3103,6 +3143,7 @@ void engine_ext::lrn_forward(lrn_desc &desc, float alpha,
       .wait();
 }
 
+inline
 void engine_ext::lrn_backward(lrn_desc &desc, float alpha,
                               const memory_desc_ext &dst_desc, void *dst,
                               const memory_desc_ext &diff_dst_desc,
@@ -3116,6 +3157,7 @@ void engine_ext::lrn_backward(lrn_desc &desc, float alpha,
       .wait();
 }
 
+inline
 sycl::event engine_ext::async_fill(const memory_desc_ext &src_desc, void *src,
                              const void *valuePtr) {
   ::dnnl::memory::data_type dt = src_desc.get_desc().get_data_type();
@@ -3136,6 +3178,7 @@ sycl::event engine_ext::async_fill(const memory_desc_ext &src_desc, void *src,
   }
 }
 
+inline
 sycl::event engine_ext::async_reorder(float alpha, const memory_desc_ext &src_desc,
                                 void *src, float beta,
                                 const memory_desc_ext &dst_desc, void *dst) {
@@ -3152,6 +3195,7 @@ sycl::event engine_ext::async_reorder(float alpha, const memory_desc_ext &src_de
                            {{alpha, beta, DNNL_ARG_DST, dst_desc, dst}});
 }
 
+inline
 sycl::event engine_ext::async_scale(float alpha, const memory_desc_ext &src_desc,
                               void *src) {
   if (alpha == 1.f) {
@@ -3172,6 +3216,7 @@ sycl::event engine_ext::async_scale(float alpha, const memory_desc_ext &src_desc
   return e;
 }
 
+inline
 sycl::event engine_ext::async_sum(float alpha, const memory_desc_ext &src_desc,
                             void *src, float beta,
                             const memory_desc_ext &dst_desc, void *dst) {
@@ -3196,6 +3241,7 @@ sycl::event engine_ext::async_sum(float alpha, const memory_desc_ext &src_desc,
   return e;
 }
 
+inline
 sycl::event engine_ext::async_binary(binary_op op, float alpha_0,
                                const memory_desc_ext &src_desc_0, void *src_0,
                                float alpha_1, const memory_desc_ext &src_desc_1,
@@ -3298,6 +3344,7 @@ sycl::event engine_ext::async_binary(binary_op op, float alpha_0,
   return e;
 }
 
+inline
 sycl::event engine_ext::async_reduction(reduction_op op, float alpha,
                                   const memory_desc_ext &src_desc, void *src,
                                   float beta, const memory_desc_ext &dst_desc,
@@ -3361,6 +3408,7 @@ sycl::event engine_ext::async_reduction(reduction_op op, float alpha,
                            {{alpha, beta, DNNL_ARG_DST, dst_desc, dst}});
 }
 
+inline
 sycl::event engine_ext::async_activation_forward(activation_desc &desc, float alpha,
                                            const memory_desc_ext &src_desc,
                                            void *src, float beta,
@@ -3380,6 +3428,7 @@ sycl::event engine_ext::async_activation_forward(activation_desc &desc, float al
                            {{alpha, beta, DNNL_ARG_DST, dst_desc, dst}});
 }
 
+inline
 sycl::event engine_ext::async_activation_backward(
     activation_desc &desc, float alpha, const memory_desc_ext &dst_desc,
     void *dst, const memory_desc_ext &diff_dst_desc, void *diff_dst,
@@ -3414,6 +3463,7 @@ sycl::event engine_ext::async_activation_backward(
       {{alpha, beta, DNNL_ARG_DIFF_SRC, diff_src_desc, diff_src}});
 }
 
+inline
 sycl::event engine_ext::async_pooling_forward(pooling_desc &desc, float alpha,
                                         const memory_desc_ext &src_desc,
                                         void *src, float beta,
@@ -3445,6 +3495,7 @@ sycl::event engine_ext::async_pooling_forward(pooling_desc &desc, float alpha,
                            {{alpha, beta, DNNL_ARG_DST, dst_desc, dst}});
 }
 
+inline
 sycl::event engine_ext::async_pooling_backward(
     pooling_desc &desc, float alpha, const memory_desc_ext &dst_desc, void *dst,
     const memory_desc_ext &diff_dst_desc, void *diff_dst,
@@ -3482,6 +3533,7 @@ sycl::event engine_ext::async_pooling_backward(
       {{alpha, beta, DNNL_ARG_DIFF_SRC, diff_src_desc, diff_src}});
 }
 
+inline
 sycl::event engine_ext::async_softmax_forward(softmax_algorithm alg,
                                         softmax_mode mode, float alpha,
                                         const memory_desc_ext &src_desc,
@@ -3514,6 +3566,7 @@ sycl::event engine_ext::async_softmax_forward(softmax_algorithm alg,
       {{alpha, beta, DNNL_ARG_DST, memory_desc_ext(help_dst_desc), dst}});
 }
 
+inline
 sycl::event engine_ext::async_softmax_backward(
     softmax_algorithm alg, softmax_mode mode, float alpha,
     const memory_desc_ext &dst_desc, void *dst,
@@ -3553,6 +3606,7 @@ sycl::event engine_ext::async_softmax_backward(
                              memory_desc_ext(help_diff_src_desc), diff_src}});
 }
 
+inline
 sycl::event engine_ext::async_lrn_forward(lrn_desc &desc, float alpha,
                                     const memory_desc_ext &src_desc, void *src,
                                     float beta, const memory_desc_ext &dst_desc,
@@ -3582,6 +3636,7 @@ sycl::event engine_ext::async_lrn_forward(lrn_desc &desc, float alpha,
                            {{alpha, beta, DNNL_ARG_DST, dst_desc, dst}});
 }
 
+inline
 sycl::event
 engine_ext::async_lrn_backward(lrn_desc &desc, float alpha,
                          const memory_desc_ext &dst_desc, void *dst,
@@ -3620,6 +3675,7 @@ engine_ext::async_lrn_backward(lrn_desc &desc, float alpha,
       {{alpha, beta, DNNL_ARG_DIFF_SRC, diff_src_desc, diff_src}});
 }
 
+inline
 size_t engine_ext::get_batch_normalization_workspace_size(
     batch_normalization_ops ops, const memory_desc_ext &src_desc) {
   if(ops == batch_normalization_ops::none) {
@@ -3628,6 +3684,7 @@ size_t engine_ext::get_batch_normalization_workspace_size(
   return src_desc.get_size();
 }
 
+inline
 sycl::event engine_ext::async_batch_normalization_forward_inference(
     batch_normalization_mode mode, float epsilon, float alpha,
     const memory_desc_ext &src_desc, void *src, float beta,
@@ -3641,6 +3698,7 @@ sycl::event engine_ext::async_batch_normalization_forward_inference(
       var, nullptr, nullptr);
 }
 
+inline
 sycl::event engine_ext::async_batch_normalization_forward_inference(
     batch_normalization_mode mode, batch_normalization_ops ops,
     activation_desc &adesc, float epsilon, float alpha,
@@ -3682,6 +3740,7 @@ sycl::event engine_ext::async_batch_normalization_forward_inference(
       scale_bias_desc, scale, bias, mean_var_desc, mean, var, nullptr, nullptr);
 }
 
+inline
 sycl::event engine_ext::async_batch_normalization_forward_training(
     batch_normalization_mode mode, float epsilon, float factor, float alpha,
     const memory_desc_ext &src_desc, void *src, float beta,
@@ -3694,6 +3753,7 @@ sycl::event engine_ext::async_batch_normalization_forward_training(
       saved_mean, saved_var, running_mean, running_var);
 }
 
+inline
 sycl::event engine_ext::async_batch_normalization_forward_training(
     batch_normalization_mode mode, batch_normalization_ops ops,
     activation_desc &adesc, float epsilon, float factor, float alpha,
@@ -3728,6 +3788,7 @@ sycl::event engine_ext::async_batch_normalization_forward_training(
       running_mean, running_var);
 }
 
+inline
 sycl::event engine_ext::async_batch_normalization_forward_training(
     batch_normalization_mode mode, batch_normalization_ops ops,
     activation_desc &adesc, float epsilon, float factor, float alpha,
@@ -3744,6 +3805,7 @@ sycl::event engine_ext::async_batch_normalization_forward_training(
       saved_var, workspace_size, workspace);
 }
 
+inline
 sycl::event engine_ext::async_batch_normalization_backward(
     batch_normalization_mode mode, float epsilon, float alpha_data,
     const memory_desc_ext &src_desc, void *src,
@@ -3760,6 +3822,7 @@ sycl::event engine_ext::async_batch_normalization_backward(
       diff_bias, diff_scale_bias_mean_var_desc, saved_mean, saved_var);
 }
 
+inline
 sycl::event engine_ext::async_batch_normalization_backward(
     batch_normalization_mode mode, batch_normalization_ops ops,
     activation_desc &adesc, float epsilon, float alpha_data,
@@ -3815,6 +3878,7 @@ sycl::event engine_ext::async_batch_normalization_backward(
   return e;
 }
 
+inline
 sycl::event engine_ext::async_batch_normalization_backward(
     batch_normalization_mode mode, batch_normalization_ops ops,
     activation_desc &adesc, float epsilon, float alpha_data,
@@ -3836,6 +3900,7 @@ sycl::event engine_ext::async_batch_normalization_backward(
       workspace_size, workspace);
 }
 
+inline
 sycl::event
 engine_ext::async_convolution_forward(convolution_desc &desc, ::dnnl::algorithm alg,
                                 float alpha, const memory_desc_ext &src_desc,
@@ -3861,6 +3926,7 @@ engine_ext::async_convolution_forward(convolution_desc &desc, ::dnnl::algorithm 
                            {{alpha, beta, DNNL_ARG_DST, dst_desc, dst}});
 }
 
+inline
 sycl::event engine_ext::async_convolution_forward(
     convolution_desc &desc, ::dnnl::algorithm alg, activation_desc &adesc,
     float alpha_0, const memory_desc_ext &src_desc, void *src,
@@ -3903,6 +3969,7 @@ sycl::event engine_ext::async_convolution_forward(
   return async_activation_forward(adesc, 1.f, dst_desc, dst, 0.f, dst_desc, dst);
 }
 
+inline
 sycl::event engine_ext::async_convolution_backward_data(
     convolution_desc &desc, ::dnnl::algorithm alg, float alpha,
     const memory_desc_ext &weight_desc, void *weight,
@@ -3937,6 +4004,7 @@ sycl::event engine_ext::async_convolution_backward_data(
       {{alpha, beta, DNNL_ARG_DIFF_SRC, diff_src_desc, diff_src}});
 }
 
+inline
 sycl::event engine_ext::async_convolution_backward_weight(
     convolution_desc &desc, ::dnnl::algorithm alg, float alpha,
     const memory_desc_ext &src_desc, void *src,
@@ -3973,6 +4041,7 @@ sycl::event engine_ext::async_convolution_backward_weight(
                              help_diff_weight_desc, diff_weight}});
 }
 
+inline
 sycl::event engine_ext::async_convolution_backward_bias(
     float alpha, const memory_desc_ext &diff_dst_desc, void *diff_dst,
     float beta, const memory_desc_ext &diff_bias_desc, void *diff_bias) {
@@ -3980,6 +4049,7 @@ sycl::event engine_ext::async_convolution_backward_bias(
                    diff_bias_desc, diff_bias);
 }
 
+inline
 void engine_ext::rnn_get_weight_space_size(const rnn_desc &desc,
                                            size_t *weight_space_size) {
   *weight_space_size = 0;
@@ -3991,6 +4061,7 @@ void engine_ext::rnn_get_weight_space_size(const rnn_desc &desc,
   return;
 }
 
+inline
 void engine_ext::rnn_get_scratchpad_workspace_size(
     const rnn_desc &desc, ::dnnl::prop_kind kind,
     const memory_desc_ext &src_desc, size_t *scratchpad_size,
@@ -4005,6 +4076,7 @@ void engine_ext::rnn_get_scratchpad_workspace_size(
   return;
 }
 
+inline
 sycl::event engine_ext::async_rnn_forward(
     const rnn_desc &desc, ::dnnl::prop_kind kind,
     const memory_desc_ext &src_desc, void *src, const memory_desc_ext &dst_desc,
@@ -4020,6 +4092,7 @@ sycl::event engine_ext::async_rnn_forward(
       nullptr);
 }
 
+inline
 sycl::event engine_ext::async_rnn_backward(
     const rnn_desc &desc, const memory_desc_ext &dst_desc, void *dst,
     void *diff_dst, const memory_desc_ext &src_desc, void *src, void *diff_src,


### PR DESCRIPTION
Make DNNL header functions inline so that programs with two files that include dnnl_utils.hpp will not have multiple definitions of 
the header functions.

Signed-off-by: Lu, John <john.lu@intel.com>