### PR TITLE
[SYCLomatic] Fix a compilation error when using gcc 11.x.

### DIFF
--- a/clang/lib/DPCT/CallExprRewriter.h
+++ b/clang/lib/DPCT/CallExprRewriter.h
@@ -1280,7 +1280,7 @@ public:
   DerefExprRewriter(
       const CallExpr *C, StringRef Source,
       const std::function<ArgValueT(const CallExpr *)> &ArgCreator)
-      : PrinterRewriter<DerefExpr>(C, Source, ArgCreator(C)) {}
+      : PrinterRewriter<dpct::DerefExpr>(C, Source, ArgCreator(C)) {}
 };
 
 class SubGroupPrinter {


### PR DESCRIPTION
Signed-off-by: Tang, Jiajun jiajun.tang@intel.com