### PR TITLE
[SYCLomatic] Use helper function in the migrated code to avoid using deprecated API sycl::atomic

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -1937,9 +1937,7 @@ void AtomicFunctionRule::MigrateAtomicFunc(
   const QualType PointeeType = Arg0Type->getPointeeType();
 
   std::string TypeName;
-  bool IsTemplateType = false;
   if (auto *SubstedType = dyn_cast<SubstTemplateTypeParmType>(PointeeType)) {
-    IsTemplateType = true;
     // Type is substituted in template initialization, use the template
     // parameter name
     if (!SubstedType->getReplacedParameter()->getIdentifier()) {
@@ -1987,58 +1985,6 @@ void AtomicFunctionRule::MigrateAtomicFunc(
     bool HasSharedAttr = false;
     bool NeedReport = false;
     getShareAttrRecursive(CE->getArg(0), HasSharedAttr, NeedReport);
-
-    // Inline the code for integer types
-    static std::unordered_map<std::string, std::string> AtomicMap = {
-        {"atomicAdd", "fetch_add"}, {"atomicSub", "fetch_sub"},
-        {"atomicAnd", "fetch_and"}, {"atomicOr", "fetch_or"},
-        {"atomicXor", "fetch_xor"}, {"atomicMin", "fetch_min"},
-        {"atomicMax", "fetch_max"},
-    };
-
-    auto IsMacro = CE->getBeginLoc().isMacroID();
-    auto Iter = AtomicMap.find(AtomicFuncName);
-    if (!IsMacro && !IsTemplateType && PointeeType->isIntegerType() &&
-        Iter != AtomicMap.end()) {
-      if (NeedReport)
-        report(CE->getArg(0)->getBeginLoc(),
-               Diagnostics::SHARE_MEMORY_ATTR_DEDUCE, false,
-               getStmtSpelling(CE->getArg(0)),
-               MapNames::getClNamespace() + "global_ptr",
-               MapNames::getClNamespace() + "local_ptr");
-
-      std::string ReplStr{MapNames::getClNamespace(true)};
-      ReplStr += "atomic<";
-      ReplStr += TypeName;
-      if (HasSharedAttr) {
-        ReplStr += ", ";
-        ReplStr += MapNames::getClNamespace();
-        ReplStr += "access::address_space::local_space";
-      }
-      ReplStr += ">(";
-      ReplStr += MapNames::getClNamespace();
-      if (HasSharedAttr)
-        ReplStr += "local_ptr<";
-      else
-        ReplStr += "global_ptr<";
-      ReplStr += TypeName;
-      ReplStr += ">(";
-
-      ArgumentAnalysis A0(CE->getArg(0), false);
-      A0.analyze();
-      ReplStr += A0.getReplacedString();
-      ReplStr += ")).";
-      ReplStr += Iter->second;
-      ReplStr += "(";
-
-      ArgumentAnalysis A1(CE->getArg(1), false);
-      A1.analyze();
-      ReplStr += A1.getReplacedString();
-      ReplStr += ")";
-
-      emplaceTransformation(new ReplaceStmt(CE, std::move(ReplStr)));
-      return;
-    }
 
     std::string SpaceName =
         MapNames::getClNamespace() + "access::address_space::local_space";

--- a/clang/test/dpct/atomic_functions_no_use_generic_space.cu
+++ b/clang/test/dpct/atomic_functions_no_use_generic_space.cu
@@ -59,7 +59,7 @@ template <>
 __global__ void test(unsigned long long int* data) {
   unsigned long long int tid = threadIdx.x;
 
-  // CHECK: sycl::atomic<unsigned long long>(sycl::global_ptr<unsigned long long>(&data[0])).fetch_add(tid);
+  // CHECK: dpct::atomic_fetch_add(&data[0], tid);
   atomicAdd(&data[0], tid);
 
   // CHECK: dpct::atomic_exchange(&data[2], tid);
@@ -126,7 +126,7 @@ __device__ void fun(){
   // CHECK: dpct::atomic_fetch_add(a, (double)b);
   atomicAdd(a, b);
 
-  // CHECK: sycl::atomic<uint32_t>(sycl::global_ptr<uint32_t>(d_error)).fetch_add(1);
+  // CHECK: dpct::atomic_fetch_add((uint32_t*)d_error, (uint32_t)1);
   atomicAdd(d_error, 1);
 }
 
@@ -141,11 +141,11 @@ int main() {
 // CHECK: void foo(sycl::nd_item<3> item_ct1, uint8_t *dpct_local, uint32_t &share_v) {
 // CHECK-NEXT:  auto share_array = (uint32_t *)dpct_local;
 // CHECK-NEXT:  for (int b = item_ct1.get_local_id(2); b < 64; b += item_ct1.get_local_range(2)) {
-// CHECK-NEXT:    sycl::atomic<uint32_t, sycl::access::address_space::local_space>(sycl::local_ptr<uint32_t>(&share_array[b])).fetch_add(1);
-// CHECK-NEXT:    sycl::atomic<uint32_t, sycl::access::address_space::local_space>(sycl::local_ptr<uint32_t>(share_array)).fetch_add(1);
+// CHECK-NEXT:    dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::local_space>(&share_array[b], (uint32_t)1);
+// CHECK-NEXT:    dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::local_space>((uint32_t*)share_array, (uint32_t)1);
 // CHECK-NEXT:  }
 // CHECK-EMPTY:
-// CHECK-NEXT:  sycl::atomic<uint32_t, sycl::access::address_space::local_space>(sycl::local_ptr<uint32_t>(&share_v)).fetch_add(1);
+// CHECK-NEXT:  dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::local_space>(&share_v, (uint32_t)1);
 // CHECK-NEXT:}
 __global__ void foo() {
   extern __shared__ uint32_t share_array[];
@@ -163,17 +163,17 @@ __shared__ uint32_t share_v;
 // CHECK-NEXT:    uint32_t *p_1 = &share_array[b];
 // CHECK-NEXT:    uint32_t *p_2 = share_array;
 // CHECK-NEXT:    uint32_t *p_3 = p_2;
-// CHECK-NEXT:    sycl::atomic<uint32_t, sycl::access::address_space::local_space>(sycl::local_ptr<uint32_t>(p_1)).fetch_add(1);
-// CHECK-NEXT:    sycl::atomic<uint32_t, sycl::access::address_space::local_space>(sycl::local_ptr<uint32_t>(p_2)).fetch_add(1);
-// CHECK-NEXT:    sycl::atomic<uint32_t, sycl::access::address_space::local_space>(sycl::local_ptr<uint32_t>(p_3)).fetch_add(1);
+// CHECK-NEXT:    dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::local_space>(p_1, (uint32_t)1);
+// CHECK-NEXT:    dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::local_space>(p_2, (uint32_t)1);
+// CHECK-NEXT:    dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::local_space>(p_3, (uint32_t)1);
 // CHECK-NEXT:  }
 // CHECK-EMPTY:
 // CHECK-NEXT:  uint32_t *p_1 = &share_v;
 // CHECK-NEXT:  uint32_t *p_2 = p_1;
 // CHECK-NEXT:  uint32_t *p_3 = p_2;
-// CHECK-NEXT:  sycl::atomic<uint32_t, sycl::access::address_space::local_space>(sycl::local_ptr<uint32_t>(p_1)).fetch_add(1);
-// CHECK-NEXT:  sycl::atomic<uint32_t, sycl::access::address_space::local_space>(sycl::local_ptr<uint32_t>(p_2)).fetch_add(1);
-// CHECK-NEXT:  sycl::atomic<uint32_t, sycl::access::address_space::local_space>(sycl::local_ptr<uint32_t>(p_3)).fetch_add(1);
+// CHECK-NEXT:  dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::local_space>(p_1, (uint32_t)1);
+// CHECK-NEXT:  dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::local_space>(p_2, (uint32_t)1);
+// CHECK-NEXT:  dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::local_space>(p_3, (uint32_t)1);
 // CHECK-NEXT:}
 __global__ void foo_2() {
   extern __shared__ uint32_t share_array[];
@@ -203,7 +203,7 @@ __shared__ uint32_t share_v;
 // CHECK-NEXT:  p_2 = p_1;
 // CHECK-NEXT:  p_3 = p_2;
 // CHECK-NEXT:  uint32_t *p_4 = p_3;
-// CHECK-NEXT:  sycl::atomic<uint32_t, sycl::access::address_space::local_space>(sycl::local_ptr<uint32_t>(p_4)).fetch_add(1);
+// CHECK-NEXT:  dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::local_space>(p_4, (uint32_t)1);
 // CHECK-NEXT:}
 __global__ void foo_3() {
 __shared__ uint32_t share_v;
@@ -227,13 +227,13 @@ __shared__ uint32_t share_v;
 // CHECK-NEXT:  p_2 = p_1;
 // CHECK-NEXT:  p_3 = p_2;
 // CHECK-NEXT:  uint32_t *p_4 = p_3;
-// CHECK-NEXT:  sycl::atomic<uint32_t, sycl::access::address_space::local_space>(sycl::local_ptr<uint32_t>(p_4)).fetch_add(1);
+// CHECK-NEXT:  dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::local_space>(p_4, (uint32_t)1);
 // CHECK-NEXT:  p_1 = share;
 // CHECK-NEXT:  p_2 = p_1;
 // CHECK-NEXT:  p_3 = p_2;
 // CHECK-NEXT:  p_3 = dmem;
 // CHECK-NEXT:  uint32_t *p_5 = p_3;
-// CHECK-NEXT:  sycl::atomic<uint32_t>(sycl::global_ptr<uint32_t>(p_5)).fetch_add(1);
+// CHECK-NEXT:  dpct::atomic_fetch_add(p_5, (uint32_t)1);
 // CHECK-NEXT:}
 __device__ uint32_t dmem[100];
 __global__ void foo_4() {
@@ -268,12 +268,12 @@ __device__ uint32_t* func(uint32_t *in){
 // CHECK-NEXT:  p_3 = p_2;
 // CHECK-NEXT:  uint32_t *p_4;
 // CHECK-NEXT:  p_4= p_4 + 1;
-// CHECK-NEXT:  sycl::atomic<uint32_t>(sycl::global_ptr<uint32_t>(p_4)).fetch_add(1);
+// CHECK-NEXT:  dpct::atomic_fetch_add(p_4, (uint32_t)1);
 // CHECK-NEXT:  p_4=func(p_3);
 // CHECK-NEXT:  /*
-// CHECK-NEXT:  DPCT1039:{{[0-9]+}}: The generated code assumes that "p_4" points to the global memory address space. If it points to a local memory address space, replace "sycl::global_ptr" with "sycl::local_ptr".
+// CHECK-NEXT:  DPCT1039:{{[0-9]+}}: The generated code assumes that "p_4" points to the global memory address space. If it points to a local memory address space, replace "dpct::atomic_fetch_add" with "dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::local_space>".
 // CHECK-NEXT:  */
-// CHECK-NEXT:  sycl::atomic<uint32_t>(sycl::global_ptr<uint32_t>(p_4)).fetch_add(1);
+// CHECK-NEXT:  dpct::atomic_fetch_add(p_4, (uint32_t)1);
 // CHECK-NEXT:}
 __global__ void foo_5() {
 extern __shared__ uint32_t share[];
@@ -302,7 +302,7 @@ extern __shared__ uint32_t share[];
 // CHECK-NEXT:  uint32_t *p_4;
 // CHECK-NEXT:  p_4= p_4 + 1;
 // CHECK-NEXT:  p_4=FUNC(p_3);
-// CHECK-NEXT:  sycl::atomic<uint32_t, sycl::access::address_space::local_space>(sycl::local_ptr<uint32_t>(p_4)).fetch_add(1);
+// CHECK-NEXT:  dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::local_space>(p_4, (uint32_t)1);
 // CHECK-NEXT:}
 __global__ void foo_6() {
 extern __shared__ uint32_t share[];
@@ -329,9 +329,9 @@ extern __shared__ uint32_t share[];
 // CHECK-NEXT:  else
 // CHECK-NEXT:    p_2 = p_3;
 // CHECK-NEXT:  /*
-// CHECK-NEXT:  DPCT1039:{{[0-9]+}}: The generated code assumes that "p_2" points to the global memory address space. If it points to a local memory address space, replace "sycl::global_ptr" with "sycl::local_ptr".
+// CHECK-NEXT:  DPCT1039:{{[0-9]+}}: The generated code assumes that "p_2" points to the global memory address space. If it points to a local memory address space, replace "dpct::atomic_fetch_add" with "dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::local_space>".
 // CHECK-NEXT:  */
-// CHECK-NEXT:  sycl::atomic<uint32_t>(sycl::global_ptr<uint32_t>(p_2)).fetch_add(1);
+// CHECK-NEXT:  dpct::atomic_fetch_add(p_2, (uint32_t)1);
 // CHECK-NEXT:}
 __global__ void foo_7(int a) {
 extern __shared__ uint32_t share[];
@@ -352,7 +352,7 @@ extern __shared__ uint32_t share[];
 // CHECK-NEXT:  auto sm = (unsigned int *)dpct_local;
 // CHECK-NEXT:  sm[OFFSET] = data[0];
 // CHECK-NEXT:  unsigned* ptr = sm + OFFSET;
-// CHECK-NEXT:  sycl::atomic<unsigned int, sycl::access::address_space::local_space>(sycl::local_ptr<unsigned int>(&ptr[0])).fetch_or(data[1]);
+// CHECK-NEXT:  dpct::atomic_fetch_or<unsigned int, sycl::access::address_space::local_space>(&ptr[0], data[1]);
 // CHECK-NEXT:  data[1] = ptr[0];
 // CHECK-NEXT:}
 __global__ void kernel(unsigned* data) {
@@ -367,7 +367,7 @@ __global__ void kernel(unsigned* data) {
 // CHECK-NEXT:  auto sm = (unsigned int *)dpct_local;
 // CHECK-NEXT:  sm[OFFSET] = data[0];
 // CHECK-NEXT:  unsigned* ptr = OFFSET + sm;
-// CHECK-NEXT:  sycl::atomic<unsigned int, sycl::access::address_space::local_space>(sycl::local_ptr<unsigned int>(&ptr[0])).fetch_or(data[1]);
+// CHECK-NEXT:  dpct::atomic_fetch_or<unsigned int, sycl::access::address_space::local_space>(&ptr[0], data[1]);
 // CHECK-NEXT:  data[1] = ptr[0];
 // CHECK-NEXT:}
 __global__ void kernel_1(unsigned* data) {
@@ -382,7 +382,7 @@ __global__ void kernel_1(unsigned* data) {
 // CHECK-NEXT:  auto sm = (unsigned int *)dpct_local;
 // CHECK-NEXT:  sm[OFFSET] = data[0];
 // CHECK-NEXT:  unsigned* ptr = OFFSET + sm + (3 + 4) + 6;
-// CHECK-NEXT:  sycl::atomic<unsigned int, sycl::access::address_space::local_space>(sycl::local_ptr<unsigned int>(&ptr[0])).fetch_or(data[1]);
+// CHECK-NEXT:  dpct::atomic_fetch_or<unsigned int, sycl::access::address_space::local_space>(&ptr[0], data[1]);
 // CHECK-NEXT:  data[1] = ptr[0];
 // CHECK-NEXT:}
 __global__ void kernel_2(unsigned* data) {
@@ -401,13 +401,13 @@ __global__ void k() {
   float f;
   __shared__ uint32_t u32;
 
-  // CHECK: sycl::atomic<int>(sycl::global_ptr<int>(&i)).fetch_add(i);
-  // CHECK-NEXT: sycl::atomic<int>(sycl::global_ptr<int>(&i)).fetch_sub(i);
-  // CHECK-NEXT: sycl::atomic<int>(sycl::global_ptr<int>(&i)).fetch_and(i);
-  // CHECK-NEXT: sycl::atomic<int>(sycl::global_ptr<int>(&i)).fetch_or(i);
-  // CHECK-NEXT: sycl::atomic<int>(sycl::global_ptr<int>(&i)).fetch_xor(i);
-  // CHECK-NEXT: sycl::atomic<int>(sycl::global_ptr<int>(&i)).fetch_min(i);
-  // CHECK-NEXT: sycl::atomic<int>(sycl::global_ptr<int>(&i)).fetch_max(i);
+  // CHECK: dpct::atomic_fetch_add(&i, i);
+  // CHECK-NEXT: dpct::atomic_fetch_sub(&i, i);
+  // CHECK-NEXT: dpct::atomic_fetch_and(&i, i);
+  // CHECK-NEXT: dpct::atomic_fetch_or(&i, i);
+  // CHECK-NEXT: dpct::atomic_fetch_xor(&i, i);
+  // CHECK-NEXT: dpct::atomic_fetch_min(&i, i);
+  // CHECK-NEXT: dpct::atomic_fetch_max(&i, i);
   atomicAdd(&i, i);
   atomicSub(&i, i);
   atomicAnd(&i, i);
@@ -416,13 +416,13 @@ __global__ void k() {
   atomicMin(&i, i);
   atomicMax(&i, i);
 
-  // CHECK: sycl::atomic<unsigned int>(sycl::global_ptr<unsigned int>(&ui)).fetch_add(ui);
-  // CHECK-NEXT: sycl::atomic<unsigned int>(sycl::global_ptr<unsigned int>(&ui)).fetch_sub(ui);
-  // CHECK-NEXT: sycl::atomic<unsigned int>(sycl::global_ptr<unsigned int>(&ui)).fetch_and(ui);
-  // CHECK-NEXT: sycl::atomic<unsigned int>(sycl::global_ptr<unsigned int>(&ui)).fetch_or(ui);
-  // CHECK-NEXT: sycl::atomic<unsigned int>(sycl::global_ptr<unsigned int>(&ui)).fetch_xor(ui);
-  // CHECK-NEXT: sycl::atomic<unsigned int>(sycl::global_ptr<unsigned int>(&ui)).fetch_min(ui);
-  // CHECK-NEXT: sycl::atomic<unsigned int>(sycl::global_ptr<unsigned int>(&ui)).fetch_max(ui);
+  // CHECK: dpct::atomic_fetch_add(&ui, ui);
+  // CHECK-NEXT: dpct::atomic_fetch_sub(&ui, ui);
+  // CHECK-NEXT: dpct::atomic_fetch_and(&ui, ui);
+  // CHECK-NEXT: dpct::atomic_fetch_or(&ui, ui);
+  // CHECK-NEXT: dpct::atomic_fetch_xor(&ui, ui);
+  // CHECK-NEXT: dpct::atomic_fetch_min(&ui, ui);
+  // CHECK-NEXT: dpct::atomic_fetch_max(&ui, ui);
   atomicAdd(&ui, ui);
   atomicSub(&ui, ui);
   atomicAnd(&ui, ui);
@@ -431,12 +431,12 @@ __global__ void k() {
   atomicMin(&ui, ui);
   atomicMax(&ui, ui);
 
-  // CHECK: sycl::atomic<unsigned long long>(sycl::global_ptr<unsigned long long>(&ull)).fetch_add(ull);
-  // CHECK-NEXT: sycl::atomic<unsigned long long>(sycl::global_ptr<unsigned long long>(&ull)).fetch_and(ull);
-  // CHECK-NEXT: sycl::atomic<unsigned long long>(sycl::global_ptr<unsigned long long>(&ull)).fetch_or(ull);
-  // CHECK-NEXT: sycl::atomic<unsigned long long>(sycl::global_ptr<unsigned long long>(&ull)).fetch_xor(ull);
-  // CHECK-NEXT: sycl::atomic<unsigned long long>(sycl::global_ptr<unsigned long long>(&ull)).fetch_min(ull);
-  // CHECK-NEXT: sycl::atomic<unsigned long long>(sycl::global_ptr<unsigned long long>(&ull)).fetch_max(ull);
+  // CHECK: dpct::atomic_fetch_add(&ull, ull);
+  // CHECK-NEXT: dpct::atomic_fetch_and(&ull, ull);
+  // CHECK-NEXT: dpct::atomic_fetch_or(&ull, ull);
+  // CHECK-NEXT: dpct::atomic_fetch_xor(&ull, ull);
+  // CHECK-NEXT: dpct::atomic_fetch_min(&ull, ull);
+  // CHECK-NEXT: dpct::atomic_fetch_max(&ull, ull);
   atomicAdd(&ull, ull);
   atomicAnd(&ull, ull);
   atomicOr(&ull, ull);
@@ -444,13 +444,13 @@ __global__ void k() {
   atomicMin(&ull, ull);
   atomicMax(&ull, ull);
 
-  // CHECK: sycl::atomic<unsigned int>(sycl::global_ptr<unsigned int>(&ui)).fetch_add(i);
+  // CHECK: dpct::atomic_fetch_add(&ui, (unsigned int)i);
   atomicAdd(&ui, i);
 
-  // CHECK: sycl::atomic<unsigned int>(sycl::global_ptr<unsigned int>(&ui)).fetch_add(i + i);
+  // CHECK: dpct::atomic_fetch_add(&ui, (unsigned int)(i + i));
   atomicAdd(&ui, i + i);
 
-  // CHECK: sycl::atomic<uint32_t, sycl::access::address_space::local_space>(sycl::local_ptr<uint32_t>(&u32)).fetch_add(u32);
+  // CHECK: dpct::atomic_fetch_add<uint32_t, sycl::access::address_space::local_space>(&u32, u32);
   atomicAdd(&u32, u32);
 
   // CHECK: dpct::atomic_fetch_add(&f, f);
@@ -462,7 +462,7 @@ __global__ void k() {
 // CHECK-NEXT:  unsigned int* as= (unsigned int*)sm;
 // CHECK-NEXT:  const int kc=item_ct1.get_local_id(2);
 // CHECK-NEXT:  const int tid=item_ct1.get_group(2)*item_ct1.get_local_range(2)+item_ct1.get_local_id(2);
-// CHECK-NEXT:  sycl::atomic<unsigned int, sycl::access::address_space::local_space>(sycl::local_ptr<unsigned int>(&as[kc])).fetch_or((unsigned int)1);
+// CHECK-NEXT:  dpct::atomic_fetch_or<unsigned int, sycl::access::address_space::local_space>(&as[kc], (unsigned int)1);
 // CHECK-NEXT:  dev[tid]=as[kc];
 // CHECK-NEXT: }
 __global__ void mykernel(unsigned int *dev) {
@@ -483,11 +483,11 @@ __global__ void mykernel(unsigned int *dev) {
 // CHECK-NEXT:  int i = item_ct1.get_local_id(2) + item_ct1.get_group(2) * item_ct1.get_local_range(2);
 // CHECK-NEXT:  int offset = item_ct1.get_local_range(2) * item_ct1.get_group_range(2);
 // CHECK-NEXT:  while (i < size) {
-// CHECK-NEXT:    sycl::atomic<unsigned int, sycl::access::address_space::local_space>(sycl::local_ptr<unsigned int>(&temp[buffer[i]])).fetch_add(1);
+// CHECK-NEXT:    dpct::atomic_fetch_add<unsigned int, sycl::access::address_space::local_space>(&temp[buffer[i]], (unsigned int)1);
 // CHECK-NEXT:    i += offset;
 // CHECK-NEXT:  }
 // CHECK-NEXT:  item_ct1.barrier(sycl::access::fence_space::local_space);
-// CHECK-NEXT:  sycl::atomic<unsigned int>(sycl::global_ptr<unsigned int>(&(histo[item_ct1.get_local_id(2)]))).fetch_add(temp[item_ct1.get_local_id(2)]);
+// CHECK-NEXT:  dpct::atomic_fetch_add(&(histo[item_ct1.get_local_id(2)]), temp[item_ct1.get_local_id(2)]);
 // CHECK-NEXT:}
 __global__ void mykernel_1(unsigned char *buffer, long size,
                              unsigned int *histo) {
@@ -517,7 +517,7 @@ __shared__ unsigned int temp[256];
 // CHECK-NEXT:  unsigned int kc = 1;
 // CHECK-NEXT:  auto sm = (unsigned int *)dpct_local;
 // CHECK-NEXT:  unsigned int* as			= (unsigned int*)(sm+2*NUM_SYMBOLS);
-// CHECK-NEXT:  sycl::atomic<unsigned int, sycl::access::address_space::local_space>(sycl::local_ptr<unsigned int>(&as[kc])).fetch_or(a);
+// CHECK-NEXT:  dpct::atomic_fetch_or<unsigned int, sycl::access::address_space::local_space>(&as[kc], a);
 // CHECK-NEXT:}
 __global__ static void vlc_encode_kernel_sm64huff() {
   unsigned int a = 1;
@@ -529,9 +529,9 @@ __global__ static void vlc_encode_kernel_sm64huff() {
 
 // CHECK:void addByte(unsigned int *s_WarpHist, unsigned int data) {
 // CHECK-NEXT:  /*
-// CHECK-NEXT:  DPCT1039:{{[0-9]+}}: The generated code assumes that "s_WarpHist + data" points to the global memory address space. If it points to a local memory address space, replace "sycl::global_ptr" with "sycl::local_ptr".
+// CHECK-NEXT:  DPCT1039:{{[0-9]+}}: The generated code assumes that "s_WarpHist + data" points to the global memory address space. If it points to a local memory address space, replace "dpct::atomic_fetch_add" with "dpct::atomic_fetch_add<unsigned int, sycl::access::address_space::local_space>".
 // CHECK-NEXT:  */
-// CHECK-NEXT:  sycl::atomic<unsigned int>(sycl::global_ptr<unsigned int>(s_WarpHist + data)).fetch_add(1);
+// CHECK-NEXT:  dpct::atomic_fetch_add(s_WarpHist + data, (unsigned int)1);
 // CHECK-NEXT:}
 __device__ void addByte(unsigned int *s_WarpHist, unsigned int data) {
   atomicAdd(s_WarpHist + data, 1);
@@ -547,7 +547,7 @@ __shared__ unsigned int s_Hist[100];
 volatile __device__ int g_mutex = 0;
 
 //CHECK:void __gpu_sync(int blocks_to_synch, volatile int &g_mutex) {
-//CHECK-NEXT:  sycl::atomic<int>(sycl::global_ptr<int>((int *)&g_mutex)).fetch_add(1);
+//CHECK-NEXT:  dpct::atomic_fetch_add((int *)&g_mutex, 1);
 //CHECK-NEXT:  while(g_mutex < blocks_to_synch);
 //CHECK-NEXT:}
 __device__ void __gpu_sync(int blocks_to_synch) {


### PR DESCRIPTION
Signed-off-by: Ni, Wenhui <wenhui.ni@intel.com>