### PR TITLE
[SYCLomatic] Fix the migration of CUFFT_FORWARD and CUFFT_INVERSE

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -390,18 +390,18 @@ void IncludesCallbacks::MacroExpands(const Token &MacroNameTok,
     auto Repl = std::make_shared<ReplaceText>(Range.getBegin(), 13,
                                               "DPCT_COMPATIBILITY_TEMP");
     ReplMap.insert(Repl->getReplacement(DpctGlobalInfo::getContext()));
-  } else if (MacroNameTok.getIdentifierInfo() &&
+  }
+  // CUFFT_FORWARD and CUFFT_INVERSE are migrated to integer literal in all
+  // places except in cufftExec call.
+  // CUFFT_FORWARD and CUFFT_INVERSE in cufftExec call are migrated with
+  // FFTDirExpr and longer replacement will overlap shorter replacement, so the
+  // migration is expected.
+  else if (MacroNameTok.getIdentifierInfo() &&
              MacroNameTok.getIdentifierInfo()->getName() == "CUFFT_FORWARD") {
-    TransformSet.emplace_back(new ReplaceText(Range.getBegin(), 13,
-                                              MapNames::getDpctNamespace() +
-                                                  "fft::fft_direction::forward"));
-    requestFeature(HelperFeatureEnum::FftUtils_fft_direction, Range.getBegin());
+    TransformSet.emplace_back(new ReplaceText(Range.getBegin(), 13, "-1"));
   } else if (MacroNameTok.getIdentifierInfo() &&
              MacroNameTok.getIdentifierInfo()->getName() == "CUFFT_INVERSE") {
-    TransformSet.emplace_back(new ReplaceText(Range.getBegin(), 13,
-                                              MapNames::getDpctNamespace() +
-                                                  "fft::fft_direction::backward"));
-    requestFeature(HelperFeatureEnum::FftUtils_fft_direction, Range.getBegin());
+    TransformSet.emplace_back(new ReplaceText(Range.getBegin(), 13, "1"));
   }
 
   // For the un-specialized struct, there is no AST for the extern function

--- a/clang/lib/DPCT/CallExprRewriterCUFFT.cpp
+++ b/clang/lib/DPCT/CallExprRewriterCUFFT.cpp
@@ -18,6 +18,9 @@ class FFTDirExpr {
 public:
   const Expr *E = nullptr;
 
+  // For CUFFT_FORWARD and CUFFT_INVERSE in cufftExec call, they will be
+  // migrated to dpct::fft::fft_direction::forward/backward
+  // In other locations, they will be migrated to integer literal.
   template <class StreamT> void print(StreamT &Stream) const {
     requestFeature(HelperFeatureEnum::FftUtils_fft_engine, E);
     Expr::EvalResult ER;

--- a/clang/lib/DPCT/ExprAnalysis.h
+++ b/clang/lib/DPCT/ExprAnalysis.h
@@ -632,7 +632,6 @@ protected:
   void analyzeExpr(const IfStmt *IS);
   void analyzeExpr(const DeclStmt *DS);
   void analyzeExpr(const ConstantExpr *CE);
-  void analyzeExpr(const IntegerLiteral *IL);
   void analyzeExpr(const InitListExpr *ILE);
 
   void removeCUDADeviceAttr(const LambdaExpr *LE);

--- a/clang/test/dpct/cufft-others.cu
+++ b/clang/test/dpct/cufft-others.cu
@@ -69,7 +69,8 @@ int foo3(cudaStream_t stream) {
   return 0;
 }
 
-void foo4() {
+void foo4(double x) {
+  //CHECK:const int dir = -1;
   const int dir = CUFFT_FORWARD;
   cufftHandle plan;
   float2* iodata;
@@ -78,9 +79,11 @@ void foo4() {
   //CHECK-NEXT:plan->compute<sycl::float2, sycl::float2>(iodata, iodata, dpct::fft::fft_direction::backward);
   cufftExecC2C(plan, iodata, iodata, dir);
   cufftExecC2C(plan, iodata, iodata, -dir);
+  const double base = dir * 3.1415926 / x;
 }
 
-void foo5() {
+void foo5(double x) {
+  //CHECK:int dir = -1;
   int dir = CUFFT_FORWARD;
   cufftHandle plan;
   float2* iodata;
@@ -89,4 +92,5 @@ void foo5() {
   //CHECK-NEXT:plan->compute<sycl::float2, sycl::float2>(iodata, iodata, -dir == 1 ? dpct::fft::fft_direction::backward : dpct::fft::fft_direction::forward);
   cufftExecC2C(plan, iodata, iodata, dir);
   cufftExecC2C(plan, iodata, iodata, -dir);
+  const double base = dir * 3.1415926 / x;
 }

--- a/clang/test/dpct/cufft-type.cu
+++ b/clang/test/dpct/cufft-type.cu
@@ -32,8 +32,8 @@ int main() {
   size = sizeof(cuComplex);
   size = sizeof(cuDoubleComplex);
 
-  //CHECK:int forward = dpct::fft::fft_direction::forward;
-  //CHECK-NEXT:int inverse = dpct::fft::fft_direction::backward;
+  //CHECK:int forward = -1;
+  //CHECK-NEXT:int inverse = 1;
   int forward = CUFFT_FORWARD;
   int inverse = CUFFT_INVERSE;
 

--- a/clang/test/dpct/test_api_level/FftUtils/api_test1.cu
+++ b/clang/test/dpct/test_api_level/FftUtils/api_test1.cu
@@ -4,7 +4,7 @@
 // RUN: FileCheck --input-file %T/FftUtils/api_test1_out/api_test1.dp.cpp --match-full-lines %s -check-prefix=CODE
 // RUN: rm -rf %T/FftUtils/api_test1_out
 
-// FEATURE_NUMBER: 2
+// FEATURE_NUMBER: 23
 // TEST_FEATURE: FftUtils_fft_direction
 // TEST_FEATURE: FftUtils_non_local_include_dependency
 
@@ -19,6 +19,10 @@
 // BBB
 
 int main() {
-  int a = CUFFT_FORWARD;
+  cufftHandle plan;
+  float2* odata;
+  float2* idata;
+  cufftPlan1d(&plan, 10, CUFFT_C2C, 3);
+  cufftExecC2C(plan, idata, odata, CUFFT_FORWARD);
   return 0;
 }


### PR DESCRIPTION
Only migrate CUFFT_{FORWARD|CUFFT_INVERSE} to fft_direction::{for|back}ward in cufftExec function call.
In other locations, they will be migrated to integer literal.

Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>