### PR TITLE
[SYCLomatic] Fix linker error of multiple definitions of 'dpct::exception_handler'

### DIFF
--- a/clang/runtime/dpct-rt/include/device.hpp.inc
+++ b/clang/runtime/dpct-rt/include/device.hpp.inc
@@ -70,7 +70,7 @@ namespace dpct {
 // DPCT_DEPENDENCY_EMPTY
 // DPCT_CODE
 /// SYCL default exception handler
-auto exception_handler = [](sycl::exception_list exceptions) {
+inline auto exception_handler = [](sycl::exception_list exceptions) {
   for (std::exception_ptr const &e : exceptions) {
     try {
       std::rethrow_exception(e);

--- a/clang/test/dpct/helper_files_ref/include/device.hpp
+++ b/clang/test/dpct/helper_files_ref/include/device.hpp
@@ -33,7 +33,7 @@
 namespace dpct {
 
 /// SYCL default exception handler
-auto exception_handler = [](sycl::exception_list exceptions) {
+inline auto exception_handler = [](sycl::exception_list exceptions) {
   for (std::exception_ptr const &e : exceptions) {
     try {
       std::rethrow_exception(e);


### PR DESCRIPTION
 Signed-off-by: chenwei.sun <chenwei.sun@intel.com>