### PR TITLE
[CI][GHA]Will not launch CI testing for draft PR

### DIFF
--- a/.github/workflows/ci_lin.yml
+++ b/.github/workflows/ci_lin.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - SYCLomatic
+    types: [opened, synchronize, reopened, ready_for_review]
 
 env:
   BUILD_CONCURRENCY: 2
@@ -13,6 +14,7 @@ env:
 jobs:
   linux-build-lit:
     name: linux-build-lit
+    if: github.event.pull_request.draft == false
     runs-on: build
     outputs:
       build_success: ${{ steps.Echo-Build-Success.outputs.build_success }}
@@ -120,7 +122,7 @@ jobs:
     runs-on: test
     needs: [linux-build-lit]
     if: |
-      needs.linux-build-lit.outputs.build_success == 'true'
+      needs.linux-build-lit.outputs.build_success == 'true' &&  github.event.pull_request.draft == false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - SYCLomatic
+    types: [opened, synchronize, reopened, ready_for_review]
 
 env:
   BUILD_CONCURRENCY: 2
@@ -13,6 +14,7 @@ env:
 jobs:
   windows-build-lit:
     name: windows-build-lit
+    if: github.event.pull_request.draft == false
     runs-on: win_build_sc
     outputs:
       build_success: ${{ steps.Echo-Build-Success.outputs.build_success }}
@@ -165,7 +167,7 @@ jobs:
     runs-on: win_build_sc
     needs: [windows-build-lit]
     if: |
-      needs.windows-build-lit.outputs.build_success == 'true'
+      needs.windows-build-lit.outputs.build_success == 'true' && github.event.pull_request.draft == false
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
This change will make CI tests not be launched if PR is draft status.
And will be launched automatically if the PR "Ready to Review"
Verified by fork internal run:
https://github.com/DoyleLi/SYCLomatic/pull/3