### PR TITLE
[SYCLomatic] Avoid collision of numeric limit max with windows.h

### DIFF
--- a/clang/runtime/dpct-rt/include/kernel.hpp.inc
+++ b/clang/runtime/dpct-rt/include/kernel.hpp.inc
@@ -128,7 +128,7 @@ static inline fs::path write_data_to_file(char const *const data, size_t size) {
   std::error_code ec;
 
   if (sizeof(size_t) >= sizeof(std::streamsize) &&
-      size > std::numeric_limits<std::streamsize>::max())
+      size > (std::numeric_limits<std::streamsize>::max)())
     throw std::runtime_error("data file too large");
 
   // random number generator

--- a/clang/test/dpct/helper_files_ref/include/kernel.hpp
+++ b/clang/test/dpct/helper_files_ref/include/kernel.hpp
@@ -72,7 +72,7 @@ static inline fs::path write_data_to_file(char const *const data, size_t size) {
   std::error_code ec;
 
   if (sizeof(size_t) >= sizeof(std::streamsize) &&
-      size > std::numeric_limits<std::streamsize>::max())
+      size > (std::numeric_limits<std::streamsize>::max)())
     throw std::runtime_error("data file too large");
 
   // random number generator


### PR DESCRIPTION
Signed-off-by: Lu, John [john.lu@intel.com](mailto:john.lu@intel.com)