### PR TITLE
[SYCLomatic] Fix migration of cub::WarpReduce::Reduce

### DIFF
--- a/clang/lib/DPCT/CUBAPIMigration.cpp
+++ b/clang/lib/DPCT/CUBAPIMigration.cpp
@@ -1239,6 +1239,9 @@ void CubRule::processWarpLevelMemberCall(const CXXMemberCallExpr *WarpMC) {
       break;
     }
     case 3: {
+      DpctGlobalInfo::getInstance().insertHeader(WarpMC->getBeginLoc(),
+                                                 HeaderType::HT_DPCT_DPL_Utils);
+      GroupOrWorkitem = DpctGlobalInfo::getItem(WarpMC, FD);
       ExprAnalysis ValidItemEA(WarpMC->getArg(2));
       OpRepl = getOpRepl(WarpMC->getArg(1));
       Repl = MapNames::getDpctNamespace() +

--- a/clang/test/dpct/cub/warplevel/warpreduce.cu
+++ b/clang/test/dpct/cub/warplevel/warpreduce.cu
@@ -3,6 +3,9 @@
 // RUN: dpct --format-range=none -in-root %S -out-root %T/warplevel/warpreduce %S/warpreduce.cu --cuda-include-path="%cuda-path/include" -- -std=c++14 -x cuda --cuda-host-only
 // RUN: FileCheck --input-file %T/warplevel/warpreduce/warpreduce.dp.cpp --match-full-lines %s
 
+// CHECK: #include <oneapi/dpl/execution>
+// CHECK: #include <oneapi/dpl/algorithm>
+// CHECK: #include <dpct/dpl_utils.hpp>
 #include <iostream>
 #include <vector>
 
@@ -69,7 +72,7 @@ __global__ void ReduceKernel(int* data) {
 //CHECK:  int threadid = item_ct1.get_local_id(2);
 //CHECK:  int input = data[threadid];
 //CHECK:  int output = 0;
-//CHECK:  output = dpct::group::reduce_over_partial_group(item_ct1.get_sub_group(), input, valid_items, sycl::plus<>());
+//CHECK:  output = dpct::group::reduce_over_partial_group(item_ct1, input, valid_items, sycl::plus<>());
 //CHECK:  data[threadid] = output;
 //CHECK:}
 __global__ void ReduceKernel2(int* data, int valid_items) {


### PR DESCRIPTION
- Insert header <dpct/dpl_utils.hpp>
- Fix the 1st arg from nd_item.get_sub_group() to nd_item

Signed-off-by: Wang, Yihan [yihan.wang@intel.com](mailto:yihan.wang@intel.com)