### PR TITLE
[SYCLomatic] Migrate CUDART_PI_F

### DIFF
--- a/clang/lib/DPCT/MapNames.cpp
+++ b/clang/lib/DPCT/MapNames.cpp
@@ -4176,6 +4176,8 @@ std::unordered_map<std::string, MacroMigrationRule> MapNames::MacroRuleMap{
      MacroMigrationRule("kernel_param_rule", RulePriority::Fallback,
                         "CU_LAUNCH_PARAM_END", "((void *) 0)",
                         HelperFeatureEnum::Kernel_kernel_library)},
+    {"CUDART_PI_F", MacroMigrationRule("CUDART_PI_F", RulePriority::Fallback,
+                        "CUDART_PI_F", "3.141592654F")}
     //...
 };
 

--- a/clang/test/dpct/cuda_pi.cu
+++ b/clang/test/dpct/cuda_pi.cu
@@ -1,0 +1,10 @@
+// RUN: dpct --format-range=none -out-root %T/cuda_pi %s --cuda-include-path="%cuda-path/include" -- -x cuda --cuda-host-only --std=c++14
+// RUN: FileCheck --input-file %T/cuda_pi/cuda_pi.dp.cpp --match-full-lines %s
+
+#include <cuda.h>
+#include <math_constants.h>
+
+__global__ void test() {
+  // CHECK: const auto pi = 3.141592654F;
+  const auto pi = CUDART_PI_F;
+}


### PR DESCRIPTION
This PR migrates the `CUDART_PI_F` macro.