### PR TITLE
[SYCLomatic] Fix a bug of filtering mode when fetching 1D image data

### DIFF
--- a/clang/runtime/dpct-rt/include/image.hpp.inc
+++ b/clang/runtime/dpct-rt/include/image.hpp.inc
@@ -1552,7 +1552,15 @@ public:
   template <class CoordT,
             bool Available = dimensions == 1 && std::is_integral<CoordT>::value>
   typename std::enable_if<Available, data_t>::type read(CoordT x) {
-    return detail::fetch_data<T>()(_img_acc.read(x, _sampler));
+    sycl::sampler smpl;
+    if (_sampler.get_filtering_mode() == sycl::filtering_mode::linear) {
+      smpl = sampler(_sampler.get_coordinate_normalization_mode(),
+                     _sampler.get_addressing_mode(),
+                     sycl::filtering_mode::nearest);
+    } else {
+      smpl = _sampler;
+    }
+    return detail::fetch_data<T>()(_img_acc.read(x, smpl));
   }
 };
 

--- a/clang/runtime/dpct-rt/include/image.hpp.inc
+++ b/clang/runtime/dpct-rt/include/image.hpp.inc
@@ -1554,9 +1554,9 @@ public:
   typename std::enable_if<Available, data_t>::type read(CoordT x) {
     sycl::sampler smpl;
     if (_sampler.get_filtering_mode() == sycl::filtering_mode::linear) {
-      smpl = sampler(_sampler.get_coordinate_normalization_mode(),
-                     _sampler.get_addressing_mode(),
-                     sycl::filtering_mode::nearest);
+      smpl = sycl::sampler(_sampler.get_coordinate_normalization_mode(),
+                           _sampler.get_addressing_mode(),
+                           sycl::filtering_mode::nearest);
     } else {
       smpl = _sampler;
     }

--- a/clang/runtime/dpct-rt/include/image.hpp.inc
+++ b/clang/runtime/dpct-rt/include/image.hpp.inc
@@ -1552,13 +1552,11 @@ public:
   template <class CoordT,
             bool Available = dimensions == 1 && std::is_integral<CoordT>::value>
   typename std::enable_if<Available, data_t>::type read(CoordT x) {
-    sycl::sampler smpl;
+    sycl::sampler smpl = _sampler;
     if (_sampler.get_filtering_mode() == sycl::filtering_mode::linear) {
       smpl = sycl::sampler(_sampler.get_coordinate_normalization_mode(),
                            _sampler.get_addressing_mode(),
                            sycl::filtering_mode::nearest);
-    } else {
-      smpl = _sampler;
     }
     return detail::fetch_data<T>()(_img_acc.read(x, smpl));
   }

--- a/clang/test/dpct/helper_files_ref/include/image.hpp
+++ b/clang/test/dpct/helper_files_ref/include/image.hpp
@@ -716,13 +716,11 @@ public:
   template <class CoordT,
             bool Available = dimensions == 1 && std::is_integral<CoordT>::value>
   typename std::enable_if<Available, data_t>::type read(CoordT x) {
-    sycl::sampler smpl;
+    sycl::sampler smpl = _sampler;
     if (_sampler.get_filtering_mode() == sycl::filtering_mode::linear) {
       smpl = sycl::sampler(_sampler.get_coordinate_normalization_mode(),
                            _sampler.get_addressing_mode(),
                            sycl::filtering_mode::nearest);
-    } else {
-      smpl = _sampler;
     }
     return detail::fetch_data<T>()(_img_acc.read(x, smpl));
   }

--- a/clang/test/dpct/helper_files_ref/include/image.hpp
+++ b/clang/test/dpct/helper_files_ref/include/image.hpp
@@ -718,9 +718,9 @@ public:
   typename std::enable_if<Available, data_t>::type read(CoordT x) {
     sycl::sampler smpl;
     if (_sampler.get_filtering_mode() == sycl::filtering_mode::linear) {
-      smpl = sampler(_sampler.get_coordinate_normalization_mode(),
-                     _sampler.get_addressing_mode(),
-                     sycl::filtering_mode::nearest);
+      smpl = sycl::sampler(_sampler.get_coordinate_normalization_mode(),
+                           _sampler.get_addressing_mode(),
+                           sycl::filtering_mode::nearest);
     } else {
       smpl = _sampler;
     }

--- a/clang/test/dpct/helper_files_ref/include/image.hpp
+++ b/clang/test/dpct/helper_files_ref/include/image.hpp
@@ -716,7 +716,15 @@ public:
   template <class CoordT,
             bool Available = dimensions == 1 && std::is_integral<CoordT>::value>
   typename std::enable_if<Available, data_t>::type read(CoordT x) {
-    return detail::fetch_data<T>()(_img_acc.read(x, _sampler));
+    sycl::sampler smpl;
+    if (_sampler.get_filtering_mode() == sycl::filtering_mode::linear) {
+      smpl = sampler(_sampler.get_coordinate_normalization_mode(),
+                     _sampler.get_addressing_mode(),
+                     sycl::filtering_mode::nearest);
+    } else {
+      smpl = _sampler;
+    }
+    return detail::fetch_data<T>()(_img_acc.read(x, smpl));
   }
 };
 


### PR DESCRIPTION
Should use nearest mode instead of linear mode when migrating tex1Dfetch