### PR TITLE
[SYCLomatic] Fix bugs in inline asm migration

### DIFF
--- a/clang/lib/DPCT/Asm/AsmIdentifierTable.cpp
+++ b/clang/lib/DPCT/Asm/AsmIdentifierTable.cpp
@@ -23,9 +23,9 @@ InlineAsmIdentifierTable::InlineAsmIdentifierTable(
 }
 
 void InlineAsmIdentifierTable::AddKeywords() {
-#define KEYWORD(X, Y) get(#X, asmtok::kw_##X);
+#define KEYWORD(X, Y) get(Y, asmtok::kw_##X);
 #define BUILTIN_ID(X, Y, Z) get(Y, asmtok::bi_##X).setBuiltinID();
-#define BUILTIN_TYPE(X, Y) get(#X, asmtok::kw_##X).setBuiltinType();
+#define BUILTIN_TYPE(X, Y) get(Y, asmtok::kw_##X).setBuiltinType();
 #define INSTRUCTION(X) get(#X, asmtok::op_##X).setInstruction();
 #include "AsmTokenKinds.def"
 }

--- a/clang/lib/DPCT/Asm/AsmLexer.cpp
+++ b/clang/lib/DPCT/Asm/AsmLexer.cpp
@@ -357,9 +357,6 @@ bool InlineAsmLexer::lexIdentifierContinue(InlineAsmToken &Result,
     break;
   }
 
-  if (Result.startOfDot())
-    ++BufferPtr; // Skip '.'
-
   const char *IdStart = BufferPtr;
   formToken(Result, CurPtr, asmtok::raw_identifier);
   Result.setRawIdentifierData(IdStart);

--- a/clang/lib/DPCT/Asm/AsmParser.cpp
+++ b/clang/lib/DPCT/Asm/AsmParser.cpp
@@ -874,6 +874,8 @@ AsmNumericLiteralParser::AsmNumericLiteralParser(StringRef TokSpelling)
   isUnsigned = false;
   isFloat = false;
   hadError = false;
+  isExactMachineFloat = false;
+  isExactMachineDouble = false;
 
   // This routine assumes that the range begin/end matches the regex for integer
   // and FP constants (specifically, the 'pp-number' regex), and assumes that
@@ -917,11 +919,10 @@ AsmNumericLiteralParser::AsmNumericLiteralParser(StringRef TokSpelling)
       isUnsigned = true;
       continue; // Success.
     }
-
-    if (s != ThisTokEnd) {
-      hadError = true;
-    }
   }
+
+  if (s != ThisTokEnd)
+    hadError = true;
 }
 
 /// ParseDecimalOrOctalCommon - This method is called for decimal or octal

--- a/clang/lib/DPCT/Asm/AsmParser.cpp
+++ b/clang/lib/DPCT/Asm/AsmParser.cpp
@@ -907,7 +907,7 @@ AsmNumericLiteralParser::AsmNumericLiteralParser(StringRef TokSpelling)
   bool isFPConstant = isFloatingLiteral();
 
   if (*s == 'U') {
-    if (isFPConstant) 
+    if (isFPConstant)
       hadError = true; // Error for floating constant.
     isUnsigned = true;
     ++s;

--- a/clang/lib/DPCT/Asm/AsmParser.cpp
+++ b/clang/lib/DPCT/Asm/AsmParser.cpp
@@ -781,7 +781,7 @@ private:
   /// Determine whether the sequence of characters [Start, End) contains
   /// any real digits (not digit separators).
   bool containsDigits(const char *Start, const char *End) {
-    return Start != End && (Start + 1 != End);
+    return Start != End;
   }
 
   enum CheckSeparatorKind { CSK_BeforeDigits, CSK_AfterDigits };

--- a/clang/lib/DPCT/Asm/AsmParser.cpp
+++ b/clang/lib/DPCT/Asm/AsmParser.cpp
@@ -919,6 +919,7 @@ AsmNumericLiteralParser::AsmNumericLiteralParser(StringRef TokSpelling)
       isUnsigned = true;
       continue; // Success.
     }
+    break;
   }
 
   if (s != ThisTokEnd)

--- a/clang/lib/DPCT/AsmMigration.cpp
+++ b/clang/lib/DPCT/AsmMigration.cpp
@@ -534,19 +534,23 @@ protected:
         if (T->isSignedInt() || T->isUnsignedInt() || T->isBitSize())
           Template = "{0} == {1}";
         else if (T->getKind() == InlineAsmBuiltinType::TK_f32)
-          Template = "!sycl::isnan({0}) && !sycl::isnan({1}) && sycl::isequal<float>({0}, {1})";
+          Template = "!sycl::isnan({0}) && !sycl::isnan({1}) && "
+                     "sycl::isequal<float>({0}, {1})";
         else if (T->getKind() == InlineAsmBuiltinType::TK_f64)
-          Template = "!sycl::isnan({0}) && !sycl::isnan({1}) && sycl::isequal<double>({0}, {1})";
+          Template = "!sycl::isnan({0}) && !sycl::isnan({1}) && "
+                     "sycl::isequal<double>({0}, {1})";
         else
           return SYCLGenError();
         break;
       case asmtok::kw_ne:
         if (T->isSignedInt() || T->isUnsignedInt() || T->isBitSize())
           Template = "{0} != {1}";
