### PR TITLE
[SYCLomatic] Migrate CUdeviceptr to dpct::device_ptr

### DIFF
--- a/clang/lib/DPCT/MapNames.cpp
+++ b/clang/lib/DPCT/MapNames.cpp
@@ -386,7 +386,7 @@ void MapNames::setExplicitNamespaceMap() {
        std::make_shared<TypeNameRule>(getClNamespace() + "filtering_mode")},
       {"CUfilter_mode_enum",
        std::make_shared<TypeNameRule>(getClNamespace() + "filtering_mode")},
-      {"CUdeviceptr", std::make_shared<TypeNameRule>("char *")},
+      {"CUdeviceptr", std::make_shared<TypeNameRule>(getDpctNamespace() + "device_ptr")},
       {"CUresourcetype_enum", std::make_shared<TypeNameRule>(
                                   getDpctNamespace() + "image_data_type",
                                   HelperFeatureEnum::Image_image_data_type)},

--- a/clang/runtime/dpct-rt/include/device.hpp.inc
+++ b/clang/runtime/dpct-rt/include/device.hpp.inc
@@ -95,6 +95,12 @@ typedef sycl::event *event_ptr;
 typedef sycl::queue *queue_ptr;
 // DPCT_LABEL_END
 
+// DPCT_LABEL_BEGIN|typedef_device_ptr|dpct
+// DPCT_DEPENDENCY_EMPTY
+// DPCT_CODE
+typedef char *device_ptr;
+// DPCT_LABEL_END
+
 // DPCT_LABEL_BEGIN|destroy_event|dpct
 // DPCT_DEPENDENCY_BEGIN
 // Device|typedef_event_ptr

