### PR TITLE
[SYCLomatic] Promote "-std" option less then C++17 to C++17 in the generated Makefile for source files which has CUDA Semantics and is compiled by non-NVCC compiler

### DIFF
--- a/clang/lib/DPCT/GenMakefile.cpp
+++ b/clang/lib/DPCT/GenMakefile.cpp
@@ -264,8 +264,10 @@ static void getCompileInfo(
         }
 
         // SYCL support c++17 as default.
-        if (HasCudaSemantics && Val <= 17)
+        if (HasCudaSemantics && Val <= 17) {
+          NewOptions += "-std=c++17 ";
           continue;
+        }
 
         // Skip duplicate options.
         if (DuplicateDuplicateFilter.find(Option) !=

--- a/clang/test/dpct/gen_build_script/Makefile.dpct.ref
+++ b/clang/test/dpct/gen_build_script/Makefile.dpct.ref
@@ -8,7 +8,7 @@
 // CHECK:TARGET_0_FLAG_0 = -std=c++20 ${FLAGS}
 // CHECK:TARGET_0_SRC_1 = ./source/bar.cpp.dp.cpp
 // CHECK:TARGET_0_OBJ_1 = ./source/bar.cpp.dp.o
-// CHECK:TARGET_0_FLAG_1 = ${FLAGS}
+// CHECK:TARGET_0_FLAG_1 = -std=c++17 ${FLAGS}
 // CHECK:TARGET_0 := app
 // CHECK:TARGET :=  ${TARGET_0}
 // CHECK:.PHONY:all clean


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>

