### PR TITLE
[SYCLomatic] bugfix for shift overflow on certain platforms

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/functional.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/functional.h.inc
@@ -456,7 +456,7 @@ public:
     mask = ~OutKeyT(0); // all ones
     mask = mask >> (sizeof(OutKeyT) * 8 -
                     (end_bit - begin_bit));           // setup appropriate mask
-    flip_sign = 1UL << (sizeof(uint_type_t) * 8 - 1); // sign bit
+    flip_sign = uint_type_t(1) << (sizeof(uint_type_t) * 8 - 1); // sign bit
     flip_key = ~uint_type_t(0);                       // 0xF...F
   }
 

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/functional.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/functional.h
@@ -327,7 +327,7 @@ public:
     mask = ~OutKeyT(0); // all ones
     mask = mask >> (sizeof(OutKeyT) * 8 -
                     (end_bit - begin_bit));           // setup appropriate mask
-    flip_sign = 1UL << (sizeof(uint_type_t) * 8 - 1); // sign bit
+    flip_sign = uint_type_t(1) << (sizeof(uint_type_t) * 8 - 1); // sign bit
     flip_key = ~uint_type_t(0);                       // 0xF...F
   }
 


### PR DESCRIPTION
Bugfix for platforms where unsigned long is not at least 64 bits.  (for example windows)