### PR TITLE
Fix for default constructor of device_pointer_base

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/memory.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/memory.h.inc
@@ -282,7 +282,8 @@ public:
 #endif
   device_pointer_base(const std::size_t count)
       : buffer(sycl::range<1>(count / sizeof(ValueType))), idx() {}
-  device_pointer_base() {}
+  // buffer has no default const we pass zero-range to create an empty buffer
+  device_pointer_base() : buffer(sycl::range<1>(0)) {}
   device_pointer_base(const device_pointer_base &in)
       : buffer(in.buffer), idx(in.idx) {}
   pointer get() const {

--- a/clang/runtime/dpct-rt/include/dpl_extras/memory.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/memory.h.inc
@@ -282,7 +282,7 @@ public:
 #endif
   device_pointer_base(const std::size_t count)
       : buffer(sycl::range<1>(count / sizeof(ValueType))), idx() {}
-  // buffer has no default const we pass zero-range to create an empty buffer
+  // buffer has no default ctor we pass zero-range to create an empty buffer
   device_pointer_base() : buffer(sycl::range<1>(0)) {}
   device_pointer_base(const device_pointer_base &in)
       : buffer(in.buffer), idx(in.idx) {}

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/memory.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/memory.h
@@ -197,7 +197,7 @@ public:
 #endif
   device_pointer_base(const std::size_t count)
       : buffer(sycl::range<1>(count / sizeof(ValueType))), idx() {}
-  // buffer has no default const we pass zero-range to create an empty buffer
+  // buffer has no default ctor we pass zero-range to create an empty buffer
   device_pointer_base() : buffer(sycl::range<1>(0)) {}
   device_pointer_base(const device_pointer_base &in)
       : buffer(in.buffer), idx(in.idx) {}

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/memory.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/memory.h
@@ -197,7 +197,8 @@ public:
 #endif
   device_pointer_base(const std::size_t count)
       : buffer(sycl::range<1>(count / sizeof(ValueType))), idx() {}
-  device_pointer_base() {}
+  // buffer has no default const we pass zero-range to create an empty buffer
+  device_pointer_base() : buffer(sycl::range<1>(0)) {}
   device_pointer_base(const device_pointer_base &in)
       : buffer(in.buffer), idx(in.idx) {}
   pointer get() const {


### PR DESCRIPTION
`sycl::buffer` has no default constructor, so we must call with an empty `sycl::range<1>(0)`.  
