### PR TITLE
[DOC] Update file to not give warnings at build-time

### DIFF
--- a/docs/_include_files/options_def.rst
+++ b/docs/_include_files/options_def.rst
@@ -1,4 +1,4 @@
-
+:orphan:
 
 .. _opt-always-use-async-handler:
 


### PR DESCRIPTION
Add :orphan: to include file to remove built-time warnings