### PR TITLE
[SYCLomatic] Removing data() from USM_NONE dpct::device_vector

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/vector.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/vector.h.inc
@@ -682,10 +682,6 @@ public:
   reference front() { return *begin(); }
   const_reference back(void) const { return *(end() - 1); }
   reference back(void) { return *(end() - 1); }
-  pointer data(void) { return reinterpret_cast<pointer>(_storage); }
-  const_pointer data(void) const {
-    return reinterpret_cast<const_pointer>(_storage);
-  }
   void shrink_to_fit(void) {
     if (_size != capacity()) {
       void *a = alloc_store(_size * sizeof(T));

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/vector.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/vector.h
@@ -627,10 +627,6 @@ public:
   reference front() { return *begin(); }
   const_reference back(void) const { return *(end() - 1); }
   reference back(void) { return *(end() - 1); }
-  pointer data(void) { return reinterpret_cast<pointer>(_storage); }
-  const_pointer data(void) const {
-    return reinterpret_cast<const_pointer>(_storage);
-  }
   void shrink_to_fit(void) {
     if (_size != capacity()) {
       void *a = alloc_store(_size * sizeof(T));


### PR DESCRIPTION
Removing the public member function `data()` of `dpct::device_vector` when `DPCT_USM_LEVEL_NONE` is defined.  

`dpct::device_vector` has two different implementations, one where USM is available and another when USM is not available which that uses `sycl::buffer` internally for its device memory.  This change only effects the implementation when USM is not available and `sycl::buffer` is used for the memory allocation.

This `data()` member function does not make a lot of sense to provide when we are using `sycl::buffer` as the memory backing for `dpct::device_vector`.  Prior to this PR, it provided a pointer into the **virtual memory space** used to track and look up buffer allocations.  Using this returned virtual pointer (when `DPCT_USM_LEVEL_NONE` is defined) to do things like `memcpy()` or as input to an algorithm would result in a segfault.  It's availability in the API only encourages incorrect usage. 

Getting a pointer to the actual device memory is not supported in any viable way by the SYCL specification when a `sycl::buffer` is the backing memory for a `dpct::device_vector`.  The public member function `get_buffer()` is provided in this case, and can be used for a similar purpose, but without encouraging incorrect usage.  