### PR TITLE
[SYCLomatic] segmented reduce argmin/max

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -2066,6 +2066,80 @@ inline ::std::pair<Iter1, Iter1> equal_range(_ExecutionPolicy &&policy,
 }
 // DPCT_LABEL_END
 
+// DPCT_LABEL_BEGIN|segmented_reduce_argmin|dpct
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasIterators|arg_index_input_iterator
+// DplExtrasIterators|key_value_pair
+// DplExtrasVector|is_iterator
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+template <typename _ExecutionPolicy, typename key_t, typename key_out_t, 
+          typename OffsetIteratorT>
+inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
+                          dpct::internal::is_iterator<key_out_t>::value>
+segmented_reduce_argmin(_ExecutionPolicy &&policy, key_t keys_in,
+                        key_out_t keys_out, ::std::int64_t n,
+                        ::std::int64_t nsegments, OffsetIteratorT begin_offsets,
+                        OffsetIteratorT end_offsets) {
+  policy.queue().submit([&](sycl::handler &cgh) {
+    cgh.parallel_for(nsegments, [=](sycl::id<1> i) {
+      ::std::int64_t segment_begin = begin_offsets[i];
+      ::std::int64_t segment_length =
+          ::std::min(n, (::std::int64_t)end_offsets[i]) - segment_begin;
+      if (segment_length <= 0) {
+        *(keys_out + i) = dpct::key_value_pair(
+            ptrdiff_t(1),
+            ::std::numeric_limits<
+                typename ::std::iterator_traits<key_t>::value_type>::max());
+      } else {
+        dpct::arg_index_input_iterator arg_index(keys_in + segment_begin);
+        *(keys_out + i) = *::std::min_element(
+            arg_index, arg_index + segment_length,
+            [](const auto &a, const auto &b) { return a.value < b.value; });
+      }
+    });
+  });
+  policy.queue().wait();
+}
+// DPCT_LABEL_END
+
+// DPCT_LABEL_BEGIN|segmented_reduce_argmax|dpct
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasIterators|arg_index_input_iterator
+// DplExtrasIterators|key_value_pair
+// DplExtrasVector|is_iterator
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
+          typename OffsetIteratorT>
+inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
+                          dpct::internal::is_iterator<key_out_t>::value>
+segmented_reduce_argmax(_ExecutionPolicy &&policy, key_t keys_in,
+                        key_out_t keys_out, ::std::int64_t n,
+                        ::std::int64_t nsegments, OffsetIteratorT begin_offsets,
+                        OffsetIteratorT end_offsets) {
+  policy.queue().submit([&](sycl::handler &cgh) {
+    cgh.parallel_for(nsegments, [=](sycl::id<1> i) {
+      ::std::int64_t segment_begin = begin_offsets[i];
+      ::std::int64_t segment_length =
+          ::std::min(n, (::std::int64_t)end_offsets[i]) - segment_begin;
+      if (segment_length <= 0) {
+        *(keys_out + i) = dpct::key_value_pair(
+            ptrdiff_t(1),
+            ::std::numeric_limits<
+                typename ::std::iterator_traits<key_t>::value_type>::lowest());
+      } else {
+        dpct::arg_index_input_iterator arg_index(keys_in + segment_begin);
+        *(keys_out + i) = *::std::max_element(
+            arg_index, arg_index + segment_length,
+            [](const auto &a, const auto &b) { return a.value < b.value; });
+      }
+    });
+  });
+  policy.queue().wait();
+}
+// DPCT_LABEL_END
+
 } // end namespace dpct
 
 #endif

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1713,6 +1713,7 @@ inline ::std::pair<Iter1, Iter1> equal_range(_ExecutionPolicy &&policy,
                                              const ValueLessComparable &value) {
   return equal_range(::std::forward<_ExecutionPolicy>(policy), start, end,
                      value, internal::__less());
+}
 
 template <typename _ExecutionPolicy, typename key_t, typename key_out_t, 
           typename OffsetIteratorT>

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1713,6 +1713,59 @@ inline ::std::pair<Iter1, Iter1> equal_range(_ExecutionPolicy &&policy,
                                              const ValueLessComparable &value) {
   return equal_range(::std::forward<_ExecutionPolicy>(policy), start, end,
                      value, internal::__less());
+
+template <typename _ExecutionPolicy, typename key_t, typename key_out_t, 
+          typename OffsetIteratorT>
+inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
+                          dpct::internal::is_iterator<key_out_t>::value>
+segmented_reduce_argmin(
+    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
+    ::std::int64_t n, ::std::int64_t nsegments,
+    OffsetIteratorT begin_offsets, OffsetIteratorT end_offsets) {
+  policy.queue().submit([&](sycl::handler &cgh) {
+    cgh.parallel_for(nsegments, [=](sycl::id<1> i) {
+      ::std::int64_t segment_begin = begin_offsets[i];
+      ::std::int64_t segment_length = ::std::min(n, (::std::int64_t)end_offsets[i]) - segment_begin;
+      if (segment_length <= 0) {
+        *(keys_out + i) = dpct::key_value_pair(ptrdiff_t(1), ::std::numeric_limits<typename ::std::iterator_traits<key_t>::value_type>::max());
+      }
+      else
+      {
+        dpct::arg_index_input_iterator arg_index(keys_in + segment_begin);
+        *(keys_out + i) = *::std::min_element(
+              arg_index,
+              arg_index + segment_length, [](const auto& a, const auto& b){return a.value < b.value;});
+      }
+    });
+  });
+  policy.queue().wait();
+}
+
+template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
+          typename OffsetIteratorT>
+inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
+                          dpct::internal::is_iterator<key_out_t>::value>
+segmented_reduce_argmax(
+    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
+    ::std::int64_t n, ::std::int64_t nsegments,
+    OffsetIteratorT begin_offsets, OffsetIteratorT end_offsets) {
+  policy.queue().submit([&](sycl::handler &cgh) {
+    cgh.parallel_for(nsegments, [=](sycl::id<1> i) {
+      ::std::int64_t segment_begin = begin_offsets[i];
+      ::std::int64_t segment_length = ::std::min(n, (::std::int64_t)end_offsets[i]) - segment_begin;
+      if (segment_length <= 0) {
+        *(keys_out + i) = dpct::key_value_pair(ptrdiff_t(1), ::std::numeric_limits<typename ::std::iterator_traits<key_t>::value_type>::lowest());
+      }
+      else
+      {
+        dpct::arg_index_input_iterator arg_index(keys_in + segment_begin);
+        *(keys_out + i) = *::std::max_element(
+              arg_index,
+              arg_index + segment_length, [](const auto& a, const auto& b){return a.value < b.value;});
+      }
+    });
+  });
+  policy.queue().wait();
 }
 
 } // end namespace dpct

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1718,23 +1718,25 @@ template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
           typename OffsetIteratorT>
 inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
                           dpct::internal::is_iterator<key_out_t>::value>