-         else if (T->getKind() == InlineAsmBuiltinType::TK_f32)
-          Template = "!sycl::isnan({0}) && !sycl::isnan({1}) && sycl::isnotequal<float>({0}, {1})";
+        else if (T->getKind() == InlineAsmBuiltinType::TK_f32)
+          Template = "!sycl::isnan({0}) && !sycl::isnan({1}) && "
+                     "sycl::isnotequal<float>({0}, {1})";
         else if (T->getKind() == InlineAsmBuiltinType::TK_f64)
-          Template = "!sycl::isnan({0}) && !sycl::isnan({1}) && sycl::isnotequal<double>({0}, {1})";
+          Template = "!sycl::isnan({0}) && !sycl::isnan({1}) && "
+                     "sycl::isnotequal<double>({0}, {1})";
         else
           return SYCLGenError();
         break;
@@ -554,9 +558,11 @@ protected:
         if (T->isSignedInt())
           Template = "{0} < {1}";
         else if (T->getKind() == InlineAsmBuiltinType::TK_f32)
-          Template = "!sycl::isnan({0}) && !sycl::isnan({1}) && sycl::isless<float>({0}, {1})";
+          Template = "!sycl::isnan({0}) && !sycl::isnan({1}) && "
+                     "sycl::isless<float>({0}, {1})";
         else if (T->getKind() == InlineAsmBuiltinType::TK_f64)
-          Template = "!sycl::isnan({0}) && !sycl::isnan({1}) && sycl::isless<double>({0}, {1})";
+          Template = "!sycl::isnan({0}) && !sycl::isnan({1}) && "
+                     "sycl::isless<double>({0}, {1})";
         else
           return SYCLGenError();
         break;
@@ -564,9 +570,11 @@ protected:
         if (T->isSignedInt())
           Template = "{0} <= {1}";
         else if (T->getKind() == InlineAsmBuiltinType::TK_f32)
-          Template = "!sycl::isnan({0}) && !sycl::isnan({1}) && sycl::islessequal<float>({0}, {1})";
+          Template = "!sycl::isnan({0}) && !sycl::isnan({1}) && "
+                     "sycl::islessequal<float>({0}, {1})";
         else if (T->getKind() == InlineAsmBuiltinType::TK_f64)
-          Template = "!sycl::isnan({0}) && !sycl::isnan({1}) && sycl::islessequal<double>({0}, {1})";
+          Template = "!sycl::isnan({0}) && !sycl::isnan({1}) && "
+                     "sycl::islessequal<double>({0}, {1})";
         else
           return SYCLGenError();
         break;
@@ -574,9 +582,11 @@ protected:
         if (T->isSignedInt())
           Template = "{0} > {1}";
         else if (T->getKind() == InlineAsmBuiltinType::TK_f32)
-          Template = "!sycl::isnan({0}) && !sycl::isnan({1}) && sycl::isgreater<float>({0}, {1})";
+          Template = "!sycl::isnan({0}) && !sycl::isnan({1}) && "
+                     "sycl::isgreater<float>({0}, {1})";
         else if (T->getKind() == InlineAsmBuiltinType::TK_f64)
-          Template = "!sycl::isnan({0}) && !sycl::isnan({1}) && sycl::isgreater<double>({0}, {1})";
+          Template = "!sycl::isnan({0}) && !sycl::isnan({1}) && "
+                     "sycl::isgreater<double>({0}, {1})";
         else
           return SYCLGenError();
         break;
@@ -584,9 +594,11 @@ protected:
         if (T->isSignedInt())
           Template = "{0} >= {1}";
         else if (T->getKind() == InlineAsmBuiltinType::TK_f32)
-          Template = "!sycl::isnan({0}) && !sycl::isnan({1}) && sycl::isgreaterequal<float>({0}, {1})";
+          Template = "!sycl::isnan({0}) && !sycl::isnan({1}) && "
+                     "sycl::isgreaterequal<float>({0}, {1})";
         else if (T->getKind() == InlineAsmBuiltinType::TK_f64)
-          Template = "!sycl::isnan({0}) && !sycl::isnan({1}) && sycl::isgreaterequal<double>({0}, {1})";
+          Template = "!sycl::isnan({0}) && !sycl::isnan({1}) && "
+                     "sycl::isgreaterequal<double>({0}, {1})";
         else
           return SYCLGenError();
         break;
@@ -616,49 +628,61 @@ protected:
         break;
       case asmtok::kw_equ:
         if (T->getKind() == InlineAsmBuiltinType::TK_f32)
-          Template = "sycl::isnan({0}) || sycl::isnan({1}) || sycl::isequal<float>({0}, {1})";
+          Template = "sycl::isnan({0}) || sycl::isnan({1}) || "
+                     "sycl::isequal<float>({0}, {1})";
         else if (T->getKind() == InlineAsmBuiltinType::TK_f64)
