### PR TITLE
[SYCLomatic] Use dpct libcommon_datatype to replace oneccl::datatype

### DIFF
--- a/clang/lib/DPCT/APINamesNccl.inc
+++ b/clang/lib/DPCT/APINamesNccl.inc
@@ -35,7 +35,9 @@ CONDITIONAL_FACTORY_ENTRY(
     CheckEnumArgStr(4, "ncclAvg"),
     UNSUPPORT_FACTORY_ENTRY("ncclAllReduce", Diagnostics::UNSUPPORTED_PARAM,
                             ARG(4)),
-    CALL_FACTORY_ENTRY("ncclAllReduce",
-                       CALL("oneapi::ccl::allreduce", ARG(0), ARG(1), ARG(2),
-                            ARG(3), ARG(4), DEREF(5),
-                            CALL("oneapi::ccl::create_stream", STREAM(6)))))
+    CALL_FACTORY_ENTRY(
+        "ncclAllReduce",
+        CALL("oneapi::ccl::allreduce", ARG(0), ARG(1), ARG(2),
+             CALL(MapNames::getDpctNamespace() + "ccl::to_ccl_datatype",
+                  ARG(3)),
+             ARG(4), DEREF(5), CALL("oneapi::ccl::create_stream", STREAM(6)))))

--- a/clang/lib/DPCT/MapNames.cpp
+++ b/clang/lib/DPCT/MapNames.cpp
@@ -426,7 +426,8 @@ void MapNames::setExplicitNamespaceMap() {
        std::make_shared<TypeNameRule>("oneapi::ccl::communicator *",
                                       HelperFeatureEnum::CclUtils_create_kvs)},
       {"ncclRedOp_t", std::make_shared<TypeNameRule>("oneapi::ccl::reduction")},
-      {"ncclDataType_t", std::make_shared<TypeNameRule>("oneapi::ccl::datatype")},
+      {"ncclDataType_t", std::make_shared<TypeNameRule>(
+                                      getDpctNamespace() + "library_data_t")},
       {"cuda::std::tuple", std::make_shared<TypeNameRule>("std::tuple")},
       {"cuda::std::complex", std::make_shared<TypeNameRule>("std::complex")},
       {"cuda::std::array", std::make_shared<TypeNameRule>("std::array")},
