### PR TITLE
[SYCLomatic] Create out-root folder when using '--gen-helper-function' before save new files

### DIFF
--- a/clang/lib/DPCT/GenHelperFunction.cpp
+++ b/clang/lib/DPCT/GenHelperFunction.cpp
@@ -125,6 +125,8 @@ std::unordered_map<std::string, std::string> HelperFileNameMap{
 } // namespace
 
 void genHelperFunction(const std::string &OutRoot) {
+  if (!llvm::sys::fs::is_directory(OutRoot))
+    llvm::sys::fs::create_directory(llvm::Twine(OutRoot));
   std::string ToPath = OutRoot + "/include";
   if (!llvm::sys::fs::is_directory(ToPath))
     llvm::sys::fs::create_directory(llvm::Twine(ToPath));


### PR DESCRIPTION
Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>