### PR TITLE
[SYCLomatic] Redeclare the MemberExpr of non-trivially copyable class used in kernel argument in template function before submit.

### DIFF
--- a/clang/lib/DPCT/ExprAnalysis.cpp
+++ b/clang/lib/DPCT/ExprAnalysis.cpp
@@ -1596,17 +1596,8 @@ void KernelArgumentAnalysis::analyzeExpr(const CXXTemporaryObjectExpr *Temp) {
 
 void KernelArgumentAnalysis::analyzeExpr(
     const CXXDependentScopeMemberExpr *Arg) {
-  if (Arg->isImplicitAccess()) {
-    IsRedeclareRequired = true;
-  } else {
-    if (Arg->isArrow())
-      IsRedeclareRequired = true;
-    if (auto TST = dyn_cast<TemplateSpecializationType>(
-            Arg->getBaseType().getDesugaredType(Context)))
-      if (auto CTD = dyn_cast<ClassTemplateDecl>(
-              TST->getTemplateName().getAsTemplateDecl()))
-        if (!CTD->getTemplatedDecl()->isTriviallyCopyable())
-          IsRedeclareRequired = true;
+  IsRedeclareRequired = true;
+  if (!Arg->isImplicitAccess()) {
     KernelArgumentAnalysis::dispatch(Arg->getBase());
   }
 }

--- a/clang/lib/DPCT/ExprAnalysis.cpp
+++ b/clang/lib/DPCT/ExprAnalysis.cpp
@@ -1601,6 +1601,12 @@ void KernelArgumentAnalysis::analyzeExpr(
   } else {
     if (Arg->isArrow())
       IsRedeclareRequired = true;
+    if (auto TST = dyn_cast<TemplateSpecializationType>(
+            Arg->getBaseType().getDesugaredType(Context)))
+      if (auto CTD = dyn_cast<ClassTemplateDecl>(
+              TST->getTemplateName().getAsTemplateDecl()))
+        if (!CTD->getTemplatedDecl()->isTriviallyCopyable())
+          IsRedeclareRequired = true;
     KernelArgumentAnalysis::dispatch(Arg->getBase());
   }
 }

--- a/clang/test/dpct/template-kernel-call.cu
+++ b/clang/test/dpct/template-kernel-call.cu
@@ -292,11 +292,16 @@ __global__ void my_kernel(T *A) {
 // CHECK-NEXT:  /*
 // CHECK-NEXT:  DPCT1049:{{[0-9]+}}: The work-group size passed to the SYCL kernel may exceed the limit. To get the device limit, query info::device::max_work_group_size. Adjust the work-group size if needed.
 // CHECK-NEXT:  */
-// CHECK-NEXT:  ptr.s->parallel_for<dpct_kernel_name<class my_kernel_{{[a-f0-9]+}}, T>>(
+// CHECK-NEXT:  ptr.s->submit(
+// CHECK-NEXT:    [&](sycl::handler &cgh) {
+// CHECK-NEXT:      auto ptr_dPtr_ct0 = ptr.dPtr;
+// CHECK-EMPTY:
+// CHECK-NEXT:      cgh.parallel_for<dpct_kernel_name<class my_kernel_{{[a-f0-9]+}}, T>>(
 // CHECK-NEXT:        sycl::nd_range<3>(sycl::range<3>(1, 1, 8) * sycl::range<3>(1, 1, block_size), sycl::range<3>(1, 1, block_size)),
 // CHECK-NEXT:        [=](sycl::nd_item<3> item_ct1) {
-// CHECK-NEXT:          my_kernel<T>(ptr.dPtr);
+// CHECK-NEXT:          my_kernel<T>(ptr_dPtr_ct0);
 // CHECK-NEXT:        });
+// CHECK-NEXT:    });
 // CHECK-NEXT:}
 template <typename T>
 static void multiply(int block_size, Image<T> &ptr, T value) {
@@ -308,11 +313,16 @@ static void multiply(int block_size, Image<T> &ptr, T value) {
 // CHECK-NEXT:  /*
 // CHECK-NEXT:  DPCT1049:{{[0-9]+}}: The work-group size passed to the SYCL kernel may exceed the limit. To get the device limit, query info::device::max_work_group_size. Adjust the work-group size if needed.
 // CHECK-NEXT:  */
-// CHECK-NEXT:  ptr.s->parallel_for<dpct_kernel_name<class my_kernel_{{[a-f0-9]+}}, dpct_placeholder/*Fix the type mannually*/>>(
+// CHECK-NEXT:  ptr.s->submit(
+// CHECK-NEXT:    [&](sycl::handler &cgh) {
+// CHECK-NEXT:      auto ptr_dPtr_ct0 = ptr.dPtr;
+// CHECK-EMPTY:
+// CHECK-NEXT:      cgh.parallel_for<dpct_kernel_name<class my_kernel_{{[a-f0-9]+}}, dpct_placeholder/*Fix the type mannually*/>>(
 // CHECK-NEXT:        sycl::nd_range<3>(sycl::range<3>(1, 1, 8) * sycl::range<3>(1, 1, size), sycl::range<3>(1, 1, size)),
 // CHECK-NEXT:        [=](sycl::nd_item<3> item_ct1) {
-// CHECK-NEXT:          my_kernel(ptr.dPtr);
+// CHECK-NEXT:          my_kernel(ptr_dPtr_ct0);
 // CHECK-NEXT:        });
+// CHECK-NEXT:    });
 // CHECK-NEXT:}
 template <typename T, int size>
 void foo1(Image<T> &ptr, T value) {
@@ -324,11 +334,16 @@ void foo1(Image<T> &ptr, T value) {
 // CHECK-NEXT:  /*
 // CHECK-NEXT:  DPCT1049:{{[0-9]+}}: The work-group size passed to the SYCL kernel may exceed the limit. To get the device limit, query info::device::max_work_group_size. Adjust the work-group size if needed.
 // CHECK-NEXT:  */
-// CHECK-NEXT:  ptr.s->parallel_for<dpct_kernel_name<class my_kernel_{{[a-f0-9]+}}, dpct_placeholder/*Fix the type mannually*/>>(
+// CHECK-NEXT:  ptr.s->submit(
+// CHECK-NEXT:    [&](sycl::handler &cgh) {
+// CHECK-NEXT:      auto ptr_dPtr_ct0 = ptr.dPtr;
+// CHECK-EMPTY:
+// CHECK-NEXT:      cgh.parallel_for<dpct_kernel_name<class my_kernel_{{[a-f0-9]+}}, dpct_placeholder/*Fix the type mannually*/>>(
 // CHECK-NEXT:        sycl::nd_range<3>(sycl::range<3>(1, 1, 8) * sycl::range<3>(2, size, 1), sycl::range<3>(2, size, 1)),
 // CHECK-NEXT:        [=](sycl::nd_item<3> item_ct1) {
-// CHECK-NEXT:          my_kernel(ptr.dPtr);
+// CHECK-NEXT:          my_kernel(ptr_dPtr_ct0);
 // CHECK-NEXT:        });
+// CHECK-NEXT:    });
 // CHECK-NEXT:}
 template <typename T, int size>
 void foo2(Image<T> &ptr, T value) {


### PR DESCRIPTION
Signed-off-by: Tang, Jiajun jiajun.tang@intel.com