### PR TITLE
[DOC] Update instructions for samples in docs

### DIFF
--- a/docs/_include_files/samples.rst
+++ b/docs/_include_files/samples.rst
@@ -1,0 +1,30 @@
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   *  -  Sample Project
+      -  Description
+   *  -  Vector Add
+
+         +  ``vector_add.cu``
+      -  The Vector Add sample demonstrates how to migrate a simple program
+         from CUDA\* to SYCL. Vector Add provides an easy way to verify that your
+         development environment is setup correctly to use |tool_name|.
+   *  -  Folder Options 
+
+         +  ``main.cu``
+         +  ``bar/util.cu``
+         +  ``bar/util.h``
+      -  The Folder Options sample shows how to migrate more complex projects
+         and to use options.
+   *  -  Rodinia needleman-wunsch
+
+         +  ``needle.cu``
+         +  ``needle.h``
+         +  ``needle_kernel.cu``
+      -  The Rodinia needleman-wunsch sample demonstrates how to migrate a Make/CMake\*
+         project from CUDA to SYCL.
+
+Review the README file provided with each sample for more detailed information
+about the purpose and usage of the sample project.
+

--- a/docs/dev_guide/migrate-a-project/before-you-begin.rst
+++ b/docs/dev_guide/migrate-a-project/before-you-begin.rst
@@ -6,43 +6,12 @@ Before You Begin
 Samples
 -------
 
-|tool_name| comes with several sample projects so you can explore
-the tool and familiarize yourself with how it functions.
-
-.. include:: /_include_files/wip.rst
-
-.. list-table::
-   :widths: 30 70
-   :header-rows: 1
-
-   * - Sample Project
-     - Description
-   * - Vector Add DPCT
-
-       - ``vector_add.cu``
-     - The Vector Add DPCT sample demonstrates how to migrate a simple program
-       from CUDA\* to |dpcpp_long|. Vector Add provides an easy way to verify
-       that your development environment is setup correctly to use |tool_name|.
-   * - Folder Options DPCT
-
-       - ``main.cu``
-       - ``bar/util.cu``
-       - ``bar/util.h``
-     - The Folder Options DPCT sample provides an example of how to migrate more
-       complex projects and use ``dpct`` options.
-   * - Rodinia NW DPCT
-
-       - ``needle.cu``
-       - ``needle.h``
-       - ``needle_kernel.cu``
-     - The Rodinia NW DPCT project demonstrates how to migrate a Make/CMake\*
-       project from CUDA to |dpcpp_long| using |tool_name|.
-
-Review the README file provided with each sample for more detailed information
-on the purpose and usage of the sample project.
+Several sample projects for |tool_name| are available to explore the tool and
+familiarize yourself with how it functions.
 
 .. include:: /_include_files/access_samples.rst
 
+.. include:: /_include_files/samples.rst
 
 .. _emitted-warnings:
 

--- a/docs/dev_guide/migrate-a-project/incremental-migration.rst
+++ b/docs/dev_guide/migrate-a-project/incremental-migration.rst
@@ -30,10 +30,10 @@ contains conditional compilation code. Content of ``sample1.cu``:
 	... code path 3 ...
 	#endif
 
-Incrementally migrate ``sample1.cu`` by executing the ``dpct`` command
-in the same working directory as the file:
+Use the following steps to incrementally migrate ``sample1.cu``.
 
-#. Generate ``sample1.dp.cpp``, which contains migrated code for code path 1:
+#. Generate ``sample1.dp.cpp``, which contains migrated code for code path 1.
+   From the same working directory as the file, run:
 
    .. code-block:: none
 
@@ -89,11 +89,12 @@ Content of source file ``sample3.cu``:
 
 	#include “sample_inc.h”
 
-Incrementally migrate the files by executing the ``dpct`` command in the same
-working directory as the files:
+Use the following steps to incrementally migrate the files.
 
 #. Generate ``sample2.dp.cpp`` and ``sample_inc.h``, which contains migrated