--- a/clang/test/dpct/USM-none.cu
+++ b/clang/test/dpct/USM-none.cu
@@ -92,7 +92,7 @@ void foo() {
   cuMemAllocHost((void **)&h_A, size);
 
   CUdeviceptr* D_ptr;
-  // CHECK: *D_ptr = (char *)dpct::dpct_malloc(size);
+  // CHECK: *D_ptr = (dpct::device_ptr)dpct::dpct_malloc(size);
   cuMemAllocManaged(D_ptr, size, CU_MEM_ATTACH_HOST);
 
   float* buffer[2];

--- a/clang/test/dpct/USM-restricted.cu
+++ b/clang/test/dpct/USM-restricted.cu
@@ -123,7 +123,7 @@ void foo() {
   cudaMallocManaged((void **)&d_A, sizeof(double2) * size * sizeof(uchar4));
 
   CUdeviceptr* D_ptr;
-  // CHECK: *D_ptr = (char *)sycl::malloc_shared(size, q_ct1);
+  // CHECK: *D_ptr = (dpct::device_ptr)sycl::malloc_shared(size, q_ct1);
   cuMemAllocManaged(D_ptr, size, CU_MEM_ATTACH_HOST);
 
   /// memcpy
@@ -828,7 +828,7 @@ void foo3() {
   MY_SAFE_CALL(cudaMemPrefetchAsync (d_A, 100, deviceID, cudaStreamPerThread));
   // CHECK: int cudevice = 0;
   CUdevice cudevice = 0;
-  // CHECK: char * devPtr;
+  // CHECK: dpct::device_ptr devPtr;
   CUdeviceptr devPtr;
   // CHECK: dpct::dev_mgr::instance().get_device(cudevice).default_queue().prefetch(devPtr, 100);
   // CHECK: dpct::dev_mgr::instance().get_device(cudevice).default_queue().prefetch(devPtr, 100);

--- a/clang/test/dpct/driver-mem-usm-none.cu
+++ b/clang/test/dpct/driver-mem-usm-none.cu
@@ -18,11 +18,11 @@ int main(){
     // CHECK: f_A = (float *)malloc(size);
     cuMemHostAlloc((void **)&f_A, size, CU_MEMHOSTALLOC_DEVICEMAP);
 
-    // CHECK: char * f_D = 0;
+    // CHECK: dpct::device_ptr f_D = 0;
     CUdeviceptr f_D = 0;
-    // CHECK: char * f_D2 = 0;
+    // CHECK: dpct::device_ptr f_D2 = 0;
     CUdeviceptr f_D2 = 0;
-    // CHECK: f_D = (char *)dpct::dpct_malloc(size);
+    // CHECK: f_D = (dpct::device_ptr)dpct::dpct_malloc(size);
     cuMemAlloc(&f_D, size);
 
     // CHECK: dpct::queue_ptr stream;

--- a/clang/test/dpct/driver-mem.cu
+++ b/clang/test/dpct/driver-mem.cu
@@ -20,11 +20,11 @@ int main(){
     cuMemHostAlloc((void **)&f_A, size, CU_MEMHOSTALLOC_DEVICEMAP);
 
 
-    // CHECK: char * f_D = 0;
+    // CHECK: dpct::device_ptr f_D = 0;
     CUdeviceptr f_D = 0;
-    // CHECK: char * f_D2 = 0;
+    // CHECK: dpct::device_ptr f_D2 = 0;
     CUdeviceptr f_D2 = 0;
-    // CHECK: f_D = (char *)sycl::malloc_device(size, q_ct1);
+    // CHECK: f_D = (dpct::device_ptr)sycl::malloc_device(size, q_ct1);
     cuMemAlloc(&f_D, size);
 
     // CHECK: dpct::queue_ptr stream;

--- a/clang/test/dpct/helper_files_ref/include/device.hpp
+++ b/clang/test/dpct/helper_files_ref/include/device.hpp
@@ -49,6 +49,8 @@ typedef sycl::event *event_ptr;
 
 typedef sycl::queue *queue_ptr;
 
+typedef char *device_ptr;
+
 /// Destroy \p event pointed memory.
 ///
 /// \param event Pointer to the sycl::event address.

--- a/clang/test/dpct/memory_management.cu
+++ b/clang/test/dpct/memory_management.cu
@@ -894,18 +894,18 @@ void testCommas_in_global_memory() {
 
   CUdeviceptr  devicePtr;
   size_t size;
-  // CHECK: devicePtr = (char *)dpct::dpct_malloc(size, size, size);
+  // CHECK: devicePtr = (dpct::device_ptr)dpct::dpct_malloc(size, size, size);
   cuMemAllocPitch((CUdeviceptr *)&devicePtr, &size, size, size, size);
 
   // CHECK:/*
   // CHECK-NEXT:DPCT1003:{{[0-9]+}}: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.
   // CHECK-NEXT:*/
-  // CHECK-NEXT: cu_err = ((devicePtr = (char *)dpct::dpct_malloc(size, size, size), 0), 0);
+  // CHECK-NEXT: cu_err = ((devicePtr = (dpct::device_ptr)dpct::dpct_malloc(size, size, size), 0), 0);
   cu_err = cuMemAllocPitch((CUdeviceptr *)&devicePtr, &size, size, size, size);
   // CHECK:/*
   // CHECK-NEXT:DPCT1003:{{[0-9]+}}: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.
   // CHECK-NEXT:*/
-  // CHECK-NEXT:  cuCheckError(((devicePtr = (char *)dpct::dpct_malloc(size, size, size), 0), 0));
+  // CHECK-NEXT:  cuCheckError(((devicePtr = (dpct::device_ptr)dpct::dpct_malloc(size, size, size), 0), 0));
   cuCheckError(cuMemAllocPitch((CUdeviceptr *)&devicePtr, &size, size, size, size));
 
   int* a;

--- a/clang/test/dpct/texture_driver.cu
+++ b/clang/test/dpct/texture_driver.cu
@@ -263,7 +263,7 @@ void test_texref() {
   func(cuTexRefSetArray(tex,arr, CU_TRSA_OVERRIDE_FORMAT));
   funcT(cuTexRefSetArray(tex,arr, CU_TRSA_OVERRIDE_FORMAT));
 
-  // CHECK: char * dptr;
+  // CHECK: dpct::device_ptr dptr;
   // CHECK-Next: size_t s, b;
   // CHECK-Next: tex->attach(dptr, b);
   // CHECK-Next: size_t desc_x_ct1, desc_y_ct1;

--- a/clang/test/dpct/texture_object_driver.cu
+++ b/clang/test/dpct/texture_object_driver.cu
@@ -55,7 +55,7 @@ int main() {
   // CHECK-NEXT: dpct::image_data res42;
   // CHECK-NEXT: dpct::sampling_info texDesc42;
   // CHECK-NEXT: res42.set_data_type(dpct::image_data_type::pitch);
-  // CHECK-NEXT: res42.set_data_ptr((char *)d_data42);
+  // CHECK-NEXT: res42.set_data_ptr((dpct::device_ptr)d_data42);
   // CHECK-NEXT: res42.set_x(sizeof(sycl::float4) * 32);
   // CHECK-NEXT: res42.set_y(32);
   // CHECK-NEXT: res42.set_pitch(sizeof(sycl::float4) * 32);
@@ -98,7 +98,7 @@ int main() {
   // CHECK-NEXT: dpct::image_data res21;
   // CHECK-NEXT: dpct::sampling_info texDesc21;
   // CHECK-NEXT: res21.set_data_type(dpct::image_data_type::linear);
-  // CHECK-NEXT: res21.set_data_ptr((char *)d_data21);
+  // CHECK-NEXT: res21.set_data_ptr((dpct::device_ptr)d_data21);
   // CHECK-NEXT: res21.set_channel_num(2);
   // CHECK-NEXT: res21.set_channel_type(sycl::image_channel_type::unsigned_int32);
   // CHECK-NEXT: res21.set_x(32*sizeof(sycl::uint2));
@@ -176,7 +176,7 @@ void foo(){
 
   float4 *d_data42;
   // CHECK: res42.set_data_type(dpct::image_data_type::pitch);
-  // CHECK-NEXT: res42.set_data_ptr((char *)d_data42);
+  // CHECK-NEXT: res42.set_data_ptr((dpct::device_ptr)d_data42);
   // CHECK-NEXT: res42.set_channel_num(4);
   // CHECK-NEXT: res42.set_channel_type(sycl::image_channel_type::fp32);
   // CHECK-NEXT: res42.set_x(sizeof(sycl::float4) * 32);
@@ -192,7 +192,7 @@ void foo(){
 
   uint2 *d_data21;
   // CHECK: res42.set_data_type(dpct::image_data_type::linear);
-  // CHECK-NEXT: res42.set_data_ptr((char *)d_data21);
+  // CHECK-NEXT: res42.set_data_ptr((dpct::device_ptr)d_data21);
   // CHECK-NEXT: res42.set_x(sizeof(sycl::float4) * 32);
   // CHECK-NEXT: res42.set_channel_num(4);
   // CHECK-NEXT: res42.set_channel_type(sycl::image_channel_type::fp32);

--- a/clang/test/dpct/types001.cu
+++ b/clang/test/dpct/types001.cu
@@ -673,3 +673,11 @@ void foo_4() {
   // CHECK: m = std::min(int64_t(threads[2]), int64_t{cfoo});
   m = std::min(int64_t{threads.x}, int64_t{cfoo});
 }
+
+
+// CHECK: dpct::device_ptr a = (dpct::device_ptr)0, b = (dpct::device_ptr)0;
+CUdeviceptr a = (CUdeviceptr)0, b = (CUdeviceptr)0;
+void test() {
+  // CHECK: dpct::device_ptr a = (dpct::device_ptr)0, b = (dpct::device_ptr)0;
+  CUdeviceptr a = (CUdeviceptr)0, b = (CUdeviceptr)0;
+}


### PR DESCRIPTION
Previously `CUdeviceptr` was migrated to `char *`. If there was a declaration like
```c++
CUdeviceptr a = (CUdeviceptr)0, b = (CUdeviceptr)0;
```
the migration would have a type error due to declarator syntax:
```c++
char * a = (char *)0, b = (char *)0;
```
(`b` would have type char, but cannot initialize `char` with `char *`)

Now, `CUdeviceptr` is migrated to `dpct::device_ptr`, which is an alias for `char *`, avoiding syntax issues.