### PR TITLE
Fixing header comments namespace for transform_output_ref_wrapper and _Unary_Out

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/iterators.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/iterators.h.inc
@@ -51,7 +51,7 @@ namespace dpct {
 
 namespace internal {
 
-// DPCT_LABEL_BEGIN|transform_output_ref_wrapper|dpct
+// DPCT_LABEL_BEGIN|transform_output_ref_wrapper|dpct::internal
 // DPCT_DEPENDENCY_EMPTY
 // DPCT_CODE
 // Wrapper class returned from a dereferenced transform_iterator which was
@@ -89,7 +89,7 @@ public:
 };
 // DPCT_LABEL_END
 
-// DPCT_LABEL_BEGIN|_Unary_Out|dpct
+// DPCT_LABEL_BEGIN|_Unary_Out|dpct::internal
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasIterators|transform_output_ref_wrapper
 // DPCT_DEPENDENCY_END


### PR DESCRIPTION
Incorrect comment labels were placing  `transform_output_ref_wrapper` and `_Unary_Out` in the wrong namespace.  This should resolve the issue.