### PR TITLE
[SYCLomatic] Fix Makefile generator crash caused by whitespace between -I and include path

### DIFF
--- a/clang/lib/DPCT/GenMakefile.cpp
+++ b/clang/lib/DPCT/GenMakefile.cpp
@@ -184,7 +184,7 @@ static void getCompileInfo(
         continue;
       }
 
-      if (llvm::StringRef(Option).startswith("-I")) {
+      if (IsIncludeWithWhitespace  || llvm::StringRef(Option).startswith("-I")) {
 
         if (llvm::StringRef(Option).trim() == "-I") {
           IsIncludeWithWhitespace = true;

--- a/clang/lib/DPCT/GenMakefile.cpp
+++ b/clang/lib/DPCT/GenMakefile.cpp
@@ -159,7 +159,7 @@ static void getCompileInfo(
     // -isystem
     bool IsSystemInclude = false;
 
-    // -I /path/to/some/header
+    // To parse option "-I <space> <path>"
     bool IsIncludeWithWhitespace = false;
 
     const std::string Directory = Entry.second[0];

--- a/clang/test/dpct/gen-build-script.cpp
+++ b/clang/test/dpct/gen-build-script.cpp
@@ -9,8 +9,8 @@
 // RUN: cp %s gen-build-script.cpp
 //
 // ------ create makefile
-// RUN: echo "gen-build-script.o      :       gen-build-script.cpp                                           "      >  Makefile
-// RUN: echo "	%clangxx -c gen-build-script.cpp -DFOOBAR -msse4.1 -mavx512vl -O2 -isystem %cuda-path/include"      >> Makefile
+// RUN: echo "gen-build-script.o      :       gen-build-script.cpp                                                                  "      >  Makefile
+// RUN: echo "	%clangxx -c gen-build-script.cpp -DFOOBAR -msse4.1 -mavx512vl -O2 -isystem %cuda-path/include -I %cuda-path/include "      >> Makefile
 //
 // ------ create compilation database
 // RUN: intercept-build make -f Makefile


### PR DESCRIPTION
Signed-off-by: Wang, Yihan [yihan.wang@intel.com](mailto:yihan.wang@intel.com)