### PR TITLE
Revert "[SYCLomatic] Add comments and use compile time warning instead of runtime warning for querying momory clock and buswidth"

### DIFF
--- a/clang/runtime/dpct-rt/include/device.hpp.inc
+++ b/clang/runtime/dpct-rt/include/device.hpp.inc
@@ -65,22 +65,6 @@
 
 namespace dpct {
 
-namespace detail{
-
-// DPCT_LABEL_BEGIN|detail_warning|dpct::detail
-// DPCT_DEPENDENCY_EMPTY
-// DPCT_CODE
-inline void warning(const std::string &warning_msg) {
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma message(warning_msg)
-#else
-#warning warning_msg
-#endif
-}
-// DPCT_LABEL_END
-
-}
-
 // DPCT_LABEL_BEGIN|exception_handler|dpct
 // DPCT_DEPENDENCY_EMPTY
 // DPCT_CODE
@@ -301,8 +285,6 @@ public:
 // Device|device_info
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
-  /// Returns the maximum clock rate of device's global memory in kHz. If
-  /// compiler does not support this API then returns default value 3200000 kHz.
   unsigned int get_memory_clock_rate() const { return _memory_clock_rate; }
 // DPCT_LABEL_END
 // DPCT_LABEL_BEGIN|device_info_get_memory_bus_width|dpct
@@ -310,8 +292,6 @@ public:
 // Device|device_info
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
-  /// Returns the maximum bus width between device and memory in bits. If
-  /// compiler does not support this API then returns default value 64 bits.
   unsigned int get_memory_bus_width() const { return _memory_bus_width; }
 // DPCT_LABEL_END
   // set interface
@@ -503,9 +483,7 @@ private:
   int _minor;
   int _integrated = 0;
   int _frequency;
-  // Set estimated value 3200000 kHz as default value.
-  unsigned int _memory_clock_rate = 3200000;
-  // Set estimated value 64 bits as default value.
+  unsigned int _memory_clock_rate = 0;
   unsigned int _memory_bus_width = 64;
   int _max_compute_units;
   int _max_work_group_size;
@@ -735,7 +713,6 @@ public:
 // Device|device_info_set_memory_clock_rate
 // Device|device_info_set_memory_bus_width
 // Device|device_info_set_max_register_size_per_work_group
-// Device|detail_warning
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
   void get_device_info(device_info &out) const {
@@ -771,21 +748,32 @@ public:
 
 #if (defined(SYCL_EXT_INTEL_DEVICE_INFO) && SYCL_EXT_INTEL_DEVICE_INFO >= 6)
     if (this->has(sycl::aspect::ext_intel_memory_clock_rate)) {
-      unsigned int tmp =
-          this->get_info<sycl::ext::intel::info::device::memory_clock_rate>();
-      if (tmp != 0)
-        prop.set_memory_clock_rate(1000 * tmp);
+      prop.set_memory_clock_rate(
+          this->get_info<sycl::ext::intel::info::device::memory_clock_rate>());
+    } else {
+      std::cerr << "Querying ext_intel_device_info_memory_clock_rate is not "
+                   "supported "
+                   "by the device"
+                << std::endl;
+      std::cerr << "memory_clock_rate default value is 0." << std::endl;
     }
     if (this->has(sycl::aspect::ext_intel_memory_bus_width)) {
       prop.set_memory_bus_width(
           this->get_info<sycl::ext::intel::info::device::memory_bus_width>());
+    } else {
+      std::cerr
+          << "Querying ext_intel_device_info_memory_bus_width is not supported "
+             "by the device"
+          << std::endl;
+      std::cerr << "memory_bus_width default value is 64." << std::endl;
     }
 #else
-    deatil::warning(
-        "get_device_info: querying memory_clock_rate and memory_bus_width are "
-        "not supported by the compiler used. \nUse 3200000 kHz as "
-        "memory_clock_rate default value.\nUse 64 bits as memory_bus_width "
-        "default value.")
+    std::cerr
+        << "get_device_info: query memory_clock_rate and memory_bus_width are "
+           "not supported by the compiler you currently used."
+        << std::endl;
+    std::cerr << "memory_clock_rate default value is 0." << std::endl;
+    std::cerr << "memory_bus_width default value is 64." << std::endl;
 #endif
 
     size_t max_sub_group_size = 1;

--- a/clang/test/dpct/helper_files_ref/include/device.hpp
+++ b/clang/test/dpct/helper_files_ref/include/device.hpp
@@ -31,18 +31,6 @@
 
 namespace dpct {
 
-namespace detail{
-
-inline void warning(const std::string &warning_msg) {
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma message(warning_msg)
-#else
-#warning warning_msg
-#endif
-}
-
-}
-
 /// SYCL default exception handler
 auto exception_handler = [](sycl::exception_list exceptions) {
   for (std::exception_ptr const &e : exceptions) {
@@ -129,11 +117,7 @@ public:
   }
   size_t get_global_mem_size() const { return _global_mem_size; }
   size_t get_local_mem_size() const { return _local_mem_size; }
-  /// Returns the maximum clock rate of device's global memory in kHz. If
-  /// compiler does not support this API then returns default value 3200000 kHz.
   unsigned int get_memory_clock_rate() const { return _memory_clock_rate; }
-  /// Returns the maximum bus width between device and memory in bits. If
-  /// compiler does not support this API then returns default value 64 bits.
   unsigned int get_memory_bus_width() const { return _memory_bus_width; }
   // set interface
   void set_name(const char* name) {
@@ -201,9 +185,7 @@ private:
   int _minor;
   int _integrated = 0;
   int _frequency;
-  // Set estimated value 3200000 kHz as default value.
-  unsigned int _memory_clock_rate = 3200000;
-  // Set estimated value 64 bits as default value.
+  unsigned int _memory_clock_rate = 0;
   unsigned int _memory_bus_width = 64;
   int _max_compute_units;
   int _max_work_group_size;
@@ -333,21 +315,32 @@ public:
 
 #if (defined(SYCL_EXT_INTEL_DEVICE_INFO) && SYCL_EXT_INTEL_DEVICE_INFO >= 6)
     if (this->has(sycl::aspect::ext_intel_memory_clock_rate)) {
-      unsigned int tmp =
-          this->get_info<sycl::ext::intel::info::device::memory_clock_rate>();
-      if (tmp != 0)
-        prop.set_memory_clock_rate(1000 * tmp);
+      prop.set_memory_clock_rate(
+          this->get_info<sycl::ext::intel::info::device::memory_clock_rate>());
+    } else {
+      std::cerr << "Querying ext_intel_device_info_memory_clock_rate is not "
+                   "supported "
+                   "by the device"
+                << std::endl;
+      std::cerr << "memory_clock_rate default value is 0." << std::endl;
     }
     if (this->has(sycl::aspect::ext_intel_memory_bus_width)) {
       prop.set_memory_bus_width(
           this->get_info<sycl::ext::intel::info::device::memory_bus_width>());
+    } else {
+      std::cerr
+          << "Querying ext_intel_device_info_memory_bus_width is not supported "
+             "by the device"
+          << std::endl;
+      std::cerr << "memory_bus_width default value is 64." << std::endl;
     }
 #else
-    deatil::warning(
-        "get_device_info: querying memory_clock_rate and memory_bus_width are "
-        "not supported by the compiler used. \nUse 3200000 kHz as "
-        "memory_clock_rate default value.\nUse 64 bits as memory_bus_width "
-        "default value.")
+    std::cerr
+        << "get_device_info: query memory_clock_rate and memory_bus_width are "
+           "not supported by the compiler you currently used."
+        << std::endl;
+    std::cerr << "memory_clock_rate default value is 0." << std::endl;
+    std::cerr << "memory_bus_width default value is 64." << std::endl;
 #endif
 
     size_t max_sub_group_size = 1;

--- a/clang/test/dpct/test_api_level/Device/api_test13.cu
+++ b/clang/test/dpct/test_api_level/Device/api_test13.cu
@@ -3,7 +3,7 @@
 // RUN: FileCheck --input-file %T/Device/api_test13_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/Device/api_test13_out
 
-// CHECK: 40
+// CHECK: 39
 // TEST_FEATURE: Device_device_info_get_global_mem_size
 // TEST_FEATURE: Device_get_current_device
 

--- a/clang/test/dpct/test_api_level/Device/api_test22.cu
+++ b/clang/test/dpct/test_api_level/Device/api_test22.cu
@@ -3,7 +3,7 @@
 // RUN: FileCheck --input-file %T/Device/api_test22_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/Device/api_test22_out
 
-// CHECK: 38
+// CHECK: 37
 // TEST_FEATURE: Device_device_ext_get_max_compute_units
 
 int main() {

--- a/clang/test/dpct/test_api_level/Device/api_test23.cu
+++ b/clang/test/dpct/test_api_level/Device/api_test23.cu
@@ -3,7 +3,7 @@
 // RUN: FileCheck --input-file %T/Device/api_test23_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/Device/api_test23_out
 
-// CHECK: 38
+// CHECK: 37
 // TEST_FEATURE: Device_device_ext_get_max_clock_frequency
 
 int main() {

--- a/clang/test/dpct/test_api_level/Device/api_test24.cu
+++ b/clang/test/dpct/test_api_level/Device/api_test24.cu
@@ -3,7 +3,7 @@
 // RUN: FileCheck --input-file %T/Device/api_test24_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/Device/api_test24_out
 
-// CHECK: 38
+// CHECK: 37
 // TEST_FEATURE: Device_device_ext_get_integrated
 
 int main() {

--- a/clang/test/dpct/test_api_level/Device/api_test28.cu
+++ b/clang/test/dpct/test_api_level/Device/api_test28.cu
@@ -3,7 +3,7 @@
 // RUN: FileCheck --input-file %T/Device/api_test28_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/Device/api_test28_out
 
-// CHECK: 37
+// CHECK: 36
 // TEST_FEATURE: Device_device_info_get_global_mem_size
 // TEST_FEATURE: Device_get_device
 // TEST_FEATURE: Device_device_ext_get_device_info_return_info

--- a/clang/test/dpct/test_api_level/Device/api_test31.cu
+++ b/clang/test/dpct/test_api_level/Device/api_test31.cu
@@ -3,7 +3,7 @@
 // RUN: FileCheck --input-file %T/Device/api_test31_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/Device/api_test31_out
 
-// CHECK: 31
+// CHECK: 30
 // TEST_FEATURE: Device_device_ext_get_memory_info
 
 int main() {

--- a/clang/test/dpct/test_api_level/Device/api_test6.cu
+++ b/clang/test/dpct/test_api_level/Device/api_test6.cu
@@ -3,7 +3,7 @@
 // RUN: FileCheck --input-file %T/Device/api_test6_out/count.txt --match-full-lines %s
 // RUN: rm -rf %T/Device/api_test6_out
 
-// CHECK: 36
+// CHECK: 35
 // TEST_FEATURE: Device_device_ext_get_device_info_return_info
 
 int main() {


### PR DESCRIPTION
Reverts oneapi-src/SYCLomatic#474
Signed-off-by: Ni, Wenhui <wenhui.ni@intel.com>