-   code for code path 1:
+   code for code path 1.
+
+   From the same working directory as the file, run:
 
    .. code-block:: none
       :linenos:

--- a/docs/dev_guide/migrate-a-project/migrate-a-project-on-linux.rst
+++ b/docs/dev_guide/migrate-a-project/migrate-a-project-on-linux.rst
@@ -6,7 +6,7 @@ Use the Command Line
 
 You can invoke |tool_name| at the command line.
 
-Use the ``dpct`` tool's ``--in-root`` option to specify the location of the
+Use the tool's ``--in-root`` option to specify the location of the
 source that should be migrated:
 
 * Any source within the ``--in-root`` directory (at any nesting
@@ -20,19 +20,16 @@ source that should be migrated:
 * If the ``--in-root`` option is not specified, the directory of the first input
   source file is implied.
 
-Use the ``dpct`` tool's ``--out-root`` option to specify the directory where the
+Use the tool's ``--out-root`` option to specify the directory where the
 SYCL code produced by |tool_name| is written:
 
 * Relative paths of the migrated files are maintained.
 * Extensions are changed to ``.dp.cpp``.
 * If the ``--out-root`` option is not specified, ``./dpct_output`` is implied.
 
-The following steps show migration of the Folder Options sample using the
-``dpct`` tool:
+The following steps show how to migrate the Folder Options sample using |tool_name|:
 
-.. include:: /_include_files/wip.rst
-
-#. Open the Folder Options sample:
+#. Get the Folder Options sample:
 
    .. include:: /_include_files/open_sample_dgr.rst
 
@@ -40,22 +37,34 @@ The following steps show migration of the Folder Options sample using the
 
    The Folder Options sample project contains a simple CUDA\* program with three
    files (``main.cu``, ``util.cu``, and ``util.h``) located in two folders
-   (``foo`` and ``bar``).
+   (``foo`` and ``bar``):
 
-#. From the parent folder of the unzipped foo folder, run |tool_name|:
+   .. code-block:: none
+
+      foo
+      ├── bar
+      │   ├── util.cu
+      │   └── util.h
+      └── main.cu
+
+#. From the root folder of the sample project, run |tool_name|:
 
    .. code-block:: none
 
       dpct --in-root=foo --out-root=result/foo foo/main.cu foo/bar/util.cu --extra-arg="-Ifoo/bar/"
 
-   Use the ``--in-root`` option to specify the location of the CUDA
-   files that need migration. Use the ``--out-root`` option to specify the
-   location for the migrated files.
-#. As a result, you should see the following files:
+   The ``--in-root`` option specifies the location of the CUDA
+   files that need migration. The ``--out-root`` option specifies the location for the migrated files.
+#. As a result of the migration command, you should see the following files:
 
-   * ``./result/foo/main.dp.cpp``
-   * ``./result/foo/bar/util.dp.cpp``
-   * ``./result/foo/bar/util.h``
+   .. code-block:: none
+
+      result/foo
+           ├── bar
+           │   ├── util.dp.cpp
+           │   └── util.h
+           └── main.dp.cpp
+
 #. Inspect the migrated source code, address any generated DPCT warnings, and
    verify correctness of the new program.
 
@@ -88,12 +97,12 @@ command lines for files with the following extensions: ``.c``, ``.C``, ``.cc``,
 |tool_name| parses the compilation database and applies the necessary
 options when migrating the input sources.
 
-This example uses the Rodinia NW DPCT sample to demonstrate the use of a
+This example uses the Rodinia needleman-wunsch sample to demonstrate the use of a
 compilation database.
 
 **Step 1: Create the Compilation Database**
 
-#. Open the Rodinia NW DPCT sample:
+#. Get the Rodinia needleman-wunsch sample:
 
    .. include:: /_include_files/open_sample_dgr.rst
 
@@ -101,21 +110,18 @@ compilation database.
    your Makefile out of ``CMakeLists.txt``. An example of a typical command is
    ``cmake ...``.
 
-#. Clean the application:
+#. Invoke the build command, prepending it with ``intercept-build``.
 
    .. code-block:: none
 
-      make clean
+      $ make clean
+      $ intercept-build make
 
-#. Invoke the build command, prepending it with ``intercept-build``:
-
-   .. code-block:: none
-
-      intercept-build make
+   This creates the file ``compile_commands.json`` in the working directory.
 
    The ``intercept-build`` script runs your project's build command without building
    the original program. It records all the compiler invocations and stores the
-   names of the input files and the compiler options in the compilation database file:
+   names of the input files and the compiler options in the compilation database file
    ``compile_commands.json``.
 
    .. note::
@@ -141,32 +147,33 @@ compilation database.
 
 By default, |tool_name| looks for the ``compile_commands.json`` file
 in the current directory and uses the compiler options from it for each input file.
-The location of the compilation database file can be changed using the ``-p``
-option.
 
-For example, the following command  will migrate ``some_file.cu`` if the
-information about it can be found in ``compiler_commands.json``,  located at
-``<some_path>``.
+Use the following command to migrate the CUDA code in the Rodinia needleman-wunsch
+sample, using the compilation database generated in the previous step:
 
 .. code-block:: none
 
-   dpct -p=some_path --in-root=../.. --out-root=dpct_output some_file.cu
+   dpct -p=compile_commands.json --in-root=. --out-root=migration
 
+The ``--in-root`` option sets the root location of the CUDA files that need
+migration. Only files and folders located within the ``--in-root`` directory will
+be considered for migration by the tool.
 
-To migrate all relevant files recorded inside the compilation database, use
-a command similar to:
+The ``--out-root`` option specifies the location for the migrated files.
+The new project will be created in the migration directory.
+
+The ``-p`` option specifies the path for the compilation database.
+
+After running the migration command, you should see the following files in the
+``migration`` output folder:
 
 .. code-block:: none
 
-   dpct -p compile_commands.json --in-root=. --out-root=migration
-
-If you run the command above with the Rodinia NW DPCT sample, you
-should see the following files in the ``migration`` out folder:
-
--  ``needle.h``
--  ``needle_kernel.dp.cpp``
--  ``needle.dp.cpp``
-
+   migration
+   └── src
+       ├── needle.h
+       ├── needle_kernel.dp.cpp
+       └── needle.dp.cpp
 
 **Step 3: Verify the Source for Correctness and Fix Anything the Tool was Unable
 to Migrate**

--- a/docs/dev_guide/migrate-a-project/migrate-a-project-on-windows.rst
+++ b/docs/dev_guide/migrate-a-project/migrate-a-project-on-windows.rst
@@ -11,16 +11,16 @@ If your project uses Microsoft Visual Studio\*, you can use the
 migration. |tool_name| will migrate the files you
 provided as input files.
 
-For example, the following steps show migration of the Vector Add sample using
-the ``dpct`` tool:
+The following steps show how to migrate the Vector Add sample using |tool_name|:
 
-.. include:: /_include_files/wip.rst
-
-#. Open the Vector Add sample:
+#. Get the Vector Add sample:
 
    .. include:: /_include_files/open_sample_dgr.rst
 
-#. Navigate to the root of the Vector Add sample project.
+#. Navigate to the root of the Vector Add sample.
+
+   The sample contains a single
+   CUDA file, ``vector_add.cu``, located in the ``src`` folder.
 
 #. From the root folder of the sample project, run |tool_name|.
 

--- a/docs/get_started/index.rst
+++ b/docs/get_started/index.rst
@@ -96,73 +96,63 @@ in the output. For example:
 Migrate a Simple Test Project
 -----------------------------
 
-|tool_name| comes with several sample projects so you can explore
-the tool and familiarize yourself with how it functions.
-
-.. include:: /_include_files/wip.rst
-
-.. list-table::
-   :widths: 30 70
-   :header-rows: 1
-
-   *  -  Sample Project
-      -  Description
-   *  -  Vector Add DPCT
-
-         +  ``vector_add.cu``
-      -  The Vector Add DPCT sample demonstrates how to migrate a simple program
-         from CUDA to SYCL. Vector Add provides an easy way to verify that your
-         development environment is setup correctly to use |tool_name|.
-   *  -  Folder Options DPCT
-
-         +  ``main.cu``
-         +  ``bar/util.cu``
-         +  ``bar/util.h``
-      -  The Folder Options DPCT sample shows how to migrate more complex projects
-         and to use options.
-   *  -  Rodinia NW DPCT
-
-         +  ``needle.cu``
-         +  ``needle.h``
-         +  ``needle_kernel.cu``
-      -  The Rodinia NW DPCT sample demonstrates how to migrate a Make/CMake
-         project from CUDA to SYCL using |tool_name|.
-
-Review the README file provided with each sample for more detailed information
-about the purpose and usage of the sample project.
+Several sample projects for |tool_name| are available to explore the tool and
+familiarize yourself with how it functions.
 
 .. include:: /_include_files/access_samples.rst
+
+.. include:: /_include_files/samples.rst
+
+
+
+
 
 
 Try a Sample Project
 ~~~~~~~~~~~~~~~~~~~~
 
-Follow these steps to migrate the Vector Add DPCT sample project using
-|tool_name|:
+The following steps show how to migrate the Vector Add sample using |tool_name|:
 
-#. Download the ``vector_add.cu`` sample.
+#. Download the `Vector Add sample <https://github.com/oneapi-src/oneAPI-samples/tree/master/Tools/Migration/vector-add-dpct>`_.
 
-#. Run |tool_name| from the sample root directory:
+#. Navigate to the root of the Vector Add sample. The sample contains a single
+   CUDA file, ``vector_add.cu``, located in the ``src`` folder.
+
+
+#. From the root folder of the sample project, run |tool_name|:
 
    .. code-block::
 
       dpct --in-root=. src/vector_add.cu
 
-   The ``vector_add.dp.cpp`` file should appear in the ``dpct_output``
-   directory. The file is now a SYCL source file.
+   The ``--in-root`` option specifies the location of the CUDA file that needs
+   migration. By default, the migrated files are created in a new folder named
+   ``dpct_output``.
+
+#. As a result of the migration command, you should see the new SYCL source file
+   in the output folder:
+
+   .. code-block::
+
+      dpct_output
+      └── src
+          └── vector_add.dp.cpp
+
+   The relative paths of the migrated files are maintained.
 
 #. Navigate to the new SYCL source file:
 
    .. code-block::
 
-      cd dpct_output
+      cd dpct_output/src
 
-   Verify the generated source code and fix any code that |tool_name|
+   Verify the migrated source code and fix any code that |tool_name|
    was unable to migrate. (The code used in this example is simple, so manual
-   changes may not be needed). For the most accurate and detailed instructions
-   on addressing warnings emitted from |tool_name|, see the
-   **Addressing Warnings in Migrated Code** section of the
-   `README files <https://github.com/oneapi-src/oneAPI-samples/tree/master/Tools/Migration>`_.
+   changes may not be needed).
+
+   For the most accurate and detailed instructions on addressing warnings emitted
+   from |tool_name|, see the **Addressing Warnings in Migrated Code** section of
+   the `README files <https://github.com/oneapi-src/oneAPI-samples/tree/master/Tools/Migration>`_.
 
    .. note::
 


### PR DESCRIPTION
- Update sample steps to be more accurate/clear (make consistent across all steps)
- Improve/standardize wording guiding user to sample repo
- Reducing wording using tool cmd as reference to tool
- Remove notice re samples untested with SYCLomatic

Signed-off-by: Kristal Dale <kristal.dale@intel.com>