### PR TITLE
[NFC][SYCLomatic] Use std::optional instead of llvm::Optional

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -126,7 +126,7 @@ int IncludesCallbacks::findPoundSign(SourceLocation DirectiveStart) {
   if (CharDataInvalid || !Entry.isFile()) {
     return -1;
   }
-  llvm::Optional<llvm::MemoryBufferRef> Buffer =
+  std::optional<llvm::MemoryBufferRef> Buffer =
       Entry.getFile().getContentCache().getBufferOrNone(
           SM.getDiagnostics(), SM.getFileManager(), SourceLocation());
   if (!Buffer.has_value())
@@ -7350,7 +7350,7 @@ void SOLVERFunctionCallRule::runRule(const MatchFinder::MatchResult &Result) {
 void SOLVERFunctionCallRule::getParameterEnd(
     const SourceLocation &ParameterEnd, SourceLocation &ParameterEndAfterComma,
     const ast_matchers::MatchFinder::MatchResult &Result) {
-  Optional<Token> TokSharedPtr;
+  std::optional<Token> TokSharedPtr;
   TokSharedPtr = Lexer::findNextToken(ParameterEnd, *(Result.SourceManager),
                                       LangOptions());
   Token TokComma = TokSharedPtr.value();
@@ -13994,7 +13994,7 @@ void TextureRule::runRule(const MatchFinder::MatchResult &Result) {
                       const Expr *, RenameWithSuffix, StringRef>>>(
                       CE, Name, CE->getArg(0), true,
                       RenameWithSuffix("set", MethodName), Value));
-      Optional<std::string> Result = Rewriter->rewrite();
+      std::optional<std::string> Result = Rewriter->rewrite();
       if (Result.has_value())
         emplaceTransformation(
             new ReplaceStmt(CE, true, std::move(Result).value()));

--- a/clang/lib/DPCT/AnalysisInfo.cpp
+++ b/clang/lib/DPCT/AnalysisInfo.cpp
@@ -19,10 +19,11 @@
 #include <algorithm>
 #include <deque>
 #include <fstream>
+#include <optional>
 
 #define TYPELOC_CAST(Target) static_cast<const Target &>(TL)
 
-llvm::Optional<std::string> getReplacedName(const clang::NamedDecl *D) {
+std::optional<std::string> getReplacedName(const clang::NamedDecl *D) {
   auto Iter = MapNames::TypeNamesMap.find(D->getQualifiedNameAsString(false));
   if (Iter != MapNames::TypeNamesMap.end()) {
     auto Range = getDefinitionRange(D->getBeginLoc(), D->getEndLoc());
@@ -33,7 +34,7 @@ llvm::Optional<std::string> getReplacedName(const clang::NamedDecl *D) {
     }
     return Iter->second->NewName;
   }
-  return llvm::Optional<std::string>();
+  return std::nullopt;
 }
 
 namespace clang {
@@ -883,7 +884,7 @@ void DpctGlobalInfo::insertBuiltinVarInfo(
   }
 }
 
-llvm::Optional<std::string> DpctGlobalInfo::getAbsolutePath(FileID ID) {
+std::optional<std::string> DpctGlobalInfo::getAbsolutePath(FileID ID) {
   assert(SM && "SourceManager must be initialized");
   if (const auto *FileEntry = SM->getFileEntryForID(ID)) {
     // To avoid potential path inconsistent issue,
@@ -900,7 +901,7 @@ llvm::Optional<std::string> DpctGlobalInfo::getAbsolutePath(FileID ID) {
     llvm::sys::path::remove_dots(FilePathAbs, true);
     return (std::string)FilePathAbs;
   }
-  return llvm::None;
+  return std::nullopt;
 }
 
 int KernelCallExpr::calculateOriginArgsSize() const {

--- a/clang/lib/DPCT/AnalysisInfo.h
+++ b/clang/lib/DPCT/AnalysisInfo.h
@@ -34,11 +34,9 @@
 #include "clang/Format/Format.h"
 #include "clang/Frontend/CompilerInstance.h"
 
-#include "llvm/ADT/Optional.h"
-
-llvm::Optional<std::string> getReplacedName(const clang::NamedDecl *D);
+std::optional<std::string> getReplacedName(const clang::NamedDecl *D);
 void setGetReplacedNamePtr(
-    llvm::Optional<std::string> (*Ptr)(const clang::NamedDecl *D));
+    std::optional<std::string> (*Ptr)(const clang::NamedDecl *D));
 
 namespace clang {
 namespace dpct {
@@ -1313,7 +1311,7 @@ public:
   }
 
   // Return the absolute path of \p ID
-  static llvm::Optional<std::string> getAbsolutePath(FileID ID);
+  static std::optional<std::string> getAbsolutePath(FileID ID);
 
   static inline std::pair<std::string, unsigned>
   getLocInfo(SourceLocation Loc, bool *IsInvalid = nullptr /* out */) {

--- a/clang/lib/DPCT/CUBAPIMigration.cpp
+++ b/clang/lib/DPCT/CUBAPIMigration.cpp
@@ -24,7 +24,6 @@
 #include "clang/Basic/LLVM.h"
 #include "clang/Tooling/Tooling.h"
 #include "llvm/ADT/None.h"
-#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"

--- a/clang/lib/DPCT/CallExprRewriter.cpp
+++ b/clang/lib/DPCT/CallExprRewriter.cpp
@@ -81,12 +81,12 @@ std::vector<std::string> CallExprRewriter::getMigratedArgs() {
   return ArgList;
 }
 
-Optional<std::string> FuncCallExprRewriter::rewrite() {
+std::optional<std::string> FuncCallExprRewriter::rewrite() {
   RewriteArgList = getMigratedArgs();
   return buildRewriteString();
 }
 
-Optional<std::string> FuncCallExprRewriter::buildRewriteString() {
+std::optional<std::string> FuncCallExprRewriter::buildRewriteString() {
   std::string Result;
   llvm::raw_string_ostream OS(Result);
   OS << TargetCalleeName << "(";

--- a/clang/lib/DPCT/CallExprRewriter.h
+++ b/clang/lib/DPCT/CallExprRewriter.h
@@ -149,7 +149,7 @@ public:
 
   /// This function should be overwritten to implement call expression
   /// rewriting.
-  virtual Optional<std::string> rewrite() = 0;
+  virtual std::optional<std::string> rewrite() = 0;
   // Emits a warning/error/note and/or comment depending on MsgID. For details
   // see Diagnostics.inc, Diagnostics.h and Diagnostics.cpp
   template <typename IDTy, typename... Ts>
@@ -252,8 +252,8 @@ public:
           .create(C);
   }
 
-  Optional<std::string> rewrite() override {
-    Optional<std::string> &&Result = Inner->rewrite();
+  std::optional<std::string> rewrite() override {
+    std::optional<std::string> &&Result = Inner->rewrite();
     if (Result.has_value() && IsAssigned)
       return "(" + Result.value() + ", 0)";
     return Result;
@@ -272,8 +272,8 @@ public:
       : CallExprRewriter(C, ""), Prefix(Prefix), Suffix(Suffix),
         Inner(InnerRewriter) {}
 
-  Optional<std::string> rewrite() override {
-    Optional<std::string> &&Result = Inner->rewrite();
+  std::optional<std::string> rewrite() override {
+    std::optional<std::string> &&Result = Inner->rewrite();
     if (Result.has_value())
       return Prefix + Result.value() + Suffix;
     return Result;
@@ -288,16 +288,16 @@ public:
   RemoveAPIRewriter(const CallExpr *C, std::string CalleeName)
       : CallExprRewriter(C, CalleeName), IsAssigned(isAssigned(C)), CalleeName(CalleeName) {}
 
-  Optional<std::string> rewrite() override {
+  std::optional<std::string> rewrite() override {
     std::string Msg = "this call is redundant in SYCL.";
     if (IsAssigned) {
       report(Diagnostics::FUNC_CALL_REMOVED_0, false,
              CalleeName, Msg);
-      return Optional<std::string>("0");
+      return std::optional<std::string>("0");
     }
     report(Diagnostics::FUNC_CALL_REMOVED, false,
            CalleeName, Msg);
-    return Optional<std::string>("");
+    return std::optional<std::string>("");
   }
 };
 
@@ -321,10 +321,10 @@ public:
     Indent = getIndent(getStmtExpansionSourceRange(C).getBegin(), SM);
   }
 
-  Optional<std::string> rewrite() override {
-    Optional<std::string> &&PredStr = Pred->rewrite();
-    Optional<std::string> &&IfBlockStr = IfBlock->rewrite();
-    Optional<std::string> &&ElseBlockStr = ElseBlock->rewrite();
+  std::optional<std::string> rewrite() override {
+    std::optional<std::string> &&PredStr = Pred->rewrite();
+    std::optional<std::string> &&IfBlockStr = IfBlock->rewrite();
+    std::optional<std::string> &&ElseBlockStr = ElseBlock->rewrite();
     return "if(" + PredStr.value() + "){" + NL.str() + Indent.str() +
            Indent.str() + IfBlockStr.value() + ";" + NL.str() +
            Indent.str() + "} else {" + NL.str() + Indent.str() + Indent.str() +
@@ -442,7 +442,7 @@ protected:
 public:
   virtual ~FuncCallExprRewriter() {}
 
-  virtual Optional<std::string> rewrite() override;
+  virtual std::optional<std::string> rewrite() override;
 
   friend FuncCallExprRewriterFactory;
 
@@ -452,7 +452,7 @@ protected:
   }
 
   // Build string which is used to replace original expression.
-  Optional<std::string> buildRewriteString();
+  std::optional<std::string> buildRewriteString();
 
   void setTargetCalleeName(const std::string &Str) { TargetCalleeName = Str; }
 };
@@ -468,7 +468,7 @@ public:
     NoRewrite = true;
   }
 
-  Optional<std::string> rewrite() override { return NewFuncName; }
+  std::optional<std::string> rewrite() override { return NewFuncName; }
 };
 
 struct ThrustFunctor {
@@ -917,7 +917,7 @@ public:
   DeleterCallExprRewriter(const CallExpr *C, StringRef Source,
                           std::function<ArgT(const CallExpr *)> ArgCreator)
       : CallExprRewriter(C, Source), Arg(ArgCreator(C)) {}
-  Optional<std::string> rewrite() override {
+  std::optional<std::string> rewrite() override {
     std::string Result;
     llvm::raw_string_ostream OS(Result);
     OS << "delete ";
@@ -933,7 +933,7 @@ public:
   ToStringExprRewriter(const CallExpr *C, StringRef Source,
                        std::function<ArgT(const CallExpr *)> ArgCreator)
       : CallExprRewriter(C, Source), Arg(ArgCreator(C)) {}
-  Optional<std::string> rewrite() override {
+  std::optional<std::string> rewrite() override {
     std::string Result;
     llvm::raw_string_ostream OS(Result);
     print(OS, Arg);
@@ -1076,7 +1076,7 @@ public:
   PrinterRewriter(const CallExpr *C, StringRef Source,
                   const std::function<ArgsT(const CallExpr *)> &...ArgCreators)
       : PrinterRewriter(C, Source, ArgCreators(C)...) {}
-  Optional<std::string> rewrite() override {
+  std::optional<std::string> rewrite() override {
     std::string Result;
     llvm::raw_string_ostream OS(Result);
     Printer::print(OS);
@@ -1099,7 +1099,7 @@ public:
       const CallExpr *C, StringRef Source,
       const std::function<StmtPrinters(const CallExpr *)> &...PrinterCreators)
       : PrinterRewriter(C, Source, PrinterCreators(C)...) {}
-  Optional<std::string> rewrite() override {
+  std::optional<std::string> rewrite() override {
     std::string Result;
     llvm::raw_string_ostream OS(Result);
     Base::print(OS);
@@ -1177,7 +1177,7 @@ public:
       const std::function<CallExprPrinter<CalleeT, ArgsT...>(const CallExpr *)>
           &PrinterFunctor)
       : CallExprRewriter(C, Source), Printer(PrinterFunctor(C)) {}
-  Optional<std::string> rewrite() override {
+  std::optional<std::string> rewrite() override {
     std::string Result;
     llvm::raw_string_ostream OS(Result);
     Printer.print(OS);
@@ -1251,7 +1251,7 @@ public:
     report(MsgID, false, getMsgArg(Args, CE)...);
   }
 
-  Optional<std::string> rewrite() override { return Optional<std::string>(); }
+  std::optional<std::string> rewrite() override { return std::nullopt; }
 
   friend UnsupportFunctionRewriterFactory<MsgArgs...>;
 };
@@ -1277,8 +1277,8 @@ public:
     buildRewriterStr(Call, OS, OB);
     OS.flush();
   }
-  Optional<std::string> rewrite() override {
-    return Optional<std::string>(ResultStr);
+  std::optional<std::string> rewrite() override {
+    return ResultStr;
   }
 
   void buildRewriterStr(const CallExpr *Call, llvm::raw_string_ostream &OS,
@@ -1357,7 +1357,7 @@ class UserDefinedRewriterFactory : public CallExprRewriterFactoryBase {
     NullRewriter(const CallExpr *C, StringRef Name)
         : CallExprRewriter(C, Name) {}
 
-    Optional<std::string> rewrite() override { return {}; }
+    std::optional<std::string> rewrite() override { return std::nullopt; }
   };
 
 public:

--- a/clang/lib/DPCT/CallExprRewriterMath.cpp
+++ b/clang/lib/DPCT/CallExprRewriterMath.cpp
@@ -32,7 +32,7 @@ using NoRewriteFuncNameRewriterFactory =
 /// Base class for rewriting math function calls
 class MathCallExprRewriter : public FuncCallExprRewriter {
 public:
-  virtual Optional<std::string> rewrite() override;
+  virtual std::optional<std::string> rewrite() override;
 
 protected:
   MathCallExprRewriter(const CallExpr *Call, StringRef SourceCalleeName,
@@ -50,7 +50,7 @@ protected:
                           StringRef TargetCalleeName)
       : Base(Call, SourceCalleeName, TargetCalleeName) {}
 
-  virtual Optional<std::string> rewrite() override;
+  virtual std::optional<std::string> rewrite() override;
 
   friend MathUnsupportedRewriterFactory;
 };
@@ -63,7 +63,7 @@ protected:
                        StringRef TargetCalleeName)
       : Base(Call, SourceCalleeName, TargetCalleeName) {}
 
-  virtual Optional<std::string> rewrite() override;
+  virtual std::optional<std::string> rewrite() override;
 
   friend MathTypeCastRewriterFactory;
 };
@@ -76,7 +76,7 @@ protected:
                         StringRef TargetCalleeName)
       : Base(Call, SourceCalleeName, TargetCalleeName) {}
 
-  virtual Optional<std::string> rewrite() override;
+  virtual std::optional<std::string> rewrite() override;
 
   friend MathSimulatedRewriterFactory;
 };
@@ -95,14 +95,14 @@ protected:
 public:
   virtual ~MathBinaryOperatorRewriter() {}
 
-  virtual Optional<std::string> rewrite() override;
+  virtual std::optional<std::string> rewrite() override;
 
 protected:
   void setLHS(std::string L) { LHS = L; }
   void setRHS(std::string R) { RHS = R; }
 
   // Build string which is used to replace original expression.
-  inline Optional<std::string> buildRewriteString() {
+  inline std::optional<std::string> buildRewriteString() {
     if (LHS == "")
       return buildString(BinaryOperator::getOpcodeStr(Op), RHS);
     return buildString(LHS, " ", BinaryOperator::getOpcodeStr(Op), " ", RHS);
@@ -119,7 +119,7 @@ protected:
       : MathCallExprRewriter(Call, SourceCalleeName, TargetCalleeName) {}
 
 public:
-  virtual Optional<std::string> rewrite() override;
+  virtual std::optional<std::string> rewrite() override;
 
 protected:
   std::string getNewFuncName();
@@ -138,7 +138,7 @@ static inline bool isTargetMathFunction(const FunctionDecl *FD) {
   return true;
 }
 
-Optional<std::string> MathFuncNameRewriter::rewrite() {
+std::optional<std::string> MathFuncNameRewriter::rewrite() {
   // If the function is not a target math function, do not migrate it
   if (!isTargetMathFunction(Call->getDirectCallee())) {
     // No actions needed here, just return an empty string
@@ -568,7 +568,7 @@ std::string MathFuncNameRewriter::getNewFuncName() {
   return NewFuncName;
 }
 
-Optional<std::string> MathCallExprRewriter::rewrite() {
+std::optional<std::string> MathCallExprRewriter::rewrite() {
   RewriteArgList = getMigratedArgs();
   setTargetCalleeName(SourceCalleeName.str());
   return buildRewriteString();
@@ -581,13 +581,13 @@ void MathCallExprRewriter::reportUnsupportedRoundingMode() {
   }
 }
 
-Optional<std::string> MathUnsupportedRewriter::rewrite() {
+std::optional<std::string> MathUnsupportedRewriter::rewrite() {
   report(Diagnostics::API_NOT_MIGRATED, false,
          MapNames::ITFName.at(SourceCalleeName.str()));
   return Base::rewrite();
 }
 
-Optional<std::string> MathTypeCastRewriter::rewrite() {
+std::optional<std::string> MathTypeCastRewriter::rewrite() {
   auto FD = Call->getDirectCallee();
   if (!FD || !FD->hasAttr<CUDADeviceAttr>())
     return Base::rewrite();
@@ -684,7 +684,7 @@ Optional<std::string> MathTypeCastRewriter::rewrite() {
   return ReplStr;
 }
 
-Optional<std::string> MathSimulatedRewriter::rewrite() {
+std::optional<std::string> MathSimulatedRewriter::rewrite() {
   std::string NamespaceStr;
   auto DRE = dyn_cast<DeclRefExpr>(Call->getCallee()->IgnoreImpCasts());
   if (DRE) {
@@ -1148,7 +1148,7 @@ Optional<std::string> MathSimulatedRewriter::rewrite() {
   return ReplStr;
 }
 
-Optional<std::string> MathBinaryOperatorRewriter::rewrite() {
+std::optional<std::string> MathBinaryOperatorRewriter::rewrite() {
   reportUnsupportedRoundingMode();
   if (SourceCalleeName == "__hneg" || SourceCalleeName == "__hneg2") {
     setLHS("");

--- a/clang/lib/DPCT/MemberExprRewriter.h
+++ b/clang/lib/DPCT/MemberExprRewriter.h
@@ -21,7 +21,7 @@ protected:
   MemberExprBaseRewriter(const MemberExpr *ME) : ME(ME) {}
 public:
   virtual ~MemberExprBaseRewriter() {}
-  virtual Optional<std::string> rewrite() = 0;
+  virtual std::optional<std::string> rewrite() = 0;
 
   // Emits a warning/error/note and/or comment depending on MsgID. For details
   // see Diagnostics.inc, Diagnostics.h and Diagnostics.cpp
@@ -44,7 +44,7 @@ public:
   MemberExprPrinterRewriter(const MemberExpr *ME, ArgsT &&...Args):
     Printer(std::forward<ArgsT>(Args)...), MemberExprBaseRewriter(ME) {}
 
-  Optional<std::string> rewrite() override {
+  std::optional<std::string> rewrite() override {
     std::string Result;
     llvm::raw_string_ostream OS(Result);
     Printer::print(OS);
@@ -122,7 +122,7 @@ public:
     report(MsgID, false, getMsgArg(Args, ME)...);
   }
 
-  Optional<std::string> rewrite() override { return Optional<std::string>(); }
+  std::optional<std::string> rewrite() override { return std::nullopt; }
 
   friend UnsupportFunctionRewriterFactory<MsgArgs...>;
 };

--- a/clang/lib/DPCT/TextModification.cpp
+++ b/clang/lib/DPCT/TextModification.cpp
@@ -169,7 +169,7 @@ ReplaceStmt::removeStmtWithCleanups(const SourceManager &SM) const {
 
   // Get the length of spaces and the semicolon after the TheStmt
   SourceLocation PostStmtLoc;
-  Optional<Token> TokSharedPtr;
+  std::optional<Token> TokSharedPtr;
   if (IsProcessMacro) {
     PostStmtLoc = End;
     if (End.getRawEncoding() == 0) {

--- a/clang/lib/DPCT/TypeLocRewriters.h
+++ b/clang/lib/DPCT/TypeLocRewriters.h
@@ -20,7 +20,7 @@ protected:
 
 public:
   virtual ~TypeLocRewriter() {}
-  virtual Optional<std::string> rewrite() = 0;
+  virtual std::optional<std::string> rewrite() = 0;
 };
 
 template <class Printer>
@@ -34,7 +34,7 @@ public:
       const TypeLoc TL,
       const std::function<ArgsT(const CallExpr *)> &...ArgCreators)
       : TypePrinterRewriter(TL, ArgCreators(TL)...) {}
-  Optional<std::string> rewrite() override {
+  std::optional<std::string> rewrite() override {
     std::string Result;
     llvm::raw_string_ostream OS(Result);
     Printer::print(OS);


### PR DESCRIPTION
Currently, `llvm::Optional` is an alias of `std::optional`, and it will be remove after `llvm-16` .

Signed-off-by: Wang, Yihan <yihan.wang@intel.com>