### PR TITLE
[SYCLomatic] Fix replace_if/replace_copy_if for corner case

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -91,7 +91,7 @@ Iter3 replace_copy_if(Policy &&policy, Iter1 first, Iter1 last, Iter2 mask,
                        std::random_access_iterator_tag>::value,
       "Iterators passed to algorithms must be random-access iterators.");
   return std::transform(std::forward<Policy>(policy), first, last, mask, result,
-                        internal::replace_if_fun<typename std::iterator_traits<Iter1>::value_type, Pred>(p, new_value));
+                        internal::replace_if_fun<typename std::iterator_traits<Iter3>::value_type, Pred>(p, new_value));
 }
 // DPCT_LABEL_END
 

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -91,7 +91,7 @@ Iter3 replace_copy_if(Policy &&policy, Iter1 first, Iter1 last, Iter2 mask,
                        std::random_access_iterator_tag>::value,
       "Iterators passed to algorithms must be random-access iterators.");
   return std::transform(std::forward<Policy>(policy), first, last, mask, result,
-                        internal::replace_if_fun<T, Pred>(p, new_value));
+                        internal::replace_if_fun<typename std::iterator_traits<Iter1>::value_type, Pred>(p, new_value));
 }
 // DPCT_LABEL_END
 

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -69,7 +69,7 @@ void replace_if(Policy &&policy, Iter1 first, Iter1 last, Iter2 mask, Pred p,
                        std::random_access_iterator_tag>::value,
       "Iterators passed to algorithms must be random-access iterators.");
   std::transform(std::forward<Policy>(policy), first, last, mask, first,
-                 internal::replace_if_fun<T, Pred>(p, new_value));
+                 internal::replace_if_fun<typename std::iterator_traits<Iter1>::value_type, Pred>(p, new_value));
 }
 // DPCT_LABEL_END
 

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -46,7 +46,7 @@ Iter3 replace_copy_if(Policy &&policy, Iter1 first, Iter1 last, Iter2 mask,
                        std::random_access_iterator_tag>::value,
       "Iterators passed to algorithms must be random-access iterators.");
   return std::transform(std::forward<Policy>(policy), first, last, mask, result,
-                        internal::replace_if_fun<typename std::iterator_traits<Iter1>::value_type, Pred>(p, new_value));
+                        internal::replace_if_fun<typename std::iterator_traits<Iter3>::value_type, Pred>(p, new_value));
 }
 
 template <typename Policy, typename Iter1, typename Iter2, typename Pred>

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -46,7 +46,7 @@ Iter3 replace_copy_if(Policy &&policy, Iter1 first, Iter1 last, Iter2 mask,
                        std::random_access_iterator_tag>::value,
       "Iterators passed to algorithms must be random-access iterators.");
   return std::transform(std::forward<Policy>(policy), first, last, mask, result,
-                        internal::replace_if_fun<T, Pred>(p, new_value));
+                        internal::replace_if_fun<typename std::iterator_traits<Iter1>::value_type, Pred>(p, new_value));
 }
 
 template <typename Policy, typename Iter1, typename Iter2, typename Pred>

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -30,7 +30,7 @@ void replace_if(Policy &&policy, Iter1 first, Iter1 last, Iter2 mask, Pred p,
                        std::random_access_iterator_tag>::value,
       "Iterators passed to algorithms must be random-access iterators.");
   std::transform(std::forward<Policy>(policy), first, last, mask, first,
-                 internal::replace_if_fun<T, Pred>(p, new_value));
+                 internal::replace_if_fun<typename std::iterator_traits<Iter1>::value_type, Pred>(p, new_value));
 }
 
 template <typename Policy, typename Iter1, typename Iter2, typename Iter3,


### PR DESCRIPTION
replace_if/replace_copy_if must be done based on type of iterator value, not on type of new value.

Signed-off-by: Lu, John <john.lu@intel.com>