@@ -1183,21 +1184,37 @@ void MapNames::setExplicitNamespaceMap() {
       {"ncclProd", std::make_shared<EnumNameRule>("oneapi::ccl::reduction::prod")},
       {"ncclMin", std::make_shared<EnumNameRule>("oneapi::ccl::reduction::min")},
       {"ncclMax", std::make_shared<EnumNameRule>("oneapi::ccl::reduction::max")},
-      {"ncclInt8", std::make_shared<EnumNameRule>("oneapi::ccl::datatype::int8")},
-      {"ncclChar", std::make_shared<EnumNameRule>("oneapi::ccl::datatype::int8")},
-      {"ncclUint8", std::make_shared<EnumNameRule>("oneapi::ccl::datatype::uint8")},
-      {"ncclInt32", std::make_shared<EnumNameRule>("oneapi::ccl::datatype::int32")},
-      {"ncclInt", std::make_shared<EnumNameRule>("oneapi::ccl::datatype::int32")},
-      {"ncclUint32", std::make_shared<EnumNameRule>("oneapi::ccl::datatype::uint32")},
-      {"ncclInt64", std::make_shared<EnumNameRule>("oneapi::ccl::datatype::int64")},
-      {"ncclUint64", std::make_shared<EnumNameRule>("oneapi::ccl::datatype::uint64")},
-      {"ncclFloat16", std::make_shared<EnumNameRule>("oneapi::ccl::datatype::float16")},
-      {"ncclHalf", std::make_shared<EnumNameRule>("oneapi::ccl::datatype::float16")},
-      {"ncclFloat32", std::make_shared<EnumNameRule>("oneapi::ccl::datatype::float32")},
-      {"ncclFloat", std::make_shared<EnumNameRule>("oneapi::ccl::datatype::float32")},
-      {"ncclFloat64", std::make_shared<EnumNameRule>("oneapi::ccl::datatype::float64")},
-      {"ncclDouble", std::make_shared<EnumNameRule>("oneapi::ccl::datatype::float64")},
-      {"ncclBfloat16", std::make_shared<EnumNameRule>("oneapi::ccl::datatype::bfloat16")},
+      {"ncclInt8", std::make_shared<EnumNameRule>(getDpctNamespace() +
+                                                  "library_data_t::real_int8")},
+      {"ncclChar", std::make_shared<EnumNameRule>(getDpctNamespace() +
+                                                  "library_data_t::real_int8")},
+      {"ncclUint8", std::make_shared<EnumNameRule>(
+                        getDpctNamespace() + "library_data_t::real_uint8")},
+      {"ncclInt32", std::make_shared<EnumNameRule>(
+                        getDpctNamespace() + "library_data_t::real_int32")},
+      {"ncclInt", std::make_shared<EnumNameRule>(getDpctNamespace() +
+                                                 "library_data_t::real_int32")},
+      {"ncclUint32", std::make_shared<EnumNameRule>(
+                         getDpctNamespace() + "library_data_t::real_uint32")},
+      {"ncclInt64", std::make_shared<EnumNameRule>(
+                        getDpctNamespace() + "library_data_t::real_int64")},
+      {"ncclUint64", std::make_shared<EnumNameRule>(
+                         getDpctNamespace() + "library_data_t::real_uint64")},
+      {"ncclFloat16", std::make_shared<EnumNameRule>(
+                          getDpctNamespace() + "library_data_t::real_half")},
+      {"ncclHalf", std::make_shared<EnumNameRule>(getDpctNamespace() +
+                                                  "library_data_t::real_half")},
+      {"ncclFloat32", std::make_shared<EnumNameRule>(
+                          getDpctNamespace() + "library_data_t::real_float")},
+      {"ncclFloat", std::make_shared<EnumNameRule>(
+                        getDpctNamespace() + "library_data_t::real_float")},
+      {"ncclFloat64", std::make_shared<EnumNameRule>(
+                          getDpctNamespace() + "library_data_t::real_double")},
+      {"ncclDouble", std::make_shared<EnumNameRule>(
+                         getDpctNamespace() + "library_data_t::real_double")},
+      {"ncclBfloat16",
+       std::make_shared<EnumNameRule>(getDpctNamespace() +
+                                      "library_data_t::real_bfloat16")},
       {"CUSOLVER_EIG_RANGE_ALL", std::make_shared<EnumNameRule>("oneapi::mkl::rangev::all")},
       {"CUSOLVER_EIG_RANGE_V", std::make_shared<EnumNameRule>("oneapi::mkl::rangev::values")},
       {"CUSOLVER_EIG_RANGE_I", std::make_shared<EnumNameRule>("oneapi::mkl::rangev::indices")},

--- a/clang/runtime/dpct-rt/include/ccl_utils.hpp.inc
+++ b/clang/runtime/dpct-rt/include/ccl_utils.hpp.inc
@@ -44,6 +44,12 @@
 #include <memory>
 // DPCT_LABEL_END
 
+// DPCT_LABEL_BEGIN|local_include_dependency|
+// DPCT_DEPENDENCY_EMPTY
+// DPCT_CODE
+// DPCT_LABEL_END
+#include "lib_common_utils.hpp"
+
 namespace dpct {
 namespace ccl {
 namespace detail {
@@ -67,6 +73,38 @@ get_kvs(const oneapi::ccl::kvs::address_type &addr) {
 // DPCT_LABEL_END
 
 } // namespace detail
+
+// DPCT_LABEL_BEGIN|ccl_datatype_convert|dpct::ccl
+// DPCT_DEPENDENCY_BEGIN
+// LibCommonUtils|library_data_t
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+/// Convert dpct::library_data_t to oneapi::ccl::datatype.
+inline oneapi::ccl::datatype to_ccl_datatype(dpct::library_data_t dt) {
+  switch (dt) {
+  case dpct::library_data_t::real_int8:
+    return oneapi::ccl::datatype::int8;
+  case dpct::library_data_t::real_uint8:
+    return oneapi::ccl::datatype::uint8;
+  case dpct::library_data_t::real_int32:
+    return oneapi::ccl::datatype::int32;
+  case dpct::library_data_t::real_uint32:
+    return oneapi::ccl::datatype::uint32;
+  case dpct::library_data_t::real_int64:
+    return oneapi::ccl::datatype::int6;
+  case dpct::library_data_t::real_half:
+    return oneapi::ccl::datatype::float16;
+  case dpct::library_data_t::real_float:
+    return oneapi::ccl::datatype::float32;
+  case dpct::library_data_t::real_double:
+    return oneapi::ccl::datatype::float64;
+  case dpct::library_data_t::real_bfloat16:
+    return oneapi::ccl::datatype::bfloat16;
+  default:
+    throw std::runtime_error("to_dnnl_data_type: unsupported data type.");
+  }
+}
+// DPCT_LABEL_END
 
 // DPCT_LABEL_BEGIN|get_version|dpct::ccl
 // DPCT_DEPENDENCY_EMPTY

--- a/clang/runtime/dpct-rt/include/ccl_utils.hpp.inc
+++ b/clang/runtime/dpct-rt/include/ccl_utils.hpp.inc
@@ -91,7 +91,7 @@ inline oneapi::ccl::datatype to_ccl_datatype(dpct::library_data_t dt) {
   case dpct::library_data_t::real_uint32:
     return oneapi::ccl::datatype::uint32;
   case dpct::library_data_t::real_int64:
-    return oneapi::ccl::datatype::int6;
+    return oneapi::ccl::datatype::int64;
   case dpct::library_data_t::real_half:
     return oneapi::ccl::datatype::float16;
   case dpct::library_data_t::real_float:

--- a/clang/runtime/dpct-rt/include/lib_common_utils.hpp.inc
+++ b/clang/runtime/dpct-rt/include/lib_common_utils.hpp.inc
@@ -102,7 +102,7 @@ inline void mkl_get_version(version_field field, int *result) {
 // DPCT_LABEL_BEGIN|library_data_t|dpct
 // DPCT_DEPENDENCY_EMPTY
 // DPCT_CODE
-enum class library_data_t : unsigned char {
+enum library_data_t {
   real_float = 0,
   complex_float,
   real_double,

--- a/clang/test/dpct/helper_files_ref/include/ccl_utils.hpp
+++ b/clang/test/dpct/helper_files_ref/include/ccl_utils.hpp
@@ -48,7 +48,7 @@ inline oneapi::ccl::datatype to_ccl_datatype(dpct::library_data_t dt) {
   case dpct::library_data_t::real_uint32:
     return oneapi::ccl::datatype::uint32;
   case dpct::library_data_t::real_int64:
-    return oneapi::ccl::datatype::int6;
+    return oneapi::ccl::datatype::int64;
   case dpct::library_data_t::real_half:
     return oneapi::ccl::datatype::float16;
   case dpct::library_data_t::real_float:

--- a/clang/test/dpct/helper_files_ref/include/ccl_utils.hpp
+++ b/clang/test/dpct/helper_files_ref/include/ccl_utils.hpp
@@ -14,6 +14,8 @@
 #include <unordered_map>
 #include <memory>
 
+#include "lib_common_utils.hpp"
+
 namespace dpct {
 namespace ccl {
 namespace detail {
@@ -33,6 +35,32 @@ get_kvs(const oneapi::ccl::kvs::address_type &addr) {
 }
 
 } // namespace detail
+
+/// Convert dpct::library_data_t to oneapi::ccl::datatype.
+inline oneapi::ccl::datatype to_ccl_datatype(dpct::library_data_t dt) {
+  switch (dt) {
+  case dpct::library_data_t::real_int8:
+    return oneapi::ccl::datatype::int8;
+  case dpct::library_data_t::real_uint8:
+    return oneapi::ccl::datatype::uint8;
+  case dpct::library_data_t::real_int32:
+    return oneapi::ccl::datatype::int32;
+  case dpct::library_data_t::real_uint32:
+    return oneapi::ccl::datatype::uint32;
+  case dpct::library_data_t::real_int64:
+    return oneapi::ccl::datatype::int6;
+  case dpct::library_data_t::real_half:
+    return oneapi::ccl::datatype::float16;
+  case dpct::library_data_t::real_float:
+    return oneapi::ccl::datatype::float32;
+  case dpct::library_data_t::real_double:
+    return oneapi::ccl::datatype::float64;
+  case dpct::library_data_t::real_bfloat16:
+    return oneapi::ccl::datatype::bfloat16;
+  default:
+    throw std::runtime_error("to_dnnl_data_type: unsupported data type.");
+  }
+}
 
 /// Get concatenated library version as an integer.
 static inline int get_version() {

--- a/clang/test/dpct/helper_files_ref/include/lib_common_utils.hpp
+++ b/clang/test/dpct/helper_files_ref/include/lib_common_utils.hpp
@@ -49,7 +49,7 @@ inline void mkl_get_version(version_field field, int *result) {
   }
 }
 
-enum class library_data_t : unsigned char {
+enum library_data_t {
   real_float = 0,
   complex_float,
   real_double,

--- a/clang/test/dpct/nccl.cu
+++ b/clang/test/dpct/nccl.cu
@@ -48,33 +48,33 @@ int main() {
     op = ncclMin;
     // CHECK: op = oneapi::ccl::reduction::max;
     op = ncclMax;
-    // CHECK: oneapi::ccl::datatype datatype = oneapi::ccl::datatype::int8;
+    // CHECK: dpct::library_data_t datatype = dpct::library_data_t::real_int8;
     ncclDataType_t datatype = ncclChar;
-    // CHECK: datatype = oneapi::ccl::datatype::int8;
+    // CHECK: datatype = dpct::library_data_t::real_int8;
     datatype = ncclChar;
-    // CHECK: datatype = oneapi::ccl::datatype::uint8;
+    // CHECK: datatype = dpct::library_data_t::real_uint8;
     datatype = ncclUint8;
-    // CHECK: datatype = oneapi::ccl::datatype::int32;
+    // CHECK: datatype = dpct::library_data_t::real_int32;
     datatype = ncclInt32;
-    // CHECK: datatype = oneapi::ccl::datatype::int32;
+    // CHECK: datatype = dpct::library_data_t::real_int32;
     datatype = ncclInt;
-    // CHECK: datatype = oneapi::ccl::datatype::uint32;
+    // CHECK: datatype = dpct::library_data_t::real_uint32;
     datatype = ncclUint32;
-    // CHECK: datatype = oneapi::ccl::datatype::int64;
+    // CHECK: datatype = dpct::library_data_t::real_int64;
     datatype = ncclInt64;
-    // CHECK: datatype = oneapi::ccl::datatype::uint64;
+    // CHECK: datatype = dpct::library_data_t::real_uint64;
     datatype = ncclUint64;
-    // CHECK: datatype = oneapi::ccl::datatype::float16;
+    // CHECK: datatype = dpct::library_data_t::real_half;
     datatype = ncclFloat16;
-    // CHECK: datatype = oneapi::ccl::datatype::float16;
+    // CHECK: datatype = dpct::library_data_t::real_half;
     datatype = ncclHalf;
-    // CHECK: datatype = oneapi::ccl::datatype::float32;
+    // CHECK: datatype = dpct::library_data_t::real_float;
     datatype = ncclFloat32;
-    // CHECK: datatype = oneapi::ccl::datatype::float32;
+    // CHECK: datatype = dpct::library_data_t::real_float;
     datatype = ncclFloat;
-    // CHECK: datatype = oneapi::ccl::datatype::float64;
+    // CHECK: datatype = dpct::library_data_t::real_double;
     datatype = ncclFloat64;
-    // CHECK: datatype = oneapi::ccl::datatype::float64;
+    // CHECK: datatype = dpct::library_data_t::real_double;
     datatype = ncclDouble;
 
     int peer;
@@ -99,7 +99,7 @@ int main() {
     // CHECK-NEXT: */
     ncclGroupEnd();
 
-    // CHECK: oneapi::ccl::allreduce(buff, recvbuff, count, oneapi::ccl::datatype::int8, oneapi::ccl::reduction::sum, *comm, oneapi::ccl::create_stream(*stream));
+    // CHECK: oneapi::ccl::allreduce(buff, recvbuff, count, dpct::ccl::to_ccl_datatype(dpct::library_data_t::real_int8), oneapi::ccl::reduction::sum, *comm, oneapi::ccl::create_stream(*stream));
     ncclAllReduce(buff, recvbuff, count, ncclChar, ncclSum, comm, stream);
 
     // CHECK:     /*


### PR DESCRIPTION
Signed-off-by: Ni, Wenhui <wenhui.ni@intel.com>