### PR TITLE
[SYCLomatic] dpct::device_vectors::shrink_to_fit() bugfix for non USM

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/vector.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/vector.h.inc
@@ -667,7 +667,8 @@ public:
                      .buffer.template reinterpret<T, 1>(sycl::range<1>(_size));
       std::copy(oneapi::dpl::execution::dpcpp_default,
                 oneapi::dpl::begin(get_buffer()),
-                oneapi::dpl::end(get_buffer()), oneapi::dpl::begin(tmp));
+                oneapi::dpl::begin(get_buffer()) + _size,
+                oneapi::dpl::begin(tmp));
       detail::mem_mgr::instance().mem_free(_storage);
       _storage = a;
     }

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/vector.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/vector.h
@@ -612,7 +612,8 @@ public:
                      .buffer.template reinterpret<T, 1>(sycl::range<1>(_size));
       std::copy(oneapi::dpl::execution::dpcpp_default,
                 oneapi::dpl::begin(get_buffer()),
-                oneapi::dpl::end(get_buffer()), oneapi::dpl::begin(tmp));
+                oneapi::dpl::begin(get_buffer()) + _size,
+                oneapi::dpl::begin(tmp));
       detail::mem_mgr::instance().mem_free(_storage);
       _storage = a;
     }


### PR DESCRIPTION
Bugfix for non-USM shrink_to_fit implementation to avoid uninitialized memory reads and out of bounds writes.