### PR TITLE
[SYCLomatic] Cleanup build warnings

### DIFF
--- a/clang/lib/DPCT/APINamesLIBCU.inc
+++ b/clang/lib/DPCT/APINamesLIBCU.inc
@@ -53,4 +53,4 @@ ARRAYSUBSCRIPT_EXPR_FACTORY_ENTRY("cuda::std::array.at",MemberExprBase(), ARG(0)
 
 ENTRY_RENAMED("cuda::std::make_tuple", "std::make_tuple")
 
-CALL_FACTORY_ENTRY("cuda::std::get", CALL(TEMPLATED_CALLEE("std::get",{0}), ARG(0)))
+CALL_FACTORY_ENTRY("cuda::std::get", CALL(TEMPLATED_CALLEE("std::get", 0), ARG(0)))

--- a/clang/lib/DPCT/CallExprRewriterMath.cpp
+++ b/clang/lib/DPCT/CallExprRewriterMath.cpp
@@ -1179,10 +1179,6 @@ auto IsPerf = [](const CallExpr *C) -> bool {
   return DpctGlobalInfo::isOptimizeMigration();
 };
 
-auto UseStdLibdevice = [](const CallExpr *C) -> bool {
-  return DpctGlobalInfo::useCAndCXXStandardLibrariesExt();
-};
-
 inline auto UseIntelDeviceMath = [](const CallExpr *C) -> bool {
   return DpctGlobalInfo::useIntelDeviceMath();
 };

--- a/clang/lib/DPCT/ThrustAPIMigration.cpp
+++ b/clang/lib/DPCT/ThrustAPIMigration.cpp
@@ -110,7 +110,6 @@ void ThrustAPIRule::thrustFuncMigration(const MatchFinder::MatchResult &Result,
     return;
   }
 
-  const unsigned NumArgs = CE->getNumArgs();
   auto QT = CE->getArg(0)->getType();
   LangOptions LO;
   std::string ArgT = QT.getAsString(PrintingPolicy(LO));


### PR DESCRIPTION
```
SYCLomatic/clang/lib/DPCT/APINamesLIBCU.inc:56:71: warning: braces around scalar initializer [-Wbraced-scalar-init]
CALL_FACTORY_ENTRY("cuda::std::get", CALL(TEMPLATED_CALLEE("std::get",{0}), ARG(0)))
                                                                      ^~~
SYCLomatic/clang/lib/DPCT/ThrustAPIMigration.cpp:113:18: warning: unused variable 'NumArgs' [-Wunused-variable]
  const unsigned NumArgs = CE->getNumArgs();
                 ^
SYCLomatic/clang/lib/DPCT/CallExprRewriterMath.cpp:1182:6: warning: unused variable 'UseStdLibdevice' [-Wunused-variable]
auto UseStdLibdevice = [](const CallExpr *C) -> bool {
     ^
```
Signed-off-by: Wang, Yihan [yihan.wang@intel.com](mailto:yihan.wang@intel.com)