-segmented_reduce_argmin(
-    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
-    ::std::int64_t n, ::std::int64_t nsegments,
-    OffsetIteratorT begin_offsets, OffsetIteratorT end_offsets) {
+segmented_reduce_argmin(_ExecutionPolicy &&policy, key_t keys_in,
+                        key_out_t keys_out, ::std::int64_t n,
+                        ::std::int64_t nsegments, OffsetIteratorT begin_offsets,
+                        OffsetIteratorT end_offsets) {
   policy.queue().submit([&](sycl::handler &cgh) {
     cgh.parallel_for(nsegments, [=](sycl::id<1> i) {
       ::std::int64_t segment_begin = begin_offsets[i];
-      ::std::int64_t segment_length = ::std::min(n, (::std::int64_t)end_offsets[i]) - segment_begin;
+      ::std::int64_t segment_length =
+          ::std::min(n, (::std::int64_t)end_offsets[i]) - segment_begin;
       if (segment_length <= 0) {
-        *(keys_out + i) = dpct::key_value_pair(ptrdiff_t(1), ::std::numeric_limits<typename ::std::iterator_traits<key_t>::value_type>::max());
-      }
-      else
-      {
+        *(keys_out + i) = dpct::key_value_pair(
+            ptrdiff_t(1),
+            ::std::numeric_limits<
+                typename ::std::iterator_traits<key_t>::value_type>::max());
+      } else {
         dpct::arg_index_input_iterator arg_index(keys_in + segment_begin);
         *(keys_out + i) = *::std::min_element(
-              arg_index,
-              arg_index + segment_length, [](const auto& a, const auto& b){return a.value < b.value;});
+            arg_index, arg_index + segment_length,
+            [](const auto &a, const auto &b) { return a.value < b.value; });
       }
     });
   });
@@ -1745,23 +1747,25 @@ template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
           typename OffsetIteratorT>
 inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
                           dpct::internal::is_iterator<key_out_t>::value>
-segmented_reduce_argmax(
-    _ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
-    ::std::int64_t n, ::std::int64_t nsegments,
-    OffsetIteratorT begin_offsets, OffsetIteratorT end_offsets) {
+segmented_reduce_argmax(_ExecutionPolicy &&policy, key_t keys_in,
+                        key_out_t keys_out, ::std::int64_t n,
+                        ::std::int64_t nsegments, OffsetIteratorT begin_offsets,
+                        OffsetIteratorT end_offsets) {
   policy.queue().submit([&](sycl::handler &cgh) {
     cgh.parallel_for(nsegments, [=](sycl::id<1> i) {
       ::std::int64_t segment_begin = begin_offsets[i];
-      ::std::int64_t segment_length = ::std::min(n, (::std::int64_t)end_offsets[i]) - segment_begin;
+      ::std::int64_t segment_length =
+          ::std::min(n, (::std::int64_t)end_offsets[i]) - segment_begin;
       if (segment_length <= 0) {
-        *(keys_out + i) = dpct::key_value_pair(ptrdiff_t(1), ::std::numeric_limits<typename ::std::iterator_traits<key_t>::value_type>::lowest());
-      }
-      else
-      {
+        *(keys_out + i) = dpct::key_value_pair(
+            ptrdiff_t(1),
+            ::std::numeric_limits<
+                typename ::std::iterator_traits<key_t>::value_type>::lowest());
+      } else {
         dpct::arg_index_input_iterator arg_index(keys_in + segment_begin);
         *(keys_out + i) = *::std::max_element(
-              arg_index,
-              arg_index + segment_length, [](const auto& a, const auto& b){return a.value < b.value;});
+            arg_index, arg_index + segment_length,
+            [](const auto &a, const auto &b) { return a.value < b.value; });
       }
     });
   });


### PR DESCRIPTION
Functional implementation of `dpct::segmented_reduce_argmin` and `dpct::segmented_reduce_argmax`. 
Tested by https://github.com/oneapi-src/SYCLomatic-test/pull/310