### PR TITLE
[SYCLomatic] moving bfe() to public namespace, enabling unsigned types 

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/dpcpp_extensions.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/dpcpp_extensions.h
@@ -18,6 +18,7 @@
 
 #include "../dpct.hpp"
 #include "functional.h"
+
 namespace dpct {
 namespace group {
 namespace detail {

--- a/clang/runtime/dpct-rt/include/dpl_extras/dpcpp_extensions.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/dpcpp_extensions.h
@@ -17,20 +17,9 @@
 #endif
 
 #include "../dpct.hpp"
-
+#include "functional.h"
 namespace dpct {
-
-template <T>
-__dpct_inline__ 
-::std::enable_if_t<::std::is_unsigned_v<T>, T>
-bfe(T source, uint32_t bit_start,
-                    uint32_t num_bits) {
-  const T MASK = (1 << num_bits) - 1;
-  return (source >> bit_start) & MASK;
-}
-
 namespace group {
-
 namespace detail {
 
 template <typename... _Args>

--- a/clang/runtime/dpct-rt/include/dpl_extras/dpcpp_extensions.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/dpcpp_extensions.h
@@ -19,6 +19,16 @@
 #include "../dpct.hpp"
 
 namespace dpct {
+
+template <T>
+__dpct_inline__ 
+::std::enable_if_t<::std::is_unsigned_v<T>, T>
+bfe(T source, uint32_t bit_start,
+                    uint32_t num_bits) {
+  const T MASK = (1 << num_bits) - 1;
+  return (source >> bit_start) & MASK;
+}
+
 namespace group {
 
 namespace detail {
@@ -162,12 +172,6 @@ template <int N, int COUNT> struct log2<N, 0, COUNT> {
   enum { VALUE = (1 << (COUNT - 1) < N) ? COUNT : COUNT - 1 };
 };
 
-__dpct_inline__ uint32_t bfe(uint32_t source, uint32_t bit_start,
-                    uint32_t num_bits) {
-  const uint32_t MASK = (1 << num_bits) - 1;
-  return (source >> bit_start) & MASK;
-}
-
 template <int RADIX_BITS, bool DESCENDING = false> class radix_rank {
 public:
   static size_t get_local_memory_size(size_t group_threads) {
@@ -192,7 +196,7 @@ public:
 
 #pragma unroll
     for (int i = 0; i < VALUES_PER_THREAD; ++i) {
-      uint32_t digit = bfe(keys[i], current_bit, num_bits);
+      uint32_t digit = ::dpct::bfe(keys[i], current_bit, num_bits);
       uint32_t sub_counter = digit >> LOG_COUNTER_LANES;
       uint32_t counter_lane = digit & (COUNTER_LANES - 1);
 

--- a/clang/runtime/dpct-rt/include/dpl_extras/functional.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/functional.h
@@ -27,10 +27,8 @@ namespace dpct {
 struct null_type {};
 
 template <typename T>
-__dpct_inline__ 
-::std::enable_if_t<::std::is_unsigned_v<T>, T>
-bfe(T source, uint32_t bit_start,
-                    uint32_t num_bits) {
+__dpct_inline__ ::std::enable_if_t<::std::is_unsigned_v<T>, T>
+bfe(T source, uint32_t bit_start, uint32_t num_bits) {
   const T MASK = (T{1} << num_bits) - 1;
   return (source >> bit_start) & MASK;
 }

--- a/clang/runtime/dpct-rt/include/dpl_extras/functional.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/functional.h
@@ -31,7 +31,7 @@ __dpct_inline__
 ::std::enable_if_t<::std::is_unsigned_v<T>, T>
 bfe(T source, uint32_t bit_start,
                     uint32_t num_bits) {
-  const T MASK = (1 << num_bits) - 1;
+  const T MASK = (T{1} << num_bits) - 1;
   return (source >> bit_start) & MASK;
 }
 

--- a/clang/runtime/dpct-rt/include/dpl_extras/functional.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/functional.h
@@ -32,6 +32,7 @@ bfe(T source, uint32_t bit_start,
   const T MASK = (1 << num_bits) - 1;
   return (source >> bit_start) & MASK;
 }
+
 namespace internal {
 
 template <class _ExecPolicy, class _T>

--- a/clang/runtime/dpct-rt/include/dpl_extras/functional.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/functional.h
@@ -24,6 +24,14 @@ namespace dpct {
 
 struct null_type {};
 
+template <T>
+__dpct_inline__ 
+::std::enable_if_t<::std::is_unsigned_v<T>, T>
+bfe(T source, uint32_t bit_start,
+                    uint32_t num_bits) {
+  const T MASK = (1 << num_bits) - 1;
+  return (source >> bit_start) & MASK;
+}
 namespace internal {
 
 template <class _ExecPolicy, class _T>

--- a/clang/runtime/dpct-rt/include/dpl_extras/functional.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/functional.h
@@ -20,6 +20,8 @@
 #include <tuple>
 #include <utility>
 
+#include "../dpct.hpp"
+
 namespace dpct {
 
 struct null_type {};

--- a/clang/runtime/dpct-rt/include/dpl_extras/functional.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/functional.h
@@ -24,7 +24,7 @@ namespace dpct {
 
 struct null_type {};
 
-template <T>
+template <typename T>
 __dpct_inline__ 
 ::std::enable_if_t<::std::is_unsigned_v<T>, T>
 bfe(T source, uint32_t bit_start,


### PR DESCRIPTION
Moving `bfe()` from internal namepace to public `dpct::bfe()` namespace, and enabling all unsigned integers as template input.

Tests found in (https://github.com/oneapi-src/SYCLomatic-test/pull/289)

*Rebased after .inc removal*