### PR TITLE
[SYCLomatic] Segmented sort keys

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -1435,7 +1435,7 @@ inline void segmented_sort_pairs_by_parallel_sorts(
   ::std::copy(::std::forward<_ExecutionPolicy>(policy), end_offsets,
               end_offsets + nsegments, host_accessible_offset_ends);
 
-  for (int i = 0; i < nsegments; i++) {
+  for (::std::uint64_t i = 0; i < nsegments; i++) {
     uint64_t segment_begin = host_accessible_offset_starts[i];
     uint64_t segment_end =
         ::std::min(n, (int64_t)host_accessible_offset_ends[i]);
@@ -1477,7 +1477,7 @@ inline void segmented_sort_keys_by_parallel_sorts(
   ::std::copy(::std::forward<_ExecutionPolicy>(policy), end_offsets,
               end_offsets + nsegments, host_accessible_offset_ends);
 
-  for (int i = 0; i < nsegments; i++) {
+  for (::std::uint64_t i = 0; i < nsegments; i++) {
     uint64_t segment_begin = host_accessible_offset_starts[i];
     uint64_t segment_end =
         ::std::min(n, (int64_t)host_accessible_offset_ends[i]);
@@ -1509,8 +1509,8 @@ inline void segmented_sort_pairs_by_parallel_for_of_sorts(
                   8) {
   policy.queue().submit([&](sycl::handler &cgh) {
     cgh.parallel_for(nsegments, [=](sycl::id<1> i) {
-      uint64_t segment_begin = begin_offsets[(int)i];
-      uint64_t segment_end = ::std::min(n, (int64_t)end_offsets[(int)i]);
+      uint64_t segment_begin = begin_offsets[i];
+      uint64_t segment_end = ::std::min(n, (int64_t)end_offsets[i]);
       if (segment_begin == segment_end) {
         return;
       }
@@ -1540,8 +1540,8 @@ inline void segmented_sort_keys_by_parallel_for_of_sorts(
                   8) {
   policy.queue().submit([&](sycl::handler &cgh) {
     cgh.parallel_for(nsegments, [=](sycl::id<1> i) {
-      uint64_t segment_begin = begin_offsets[(int)i];
-      uint64_t segment_end = ::std::min(n, (int64_t)end_offsets[(int)i]);
+      uint64_t segment_begin = begin_offsets[i];
+      uint64_t segment_end = ::std::min(n, (int64_t)end_offsets[i]);
       if (segment_begin == segment_end) {
         return;
       }

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -1452,6 +1452,46 @@ inline void segmented_sort_pairs_by_parallel_sorts(
 }
 // DPCT_LABEL_END
 
+// DPCT_LABEL_BEGIN|segmented_sort_keys_by_parallel_sorts|dpct::internal
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasAlgorithm|sort_keys
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+template <typename _ExecutionPolicy, typename key_t, typename OffsetIteratorT>
+inline void segmented_sort_keys_by_parallel_sorts(
+    _ExecutionPolicy &&policy, key_t keys_in, key_t keys_out, int64_t n,
+    int64_t nsegments, OffsetIteratorT begin_offsets,
+     OffsetIteratorT end_offsets, bool descending = false, int begin_bit = 0,
+    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
+                  8) {
+  using offset_type =
+      typename ::std::iterator_traits<OffsetIteratorT>::value_type;
+  auto host_accessible_offset_starts =
+      sycl::malloc_shared<offset_type>(nsegments, policy.queue());
+  auto host_accessible_offset_ends =
+      sycl::malloc_shared<offset_type>(nsegments, policy.queue());
+  // make offsets accessible on host
+  ::std::copy(::std::forward<_ExecutionPolicy>(policy), begin_offsets,
+              begin_offsets + nsegments, host_accessible_offset_starts);
+  ::std::copy(::std::forward<_ExecutionPolicy>(policy), end_offsets,
+              end_offsets + nsegments, host_accessible_offset_ends);
+
+  for (int i = 0; i < nsegments; i++) {
+    uint64_t segment_begin = host_accessible_offset_starts[i];
+    uint64_t segment_end =
+        ::std::min(n, (int64_t)host_accessible_offset_ends[i]);
+    if (segment_begin < segment_end) {
+      ::dpct::sort_keys(::std::forward<_ExecutionPolicy>(policy),
+                         keys_in + segment_begin, keys_out + segment_begin,
+                         segment_end - segment_begin, descending, begin_bit,
+                         end_bit);
+    }
+  }
+  sycl::free(host_accessible_offset_starts, policy.queue());
+  sycl::free(host_accessible_offset_ends, policy.queue());
+}
+// DPCT_LABEL_END
+
 // DPCT_LABEL_BEGIN|segmented_sort_pairs_by_parallel_for_of_sorts|dpct::internal
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasAlgorithm|sort_pairs
@@ -1484,9 +1524,9 @@ inline void segmented_sort_pairs_by_parallel_for_of_sorts(
 }
 // DPCT_LABEL_END
 
-// DPCT_LABEL_BEGIN|segmented_sort_pairs_by_two_pair_sorts|dpct::internal
+// DPCT_LABEL_BEGIN|segmented_sort_keys_by_parallel_for_of_sorts|dpct::internal
 // DPCT_DEPENDENCY_BEGIN
-// DplExtrasAlgorithm|sort_pairs
+// DplExtrasAlgorithm|sort_keys
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
@@ -1498,14 +1538,30 @@ inline void segmented_sort_pairs_by_two_pair_sorts(
     bool descending = false, int begin_bit = 0,
     int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
                   8) {
-  using key_t_value_t = typename ::std::iterator_traits<key_t>::value_type;
-  using value_t_value_t = typename ::std::iterator_traits<value_t>::value_type;
-  ::std::size_t *segments =
-      sycl::malloc_device<::std::size_t>(n, policy.queue());
-  ::std::size_t *segments_sorted =
-      sycl::malloc_device<::std::size_t>(n, policy.queue());
-  auto keys_temp = sycl::malloc_device<key_t_value_t>(n, policy.queue());
-  auto values_temp = sycl::malloc_device<value_t_value_t>(n, policy.queue());
+  policy.queue().submit([&](sycl::handler &cgh) {
+    cgh.parallel_for(nsegments, [=](sycl::id<1> i) {
+      uint64_t segment_begin = begin_offsets[(int)i];
+      uint64_t segment_end = ::std::min(n, (int64_t)end_offsets[(int)i]);
+      if (segment_begin == segment_end) {
+        return;
+      }
+      ::dpct::sort_keys(::std::execution::seq, keys_in + segment_begin,
+                         keys_out + segment_begin, segment_end - segment_begin,
+                         descending, begin_bit, end_bit);
+    });
+  });
+  policy.queue().wait();
+}
+// DPCT_LABEL_END
+
+// DPCT_LABEL_BEGIN|mark_segments|dpct::internal
+// DPCT_DEPENDENCY_EMPTY
+// DPCT_CODE
+template <typename _ExecutionPolicy, typename OffsetIteratorT>
+inline void mark_segments(_ExecutionPolicy &&policy,
+                          OffsetIteratorT begin_offsets,
+                          OffsetIteratorT end_offsets, int64_t n,
+                          int64_t nsegments, ::std::size_t *segments) {
 
   ::std::size_t work_group_size =
       policy.queue()
@@ -1518,7 +1574,7 @@ inline void segmented_sort_pairs_by_two_pair_sorts(
   ::std::size_t sub_group_size = sg_sizes.empty() ? 0 : sg_sizes.back();
 
   float avg_seg_size = (float)n / (float)nsegments;
-  if (avg_seg_size > work_group_size) {
+ if (avg_seg_size > work_group_size) {
     // If average segment size is larger than workgroup, use workgroup to
     // coordinate to mark segments
     policy.queue()
@@ -1576,6 +1632,72 @@ inline void segmented_sort_pairs_by_two_pair_sorts(
         })
         .wait();
   }
+}
+// DPCT_LABEL_END
+
+// DPCT_LABEL_BEGIN|segmented_sort_keys_by_two_pair_sorts|dpct::internal
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasAlgorithm|sort_pairs
+// DplExtrasAlgorithm|mark_segments
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+template <typename _ExecutionPolicy, typename key_t, typename OffsetIteratorT>
+inline void segmented_sort_keys_by_two_pair_sorts(
+    _ExecutionPolicy &&policy, key_t keys_in, key_t keys_out, int64_t n,
+    int64_t nsegments, OffsetIteratorT begin_offsets,
+    OffsetIteratorT end_offsets, bool descending = false, int begin_bit = 0,
+    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
+                  8) {
+  using key_t_value_t = typename ::std::iterator_traits<key_t>::value_type;
+  ::std::size_t *segments =
+      sycl::malloc_device<::std::size_t>(n, policy.queue());
+  ::std::size_t *segments_sorted =
+      sycl::malloc_device<::std::size_t>(n, policy.queue());
+  auto keys_temp = sycl::malloc_device<key_t_value_t>(n, policy.queue());
+
+  mark_segments(::std::forward<_ExecutionPolicy>(policy), begin_offsets, 
+                end_offsets, n, nsegments, segments);
+
+  // Part 1: Sort by keys keeping track of which segment were in
+  dpct::sort_pairs(::std::forward<_ExecutionPolicy>(policy), keys_in, keys_temp,
+                   segments, segments_sorted, n, descending);
+
+  // Part 2: Sort the segments with a stable sort to get back sorted segments.
+  dpct::sort_pairs(::std::forward<_ExecutionPolicy>(policy), segments_sorted,
+                   segments, keys_temp, keys_out, n, false);
+
+  sycl::free(segments, policy.queue());
+  sycl::free(segments_sorted, policy.queue());
+  sycl::free(keys_temp, policy.queue());
+}
+// DPCT_LABEL_END
+
+// DPCT_LABEL_BEGIN|segmented_sort_pairs_by_two_pair_sorts|dpct::internal
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasAlgorithm|sort_pairs
+// DplExtrasAlgorithm|mark_segments
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+template <typename _ExecutionPolicy, typename key_t, typename value_t,
+          typename OffsetIteratorT>
+inline void segmented_sort_pairs_by_two_pair_sorts(
+    _ExecutionPolicy &&policy, key_t keys_in, key_t keys_out, value_t values_in,
+    value_t values_out, int64_t n, int64_t nsegments,
+    OffsetIteratorT begin_offsets, OffsetIteratorT end_offsets,
+    bool descending = false, int begin_bit = 0,
+    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
+                  8) {
+  using key_t_value_t = typename ::std::iterator_traits<key_t>::value_type;
+  using value_t_value_t = typename ::std::iterator_traits<value_t>::value_type;
+  ::std::size_t *segments =
+      sycl::malloc_device<::std::size_t>(n, policy.queue());
+  ::std::size_t *segments_sorted =
+      sycl::malloc_device<::std::size_t>(n, policy.queue());
+  auto keys_temp = sycl::malloc_device<key_t_value_t>(n, policy.queue());
+  auto values_temp = sycl::malloc_device<value_t_value_t>(n, policy.queue());
+
+  mark_segments(::std::forward<_ExecutionPolicy>(policy), begin_offsets, 
+                end_offsets, n, nsegments, segments);
 
   auto zip_seg_vals = oneapi::dpl::make_zip_iterator(segments, values_in);
   auto zip_seg_vals_out =
@@ -1705,6 +1827,52 @@ inline void sort_keys(
             n, descending, begin_bit, end_bit);
   if (do_swap_iters)
     keys.swap();
+}
+// DPCT_LABEL_END
+
+// DPCT_LABEL_BEGIN|segmented_sort_keys|dpct
+// DPCT_DEPENDENCY_BEGIN 
+// DplExtrasAlgorithm|segmented_sort_keys_by_parallel_sorts
+// DplExtrasAlgorithm|segmented_sort_keys_by_parallel_for_of_sorts
+// DplExtrasAlgorithm|segmented_sort_keys_by_two_pair_sorts
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+template <typename _ExecutionPolicy, typename key_t, typename OffsetIteratorT>
+inline void segmented_sort_keys(
+    _ExecutionPolicy &&policy, key_t keys_in, key_t keys_out, int64_t n,
+    int64_t nsegments, OffsetIteratorT begin_offsets,
+    OffsetIteratorT end_offsets, bool descending = false, int begin_bit = 0,
+    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
+                  8) {
+  int compute_units =
+      policy.queue()
+          .get_device()
+          .template get_info<sycl::info::device::max_compute_units>();
+  auto sg_sizes = policy.queue()
+                      .get_device()
+                      .template get_info<sycl::info::device::sub_group_sizes>();
+  int subgroup_size = sg_sizes.empty() ? 1 : sg_sizes.back();
+  // parallel for of serial sorts when we have sufficient number of segments for
+  // load balance when number of segments is large as compared to our target
+  // compute capability
+  if (nsegments >
+      compute_units *
+          (policy.queue().get_device().is_gpu() ? subgroup_size : 1)) {
+    dpct::internal::segmented_sort_keys_by_parallel_for_of_sorts(
+        ::std::forward<_ExecutionPolicy>(policy), keys_in, keys_out, n,
+        nsegments, begin_offsets, end_offsets, descending, begin_bit, end_bit);
+  } else if (nsegments < 512) // for loop of parallel sorts when we have a small
+                              // number of total sorts to limit total overhead
+  {
+    dpct::internal::segmented_sort_keys_by_parallel_sorts(
+        ::std::forward<_ExecutionPolicy>(policy), keys_in, keys_out, n,
+        nsegments, begin_offsets, end_offsets, descending, begin_bit, end_bit);
+  } else // decent catch all using 2 full sorts
+  {
+    dpct::internal::segmented_sort_keys_by_two_pair_sorts(
+        ::std::forward<_ExecutionPolicy>(policy), keys_in, keys_out, n,
+        nsegments, begin_offsets, end_offsets, descending, begin_bit, end_bit);
+  }
 }
 // DPCT_LABEL_END
 

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -1455,11 +1455,15 @@ inline void segmented_sort_pairs_by_parallel_sorts(
 // DPCT_LABEL_BEGIN|segmented_sort_keys_by_parallel_sorts|dpct::internal
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasAlgorithm|sort_keys
+// DplExtrasVector|is_iterator
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
-template <typename _ExecutionPolicy, typename key_t, typename OffsetIteratorT>
-inline void segmented_sort_keys_by_parallel_sorts(
-    _ExecutionPolicy &&policy, key_t keys_in, key_t keys_out, int64_t n,
+template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
+          typename OffsetIteratorT>
+inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
+                          dpct::internal::is_iterator<key_out_t>::value>
+segmented_sort_keys_by_parallel_sorts(
+    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out, int64_t n,
     int64_t nsegments, OffsetIteratorT begin_offsets,
      OffsetIteratorT end_offsets, bool descending = false, int begin_bit = 0,
     int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
@@ -1527,15 +1531,17 @@ inline void segmented_sort_pairs_by_parallel_for_of_sorts(
 // DPCT_LABEL_BEGIN|segmented_sort_keys_by_parallel_for_of_sorts|dpct::internal
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasAlgorithm|sort_keys
+// DplExtrasVector|is_iterator
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
-          typename value_t, typename value_out_t, typename OffsetIteratorT>
-inline void segmented_sort_pairs_by_two_pair_sorts(
-    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
-    value_out_t values_in, value_t values_out, int64_t n, int64_t nsegments,
-    OffsetIteratorT begin_offsets, OffsetIteratorT end_offsets,
-    bool descending = false, int begin_bit = 0,
+          typename OffsetIteratorT>
+inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
+                          dpct::internal::is_iterator<key_out_t>::value>
+segmented_sort_keys_by_parallel_for_of_sorts(
+    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out, int64_t n,
+    int64_t nsegments, OffsetIteratorT begin_offsets,
+    OffsetIteratorT end_offsets, bool descending = false, int begin_bit = 0,
     int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
                   8) {
   policy.queue().submit([&](sycl::handler &cgh) {
@@ -1639,11 +1645,15 @@ inline void mark_segments(_ExecutionPolicy &&policy,
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasAlgorithm|sort_pairs
 // DplExtrasAlgorithm|mark_segments
+// DplExtrasVector|is_iterator
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
-template <typename _ExecutionPolicy, typename key_t, typename OffsetIteratorT>
-inline void segmented_sort_keys_by_two_pair_sorts(
-    _ExecutionPolicy &&policy, key_t keys_in, key_t keys_out, int64_t n,
+template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
+          typename OffsetIteratorT>
+inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
+                          dpct::internal::is_iterator<key_out_t>::value>
+segmented_sort_keys_by_two_pair_sorts(
+    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out, int64_t n,
     int64_t nsegments, OffsetIteratorT begin_offsets,
     OffsetIteratorT end_offsets, bool descending = false, int begin_bit = 0,
     int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
@@ -1835,11 +1845,15 @@ inline void sort_keys(
 // DplExtrasAlgorithm|segmented_sort_keys_by_parallel_sorts
 // DplExtrasAlgorithm|segmented_sort_keys_by_parallel_for_of_sorts
 // DplExtrasAlgorithm|segmented_sort_keys_by_two_pair_sorts
+// DplExtrasVector|is_iterator
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
-template <typename _ExecutionPolicy, typename key_t, typename OffsetIteratorT>
-inline void segmented_sort_keys(
-    _ExecutionPolicy &&policy, key_t keys_in, key_t keys_out, int64_t n,
+template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
+          typename OffsetIteratorT>
+inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
+                          dpct::internal::is_iterator<key_out_t>::value>
+segmented_sort_keys(
+    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out, int64_t n,
     int64_t nsegments, OffsetIteratorT begin_offsets,
     OffsetIteratorT end_offsets, bool descending = false, int begin_bit = 0,
     int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
@@ -1872,6 +1886,29 @@ inline void segmented_sort_keys(
     dpct::internal::segmented_sort_keys_by_two_pair_sorts(
         ::std::forward<_ExecutionPolicy>(policy), keys_in, keys_out, n,
         nsegments, begin_offsets, end_offsets, descending, begin_bit, end_bit);
+  }
+}
+// DPCT_LABEL_END
+
+// DPCT_LABEL_BEGIN|segmented_sort_pairs_io_iterator_pair|dpct
+// DPCT_DEPENDENCY_BEGIN 
+// DplExtrasAlgorithm|segmented_sort_keys
+// DplExtrasIterators|io_iterator_pair
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+template <typename _ExecutionPolicy, typename key_t, typename OffsetIteratorT>
+inline void segmented_sort_keys(
+    _ExecutionPolicy &&policy, io_iterator_pair<key_t> &keys, int64_t n,
+    int64_t nsegments, OffsetIteratorT begin_offsets,
+    OffsetIteratorT end_offsets, bool descending = false,
+    bool do_swap_iters = false, int begin_bit = 0,
+    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
+                  8) {
+  segmented_sort_keys(std::forward<_ExecutionPolicy>(policy), keys.first(),
+                      keys.second(), n, nsegments, begin_offsets, end_offsets,
+                      descending, begin_bit, end_bit);
+  if (do_swap_iters) {
+    keys.swap();
   }
 }
 // DPCT_LABEL_END

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -1574,7 +1574,7 @@ inline void mark_segments(_ExecutionPolicy &&policy,
   ::std::size_t sub_group_size = sg_sizes.empty() ? 0 : sg_sizes.back();
 
   float avg_seg_size = (float)n / (float)nsegments;
- if (avg_seg_size > work_group_size) {
+  if (avg_seg_size > work_group_size) {
     // If average segment size is larger than workgroup, use workgroup to
     // coordinate to mark segments
     policy.queue()

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -1688,11 +1688,11 @@ segmented_sort_keys_by_two_pair_sorts(
 // DplExtrasAlgorithm|mark_segments
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
-template <typename _ExecutionPolicy, typename key_t, typename value_t,
-          typename OffsetIteratorT>
+template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
+          typename value_t, typename value_out_t, typename OffsetIteratorT>
 inline void segmented_sort_pairs_by_two_pair_sorts(
-    _ExecutionPolicy &&policy, key_t keys_in, key_t keys_out, value_t values_in,
-    value_t values_out, int64_t n, int64_t nsegments,
+    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
+    value_out_t values_in, value_t values_out, int64_t n, int64_t nsegments,
     OffsetIteratorT begin_offsets, OffsetIteratorT end_offsets,
     bool descending = false, int begin_bit = 0,
     int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -1890,7 +1890,7 @@ segmented_sort_keys(
 }
 // DPCT_LABEL_END
 
-// DPCT_LABEL_BEGIN|segmented_sort_pairs_io_iterator_pair|dpct
+// DPCT_LABEL_BEGIN|segmented_sort_keys_io_iterator_pair|dpct
 // DPCT_DEPENDENCY_BEGIN 
 // DplExtrasAlgorithm|segmented_sort_keys
 // DplExtrasIterators|io_iterator_pair

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -1455,14 +1455,11 @@ inline void segmented_sort_pairs_by_parallel_sorts(
 // DPCT_LABEL_BEGIN|segmented_sort_keys_by_parallel_sorts|dpct::internal
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasAlgorithm|sort_keys
-// DplExtrasVector|is_iterator
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
           typename OffsetIteratorT>
-inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
-                          dpct::internal::is_iterator<key_out_t>::value>
-segmented_sort_keys_by_parallel_sorts(
+inline void segmented_sort_keys_by_parallel_sorts(
     _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out, int64_t n,
     int64_t nsegments, OffsetIteratorT begin_offsets,
      OffsetIteratorT end_offsets, bool descending = false, int begin_bit = 0,
@@ -1531,14 +1528,11 @@ inline void segmented_sort_pairs_by_parallel_for_of_sorts(
 // DPCT_LABEL_BEGIN|segmented_sort_keys_by_parallel_for_of_sorts|dpct::internal
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasAlgorithm|sort_keys
-// DplExtrasVector|is_iterator
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
           typename OffsetIteratorT>
-inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
-                          dpct::internal::is_iterator<key_out_t>::value>
-segmented_sort_keys_by_parallel_for_of_sorts(
+inline void segmented_sort_keys_by_parallel_for_of_sorts(
     _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out, int64_t n,
     int64_t nsegments, OffsetIteratorT begin_offsets,
     OffsetIteratorT end_offsets, bool descending = false, int begin_bit = 0,
@@ -1645,14 +1639,11 @@ inline void mark_segments(_ExecutionPolicy &&policy,
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasAlgorithm|sort_pairs
 // DplExtrasAlgorithm|mark_segments
-// DplExtrasVector|is_iterator
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
           typename OffsetIteratorT>
-inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
-                          dpct::internal::is_iterator<key_out_t>::value>
-segmented_sort_keys_by_two_pair_sorts(
+inline void segmented_sort_keys_by_two_pair_sorts(
     _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out, int64_t n,
     int64_t nsegments, OffsetIteratorT begin_offsets,
     OffsetIteratorT end_offsets, bool descending = false, int begin_bit = 0,
@@ -1740,10 +1731,10 @@ inline void segmented_sort_pairs_by_two_pair_sorts(
 // DPCT_CODE
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
           typename value_t, typename value_out_t>
-inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value && 
+inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
                         dpct::internal::is_iterator<key_out_t>::value &&
                         dpct::internal::is_iterator<value_t>::value &&
-                        dpct::internal::is_iterator<value_out_t>::value> 
+                        dpct::internal::is_iterator<value_out_t>::value>
 sort_pairs(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
                 value_t values_in, value_out_t values_out, int64_t n,
                 bool descending, int begin_bit, int end_bit) {
@@ -1785,7 +1776,7 @@ inline void sort_pairs(
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t>
-inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value && 
+inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
                         dpct::internal::is_iterator<key_out_t>::value>
 sort_keys(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
           int64_t n, bool descending, int begin_bit, int end_bit) {

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -1613,8 +1613,8 @@ inline void mark_segments(_ExecutionPolicy &&policy,
                 ::std::size_t sub_group_id = sub_group.get_group_id();
                 while (sub_group_id < nsegments) {
                   ::std::size_t subgroup_local_id = sub_group.get_local_id();
-                  std::size_t i = begin_offsets[sub_group_id];
-                  std::size_t end = end_offsets[sub_group_id];
+                  ::std::size_t i = begin_offsets[sub_group_id];
+                  ::std::size_t end = end_offsets[sub_group_id];
                   while (i + subgroup_local_id < end) {
                     segments[i + subgroup_local_id] = sub_group_id;
                     i += local_size;
@@ -1630,7 +1630,7 @@ inline void mark_segments(_ExecutionPolicy &&policy,
     policy.queue()
         .submit([&](sycl::handler &h) {
           h.parallel_for(nsegments, ([=](sycl::id<1> seg) {
-                           for (std::size_t i = begin_offsets[seg];
+                           for (::std::size_t i = begin_offsets[seg];
                                 i < end_offsets[seg]; i++) {
                              segments[i] = seg;
                            }
@@ -1904,7 +1904,7 @@ inline void segmented_sort_keys(
     bool do_swap_iters = false, int begin_bit = 0,
     int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
                   8) {
-  segmented_sort_keys(std::forward<_ExecutionPolicy>(policy), keys.first(),
+  segmented_sort_keys(::std::forward<_ExecutionPolicy>(policy), keys.first(),
                       keys.second(), n, nsegments, begin_offsets, end_offsets,
                       descending, begin_bit, end_bit);
   if (do_swap_iters) {

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1201,7 +1201,7 @@ inline void segmented_sort_pairs_by_parallel_sorts(
   ::std::copy(::std::forward<_ExecutionPolicy>(policy), end_offsets,
               end_offsets + nsegments, host_accessible_offset_ends);
 
-  for (int i = 0; i < nsegments; i++) {
+  for (::std::uint64_t i = 0; i < nsegments; i++) {
     uint64_t segment_begin = host_accessible_offset_starts[i];
     uint64_t segment_end =
         ::std::min(n, (int64_t)host_accessible_offset_ends[i]);
@@ -1237,7 +1237,7 @@ inline void segmented_sort_keys_by_parallel_sorts(
   ::std::copy(::std::forward<_ExecutionPolicy>(policy), end_offsets,
               end_offsets + nsegments, host_accessible_offset_ends);
 
-  for (int i = 0; i < nsegments; i++) {
+  for (::std::uint64_t i = 0; i < nsegments; i++) {
     uint64_t segment_begin = host_accessible_offset_starts[i];
     uint64_t segment_end =
         ::std::min(n, (int64_t)host_accessible_offset_ends[i]);
@@ -1263,8 +1263,8 @@ inline void segmented_sort_pairs_by_parallel_for_of_sorts(
                   8) {
   policy.queue().submit([&](sycl::handler &cgh) {
     cgh.parallel_for(nsegments, [=](sycl::id<1> i) {
-      uint64_t segment_begin = begin_offsets[(int)i];
-      uint64_t segment_end = ::std::min(n, (int64_t)end_offsets[(int)i]);
+      uint64_t segment_begin = begin_offsets[i];
+      uint64_t segment_end = ::std::min(n, (int64_t)end_offsets[i]);
       if (segment_begin == segment_end) {
         return;
       }
@@ -1288,8 +1288,8 @@ inline void segmented_sort_keys_by_parallel_for_of_sorts(
                   8) {
   policy.queue().submit([&](sycl::handler &cgh) {
     cgh.parallel_for(nsegments, [=](sycl::id<1> i) {
-      uint64_t segment_begin = begin_offsets[(int)i];
-      uint64_t segment_end = ::std::min(n, (int64_t)end_offsets[(int)i]);
+      uint64_t segment_begin = begin_offsets[i];
+      uint64_t segment_end = ::std::min(n, (int64_t)end_offsets[i]);
       if (segment_begin == segment_end) {
         return;
       }

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1219,9 +1219,7 @@ inline void segmented_sort_pairs_by_parallel_sorts(
 
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
           typename OffsetIteratorT>
-inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
-                          dpct::internal::is_iterator<key_out_t>::value>
-segmented_sort_keys_by_parallel_sorts(
+inline void segmented_sort_keys_by_parallel_sorts(
     _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out, int64_t n,
     int64_t nsegments, OffsetIteratorT begin_offsets,
      OffsetIteratorT end_offsets, bool descending = false, int begin_bit = 0,
@@ -1282,9 +1280,7 @@ inline void segmented_sort_pairs_by_parallel_for_of_sorts(
 
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
           typename OffsetIteratorT>
-inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
-                          dpct::internal::is_iterator<key_out_t>::value>
-segmented_sort_keys_by_parallel_for_of_sorts(
+inline void segmented_sort_keys_by_parallel_for_of_sorts(
     _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out, int64_t n,
     int64_t nsegments, OffsetIteratorT begin_offsets,
     OffsetIteratorT end_offsets, bool descending = false, int begin_bit = 0,
@@ -1384,9 +1380,7 @@ inline void mark_segments(_ExecutionPolicy &&policy,
 
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
           typename OffsetIteratorT>
-inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
-                          dpct::internal::is_iterator<key_out_t>::value>
-segmented_sort_keys_by_two_pair_sorts(
+inline void segmented_sort_keys_by_two_pair_sorts(
     _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out, int64_t n,
     int64_t nsegments, OffsetIteratorT begin_offsets,
     OffsetIteratorT end_offsets, bool descending = false, int begin_bit = 0,
@@ -1459,10 +1453,10 @@ inline void segmented_sort_pairs_by_two_pair_sorts(
 
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
           typename value_t, typename value_out_t>
-inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value && 
+inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
                         dpct::internal::is_iterator<key_out_t>::value &&
                         dpct::internal::is_iterator<value_t>::value &&
-                        dpct::internal::is_iterator<value_out_t>::value> 
+                        dpct::internal::is_iterator<value_out_t>::value>
 sort_pairs(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
                 value_t values_in, value_out_t values_out, int64_t n,
                 bool descending, int begin_bit, int end_bit) {
@@ -1489,7 +1483,7 @@ inline void sort_pairs(
 }
 
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t>
-inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value && 
+inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
                         dpct::internal::is_iterator<key_out_t>::value>
 sort_keys(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
           int64_t n, bool descending, int begin_bit, int end_bit) {

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1217,9 +1217,12 @@ inline void segmented_sort_pairs_by_parallel_sorts(
   sycl::free(host_accessible_offset_ends, policy.queue());
 }
 
-template <typename _ExecutionPolicy, typename key_t, typename OffsetIteratorT>
-inline void segmented_sort_keys_by_parallel_sorts(
-    _ExecutionPolicy &&policy, key_t keys_in, key_t keys_out, int64_t n,
+template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
+          typename OffsetIteratorT>
+inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
+                          dpct::internal::is_iterator<key_out_t>::value>
+segmented_sort_keys_by_parallel_sorts(
+    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out, int64_t n,
     int64_t nsegments, OffsetIteratorT begin_offsets,
      OffsetIteratorT end_offsets, bool descending = false, int begin_bit = 0,
     int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
@@ -1277,9 +1280,12 @@ inline void segmented_sort_pairs_by_parallel_for_of_sorts(
   policy.queue().wait();
 }
 
-template <typename _ExecutionPolicy, typename key_t, typename OffsetIteratorT>
-inline void segmented_sort_keys_by_parallel_for_of_sorts(
-    _ExecutionPolicy &&policy, key_t keys_in, key_t keys_out, int64_t n,
+template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
+          typename OffsetIteratorT>
+inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
+                          dpct::internal::is_iterator<key_out_t>::value>
+segmented_sort_keys_by_parallel_for_of_sorts(
+    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out, int64_t n,
     int64_t nsegments, OffsetIteratorT begin_offsets,
     OffsetIteratorT end_offsets, bool descending = false, int begin_bit = 0,
     int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
@@ -1376,9 +1382,12 @@ inline void mark_segments(_ExecutionPolicy &&policy,
   }
 }
 
-template <typename _ExecutionPolicy, typename key_t, typename OffsetIteratorT>
-inline void segmented_sort_keys_by_two_pair_sorts(
-    _ExecutionPolicy &&policy, key_t keys_in, key_t keys_out, int64_t n,
+template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
+          typename OffsetIteratorT>
+inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
+                          dpct::internal::is_iterator<key_out_t>::value>
+segmented_sort_keys_by_two_pair_sorts(
+    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out, int64_t n,
     int64_t nsegments, OffsetIteratorT begin_offsets,
     OffsetIteratorT end_offsets, bool descending = false, int begin_bit = 0,
     int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
@@ -1527,9 +1536,12 @@ inline void sort_keys(
     keys.swap();
 }
 
-template <typename _ExecutionPolicy, typename key_t, typename OffsetIteratorT>
-inline void segmented_sort_keys(
-    _ExecutionPolicy &&policy, key_t keys_in, key_t keys_out, int64_t n,
+template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
+          typename OffsetIteratorT>
+inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
+                          dpct::internal::is_iterator<key_out_t>::value>
+segmented_sort_keys(
+    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out, int64_t n,
     int64_t nsegments, OffsetIteratorT begin_offsets,
     OffsetIteratorT end_offsets, bool descending = false, int begin_bit = 0,
     int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
@@ -1562,6 +1574,22 @@ inline void segmented_sort_keys(
     dpct::internal::segmented_sort_keys_by_two_pair_sorts(
         ::std::forward<_ExecutionPolicy>(policy), keys_in, keys_out, n,
         nsegments, begin_offsets, end_offsets, descending, begin_bit, end_bit);
+  }
+}
+
+template <typename _ExecutionPolicy, typename key_t, typename OffsetIteratorT>
+inline void segmented_sort_keys(
+    _ExecutionPolicy &&policy, io_iterator_pair<key_t> &keys, int64_t n,
+    int64_t nsegments, OffsetIteratorT begin_offsets,
+    OffsetIteratorT end_offsets, bool descending = false,
+    bool do_swap_iters = false, int begin_bit = 0,
+    int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
+                  8) {
+  segmented_sort_keys(std::forward<_ExecutionPolicy>(policy), keys.first(),
+                      keys.second(), n, nsegments, begin_offsets, end_offsets,
+                      descending, begin_bit, end_bit);
+  if (do_swap_iters) {
+    keys.swap();
   }
 }
 

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1318,7 +1318,7 @@ inline void mark_segments(_ExecutionPolicy &&policy,
   ::std::size_t sub_group_size = sg_sizes.empty() ? 0 : sg_sizes.back();
 
   float avg_seg_size = (float)n / (float)nsegments;
- if (avg_seg_size > work_group_size) {
+  if (avg_seg_size > work_group_size) {
     // If average segment size is larger than workgroup, use workgroup to
     // coordinate to mark segments
     policy.queue()

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1300,12 +1300,10 @@ inline void segmented_sort_keys_by_parallel_for_of_sorts(
 }
 
 template <typename _ExecutionPolicy, typename OffsetIteratorT>
-inline void 
-mark_segments(_ExecutionPolicy &&policy, OffsetIteratorT begin_offsets,
-              OffsetIteratorT end_offsets, int64_t n, int64_t nsegments,
-              ::std::size_t* segments)
-{
-
+inline void mark_segments(_ExecutionPolicy &&policy,
+                          OffsetIteratorT begin_offsets,
+                          OffsetIteratorT end_offsets, int64_t n,
+                          int64_t nsegments, ::std::size_t *segments) {
 
   ::std::size_t work_group_size =
       policy.queue()
@@ -1529,8 +1527,7 @@ inline void sort_keys(
     keys.swap();
 }
 
-template <typename _ExecutionPolicy, typename key_t,
-          typename OffsetIteratorT>
+template <typename _ExecutionPolicy, typename key_t, typename OffsetIteratorT>
 inline void segmented_sort_keys(
     _ExecutionPolicy &&policy, key_t keys_in, key_t keys_out, int64_t n,
     int64_t nsegments, OffsetIteratorT begin_offsets,

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1355,8 +1355,8 @@ inline void mark_segments(_ExecutionPolicy &&policy,
                 ::std::size_t sub_group_id = sub_group.get_group_id();
                 while (sub_group_id < nsegments) {
                   ::std::size_t subgroup_local_id = sub_group.get_local_id();
-                  std::size_t i = begin_offsets[sub_group_id];
-                  std::size_t end = end_offsets[sub_group_id];
+                  ::std::size_t i = begin_offsets[sub_group_id];
+                  ::std::size_t end = end_offsets[sub_group_id];
                   while (i + subgroup_local_id < end) {
                     segments[i + subgroup_local_id] = sub_group_id;
                     i += local_size;
@@ -1372,7 +1372,7 @@ inline void mark_segments(_ExecutionPolicy &&policy,
     policy.queue()
         .submit([&](sycl::handler &h) {
           h.parallel_for(nsegments, ([=](sycl::id<1> seg) {
-                           for (std::size_t i = begin_offsets[seg];
+                           for (::std::size_t i = begin_offsets[seg];
                                 i < end_offsets[seg]; i++) {
                              segments[i] = seg;
                            }
@@ -1585,7 +1585,7 @@ inline void segmented_sort_keys(
     bool do_swap_iters = false, int begin_bit = 0,
     int end_bit = sizeof(typename ::std::iterator_traits<key_t>::value_type) *
                   8) {
-  segmented_sort_keys(std::forward<_ExecutionPolicy>(policy), keys.first(),
+  segmented_sort_keys(::std::forward<_ExecutionPolicy>(policy), keys.first(),
                       keys.second(), n, nsegments, begin_offsets, end_offsets,
                       descending, begin_bit, end_bit);
   if (do_swap_iters) {

--- a/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test15.cu
+++ b/clang/test/dpct/test_api_level/DplExtrasAlgorithm/api_test15.cu
@@ -5,7 +5,7 @@
 // RUN: FileCheck --input-file %T/DplExtrasAlgorithm/api_test15/count.txt --match-full-lines %s
 // RUN: rm -rf %T/DplExtrasAlgorithm/api_test15
 
-// CHECK: 31
+// CHECK: 32
 // TEST_FEATURE: DplExtrasAlgorithm_segmented_sort_pairs
 
 #include <cub/cub.cuh>


### PR DESCRIPTION
Adding dpct::segmented_sort_keys functional mapping in the same style as dpct::segmented_sort_pairs.

Testing provided by https://github.com/oneapi-src/SYCLomatic-test/pull/232.