### PR TITLE
[SYCLomatic] segmented_reduce_argmin remove n param, change return type

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -2053,22 +2053,21 @@ inline ::std::pair<Iter1, Iter1> equal_range(_ExecutionPolicy &&policy,
 // DplExtrasVector|is_iterator
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
-template <typename Policy, typename KeyT, typename KeyOutT,
-          typename OffsetIteratorT>
-inline ::std::enable_if_t<dpct::internal::is_iterator<KeyT>::value &&
-                          dpct::internal::is_iterator<KeyOutT>::value>
-segmented_reduce_argmin(Policy &&policy, KeyT keys_in, KeyOutT keys_out,
-                        ::std::int64_t nsegments, OffsetIteratorT begin_offsets,
-                        OffsetIteratorT end_offsets) {
+template <typename Policy, typename Iter1, typename Iter2, typename Iter3>
+inline ::std::enable_if_t<dpct::internal::is_iterator<Iter1>::value &&
+                          dpct::internal::is_iterator<Iter2>::value>
+segmented_reduce_argmin(Policy &&policy, Iter1 keys_in, Iter2 keys_out,
+                        ::std::int64_t nsegments, Iter3 begin_offsets,
+                        Iter3 end_offsets) {
   policy.queue().submit([&](sycl::handler &cgh) {
     cgh.parallel_for(nsegments, [=](sycl::id<1> i) {
       if (end_offsets[i] <= begin_offsets[i]) {
         keys_out[i] = dpct::key_value_pair(
             1, ::std::numeric_limits<
-                   typename ::std::iterator_traits<KeyT>::value_type>::max());
+                   typename ::std::iterator_traits<Iter1>::value_type>::max());
       } else {
-        dpct::arg_index_input_iterator<KeyT, int> arg_index(keys_in +
-                                                            begin_offsets[i]);
+        dpct::arg_index_input_iterator<Iter1, int> arg_index(keys_in +
+                                                             begin_offsets[i]);
         keys_out[i] = *::std::min_element(
             arg_index, arg_index + +end_offsets[i] - begin_offsets[i],
             [](const auto &a, const auto &b) { return a.value < b.value; });
@@ -2086,23 +2085,22 @@ segmented_reduce_argmin(Policy &&policy, KeyT keys_in, KeyOutT keys_out,
 // DplExtrasVector|is_iterator
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
-template <typename Policy, typename KeyT, typename KeyOutT,
-          typename OffsetIteratorT>
-inline ::std::enable_if_t<dpct::internal::is_iterator<KeyT>::value &&
-                          dpct::internal::is_iterator<KeyOutT>::value>
-segmented_reduce_argmax(Policy &&policy, KeyT keys_in, KeyOutT keys_out,
-                        ::std::int64_t nsegments, OffsetIteratorT begin_offsets,
-                        OffsetIteratorT end_offsets) {
+template <typename Policy, typename Iter1, typename Iter2, typename Iter3>
+inline ::std::enable_if_t<dpct::internal::is_iterator<Iter1>::value &&
+                          dpct::internal::is_iterator<Iter2>::value>
+segmented_reduce_argmax(Policy &&policy, Iter1 keys_in, Iter2 keys_out,
+                        ::std::int64_t nsegments, Iter3 begin_offsets,
+                        Iter3 end_offsets) {
   policy.queue().submit([&](sycl::handler &cgh) {
     cgh.parallel_for(nsegments, [=](sycl::id<1> i) {
       if (end_offsets[i] <= begin_offsets[i]) {
         keys_out[i] = dpct::key_value_pair(
             1,
             ::std::numeric_limits<
-                typename ::std::iterator_traits<KeyT>::value_type>::lowest());
+                typename ::std::iterator_traits<Iter1>::value_type>::lowest());
       } else {
-        dpct::arg_index_input_iterator<KeyT, int> arg_index(keys_in +
-                                                            begin_offsets[i]);
+        dpct::arg_index_input_iterator<Iter1, int> arg_index(keys_in +
+                                                             begin_offsets[i]);
         keys_out[i] = *::std::max_element(
             arg_index, arg_index + end_offsets[i] - begin_offsets[i],
             [](const auto &a, const auto &b) { return a.value < b.value; });

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -2051,11 +2051,14 @@ inline ::std::pair<Iter1, Iter1> equal_range(_ExecutionPolicy &&policy,
 // DplExtrasIterators|arg_index_input_iterator
 // DplExtrasIterators|key_value_pair
 // DplExtrasVector|is_iterator
+// DplExtrasFunctional|is_hetero_execution_policy
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
 template <typename Policy, typename Iter1, typename Iter2, typename Iter3>
-inline ::std::enable_if_t<dpct::internal::is_iterator<Iter1>::value &&
-                          dpct::internal::is_iterator<Iter2>::value>
+inline ::std::enable_if_t<
+    dpct::internal::is_iterator<Iter1>::value &&
+    dpct::internal::is_iterator<Iter2>::value &&
+    internal::is_hetero_execution_policy<::std::decay_t<Policy>>::value>
 segmented_reduce_argmin(Policy &&policy, Iter1 keys_in, Iter2 keys_out,
                         ::std::int64_t nsegments, Iter3 begin_offsets,
                         Iter3 end_offsets) {
@@ -2083,11 +2086,14 @@ segmented_reduce_argmin(Policy &&policy, Iter1 keys_in, Iter2 keys_out,
 // DplExtrasIterators|arg_index_input_iterator
 // DplExtrasIterators|key_value_pair
 // DplExtrasVector|is_iterator
+// DplExtrasFunctional|is_hetero_execution_policy
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
 template <typename Policy, typename Iter1, typename Iter2, typename Iter3>
-inline ::std::enable_if_t<dpct::internal::is_iterator<Iter1>::value &&
-                          dpct::internal::is_iterator<Iter2>::value>
+inline ::std::enable_if_t<
+    dpct::internal::is_iterator<Iter1>::value &&
+    dpct::internal::is_iterator<Iter2>::value &&
+    internal::is_hetero_execution_policy<::std::decay_t<Policy>>::value>
 segmented_reduce_argmax(Policy &&policy, Iter1 keys_in, Iter2 keys_out,
                         ::std::int64_t nsegments, Iter3 begin_offsets,
                         Iter3 end_offsets) {

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -2053,28 +2053,24 @@ inline ::std::pair<Iter1, Iter1> equal_range(_ExecutionPolicy &&policy,
 // DplExtrasVector|is_iterator
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
-template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
+template <typename Policy, typename KeyT, typename KeyOutT,
           typename OffsetIteratorT>
-inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
-                          dpct::internal::is_iterator<key_out_t>::value>
-segmented_reduce_argmin(_ExecutionPolicy &&policy, key_t keys_in,
-                        key_out_t keys_out, ::std::int64_t nsegments,
-                        OffsetIteratorT begin_offsets,
+inline ::std::enable_if_t<dpct::internal::is_iterator<KeyT>::value &&
+                          dpct::internal::is_iterator<KeyOutT>::value>
+segmented_reduce_argmin(Policy &&policy, KeyT keys_in, KeyOutT keys_out,
+                        ::std::int64_t nsegments, OffsetIteratorT begin_offsets,
                         OffsetIteratorT end_offsets) {
   policy.queue().submit([&](sycl::handler &cgh) {
     cgh.parallel_for(nsegments, [=](sycl::id<1> i) {
-      ::std::int64_t segment_begin = begin_offsets[i];
-      ::std::int64_t segment_length =
-          ((::std::int64_t)end_offsets[i]) - segment_begin;
-      if (segment_length <= 0) {
-        *(keys_out + i) = dpct::key_value_pair(
+      if (end_offsets[i] <= begin_offsets[i]) {
+        keys_out[i] = dpct::key_value_pair(
             1, ::std::numeric_limits<
-                   typename ::std::iterator_traits<key_t>::value_type>::max());
+                   typename ::std::iterator_traits<KeyT>::value_type>::max());
       } else {
-        dpct::arg_index_input_iterator<decltype(keys_in), int> arg_index(
-            keys_in + segment_begin);
-        *(keys_out + i) = *::std::min_element(
-            arg_index, arg_index + segment_length,
+        dpct::arg_index_input_iterator<KeyT, int> arg_index(keys_in +
+                                                            begin_offsets[i]);
+        keys_out[i] = *::std::min_element(
+            arg_index, arg_index + +end_offsets[i] - begin_offsets[i],
             [](const auto &a, const auto &b) { return a.value < b.value; });
       }
     });
@@ -2090,29 +2086,25 @@ segmented_reduce_argmin(_ExecutionPolicy &&policy, key_t keys_in,
 // DplExtrasVector|is_iterator
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
-template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
+template <typename Policy, typename KeyT, typename KeyOutT,
           typename OffsetIteratorT>
-inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
-                          dpct::internal::is_iterator<key_out_t>::value>
-segmented_reduce_argmax(_ExecutionPolicy &&policy, key_t keys_in,
-                        key_out_t keys_out, ::std::int64_t nsegments,
-                        OffsetIteratorT begin_offsets,
+inline ::std::enable_if_t<dpct::internal::is_iterator<KeyT>::value &&
+                          dpct::internal::is_iterator<KeyOutT>::value>
+segmented_reduce_argmax(Policy &&policy, KeyT keys_in, KeyOutT keys_out,
+                        ::std::int64_t nsegments, OffsetIteratorT begin_offsets,
                         OffsetIteratorT end_offsets) {
   policy.queue().submit([&](sycl::handler &cgh) {
     cgh.parallel_for(nsegments, [=](sycl::id<1> i) {
-      ::std::int64_t segment_begin = begin_offsets[i];
-      ::std::int64_t segment_length =
-          ((::std::int64_t)end_offsets[i]) - segment_begin;
-      if (segment_length <= 0) {
-        *(keys_out + i) = dpct::key_value_pair(
+      if (end_offsets[i] <= begin_offsets[i]) {
+        keys_out[i] = dpct::key_value_pair(
             1,
             ::std::numeric_limits<
-                typename ::std::iterator_traits<key_t>::value_type>::lowest());
+                typename ::std::iterator_traits<KeyT>::value_type>::lowest());
       } else {
-        dpct::arg_index_input_iterator<decltype(keys_in), int> arg_index(
-            keys_in + segment_begin);
-        *(keys_out + i) = *::std::max_element(
-            arg_index, arg_index + segment_length,
+        dpct::arg_index_input_iterator<KeyT, int> arg_index(keys_in +
+                                                            begin_offsets[i]);
+        keys_out[i] = *::std::max_element(
+            arg_index, arg_index + end_offsets[i] - begin_offsets[i],
             [](const auto &a, const auto &b) { return a.value < b.value; });
       }
     });

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -2069,7 +2069,7 @@ segmented_reduce_argmin(Policy &&policy, Iter1 keys_in, Iter2 keys_out,
         dpct::arg_index_input_iterator<Iter1, int> arg_index(keys_in +
                                                              begin_offsets[i]);
         keys_out[i] = *::std::min_element(
-            arg_index, arg_index + +end_offsets[i] - begin_offsets[i],
+            arg_index, arg_index + (end_offsets[i] - begin_offsets[i]),
             [](const auto &a, const auto &b) { return a.value < b.value; });
       }
     });
@@ -2102,7 +2102,7 @@ segmented_reduce_argmax(Policy &&policy, Iter1 keys_in, Iter2 keys_out,
         dpct::arg_index_input_iterator<Iter1, int> arg_index(keys_in +
                                                              begin_offsets[i]);
         keys_out[i] = *::std::max_element(
-            arg_index, arg_index + end_offsets[i] - begin_offsets[i],
+            arg_index, arg_index + (end_offsets[i] - begin_offsets[i]),
             [](const auto &a, const auto &b) { return a.value < b.value; });
       }
     });

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -2053,26 +2053,26 @@ inline ::std::pair<Iter1, Iter1> equal_range(_ExecutionPolicy &&policy,
 // DplExtrasVector|is_iterator
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
-template <typename _ExecutionPolicy, typename key_t, typename key_out_t, 
+template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
           typename OffsetIteratorT>
 inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
                           dpct::internal::is_iterator<key_out_t>::value>
 segmented_reduce_argmin(_ExecutionPolicy &&policy, key_t keys_in,
-                        key_out_t keys_out, ::std::int64_t n,
-                        ::std::int64_t nsegments, OffsetIteratorT begin_offsets,
+                        key_out_t keys_out, ::std::int64_t nsegments,
+                        OffsetIteratorT begin_offsets,
                         OffsetIteratorT end_offsets) {
   policy.queue().submit([&](sycl::handler &cgh) {
     cgh.parallel_for(nsegments, [=](sycl::id<1> i) {
       ::std::int64_t segment_begin = begin_offsets[i];
       ::std::int64_t segment_length =
-          ::std::min(n, (::std::int64_t)end_offsets[i]) - segment_begin;
+          ((::std::int64_t)end_offsets[i]) - segment_begin;
       if (segment_length <= 0) {
         *(keys_out + i) = dpct::key_value_pair(
-            ptrdiff_t(1),
-            ::std::numeric_limits<
-                typename ::std::iterator_traits<key_t>::value_type>::max());
+            1, ::std::numeric_limits<
+                   typename ::std::iterator_traits<key_t>::value_type>::max());
       } else {
-        dpct::arg_index_input_iterator arg_index(keys_in + segment_begin);
+        dpct::arg_index_input_iterator<decltype(keys_in), int> arg_index(
+            keys_in + segment_begin);
         *(keys_out + i) = *::std::min_element(
             arg_index, arg_index + segment_length,
             [](const auto &a, const auto &b) { return a.value < b.value; });
@@ -2095,21 +2095,22 @@ template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
 inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
                           dpct::internal::is_iterator<key_out_t>::value>
 segmented_reduce_argmax(_ExecutionPolicy &&policy, key_t keys_in,
-                        key_out_t keys_out, ::std::int64_t n,
-                        ::std::int64_t nsegments, OffsetIteratorT begin_offsets,
+                        key_out_t keys_out, ::std::int64_t nsegments,
+                        OffsetIteratorT begin_offsets,
                         OffsetIteratorT end_offsets) {
   policy.queue().submit([&](sycl::handler &cgh) {
     cgh.parallel_for(nsegments, [=](sycl::id<1> i) {
       ::std::int64_t segment_begin = begin_offsets[i];
       ::std::int64_t segment_length =
-          ::std::min(n, (::std::int64_t)end_offsets[i]) - segment_begin;
+          ((::std::int64_t)end_offsets[i]) - segment_begin;
       if (segment_length <= 0) {
         *(keys_out + i) = dpct::key_value_pair(
-            ptrdiff_t(1),
+            1,
             ::std::numeric_limits<
                 typename ::std::iterator_traits<key_t>::value_type>::lowest());
       } else {
-        dpct::arg_index_input_iterator arg_index(keys_in + segment_begin);
+        dpct::arg_index_input_iterator<decltype(keys_in), int> arg_index(
+            keys_in + segment_begin);
         *(keys_out + i) = *::std::max_element(
             arg_index, arg_index + segment_length,
             [](const auto &a, const auto &b) { return a.value < b.value; });

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1701,9 +1701,8 @@ template <typename Policy, typename KeyT, typename KeyOutT,
           typename OffsetIteratorT>
 inline ::std::enable_if_t<dpct::internal::is_iterator<KeyT>::value &&
                           dpct::internal::is_iterator<KeyOutT>::value>
-segmented_reduce_argmin(Policy &&policy, KeyT keys_in,
-                        KeyOutT keys_out, ::std::int64_t nsegments,
-                        OffsetIteratorT begin_offsets,
+segmented_reduce_argmin(Policy &&policy, KeyT keys_in, KeyOutT keys_out,
+                        ::std::int64_t nsegments, OffsetIteratorT begin_offsets,
                         OffsetIteratorT end_offsets) {
   policy.queue().submit([&](sycl::handler &cgh) {
     cgh.parallel_for(nsegments, [=](sycl::id<1> i) {
@@ -1712,10 +1711,10 @@ segmented_reduce_argmin(Policy &&policy, KeyT keys_in,
             1, ::std::numeric_limits<
                    typename ::std::iterator_traits<KeyT>::value_type>::max());
       } else {
-        dpct::arg_index_input_iterator<KeyT, int> arg_index(
-            keys_in + begin_offsets[i]);
+        dpct::arg_index_input_iterator<KeyT, int> arg_index(keys_in +
+                                                            begin_offsets[i]);
         keys_out[i] = *::std::min_element(
-            arg_index, arg_index + + end_offsets[i] - begin_offsets[i],
+            arg_index, arg_index + +end_offsets[i] - begin_offsets[i],
             [](const auto &a, const auto &b) { return a.value < b.value; });
       }
     });
@@ -1727,9 +1726,8 @@ template <typename Policy, typename KeyT, typename KeyOutT,
           typename OffsetIteratorT>
 inline ::std::enable_if_t<dpct::internal::is_iterator<KeyT>::value &&
                           dpct::internal::is_iterator<KeyOutT>::value>
-segmented_reduce_argmax(Policy &&policy, KeyT keys_in,
-                        KeyOutT keys_out, ::std::int64_t nsegments,
-                        OffsetIteratorT begin_offsets,
+segmented_reduce_argmax(Policy &&policy, KeyT keys_in, KeyOutT keys_out,
+                        ::std::int64_t nsegments, OffsetIteratorT begin_offsets,
                         OffsetIteratorT end_offsets) {
   policy.queue().submit([&](sycl::handler &cgh) {
     cgh.parallel_for(nsegments, [=](sycl::id<1> i) {
@@ -1739,8 +1737,8 @@ segmented_reduce_argmax(Policy &&policy, KeyT keys_in,
             ::std::numeric_limits<
                 typename ::std::iterator_traits<KeyT>::value_type>::lowest());
       } else {
-        dpct::arg_index_input_iterator<KeyT, int> arg_index(
-            keys_in + begin_offsets[i]);
+        dpct::arg_index_input_iterator<KeyT, int> arg_index(keys_in +
+                                                            begin_offsets[i]);
         keys_out[i] = *::std::max_element(
             arg_index, arg_index + end_offsets[i] - begin_offsets[i],
             [](const auto &a, const auto &b) { return a.value < b.value; });

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1713,7 +1713,7 @@ segmented_reduce_argmin(Policy &&policy, Iter1 keys_in, Iter2 keys_out,
         dpct::arg_index_input_iterator<Iter1, int> arg_index(keys_in +
                                                              begin_offsets[i]);
         keys_out[i] = *::std::min_element(
-            arg_index, arg_index + +end_offsets[i] - begin_offsets[i],
+            arg_index, arg_index + (end_offsets[i] - begin_offsets[i]),
             [](const auto &a, const auto &b) { return a.value < b.value; });
       }
     });
@@ -1738,7 +1738,7 @@ segmented_reduce_argmax(Policy &&policy, Iter1 keys_in, Iter2 keys_out,
         dpct::arg_index_input_iterator<Iter1, int> arg_index(keys_in +
                                                              begin_offsets[i]);
         keys_out[i] = *::std::max_element(
-            arg_index, arg_index + end_offsets[i] - begin_offsets[i],
+            arg_index, arg_index + (end_offsets[i] - begin_offsets[i]),
             [](const auto &a, const auto &b) { return a.value < b.value; });
       }
     });

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1697,22 +1697,21 @@ inline ::std::pair<Iter1, Iter1> equal_range(_ExecutionPolicy &&policy,
                      value, internal::__less());
 }
 
-template <typename Policy, typename KeyT, typename KeyOutT,
-          typename OffsetIteratorT>
-inline ::std::enable_if_t<dpct::internal::is_iterator<KeyT>::value &&
-                          dpct::internal::is_iterator<KeyOutT>::value>
-segmented_reduce_argmin(Policy &&policy, KeyT keys_in, KeyOutT keys_out,
-                        ::std::int64_t nsegments, OffsetIteratorT begin_offsets,
-                        OffsetIteratorT end_offsets) {
+template <typename Policy, typename Iter1, typename Iter2, typename Iter3>
+inline ::std::enable_if_t<dpct::internal::is_iterator<Iter1>::value &&
+                          dpct::internal::is_iterator<Iter2>::value>
+segmented_reduce_argmin(Policy &&policy, Iter1 keys_in, Iter2 keys_out,
+                        ::std::int64_t nsegments, Iter3 begin_offsets,
+                        Iter3 end_offsets) {
   policy.queue().submit([&](sycl::handler &cgh) {
     cgh.parallel_for(nsegments, [=](sycl::id<1> i) {
       if (end_offsets[i] <= begin_offsets[i]) {
         keys_out[i] = dpct::key_value_pair(
             1, ::std::numeric_limits<
-                   typename ::std::iterator_traits<KeyT>::value_type>::max());
+                   typename ::std::iterator_traits<Iter1>::value_type>::max());
       } else {
-        dpct::arg_index_input_iterator<KeyT, int> arg_index(keys_in +
-                                                            begin_offsets[i]);
+        dpct::arg_index_input_iterator<Iter1, int> arg_index(keys_in +
+                                                             begin_offsets[i]);
         keys_out[i] = *::std::min_element(
             arg_index, arg_index + +end_offsets[i] - begin_offsets[i],
             [](const auto &a, const auto &b) { return a.value < b.value; });
@@ -1722,23 +1721,22 @@ segmented_reduce_argmin(Policy &&policy, KeyT keys_in, KeyOutT keys_out,
   policy.queue().wait();
 }
 
-template <typename Policy, typename KeyT, typename KeyOutT,
-          typename OffsetIteratorT>
-inline ::std::enable_if_t<dpct::internal::is_iterator<KeyT>::value &&
-                          dpct::internal::is_iterator<KeyOutT>::value>
-segmented_reduce_argmax(Policy &&policy, KeyT keys_in, KeyOutT keys_out,
-                        ::std::int64_t nsegments, OffsetIteratorT begin_offsets,
-                        OffsetIteratorT end_offsets) {
+template <typename Policy, typename Iter1, typename Iter2, typename Iter3>
+inline ::std::enable_if_t<dpct::internal::is_iterator<Iter1>::value &&
+                          dpct::internal::is_iterator<Iter2>::value>
+segmented_reduce_argmax(Policy &&policy, Iter1 keys_in, Iter2 keys_out,
+                        ::std::int64_t nsegments, Iter3 begin_offsets,
+                        Iter3 end_offsets) {
   policy.queue().submit([&](sycl::handler &cgh) {
     cgh.parallel_for(nsegments, [=](sycl::id<1> i) {
       if (end_offsets[i] <= begin_offsets[i]) {
         keys_out[i] = dpct::key_value_pair(
             1,
             ::std::numeric_limits<
-                typename ::std::iterator_traits<KeyT>::value_type>::lowest());
+                typename ::std::iterator_traits<Iter1>::value_type>::lowest());
       } else {
-        dpct::arg_index_input_iterator<KeyT, int> arg_index(keys_in +
-                                                            begin_offsets[i]);
+        dpct::arg_index_input_iterator<Iter1, int> arg_index(keys_in +
+                                                             begin_offsets[i]);
         keys_out[i] = *::std::max_element(
             arg_index, arg_index + end_offsets[i] - begin_offsets[i],
             [](const auto &a, const auto &b) { return a.value < b.value; });

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1712,11 +1712,11 @@ segmented_reduce_argmin(_ExecutionPolicy &&policy, key_t keys_in,
           ((::std::int64_t)end_offsets[i]) - segment_begin;
       if (segment_length <= 0) {
         *(keys_out + i) = dpct::key_value_pair(
-            ptrdiff_t(1),
-            ::std::numeric_limits<
-                typename ::std::iterator_traits<key_t>::value_type>::max());
+            1, ::std::numeric_limits<
+                   typename ::std::iterator_traits<key_t>::value_type>::max());
       } else {
-        dpct::arg_index_input_iterator arg_index(keys_in + segment_begin);
+        dpct::arg_index_input_iterator<decltype(keys_in), int> arg_index(
+            keys_in + segment_begin);
         *(keys_out + i) = *::std::min_element(
             arg_index, arg_index + segment_length,
             [](const auto &a, const auto &b) { return a.value < b.value; });
@@ -1741,11 +1741,12 @@ segmented_reduce_argmax(_ExecutionPolicy &&policy, key_t keys_in,
           ((::std::int64_t)end_offsets[i]) - segment_begin;
       if (segment_length <= 0) {
         *(keys_out + i) = dpct::key_value_pair(
-            ptrdiff_t(1),
+            1,
             ::std::numeric_limits<
                 typename ::std::iterator_traits<key_t>::value_type>::lowest());
       } else {
-        dpct::arg_index_input_iterator arg_index(keys_in + segment_begin);
+        dpct::arg_index_input_iterator<decltype(keys_in), int> arg_index(
+            keys_in + segment_begin);
         *(keys_out + i) = *::std::max_element(
             arg_index, arg_index + segment_length,
             [](const auto &a, const auto &b) { return a.value < b.value; });

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1698,8 +1698,10 @@ inline ::std::pair<Iter1, Iter1> equal_range(_ExecutionPolicy &&policy,
 }
 
 template <typename Policy, typename Iter1, typename Iter2, typename Iter3>
-inline ::std::enable_if_t<dpct::internal::is_iterator<Iter1>::value &&
-                          dpct::internal::is_iterator<Iter2>::value>
+inline ::std::enable_if_t<
+    dpct::internal::is_iterator<Iter1>::value &&
+    dpct::internal::is_iterator<Iter2>::value &&
+    internal::is_hetero_execution_policy<::std::decay_t<Policy>>::value>
 segmented_reduce_argmin(Policy &&policy, Iter1 keys_in, Iter2 keys_out,
                         ::std::int64_t nsegments, Iter3 begin_offsets,
                         Iter3 end_offsets) {
@@ -1722,8 +1724,10 @@ segmented_reduce_argmin(Policy &&policy, Iter1 keys_in, Iter2 keys_out,
 }
 
 template <typename Policy, typename Iter1, typename Iter2, typename Iter3>
-inline ::std::enable_if_t<dpct::internal::is_iterator<Iter1>::value &&
-                          dpct::internal::is_iterator<Iter2>::value>
+inline ::std::enable_if_t<
+    dpct::internal::is_iterator<Iter1>::value &&
+    dpct::internal::is_iterator<Iter2>::value &&
+    internal::is_hetero_execution_policy<::std::decay_t<Policy>>::value>
 segmented_reduce_argmax(Policy &&policy, Iter1 keys_in, Iter2 keys_out,
                         ::std::int64_t nsegments, Iter3 begin_offsets,
                         Iter3 end_offsets) {

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1697,19 +1697,19 @@ inline ::std::pair<Iter1, Iter1> equal_range(_ExecutionPolicy &&policy,
                      value, internal::__less());
 }
 
-template <typename _ExecutionPolicy, typename key_t, typename key_out_t, 
+template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
           typename OffsetIteratorT>
 inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
                           dpct::internal::is_iterator<key_out_t>::value>
 segmented_reduce_argmin(_ExecutionPolicy &&policy, key_t keys_in,
-                        key_out_t keys_out, ::std::int64_t n,
-                        ::std::int64_t nsegments, OffsetIteratorT begin_offsets,
+                        key_out_t keys_out, ::std::int64_t nsegments,
+                        OffsetIteratorT begin_offsets,
                         OffsetIteratorT end_offsets) {
   policy.queue().submit([&](sycl::handler &cgh) {
     cgh.parallel_for(nsegments, [=](sycl::id<1> i) {
       ::std::int64_t segment_begin = begin_offsets[i];
       ::std::int64_t segment_length =
-          ::std::min(n, (::std::int64_t)end_offsets[i]) - segment_begin;
+          ((::std::int64_t)end_offsets[i]) - segment_begin;
       if (segment_length <= 0) {
         *(keys_out + i) = dpct::key_value_pair(
             ptrdiff_t(1),
@@ -1731,14 +1731,14 @@ template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
 inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
                           dpct::internal::is_iterator<key_out_t>::value>
 segmented_reduce_argmax(_ExecutionPolicy &&policy, key_t keys_in,
-                        key_out_t keys_out, ::std::int64_t n,
-                        ::std::int64_t nsegments, OffsetIteratorT begin_offsets,
+                        key_out_t keys_out, ::std::int64_t nsegments,
+                        OffsetIteratorT begin_offsets,
                         OffsetIteratorT end_offsets) {
   policy.queue().submit([&](sycl::handler &cgh) {
     cgh.parallel_for(nsegments, [=](sycl::id<1> i) {
       ::std::int64_t segment_begin = begin_offsets[i];
       ::std::int64_t segment_length =
-          ::std::min(n, (::std::int64_t)end_offsets[i]) - segment_begin;
+          ((::std::int64_t)end_offsets[i]) - segment_begin;
       if (segment_length <= 0) {
         *(keys_out + i) = dpct::key_value_pair(
             ptrdiff_t(1),

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1697,28 +1697,25 @@ inline ::std::pair<Iter1, Iter1> equal_range(_ExecutionPolicy &&policy,
                      value, internal::__less());
 }
 
-template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
+template <typename Policy, typename KeyT, typename KeyOutT,
           typename OffsetIteratorT>
-inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
-                          dpct::internal::is_iterator<key_out_t>::value>
-segmented_reduce_argmin(_ExecutionPolicy &&policy, key_t keys_in,
-                        key_out_t keys_out, ::std::int64_t nsegments,
+inline ::std::enable_if_t<dpct::internal::is_iterator<KeyT>::value &&
+                          dpct::internal::is_iterator<KeyOutT>::value>
+segmented_reduce_argmin(Policy &&policy, KeyT keys_in,
+                        KeyOutT keys_out, ::std::int64_t nsegments,
                         OffsetIteratorT begin_offsets,
                         OffsetIteratorT end_offsets) {
   policy.queue().submit([&](sycl::handler &cgh) {
     cgh.parallel_for(nsegments, [=](sycl::id<1> i) {
-      ::std::int64_t segment_begin = begin_offsets[i];
-      ::std::int64_t segment_length =
-          ((::std::int64_t)end_offsets[i]) - segment_begin;
-      if (segment_length <= 0) {
-        *(keys_out + i) = dpct::key_value_pair(
+      if (end_offsets[i] <= begin_offsets[i]) {
+        keys_out[i] = dpct::key_value_pair(
             1, ::std::numeric_limits<
-                   typename ::std::iterator_traits<key_t>::value_type>::max());
+                   typename ::std::iterator_traits<KeyT>::value_type>::max());
       } else {
-        dpct::arg_index_input_iterator<decltype(keys_in), int> arg_index(
-            keys_in + segment_begin);
-        *(keys_out + i) = *::std::min_element(
-            arg_index, arg_index + segment_length,
+        dpct::arg_index_input_iterator<KeyT, int> arg_index(
+            keys_in + begin_offsets[i]);
+        keys_out[i] = *::std::min_element(
+            arg_index, arg_index + + end_offsets[i] - begin_offsets[i],
             [](const auto &a, const auto &b) { return a.value < b.value; });
       }
     });
@@ -1726,29 +1723,26 @@ segmented_reduce_argmin(_ExecutionPolicy &&policy, key_t keys_in,
   policy.queue().wait();
 }
 
-template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
+template <typename Policy, typename KeyT, typename KeyOutT,
           typename OffsetIteratorT>
-inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
-                          dpct::internal::is_iterator<key_out_t>::value>
-segmented_reduce_argmax(_ExecutionPolicy &&policy, key_t keys_in,
-                        key_out_t keys_out, ::std::int64_t nsegments,
+inline ::std::enable_if_t<dpct::internal::is_iterator<KeyT>::value &&
+                          dpct::internal::is_iterator<KeyOutT>::value>
+segmented_reduce_argmax(Policy &&policy, KeyT keys_in,
+                        KeyOutT keys_out, ::std::int64_t nsegments,
                         OffsetIteratorT begin_offsets,
                         OffsetIteratorT end_offsets) {
   policy.queue().submit([&](sycl::handler &cgh) {
     cgh.parallel_for(nsegments, [=](sycl::id<1> i) {
-      ::std::int64_t segment_begin = begin_offsets[i];
-      ::std::int64_t segment_length =
-          ((::std::int64_t)end_offsets[i]) - segment_begin;
-      if (segment_length <= 0) {
-        *(keys_out + i) = dpct::key_value_pair(
+      if (end_offsets[i] <= begin_offsets[i]) {
+        keys_out[i] = dpct::key_value_pair(
             1,
             ::std::numeric_limits<
-                typename ::std::iterator_traits<key_t>::value_type>::lowest());
+                typename ::std::iterator_traits<KeyT>::value_type>::lowest());
       } else {
-        dpct::arg_index_input_iterator<decltype(keys_in), int> arg_index(
-            keys_in + segment_begin);
-        *(keys_out + i) = *::std::max_element(
-            arg_index, arg_index + segment_length,
+        dpct::arg_index_input_iterator<KeyT, int> arg_index(
+            keys_in + begin_offsets[i]);
+        keys_out[i] = *::std::max_element(
+            arg_index, arg_index + end_offsets[i] - begin_offsets[i],
             [](const auto &a, const auto &b) { return a.value < b.value; });
       }
     });


### PR DESCRIPTION
Removing unnecessary parameter n from function signature.
Changing return type to use int rather than ptrdiff_t.

Fixing naming conventions and formatting. 
Minor misc. fixes.