### PR TITLE
[SYCLomatic] Fix potential compute overflow during multiplication of two large integers

### DIFF
--- a/clang/runtime/dpct-rt/include/util.hpp.inc
+++ b/clang/runtime/dpct-rt/include/util.hpp.inc
@@ -110,7 +110,7 @@ inline void matrix_mem_copy(void *to_ptr, const void *from_ptr, int to_ld,
   }
 
   if (to_ld == from_ld) {
-    size_t cpoy_size = elem_size * ((cols - 1) * to_ld + rows);
+    size_t cpoy_size = elem_size * ((cols - 1) * (size_t)to_ld + rows);
     if (async)
       detail::dpct_memcpy(queue, (void *)to_ptr, (void *)from_ptr,
                           cpoy_size, direction);

--- a/clang/test/dpct/helper_files_ref/include/util.hpp
+++ b/clang/test/dpct/helper_files_ref/include/util.hpp
@@ -56,7 +56,7 @@ inline void matrix_mem_copy(void *to_ptr, const void *from_ptr, int to_ld,
   }
 
   if (to_ld == from_ld) {
-    size_t cpoy_size = elem_size * ((cols - 1) * to_ld + rows);
+    size_t cpoy_size = elem_size * ((cols - 1) * (size_t)to_ld + rows);
     if (async)
       detail::dpct_memcpy(queue, (void *)to_ptr, (void *)from_ptr,
                           cpoy_size, direction);


### PR DESCRIPTION
 Signed-off-by: chenwei.sun <chenwei.sun@intel.com>
