### PR TITLE
[SYCLomatic]Fix massive build warning for IsTemplate initialized before IsReference

### DIFF
--- a/clang/lib/DPCT/AnalysisInfo.h
+++ b/clang/lib/DPCT/AnalysisInfo.h
@@ -2204,7 +2204,7 @@ public:
   // will be the size string.
   CtTypeInfo(const TypeLoc &TL, bool NeedSizeFold = false);
   CtTypeInfo(const VarDecl *D, bool NeedSizeFold = false)
-      : PointerLevel(0), IsTemplate(false), IsReference(false) {
+      : PointerLevel(0), IsReference(false), IsTemplate(false) {
     if (D && D->getTypeSourceInfo()) {
       auto TL = D->getTypeSourceInfo()->getTypeLoc();
       setTypeInfo(TL, NeedSizeFold);


### PR DESCRIPTION
In class `CtTypeInfo`:
```
class CtTypeInfo {

private:
bool IsReference;
bool IsTemplate;
}
```
IsTemplate is defined behind of IsReference.
When initializing them with initialization lists, the order should match their definition.