### PR TITLE
[SYCLomatic][DPCT] Decouple sycl version check from oneDPL 

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/memory.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/memory.h.inc
@@ -68,6 +68,19 @@ struct make_allocatable<void>
 };
 // DPCT_LABEL_END
 
+// DPCT_LABEL_BEGIN|_DPCT_LIBSYCL_VERSION|dpct::detail
+// DPCT_DEPENDENCY_EMPTY
+// DPCT_CODE
+#if defined(__LIBSYCL_MAJOR_VERSION) && defined(__LIBSYCL_MINOR_VERSION) &&    \
+    defined(__LIBSYCL_PATCH_VERSION)
+#define _DPCT_LIBSYCL_VERSION                                                  \
+  (__LIBSYCL_MAJOR_VERSION * 10000 + __LIBSYCL_MINOR_VERSION * 100 +           \
+   __LIBSYCL_PATCH_VERSION)
+#else
+#define _DPCT_LIBSYCL_VERSION 0
+#endif
+// DPCT_LABEL_END
+
 // DPCT_LABEL_BEGIN|__buffer_allocator|dpct::detail
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasMemory|make_allocatable
@@ -75,11 +88,11 @@ struct make_allocatable<void>
 // DPCT_CODE
 template <typename _DataT>
 using __buffer_allocator =
-#if _ONEDPL_LIBSYCL_VERSION >= 50707
-    sycl::buffer_allocator<typename make_allocatable<_DataT>::type>;
-#else
+ #if _DPCT_LIBSYCL_VERSION >= 60000
+     sycl::buffer_allocator<typename make_allocatable<_DataT>::type>;
+ #else
     sycl::buffer_allocator;
-#endif
+ #endif
 // DPCT_LABEL_END
 } // namespace detail
 

--- a/clang/runtime/dpct-rt/include/dpl_extras/memory.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/memory.h.inc
@@ -88,11 +88,11 @@ struct make_allocatable<void>
 // DPCT_CODE
 template <typename _DataT>
 using __buffer_allocator =
- #if _DPCT_LIBSYCL_VERSION >= 60000
-     sycl::buffer_allocator<typename make_allocatable<_DataT>::type>;
- #else
+#if _DPCT_LIBSYCL_VERSION >= 60000
+    sycl::buffer_allocator<typename make_allocatable<_DataT>::type>;
+#else
     sycl::buffer_allocator;
- #endif
+#endif
 // DPCT_LABEL_END
 } // namespace detail
 

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/memory.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/memory.h
@@ -28,9 +28,18 @@ struct make_allocatable<void>
   using type = dpct::byte_t;
 };
 
+#if defined(__LIBSYCL_MAJOR_VERSION) && defined(__LIBSYCL_MINOR_VERSION) &&    \
+    defined(__LIBSYCL_PATCH_VERSION)
+#define _DPCT_LIBSYCL_VERSION                                                  \
+  (__LIBSYCL_MAJOR_VERSION * 10000 + __LIBSYCL_MINOR_VERSION * 100 +           \
+   __LIBSYCL_PATCH_VERSION)
+#else
+#define _DPCT_LIBSYCL_VERSION 0
+#endif
+
 template <typename _DataT>
 using __buffer_allocator =
-#if _ONEDPL_LIBSYCL_VERSION >= 50707
+#if _DPCT_LIBSYCL_VERSION >= 60000
     sycl::buffer_allocator<typename make_allocatable<_DataT>::type>;
 #else
     sycl::buffer_allocator;


### PR DESCRIPTION
Decoupling version check from oneDPL internal preprocessor variable so that this header works with any version of oneDPL.  `_ONEDPL_LIBSYCL_VERSION` had its name changed recently in oneDPL, causing co-dependency with change of the name here.  It is easy enough to break that dependence by relying on the source.

Also, correcting a version number for `sycl::buffer_allocator<>` to 60000, as was done in oneDPL here: https://github.com/oneapi-src/oneDPL/pull/707.