-          Template = "sycl::isnan({0}) || sycl::isnan({1}) || sycl::isequal<double>({0}, {1})";
+          Template = "sycl::isnan({0}) || sycl::isnan({1}) || "
+                     "sycl::isequal<double>({0}, {1})";
         else
           return SYCLGenError();
         break;
       case asmtok::kw_neu:
         if (T->getKind() == InlineAsmBuiltinType::TK_f32)
-          Template = "sycl::isnan({0}) || sycl::isnan({1}) || sycl::isnotequal<float>({0}, {1})";
+          Template = "sycl::isnan({0}) || sycl::isnan({1}) || "
+                     "sycl::isnotequal<float>({0}, {1})";
         else if (T->getKind() == InlineAsmBuiltinType::TK_f64)
-          Template = "sycl::isnan({0}) || sycl::isnan({1}) || sycl::isnotequal<double>({0}, {1})";
+          Template = "sycl::isnan({0}) || sycl::isnan({1}) || "
+                     "sycl::isnotequal<double>({0}, {1})";
         else
           return SYCLGenError();
         break;
       case asmtok::kw_ltu:
         if (T->getKind() == InlineAsmBuiltinType::TK_f32)
-          Template = "sycl::isnan({0}) || sycl::isnan({1}) || sycl::isless<float>({0}, {1})";
+          Template = "sycl::isnan({0}) || sycl::isnan({1}) || "
+                     "sycl::isless<float>({0}, {1})";
         else if (T->getKind() == InlineAsmBuiltinType::TK_f64)
-          Template = "sycl::isnan({0}) || sycl::isnan({1}) || sycl::isless<double>({0}, {1})";
+          Template = "sycl::isnan({0}) || sycl::isnan({1}) || "
+                     "sycl::isless<double>({0}, {1})";
         else
           return SYCLGenError();
         break;
       case asmtok::kw_leu:
         if (T->getKind() == InlineAsmBuiltinType::TK_f32)
-          Template = "sycl::isnan({0}) || sycl::isnan({1}) || sycl::islessequal<float>({0}, {1})";
+          Template = "sycl::isnan({0}) || sycl::isnan({1}) || "
+                     "sycl::islessequal<float>({0}, {1})";
         else if (T->getKind() == InlineAsmBuiltinType::TK_f64)
-          Template = "sycl::isnan({0}) || sycl::isnan({1}) || sycl::islessequal<double>({0}, {1})";
+          Template = "sycl::isnan({0}) || sycl::isnan({1}) || "
+                     "sycl::islessequal<double>({0}, {1})";
         else
           return SYCLGenError();
         break;
       case asmtok::kw_gtu:
-         if (T->getKind() == InlineAsmBuiltinType::TK_f32)
-          Template = "sycl::isnan({0}) || sycl::isnan({1}) || sycl::isgreater<float>({0}, {1})";
+        if (T->getKind() == InlineAsmBuiltinType::TK_f32)
+          Template = "sycl::isnan({0}) || sycl::isnan({1}) || "
+                     "sycl::isgreater<float>({0}, {1})";
         else if (T->getKind() == InlineAsmBuiltinType::TK_f64)
-          Template = "sycl::isnan({0}) || sycl::isnan({1}) || sycl::isgreater<double>({0}, {1})";
+          Template = "sycl::isnan({0}) || sycl::isnan({1}) || "
+                     "sycl::isgreater<double>({0}, {1})";
         else
           return SYCLGenError();
         break;
       case asmtok::kw_geu:
-         if (T->getKind() == InlineAsmBuiltinType::TK_f32)
-          Template = "sycl::isnan({0}) || sycl::isnan({1}) || sycl::isgreaterequal<float>({0}, {1})";
+        if (T->getKind() == InlineAsmBuiltinType::TK_f32)
+          Template = "sycl::isnan({0}) || sycl::isnan({1}) || "
+                     "sycl::isgreaterequal<float>({0}, {1})";
         else if (T->getKind() == InlineAsmBuiltinType::TK_f64)
-          Template = "sycl::isnan({0}) || sycl::isnan({1}) || sycl::isgreaterequal<double>({0}, {1})";
+          Template = "sycl::isnan({0}) || sycl::isnan({1}) || "
+                     "sycl::isgreaterequal<double>({0}, {1})";
         else
           return SYCLGenError();
         break;
@@ -742,7 +766,7 @@ protected:
       EMPTY16, EMPTY, EMPTY, EMPTY,
       /*0xfe*/ "{0} | {1} | {2}",
       /*0xff*/ "uint32_t(-1)"};
-      // clang-format on
+    // clang-format on
 
 #undef EMPTY16
 #undef EMPTY4

