### PR TITLE
[NFC][SYCLomatic] Fix build warnings

### DIFF
--- a/.github/workflows/ci_lin.yml
+++ b/.github/workflows/ci_lin.yml
@@ -48,7 +48,6 @@ jobs:
           cmake \
             -G Ninja \
             -DLLVM_ENABLE_PROJECTS="clang"  \
-            -DCMAKE_COLOR_MAKEFILE=0 \
             -DCMAKE_BUILD_TYPE=Release \
             -DLLVM_TARGETS_TO_BUILD="X86;NVPTX" \
             -DLLVM_ENABLE_TERMINFO=OFF  \

--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -61,7 +61,6 @@ jobs:
           cmake \
             -G Ninja \
             -DLLVM_ENABLE_PROJECTS="clang"  \
-            -DCMAKE_COLOR_MAKEFILE=0 \
             -DCMAKE_BUILD_TYPE=Release \
             -DLLVM_TARGETS_TO_BUILD="X86;NVPTX" \
             -DLLVM_ENABLE_TERMINFO=OFF  \

--- a/clang/lib/DPCT/CallExprRewriterThrust.cpp
+++ b/clang/lib/DPCT/CallExprRewriterThrust.cpp
@@ -20,7 +20,7 @@ public:
   CheckThrustArgType(unsigned I, std::string Name) : Idx(I), TypeName(Name) {}
   bool operator()(const CallExpr *C) {
     std::string ArgType;
-    int NumArgs = C->getNumArgs();
+    unsigned NumArgs = C->getNumArgs();
     if (Idx < NumArgs) {
       ArgType = C->getArg(Idx)
                     ->getType()

--- a/clang/lib/DPCT/MigrationAction.cpp
+++ b/clang/lib/DPCT/MigrationAction.cpp
@@ -70,7 +70,7 @@ bool canCacheMoreTranslateUnit() {
 
     return Available * 100 / Total > MinAvailableMemoryPercent &&
            Available * 1024 > MinAvailableMemorySize;
-  } catch (std::exception) {
+  } catch (std::exception &) {
     /// Return false if any exception
     return false;
   }


### PR DESCRIPTION
```
SYCLomatic/clang/lib/DPCT/MigrationAction.cpp:73:17: warning: catching polymorphic type ‘class std::exception’ by value 

SYCLomatic/clang/lib/DPCT/CallExprRewriterThrust.cpp:24:13: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘int’

 Manually-specified variables were not used by the project:

    CMAKE_COLOR_MAKEFILE
```
Signed-off-by: Wang, Yihan [yihan.wang@intel.com](mailto:yihan.wang@intel.com)