### PR TITLE
[SYCLomatic] Migrate cudnnGetErrorString

### DIFF
--- a/clang/lib/DPCT/APINamesErrorHandling.inc
+++ b/clang/lib/DPCT/APINamesErrorHandling.inc
@@ -7,6 +7,14 @@
 //===----------------------------------------------------------------------===//
 
 WARNING_FACTORY_ENTRY(
+    "cudnnGetErrorString",
+    INSERT_AROUND_FACTORY(CALL_FACTORY_ENTRY("cudnnGetErrorString",
+                                             CALL("cudnnGetErrorString",
+                                                  ARG_WC(0))),
+                          "\"cudnnGetErrorString is not supported\"/*", "*/"),
+    Diagnostics::TRNA_WARNING_ERROR_HANDLING_API_COMMENTED)
+
+WARNING_FACTORY_ENTRY(
     "cudaGetErrorString",
     INSERT_AROUND_FACTORY(CALL_FACTORY_ENTRY("cudaGetErrorString",
                                              CALL("cudaGetErrorString",

--- a/clang/lib/DPCT/APINames_cuDNN.inc
+++ b/clang/lib/DPCT/APINames_cuDNN.inc
@@ -75,7 +75,7 @@ ENTRY(cudnnGetAlgorithmSpaceSize, cudnnGetAlgorithmSpaceSize, false, NO_FLAG, P4
 ENTRY(cudnnGetCallback, cudnnGetCallback, false, NO_FLAG, P4, "comment")
 ENTRY(cudnnGetCudartVersion, cudnnGetCudartVersion, false, NO_FLAG, P4, "comment")
 ENTRY(cudnnGetDropoutDescriptor, cudnnGetDropoutDescriptor, false, NO_FLAG, P4, "comment")
-ENTRY(cudnnGetErrorString, cudnnGetErrorString, false, NO_FLAG, P4, "comment")
+ENTRY(cudnnGetErrorString, cudnnGetErrorString, true, NO_FLAG, P4, "Successful")
 ENTRY(cudnnGetFilter4dDescriptor, cudnnGetFilter4dDescriptor, true, NO_FLAG, P4, "comment")
 ENTRY(cudnnGetFilterNdDescriptor, cudnnGetFilterNdDescriptor, true, NO_FLAG, P4, "comment")
 ENTRY(cudnnGetFilterSizeInBytes, cudnnGetFilterSizeInBytes, true, NO_FLAG, P4, "comment")

--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -7480,7 +7480,7 @@ void FunctionCallRule::registerMatcher(MatchFinder &MF) {
         "cudaDeviceGetAttribute", "cudaDeviceGetP2PAttribute",
         "cudaDeviceGetPCIBusId", "cudaGetDevice", "cudaDeviceSetLimit",
         "cudaGetLastError", "cudaPeekAtLastError", "cudaDeviceSynchronize",
-        "cudaThreadSynchronize", "cudaGetErrorString", "cudaGetErrorName",
+        "cudaThreadSynchronize", "cudnnGetErrorString", "cudaGetErrorString", "cudaGetErrorName",
         "cudaDeviceSetCacheConfig", "cudaDeviceGetCacheConfig", "clock",
         "cudaOccupancyMaxPotentialBlockSize", "cudaThreadSetLimit",
         "cudaFuncSetCacheConfig", "cudaThreadExit", "cudaDeviceGetLimit",

--- a/clang/test/dpct/cudnn-get-error-string.cu
+++ b/clang/test/dpct/cudnn-get-error-string.cu
@@ -1,0 +1,51 @@
+// RUN: dpct --format-range=none -out-root %T/cudnn-get-error-string %s --cuda-include-path="%cuda-path/include" -- -std=c++14 -x cuda --cuda-host-only
+// RUN: FileCheck %s --match-full-lines --input-file %T/cudnn-get-error-string/cudnn-get-error-string.dp.cpp
+
+#include <cudnn.h>
+
+int printf(const char *format, ...);
+
+// CHECK: /*
+// CHECK-NEXT: DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
+// CHECK-NEXT: */
+// CHECK-NEXT: #define PRINT_ERROR_STR(X) printf("%s\n", "cudnnGetErrorString is not supported"/*cudnnGetErrorString(X)*/)
+#define PRINT_ERROR_STR(X) printf("%s\n", cudnnGetErrorString(X))
+
+// CHECK:  /*
+// CHECK-NEXT:  DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
+// CHECK-NEXT:  */
+// CHECK-NEXT: #define PRINT_ERROR_STR2(X)\
+// CHECK-NEXT:  printf("%s\n", "cudnnGetErrorString is not supported"/*cudnnGetErrorString(X)*/)
+#define PRINT_ERROR_STR2(X)\
+  printf("%s\n", cudnnGetErrorString(X))
+
+// CHECK: /*
+// CHECK-NEXT: DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
+// CHECK-NEXT: */
+// CHECK-NEXT: #define PRINT_ERROR_STR3(X)\
+// CHECK-NEXT:   printf("%s\
+// CHECK-NEXT:          \n", "cudnnGetErrorString is not supported"/*cudnnGetErrorString(X)*/)
+#define PRINT_ERROR_STR3(X)\
+  printf("%s\
+         \n", cudnnGetErrorString(X))
+
+
+const char *test_function(cudnnStatus_t status) {
+
+//CHECK:/*
+//CHECK-NEXT:DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
+//CHECK-NEXT:*/
+//CHECK-NEXT:  printf("%s\n", "cudnnGetErrorString is not supported"/*cudnnGetErrorString(status)*/);
+  printf("%s\n", cudnnGetErrorString(status));
+
+//CHECK:/*
+//CHECK-NEXT:DPCT1009:{{[0-9]+}}: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.
+//CHECK-NEXT:*/
+//CHECK-NEXT:  printf("%s\n", "cudnnGetErrorString is not supported"/*cudnnGetErrorString(CUDNN_STATUS_SUCCESS)*/);
+  printf("%s\n", cudnnGetErrorString(CUDNN_STATUS_SUCCESS));
+
+  PRINT_ERROR_STR(status);
+  PRINT_ERROR_STR2(status);
+  PRINT_ERROR_STR3(status);  
+}
+


### PR DESCRIPTION
Migrate cudnnGetErrorString.  Based on cudaGetErrorString.

Signed-off-by: Lu, John <john.lu@intel.com>