### PR TITLE
[SYCLomatic] cuda/std/array requires CUDA 11.7+

### DIFF
--- a/clang/test/dpct/LibCU/libcu_array.cu
+++ b/clang/test/dpct/LibCU/libcu_array.cu
@@ -1,5 +1,5 @@
 // UNSUPPORTED: v7.0, v7.5, v8.0, v9.0, v9.2, v10.0, v10.1, v10.2, v11.0, v11.1
-// UNSUPPORTED: cuda-7.0, cuda-7.5, cuda-8.0, cuda-9.0, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.1
+// UNSUPPORTED: cuda-7.0, cuda-7.5, cuda-8.0, cuda-9.0, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.1, cuda-11.2, cuda-11.3, cuda-11.4, cuda-11.5, cuda-11.6
 // RUN: dpct --format-range=none -in-root %S -out-root %T/Libcu %S/libcu_array.cu --cuda-include-path="%cuda-path/include" -- -std=c++14 -x cuda --cuda-host-only
 // RUN: FileCheck --input-file %T/Libcu/libcu_array.dp.cpp --match-full-lines %s
 


### PR DESCRIPTION
Disable libcuarray.cu test if CUDA version does not support cuda/std/array.
cuda/std/array was added in CUDA 11.7.

Signed-off-by: Lu, John <john.lu@intel.com>