### PR TITLE
[SYCLomatic] null_type

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/functional.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/functional.h.inc
@@ -56,6 +56,12 @@
 
 namespace dpct {
 
+// DPCT_LABEL_BEGIN|null_type|dpct
+// DPCT_DEPENDENCY_EMPTY
+// DPCT_CODE
+struct null_type {};
+// DPCT_LABEL_END
+
 namespace internal {
 
 // DPCT_LABEL_BEGIN|enable_if_execution_policy|dpct::internal

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/functional.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/functional.h
@@ -22,6 +22,8 @@
 
 namespace dpct {
 
+struct null_type {};
+
 namespace internal {
 
 template <class _ExecPolicy, class _T>


### PR DESCRIPTION
Implementation for dpct::null_type for to indicate the lack of argument.