### PR TITLE
[SYCLomatic] Fix convolution_desc bool conversion

### DIFF
--- a/clang/runtime/dpct-rt/include/dnnl_utils.hpp.inc
+++ b/clang/runtime/dpct-rt/include/dnnl_utils.hpp.inc
@@ -668,9 +668,9 @@ public:
   }
 
   operator bool() const {
-    return _strides.size() == 0
-      && _dilates.size() == 0
-      && _paddings.size() == 0;
+    return !(_strides.size() == 0
+             && _dilates.size() == 0
+             && _paddings.size() == 0);
   }
 };
 // DPCT_LABEL_END

--- a/clang/test/dpct/helper_files_ref/include/dnnl_utils.hpp
+++ b/clang/test/dpct/helper_files_ref/include/dnnl_utils.hpp
@@ -600,9 +600,9 @@ public:
   }
 
   operator bool() const {
-    return _strides.size() == 0
-      && _dilates.size() == 0
-      && _paddings.size() == 0;
+    return !(_strides.size() == 0
+             && _dilates.size() == 0
+             && _paddings.size() == 0);
   }
 };
 


### PR DESCRIPTION
After calling `convolution_desc::operator=(std::nullptr_t)`, `convolution_desc::operator bool()` should return false. This is the opposite of what it should be right now (it returns true).