### PR TITLE
[SYCLomatic]Fix wrong template parameter for variable in atomic_compare_exchange_strong

### DIFF
--- a/clang/runtime/dpct-rt/include/atomic.hpp.inc
+++ b/clang/runtime/dpct-rt/include/atomic.hpp.inc
@@ -692,12 +692,10 @@ template <typename T,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
 T atomic_compare_exchange_strong(
-    sycl::multi_ptr<T, sycl::access::address_space::global_space> addr,
-    T expected, T desired,
+    sycl::multi_ptr<T, addressSpace> addr, T expected, T desired,
     sycl::memory_order success = sycl::memory_order::relaxed,
     sycl::memory_order fail = sycl::memory_order::relaxed) {
-  auto atm =
-      sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(*addr);
+  auto atm = sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(*addr);
 
   atm.compare_exchange_strong(expected, desired, success, fail);
   return expected;
@@ -709,11 +707,11 @@ template <sycl::access::address_space addressSpace =
           sycl::memory_scope memoryScope = sycl::memory_scope::device,
           typename T1, typename T2, typename T3>
 T1 atomic_compare_exchange_strong(
-    sycl::multi_ptr<T1, sycl::access::address_space::global_space> addr,
-    T2 expected, T3 desired,
+    sycl::multi_ptr<T1, addressSpace> addr, T2 expected, T3 desired,
     sycl::memory_order success = sycl::memory_order::relaxed,
     sycl::memory_order fail = sycl::memory_order::relaxed) {
-  auto atm = sycl::atomic_ref<T1, memoryOrder, memoryScope, addressSpace>(*addr);
+  auto atm =
+      sycl::atomic_ref<T1, memoryOrder, memoryScope, addressSpace>(*addr);
   T1 expected_value = expected;
   atm.compare_exchange_strong(expected_value, desired, success, fail);
   return expected;

--- a/clang/test/dpct/helper_files_ref/include/atomic.hpp
+++ b/clang/test/dpct/helper_files_ref/include/atomic.hpp
@@ -615,12 +615,10 @@ template <typename T,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
 T atomic_compare_exchange_strong(
-    sycl::multi_ptr<T, sycl::access::address_space::global_space> addr,
-    T expected, T desired,
+    sycl::multi_ptr<T, addressSpace> addr, T expected, T desired,
     sycl::memory_order success = sycl::memory_order::relaxed,
     sycl::memory_order fail = sycl::memory_order::relaxed) {
-  auto atm =
-      sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(*addr);
+  auto atm = sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(*addr);
 
   atm.compare_exchange_strong(expected, desired, success, fail);
   return expected;
@@ -632,11 +630,11 @@ template <sycl::access::address_space addressSpace =
           sycl::memory_scope memoryScope = sycl::memory_scope::device,
           typename T1, typename T2, typename T3>
 T1 atomic_compare_exchange_strong(
-    sycl::multi_ptr<T1, sycl::access::address_space::global_space> addr,
-    T2 expected, T3 desired,
+    sycl::multi_ptr<T1, addressSpace> addr, T2 expected, T3 desired,
     sycl::memory_order success = sycl::memory_order::relaxed,
     sycl::memory_order fail = sycl::memory_order::relaxed) {
-  auto atm = sycl::atomic_ref<T1, memoryOrder, memoryScope, addressSpace>(*addr);
+  auto atm =
+      sycl::atomic_ref<T1, memoryOrder, memoryScope, addressSpace>(*addr);
   T1 expected_value = expected;
   atm.compare_exchange_strong(expected_value, desired, success, fail);
   return expected;


### PR DESCRIPTION
Signed-off-by: Ni, Wenhui <wenhui.ni@intel.com>