### PR TITLE
[SYCLomatic] Ensure semicolon is not removed when removing a call not surrounded by curly braces

### DIFF
--- a/clang/lib/DPCT/TextModification.cpp
+++ b/clang/lib/DPCT/TextModification.cpp
@@ -24,6 +24,14 @@ using namespace clang;
 using namespace clang::dpct;
 using namespace clang::tooling;
 
+bool ReplaceStmt::inCompoundStmt(const Stmt *E) {
+  auto &context = DpctGlobalInfo::getContext();
+  const auto parents = context.getParents(*E);
+  return std::find_if(parents.begin(), parents.end(), [](const DynTypedNode &n) {
+    return bool(n.get<CompoundStmt>());
+  }) != parents.end();
+}
+
 std::shared_ptr<ExtReplacement>
 ReplaceStmt::getReplacement(const ASTContext &Context) const {
   if (this->isIgnoreTM())

--- a/clang/lib/DPCT/TextModification.h
+++ b/clang/lib/DPCT/TextModification.h
@@ -273,17 +273,21 @@ class ReplaceStmt : public TextModification {
   // this macro will be removed also.
   mutable bool IsMacroRemoved = false;
 
+  static bool inCompoundStmt(const Stmt *E);
+
 public:
   template <class... Args>
   ReplaceStmt(const Stmt *E, Args &&...S)
       : TextModification(TMID::ReplaceStmt), TheStmt(E), IsProcessMacro(false),
-        ReplacementString(std::forward<Args>(S)...) {}
+        ReplacementString(std::forward<Args>(S)...),
+        IsCleanup(inCompoundStmt(E)) {}
 
   template <class... Args>
   ReplaceStmt(const Stmt *E, bool IsNeedProcessMacro, Args &&...S)
       : TextModification(TMID::ReplaceStmt), TheStmt(E),
         IsProcessMacro(IsNeedProcessMacro),
-        ReplacementString(std::forward<Args>(S)...) {}
+        ReplacementString(std::forward<Args>(S)...),
+        IsCleanup(inCompoundStmt(E)) {}
 
   template <class... Args>
   ReplaceStmt(const Stmt *E, bool IsNeedProcessMacro, bool IsNeedCleanup,

--- a/clang/test/dpct/dnn/semicolon.cu
+++ b/clang/test/dpct/dnn/semicolon.cu
@@ -3,6 +3,15 @@
 #include <cudnn.h>
 
 int main() {
+  // CHECK:      if (true) {
+  // CHECK-NEXT:   /*
+  // CHECK-NEXT:   DPCT1026:0: The call to cudnnDestroy was removed because this call is redundant in SYCL.
+  // CHECK-NEXT:   */
+  // CHECK-NEXT: }
+  if (true) {
+    cudnnDestroy(nullptr);
+  }
+
   // CHECK:      if (true)
   // CHECK-NEXT:   /*
   // CHECK-NEXT:   DPCT1026:{{[0-9]+}}: The call to cudnnDestroy was removed because this call is redundant in SYCL.

--- a/clang/test/dpct/dnn/semicolon.cu
+++ b/clang/test/dpct/dnn/semicolon.cu
@@ -1,0 +1,133 @@
+// RUN: dpct %s --out-root %T/semicolon --cuda-include-path="%cuda-path/include" --format-range=none 
+// RUN: FileCheck %s --match-full-lines --input-file %T/semicolon/semicolon.dp.cpp
+#include <cudnn.h>
+
+int main() {
+  // CHECK:      if (true)
+  // CHECK-NEXT:   /*
+  // CHECK-NEXT:   DPCT1026:{{[0-9]+}}: The call to cudnnDestroy was removed because this call is redundant in SYCL.
+  // CHECK-NEXT:   */
+  // CHECK-NEXT:   ;
+  if (true)
+    cudnnDestroy(nullptr);
+
+  // CHECK:      /*
+  // CHECK-NEXT: DPCT1026:{{[0-9]+}}: The call to cudnnCreateTensorDescriptor was removed because this call is redundant in SYCL.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: if (true) ;
+  if (true) cudnnCreateTensorDescriptor(nullptr);
+
+  // CHECK:      /*
+  // CHECK-NEXT: DPCT1026:{{[0-9]+}}: The call to cudnnDestroyTensorDescriptor was removed because this call is redundant in SYCL.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: if (true) ;
+  if (true) cudnnDestroyTensorDescriptor(nullptr);
+
+  // CHECK:      /*
+  // CHECK-NEXT: DPCT1026:{{[0-9]+}}: The call to cudnnCreateActivationDescriptor was removed because this call is redundant in SYCL.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: if (true) ;
+  if (true) cudnnCreateActivationDescriptor(nullptr);
+
+  // CHECK:      /*
+  // CHECK-NEXT: DPCT1026:{{[0-9]+}}: The call to cudnnDestroyActivationDescriptor was removed because this call is redundant in SYCL.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: if (true) ;
+  if (true) cudnnDestroyActivationDescriptor(nullptr);
+
+  // CHECK:      /*
+  // CHECK-NEXT: DPCT1026:{{[0-9]+}}: The call to cudnnCreateLRNDescriptor was removed because this call is redundant in SYCL.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: if (true) ;
+  if (true) cudnnCreateLRNDescriptor(nullptr);
+
+  // CHECK:      /*
+  // CHECK-NEXT: DPCT1026:{{[0-9]+}}: The call to cudnnDestroyLRNDescriptor was removed because this call is redundant in SYCL.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: if (true) ;
+  if (true) cudnnDestroyLRNDescriptor(nullptr);
+
+  // CHECK:      /*
+  // CHECK-NEXT: DPCT1026:{{[0-9]+}}: The call to cudnnCreatePoolingDescriptor was removed because this call is redundant in SYCL.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: if (true) ;
+  if (true) cudnnCreatePoolingDescriptor(nullptr);
+
+  // CHECK:      /*
+  // CHECK-NEXT: DPCT1026:{{[0-9]+}}: The call to cudnnDestroyPoolingDescriptor was removed because this call is redundant in SYCL.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: if (true) ;
+  if (true) cudnnDestroyPoolingDescriptor(nullptr);
+
+  // CHECK:      /*
+  // CHECK-NEXT: DPCT1026:{{[0-9]+}}: The call to cudnnCreateReduceTensorDescriptor was removed because this call is redundant in SYCL.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: if (true) ;
+  if (true) cudnnCreateReduceTensorDescriptor(nullptr);
+
+  // CHECK:      /*
+  // CHECK-NEXT: DPCT1026:{{[0-9]+}}: The call to cudnnDestroyReduceTensorDescriptor was removed because this call is redundant in SYCL.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: if (true) ;
+  if (true) cudnnDestroyReduceTensorDescriptor(nullptr);
+
+  // CHECK:      /*
+  // CHECK-NEXT: DPCT1026:{{[0-9]+}}: The call to cudnnCreateOpTensorDescriptor was removed because this call is redundant in SYCL.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: if (true) ;
+  if (true) cudnnCreateOpTensorDescriptor(nullptr);
+
+  // CHECK:      /*
+  // CHECK-NEXT: DPCT1026:{{[0-9]+}}: The call to cudnnDestroyOpTensorDescriptor was removed because this call is redundant in SYCL.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: if (true) ;
+  if (true) cudnnDestroyOpTensorDescriptor(nullptr);
+
+  // CHECK:      /*
+  // CHECK-NEXT: DPCT1026:{{[0-9]+}}: The call to cudnnCreateFilterDescriptor was removed because this call is redundant in SYCL.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: if (true) ;
+  if (true) cudnnCreateFilterDescriptor(nullptr);
+
+  // CHECK:      /*
+  // CHECK-NEXT: DPCT1026:{{[0-9]+}}: The call to cudnnDestroyFilterDescriptor was removed because this call is redundant in SYCL.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: if (true) ;
+  if (true) cudnnDestroyFilterDescriptor(nullptr);
+
+  // CHECK:      /*
+  // CHECK-NEXT: DPCT1026:{{[0-9]+}}: The call to cudnnCreateConvolutionDescriptor was removed because this call is redundant in SYCL.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: if (true) ;
+  if (true) cudnnCreateConvolutionDescriptor(nullptr);
+
+  // CHECK:      /*
+  // CHECK-NEXT: DPCT1026:{{[0-9]+}}: The call to cudnnDestroyConvolutionDescriptor was removed because this call is redundant in SYCL.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: if (true) ;
+  if (true) cudnnDestroyConvolutionDescriptor(nullptr);
+
+  // CHECK:      /*
+  // CHECK-NEXT: DPCT1026:{{[0-9]+}}: The call to cudnnCreateRNNDescriptor was removed because this call is redundant in SYCL.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: if (true) ;
+  if (true) cudnnCreateRNNDescriptor(nullptr);
+
+  // CHECK:      /*
+  // CHECK-NEXT: DPCT1026:{{[0-9]+}}: The call to cudnnCreateRNNDataDescriptor was removed because this call is redundant in SYCL.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: if (true) ;
+  if (true) cudnnCreateRNNDataDescriptor(nullptr);
+
+  // CHECK:      /*
+  // CHECK-NEXT: DPCT1026:{{[0-9]+}}: The call to cudnnDestroyRNNDescriptor was removed because this call is redundant in SYCL.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: if (true) ;
+  if (true) cudnnDestroyRNNDescriptor(nullptr);
+
+  // CHECK:      /*
+  // CHECK-NEXT: DPCT1026:{{[0-9]+}}: The call to cudnnDestroyRNNDataDescriptor was removed because this call is redundant in SYCL.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: if (true) ;
+  if (true) cudnnDestroyRNNDataDescriptor(nullptr);
+}


### PR DESCRIPTION
Currently, code removed using the `REMOVE_API_FACTORY_ENTRY` rewriter have the same behavior of removing a semicolon after the expression. Example:
```c++
if(x) cudnnDestroy(x);
std::cout << "cleanup complete.\n"
```
The migrated code will be 
```c++
if(x) std::cout << "cleanup complete.\n"
```
Now, the semicolon is not removed, giving the following migration:
```c++
if(x) ;
std::cout << "cleanup complete.\n"
```
---
The original replacement generated by ExprAnalysis does not remove the semicolon, but the call of `ReplaceStmt::getReplacement` from 

https://github.com/oneapi-src/SYCLomatic/blob/77ef8ab0126e6d0ff737f2ae1f4cb27c89aae7b7/clang/lib/DPCT/MigrationAction.cpp#L189

modifies the original replacement to remove the semicolon. This is because the returned replacement is from 

https://github.com/oneapi-src/SYCLomatic/blob/77ef8ab0126e6d0ff737f2ae1f4cb27c89aae7b7/clang/lib/DPCT/TextModification.cpp#L75-L76 

where `removeStmtWithCleanups` has the logic for removing the semicolon. The PR changes the intialization of `IsCleanup` so that when the statement being removed is not in a compound statement, the semicolon is not removed.