### PR TITLE
[SYCLomatic] Fix compile fail of atomic_compare_exchange_strong due to potential type conversion

### DIFF
--- a/clang/runtime/dpct-rt/include/atomic.hpp.inc
+++ b/clang/runtime/dpct-rt/include/atomic.hpp.inc
@@ -714,8 +714,8 @@ T1 atomic_compare_exchange_strong(
     sycl::memory_order success = sycl::memory_order::relaxed,
     sycl::memory_order fail = sycl::memory_order::relaxed) {
   auto atm = sycl::atomic_ref<T1, memoryOrder, memoryScope, addressSpace>(*addr);
-
-  atm.compare_exchange_strong(expected, desired, success, fail);
+  T1 expected_value = expected;
+  atm.compare_exchange_strong(expected_value, desired, success, fail);
   return expected;
 }
 
@@ -752,9 +752,10 @@ T1 atomic_compare_exchange_strong(
     T1 *addr, T2 expected, T3 desired,
     sycl::memory_order success = sycl::memory_order::relaxed,
     sycl::memory_order fail = sycl::memory_order::relaxed) {
+  T1 expected_value = expected;
   auto atm =
       sycl::atomic_ref<T1, memoryOrder, memoryScope, addressSpace>(addr[0]);
-  atm.compare_exchange_strong(expected, desired, success, fail);
+  atm.compare_exchange_strong(expected_value, desired, success, fail);
   return expected;
 }
 // DPCT_LABEL_END

--- a/clang/test/dpct/helper_files_ref/include/atomic.hpp
+++ b/clang/test/dpct/helper_files_ref/include/atomic.hpp
@@ -637,8 +637,8 @@ T1 atomic_compare_exchange_strong(
     sycl::memory_order success = sycl::memory_order::relaxed,
     sycl::memory_order fail = sycl::memory_order::relaxed) {
   auto atm = sycl::atomic_ref<T1, memoryOrder, memoryScope, addressSpace>(*addr);
-
-  atm.compare_exchange_strong(expected, desired, success, fail);
+  T1 expected_value = expected;
+  atm.compare_exchange_strong(expected_value, desired, success, fail);
   return expected;
 }
 
@@ -675,9 +675,10 @@ T1 atomic_compare_exchange_strong(
     T1 *addr, T2 expected, T3 desired,
     sycl::memory_order success = sycl::memory_order::relaxed,
     sycl::memory_order fail = sycl::memory_order::relaxed) {
+  T1 expected_value = expected;
   auto atm =
       sycl::atomic_ref<T1, memoryOrder, memoryScope, addressSpace>(addr[0]);
-  atm.compare_exchange_strong(expected, desired, success, fail);
+  atm.compare_exchange_strong(expected_value, desired, success, fail);
   return expected;
 }
 


### PR DESCRIPTION
Signed-off-by: Ni, Wenhui <wenhui.ni@intel.com>