--- a/clang/lib/DPCT/AsmMigration.cpp
+++ b/clang/lib/DPCT/AsmMigration.cpp
@@ -835,7 +835,6 @@ void AsmRule::doMigrateInternel(const GCCAsmStmt *GAS) {
     CodeGen.setInMacroDefine();
 
   auto getReplaceString = [&](const Expr *E) {
-    
     ArgumentAnalysis AA(CodeGen.isInMacroDefine());
     AA.setCallSpelling(SM.getSpellingLoc(GAS->getBeginLoc()),
                        SM.getSpellingLoc(GAS->getEndLoc()));

--- a/clang/lib/DPCT/AsmMigration.cpp
+++ b/clang/lib/DPCT/AsmMigration.cpp
@@ -780,13 +780,13 @@ void AsmRule::doMigrateInternel(const GCCAsmStmt *GAS) {
 
   auto getReplaceString = [&](const Expr *E) {
     auto &SM = DpctGlobalInfo::getSourceManager();
-    ArgumentAnalysis EA(CodeGen.isInMacroDefine());
-    EA.setCallSpelling(SM.getSpellingLoc(GAS->getBeginLoc()),
+    ArgumentAnalysis AA(CodeGen.isInMacroDefine());
+    AA.setCallSpelling(SM.getSpellingLoc(GAS->getBeginLoc()),
                        SM.getSpellingLoc(GAS->getEndLoc()));
-    EA.analyze(E);
+    AA.analyze(E);
     if (needExtraParens(E))
-      return "(" + EA.getRewriteString() + ")";
-    return EA.getRewriteString();
+      return "(" + AA.getRewriteString() + ")";
+    return AA.getRewriteString();
   };
   Parser.addBuiltinIdentifier();
   for (unsigned I = 0, E = GAS->getNumOutputs(); I != E; ++I)

--- a/clang/lib/DPCT/AsmMigration.cpp
+++ b/clang/lib/DPCT/AsmMigration.cpp
@@ -49,12 +49,13 @@ inline bool SYCLGenSuccess() { return false; }
 
 /// This is used to handle all the AST nodes (except specific instructions).
 class SYCLGenBase {
-  llvm::raw_ostream *Stream;
+  bool IsInMacroDef = false;
   bool EmitNewLine = true;
   bool EmitSemi = true;
   unsigned NumIndent = 0;
   llvm::SmallString<4> IndentUnit{"  "};
   llvm::SmallString<16> Indent;
+  llvm::raw_ostream *Stream;
 
   class BlockDelimiterGuard {
     SYCLGenBase &CodeGen;
@@ -75,12 +76,9 @@ class SYCLGenBase {
   };
 
 public:
-  SYCLGenBase(llvm::raw_ostream &OS, StringRef IU = "")
-      : Stream(&OS), IndentUnit(IU) {
-    incIndent();
-  }
+  SYCLGenBase(llvm::raw_ostream &OS) : Stream(&OS) {}
 
-  virtual ~SYCLGenBase() { decIndent(); }
+  virtual ~SYCLGenBase() = default;
 
   unsigned getNumIndent() const { return NumIndent; }
 
@@ -89,7 +87,9 @@ public:
       IndentUnit = Unit;
   }
 
-protected:
+  void setInMacroDefine() { IsInMacroDef = true; }
+  bool isInMacroDefine() const { return IsInMacroDef; }
+
   void decIndent(unsigned Num = 1) {
     if (NumIndent >= Num) {
       NumIndent -= Num;
@@ -107,11 +107,13 @@ protected:
       Indent.append(IndentUnit);
   }
 
+protected:
   void indent() { OS() << Indent; }
 
   void endl() {
-    if (EmitNewLine)
-      OS() << getNL();
+    if (EmitNewLine) {
+      OS() << (isInMacroDefine() ? "\\" : "") << getNL();
+    }
   }
 
   void semi() {
@@ -369,7 +371,7 @@ bool SYCLGenBase::emitFloatingLiteral(const InlineAsmFloatingLiteral *Fp) {
   if (!Fp->isExactMachineFloatingLiteral()) {
     OS() << Fp->getLiteral();
   } else {
-    constexpr char *Template = "sycl::bit_cast<{0}>({1}(0x{2}{3}))";
+    const char *Template = "sycl::bit_cast<{0}>({1}(0x{2}{3}))";
     if (const auto *T = dyn_cast<InlineAsmBuiltinType>(Fp->getType())) {
       switch (T->getKind()) {
       case InlineAsmBuiltinType::TK_f32:
@@ -480,7 +482,7 @@ bool SYCLGenBase::emitVariableDeclaration(const InlineAsmVariableDecl *D) {
 /// This used to handle the specific instruction.
 class SYCLGen : public SYCLGenBase {
 public:
-  SYCLGen(llvm::raw_ostream &OS, StringRef IU) : SYCLGenBase(OS, IU) {}
+  SYCLGen(llvm::raw_ostream &OS) : SYCLGenBase(OS) {}
 
   bool handleStatement(const InlineAsmStmt *S) { return emitStatement(S); }
 
@@ -760,19 +762,36 @@ void AsmRule::doMigrateInternel(const GCCAsmStmt *GAS) {
   const auto &C = DpctGlobalInfo::getContext();
   std::string S = GAS->generateAsmString(C);
   InlineAsmContext Context;
-  std::string Replacement;
-  llvm::raw_string_ostream OS(Replacement);
   llvm::SourceMgr Mgr;
   std::string Buffer = GAS->getAsmString()->getString().str();
   Mgr.AddNewSourceBuffer(llvm::MemoryBuffer::getMemBuffer(Buffer),
                          llvm::SMLoc());
   InlineAsmParser Parser(Context, Mgr);
+  std::string ReplaceString;
+  llvm::raw_string_ostream OS(ReplaceString);
+  SYCLGen CodeGen(OS);
+  StringRef Indent =
+      getIndent(GAS->getBeginLoc(), DpctGlobalInfo::getSourceManager());
+
+  CodeGen.setIndentUnit(Indent);
+  CodeGen.incIndent();
+  auto ASRange =
+      getDefinitionRange(GAS->getBeginLoc(), GAS->getEndLoc());
+  auto It = dpct::DpctGlobalInfo::getExpansionRangeToMacroRecord().find(
+      getCombinedStrFromLoc(ASRange.getEnd()));
+  if (It != dpct::DpctGlobalInfo::getExpansionRangeToMacroRecord().end()) {
+    CodeGen.setInMacroDefine();
+  }
+
   auto getReplaceString = [&](const Expr *E) {
-    ExprAnalysis EA;
+    auto &SM = DpctGlobalInfo::getSourceManager();
+    ArgumentAnalysis EA(CodeGen.isInMacroDefine());
+    EA.setCallSpelling(SM.getSpellingLoc(GAS->getBeginLoc()),
+                       SM.getSpellingLoc(GAS->getEndLoc()));
     EA.analyze(E);
     if (needExtraParens(E))
-      return "(" + EA.getReplacedString() + ")";
-    return EA.getReplacedString();
+      return "(" + EA.getRewriteString() + ")";
+    return EA.getRewriteString();
   };
   Parser.addBuiltinIdentifier();
   for (unsigned I = 0, E = GAS->getNumOutputs(); I != E; ++I)
@@ -782,11 +801,6 @@ void AsmRule::doMigrateInternel(const GCCAsmStmt *GAS) {
   for (unsigned I = 0, E = GAS->getNumInputs(); I != E; ++I)
     Parser.addInlineAsmOperands(getReplaceString(GAS->getInputExpr(I)),
                                 GAS->getInputConstraint(I));
-
-  StringRef Indent =
-      getIndent(GAS->getBeginLoc(), DpctGlobalInfo::getSourceManager());
-
-  SYCLGen CodeGen(OS, Indent);
 
   do {
     auto Inst = Parser.ParseStatement();
@@ -801,16 +815,26 @@ void AsmRule::doMigrateInternel(const GCCAsmStmt *GAS) {
     }
   } while (!Parser.getCurToken().is(asmtok::eof));
 
-  OS.flush();
-  auto *Repl = new ReplaceStmt(GAS, Replacement);
+  StringRef Ref = ReplaceString;
+  if (CodeGen.isInMacroDefine()) {
+    if (Ref.ends_with("\\\n")) {
+      ReplaceString.erase(ReplaceString.end() - 2);
+    } else if (Ref.ends_with("\\\r\n")) {
+      ReplaceString.erase(ReplaceString.end() - 3);
+    }
+  }
+
+  auto *Repl = new ReplaceStmt(GAS, std::move(ReplaceString));
   Repl->setBlockLevelFormatFlag();
   emplaceTransformation(Repl);
 
-  auto Tok =
-      Lexer::findNextToken(GAS->getEndLoc(), DpctGlobalInfo::getSourceManager(),
-                           DpctGlobalInfo::getContext().getLangOpts());
-  if (Tok.has_value() && Tok->is(tok::semi))
-    emplaceTransformation(new ReplaceToken(Tok->getLocation(), ""));
+  if (!CodeGen.isInMacroDefine()) {
+    auto Tok =
+        Lexer::findNextToken(GAS->getEndLoc(), DpctGlobalInfo::getSourceManager(),
+                            DpctGlobalInfo::getContext().getLangOpts());
+    if (Tok.has_value() && Tok->is(tok::semi))
+      emplaceTransformation(new ReplaceToken(Tok->getLocation(), ""));
+  }
   return;
 }
 

--- a/clang/test/dpct/asm.cu
+++ b/clang/test/dpct/asm.cu
@@ -216,7 +216,7 @@ __device__ int cond(int x) {
 // CHECK-NEXT: p[7] = p[6];\
 // CHECK-NEXT: p[8] = p[7];\
 // CHECK-NEXT: p[9] = p[8];\
-// CHECK-NEXT: V = p[8];\
+// CHECK-NEXT: V = p[9];\
 // CHECK-NEXT: }
 // CHECK: int x = 34;
 // CHECK-NEXT: int y = 0;
@@ -249,13 +249,10 @@ __global__ void declaration(int *ec) {
       " mov.u32 p7, p6;\n\t"        \
       " mov.u32 p8, p7;\n\t"        \
       " mov.u32 p9, p8;\n\t"        \
-      " mov.u32 %0, p8;\n\t"        \
+      " mov.u32 %0, p9;\n\t"        \
       "}"                           \
       : "=r"(V))
 
-  // This variable was used to test compound statement in inline asm,
-  // if the '{...}' was not correctly emitted, then, it will cause 
-  // variable redefinition.
   int x = 34;
   int y = 0;
   COND(x, y);

--- a/clang/test/dpct/asm.cu
+++ b/clang/test/dpct/asm.cu
@@ -2,7 +2,6 @@
 // RUN: FileCheck %s --match-full-lines --input-file %T/asm/asm.dp.cpp
 // clang-format off
 #include "cuda_runtime.h"
-#include "device_launch_parameters.h"
 
 #include <stdio.h>
 
@@ -32,32 +31,32 @@ __global__ void gpu_ptx(int *d_ptr, int length) {
 // CHECK-NEXT:     bool _p_p[20], _p_q[20];
 // CHECK-NEXT:     float fp;
 // CHECK-NEXT:     fp = sycl::bit_cast<float>(uint32_t(0x3f800000U));
-// CHECK-NEXT:     _p_p[1] = !sycl::isnan(x) && !sycl::isnan(fp) && x == fp;
-// CHECK-NEXT:     _p_p[2] = !sycl::isnan(x) && !sycl::isnan(fp) && x != fp;
-// CHECK-NEXT:     _p_p[3] = !sycl::isnan(x) && !sycl::isnan(fp) && x < fp;
-// CHECK-NEXT:     _p_p[4] = !sycl::isnan(x) && !sycl::isnan(fp) && x <= fp;
-// CHECK-NEXT:     _p_p[5] = !sycl::isnan(x) && !sycl::isnan(fp) && x > fp;
-// CHECK-NEXT:     _p_p[6] = !sycl::isnan(x) && !sycl::isnan(fp) && x >= fp;
-// CHECK-NEXT:     _p_p[7] = sycl::isnan(x) || sycl::isnan(fp) || x == fp;
-// CHECK-NEXT:     _p_p[8] =  sycl::isnan(x) || sycl::isnan(fp) || x != fp;
-// CHECK-NEXT:     _p_p[9] = sycl::isnan(x) || sycl::isnan(fp) || x < fp;
-// CHECK-NEXT:     _p_p[10] = sycl::isnan(x) || sycl::isnan(fp) || x <= fp;
-// CHECK-NEXT:     _p_p[11] = sycl::isnan(x) || sycl::isnan(fp) || x > fp;
-// CHECK-NEXT:     _p_p[12] = sycl::isnan(x) || sycl::isnan(fp) || x >= fp;
+// CHECK-NEXT:     _p_p[1] = !sycl::isnan(x) && !sycl::isnan(fp) && sycl::isequal<float>(x, fp);
+// CHECK-NEXT:     _p_p[2] = !sycl::isnan(x) && !sycl::isnan(fp) && sycl::isnotequal<float>(x, fp);
+// CHECK-NEXT:     _p_p[3] = !sycl::isnan(x) && !sycl::isnan(fp) && sycl::isless<float>(x, fp);
+// CHECK-NEXT:     _p_p[4] = !sycl::isnan(x) && !sycl::isnan(fp) && sycl::islessequal<float>(x, fp);
+// CHECK-NEXT:     _p_p[5] = !sycl::isnan(x) && !sycl::isnan(fp) && sycl::isgreater<float>(x, fp);
+// CHECK-NEXT:     _p_p[6] = !sycl::isnan(x) && !sycl::isnan(fp) && sycl::isgreaterequal<float>(x, fp);
+// CHECK-NEXT:     _p_p[7] = sycl::isnan(x) || sycl::isnan(fp) || sycl::isequal<float>(x, fp);
+// CHECK-NEXT:     _p_p[8] = sycl::isnan(x) || sycl::isnan(fp) || sycl::isnotequal<float>(x, fp);
+// CHECK-NEXT:     _p_p[9] = sycl::isnan(x) || sycl::isnan(fp) || sycl::isless<float>(x, fp);
+// CHECK-NEXT:     _p_p[10] = sycl::isnan(x) || sycl::isnan(fp) || sycl::islessequal<float>(x, fp);
+// CHECK-NEXT:     _p_p[11] = sycl::isnan(x) || sycl::isnan(fp) || sycl::isgreater<float>(x, fp);
+// CHECK-NEXT:     _p_p[12] = sycl::isnan(x) || sycl::isnan(fp) || sycl::isgreaterequal<float>(x, fp);
 // CHECK-NEXT:     _p_p[13] = !sycl::isnan(x) && !sycl::isnan(fp);
 // CHECK-NEXT:     _p_p[14] = sycl::isnan(x) || sycl::isnan(fp);
-// CHECK-NEXT:     _p_p[1] = !sycl::isnan(x) && !sycl::isnan(fp) && x == fp;
-// CHECK-NEXT:     _p_p[2] = !sycl::isnan(x) && !sycl::isnan(fp) && x != fp;
-// CHECK-NEXT:     _p_p[3] = !sycl::isnan(x) && !sycl::isnan(fp) && x < fp;
-// CHECK-NEXT:     _p_p[4] = !sycl::isnan(x) && !sycl::isnan(fp) && x <= fp;
-// CHECK-NEXT:     _p_p[5] = !sycl::isnan(x) && !sycl::isnan(fp) && x > fp;
-// CHECK-NEXT:     _p_p[6] = !sycl::isnan(x) && !sycl::isnan(fp) && x >= fp;
-// CHECK-NEXT:     _p_p[7] = sycl::isnan(x) || sycl::isnan(fp) || x == fp;
-// CHECK-NEXT:     _p_p[8] =  sycl::isnan(x) || sycl::isnan(fp) || x != fp;
-// CHECK-NEXT:     _p_p[9] = sycl::isnan(x) || sycl::isnan(fp) || x < fp;
-// CHECK-NEXT:     _p_p[10] = sycl::isnan(x) || sycl::isnan(fp) || x <= fp;
-// CHECK-NEXT:     _p_p[11] = sycl::isnan(x) || sycl::isnan(fp) || x > fp;
-// CHECK-NEXT:     _p_p[12] = sycl::isnan(x) || sycl::isnan(fp) || x >= fp;
+// CHECK-NEXT:     _p_p[1] = !sycl::isnan(x) && !sycl::isnan(fp) && sycl::isequal<double>(x, fp);
+// CHECK-NEXT:     _p_p[2] = !sycl::isnan(x) && !sycl::isnan(fp) && sycl::isnotequal<double>(x, fp);
+// CHECK-NEXT:     _p_p[3] = !sycl::isnan(x) && !sycl::isnan(fp) && sycl::isless<double>(x, fp);
+// CHECK-NEXT:     _p_p[4] = !sycl::isnan(x) && !sycl::isnan(fp) && sycl::islessequal<double>(x, fp);
+// CHECK-NEXT:     _p_p[5] = !sycl::isnan(x) && !sycl::isnan(fp) && sycl::isgreater<double>(x, fp);
+// CHECK-NEXT:     _p_p[6] = !sycl::isnan(x) && !sycl::isnan(fp) && sycl::isgreaterequal<double>(x, fp);
+// CHECK-NEXT:     _p_p[7] = sycl::isnan(x) || sycl::isnan(fp) || sycl::isequal<double>(x, fp);
+// CHECK-NEXT:     _p_p[8] = sycl::isnan(x) || sycl::isnan(fp) || sycl::isnotequal<double>(x, fp);
+// CHECK-NEXT:     _p_p[9] = sycl::isnan(x) || sycl::isnan(fp) || sycl::isless<double>(x, fp);
+// CHECK-NEXT:     _p_p[10] = sycl::isnan(x) || sycl::isnan(fp) || sycl::islessequal<double>(x, fp);
+// CHECK-NEXT:     _p_p[11] = sycl::isnan(x) || sycl::isnan(fp) || sycl::isgreater<double>(x, fp);
+// CHECK-NEXT:     _p_p[12] = sycl::isnan(x) || sycl::isnan(fp) || sycl::isgreaterequal<double>(x, fp);
 // CHECK-NEXT:     _p_p[13] = !sycl::isnan(x) && !sycl::isnan(fp);
 // CHECK-NEXT:     _p_p[14] = sycl::isnan(x) || sycl::isnan(fp);
 // CHECK-NEXT:     _p_q[1] = a == b;

--- a/clang/test/dpct/asm.cu
+++ b/clang/test/dpct/asm.cu
@@ -117,25 +117,26 @@ __device__ void setp() {
       : "=f"(y) : "f"(x), "r"(a), "r"(b));
 }
 
-// CHECK:void mov(float *output) {
+// CHECK:void mov() {
 // CHECK-NEXT: unsigned p;
 // CHECK-NEXT: double d;
-// CHECK-NEXT: p = 123 * 123U + 456 * ((4 ^ 7) + 2 ^ 3) | 777 & 128 == 2 != 3 > 4 < 5 <= 3 >= 5 >> 1 << 2 && 1 || 7 && !0;
-// CHECK: (*output) = sycl::bit_cast<float>(uint32_t(0x3f800000U));
-// CHECK: (*output) = sycl::bit_cast<float>(uint32_t(0x3f800000U));
+// CHECK-NEXT: float f;
+// CHECK-NEXT: p = 123 * 123U + 456 * ((4 ^ 7) + 2 ^ 3) | 777 & 128U == 2 != 3 > 4 < 5 <= 3 >= 5 >> 1 << 2 && 1 || 7 && !0;
+// CHECK: f = sycl::bit_cast<float>(uint32_t(0x3f800000U));
+// CHECK: f = sycl::bit_cast<float>(uint32_t(0x3f800000U));
 // CHECK: d = sycl::bit_cast<double>(uint64_t(0x40091EB851EB851FULL));
 // CHECK: d = sycl::bit_cast<double>(uint64_t(0x40091EB851EB851FULL));
-// CHECK: *output = p;
-// CHECK-NEXT:}
-__global__ void mov(float *output) {
+// CHECK: }
+__global__ void mov() {
   unsigned p;
   double d;
-  asm ("mov.s32 %0, 123 * 123U + 456 * ((4 ^7) + 2 ^ 3) | 777 & 128 == 2 != 3 > 4 < 5 <= 3 >= 5 >> 1 << 2 && 1 || 7 && !0;" : "=r"(p) );
-  asm ("mov.s32 %0, 0F3f800000;" : "=r"(*output));
-  asm ("mov.s32 %0, 0f3f800000;" : "=r"(*output));
-  asm ("mov.s32 %0, 0D40091EB851EB851F;" : "=r"(d));
-  asm ("mov.s32 %0, 0d40091EB851EB851F;" : "=r"(d));
-  *output = p;
+  float f;
+  asm ("mov.s32 %0, 123 * 123U + 456 * ((4 ^7) + 2 ^ 3) | 777 & 128U == 2 != 3 > 4 < 5 <= 3 >= 5 >> 1 << 2 && 1 || 7 && !0;" : "=r"(p) );
+  asm ("mov.f32 %0, 0F3f800000;" : "=f"(f));
+  asm ("mov.f32 %0, 0f3f800000;" : "=f"(f));
+  asm ("mov.f64 %0, 0D40091EB851EB851F;" : "=d"(d));
+  asm ("mov.f64 %0, 0d40091EB851EB851F;" : "=d"(d));
+  return;
 }
 
 // CHECK: void clean_specifial_character() {
@@ -192,6 +193,94 @@ __device__ int cond(int x) {
       "}"                             // conceptually y = (x==34)?1:y
       : "+r"(y) : "r" (x));
   return y;
+}
+
+// CHECK: void declaration(int *ec) {
+// CHECK: #define COND(X, Y) \
+// CHECK-NEXT: {\
+// CHECK-NEXT: bool p;\
+// CHECK-NEXT: p = X == 34;\
+// CHECK-NEXT: if (p) {\
+// CHECK-NEXT: Y = 1;\
+// CHECK-NEXT: }\
+// CHECK-NEXT: }
+// CHECK: #define ARR(V) \
+// CHECK-NEXT: {\
+// CHECK-NEXT: uint32_t p[10];\
+// CHECK-NEXT: p[0] = 2013;\
+// CHECK-NEXT: p[1] = p[0];\
+// CHECK-NEXT: p[2] = p[1];\
+// CHECK-NEXT: p[3] = p[2];\
+// CHECK-NEXT: p[4] = p[3];\
+// CHECK-NEXT: p[5] = p[4];\
+// CHECK-NEXT: p[6] = p[5];\
+// CHECK-NEXT: p[7] = p[6];\
+// CHECK-NEXT: p[8] = p[7];\
+// CHECK-NEXT: p[9] = p[8];\
+// CHECK-NEXT: V = p[8];\
+// CHECK-NEXT: }
+// CHECK: int x = 34;
+// CHECK-NEXT: int y = 0;
+// CHECK-NEXT: COND(x, y);
+// CHECK: x = 33;
+// CHECK-NEXT: y = 0;
+// CHECK-NEXT: COND(x, y);
+// CHECK: x = 0;
+// CHECK-NEXT: ARR(x);
+// CHECK: }
+__global__ void declaration(int *ec) {
+#define COND(X, Y)                  \
+  asm("{\n\t"                       \
+      " .reg .pred p;\n\t"          \
+      " setp.eq.s32 p, %1, 34;\n\t" \
+      " @p mov.s32 %0, 1;\n\t"      \
+      "}"                           \
+      : "+r"(Y) : "r" (X))
+
+#define ARR(V)                      \
+  asm("{\n\t"                       \
+      " .reg .u32 p<10>;\n\t"       \
+      " mov.u32 p0, 2013;\n\t"      \
+      " mov.u32 p1, p0;\n\t"        \
+      " mov.u32 p2, p1;\n\t"        \
+      " mov.u32 p3, p2;\n\t"        \
+      " mov.u32 p4, p3;\n\t"        \
+      " mov.u32 p5, p4;\n\t"        \
+      " mov.u32 p6, p5;\n\t"        \
+      " mov.u32 p7, p6;\n\t"        \
+      " mov.u32 p8, p7;\n\t"        \
+      " mov.u32 p9, p8;\n\t"        \
+      " mov.u32 %0, p8;\n\t"        \
+      "}"                           \
+      : "=r"(V))
+
+  // This variable was used to test compound statement in inline asm,
+  // if the '{...}' was not correctly emitted, then, it will cause 
+  // variable redefinition.
+  int x = 34;
+  int y = 0;
+  COND(x, y);
+  if (y != 1) {
+    *ec = 1;
+    return;
+  }
+
+  x = 33;
+  y = 0;
+  COND(x, y);
+  if (y == 1) {
+    *ec = 2;
+    return;
+  }
+
+  x = 0;
+  ARR(x);
+  if (x != 2013) {
+    *ec = 3;
+    return;
+  }
+
+  *ec = 0;
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
- Fix uninitialized class member variable in InlineAsmNumericLiteralParser.
- Fix numeric literal postfix parsing in InlineAsmNumericLiteralParser.
- Avoid user define variable name conflict with asm keyword.
- Fix the migration of inline asm statement which in a function like macro.
- Relax the return value of APFloat::convertFromString, allow APFloat::OpInexact.
- Strengthen lit.
- Fix the migration of setp, when the operand type is floating point, use SYCL relational functions instead of builtin compare operators.

Signed-off-by: Wang, Yihan [yihan.wang@intel.com](mailto:yihan.wang@intel.com)