### PR TITLE
[SYCLomatic] Adding mutable to helper functions

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/functional.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/functional.h.inc
@@ -248,7 +248,7 @@ template <typename Compare = class internal::__less> struct compare_key_fun {
   }
 
 private:
-  Compare comp;
+  mutable Compare comp;
 };
 // DPCT_LABEL_END
 
@@ -268,7 +268,7 @@ template <typename Predicate> struct predicate_key_fun {
   }
 
 private:
-  Predicate pred;
+  mutable Predicate pred;
 };
 // DPCT_LABEL_END
 
@@ -286,7 +286,7 @@ template <typename Predicate> struct negate_predicate_key_fun {
   }
 
 private:
-  Predicate pred;
+  mutable Predicate pred;
 };
 // DPCT_LABEL_END
 
@@ -320,7 +320,7 @@ template <typename Predicate> struct unique_fun {
   }
 
 private:
-  Predicate pred;
+  mutable Predicate pred;
 };
 // DPCT_LABEL_END
 
@@ -340,7 +340,7 @@ public:
   }
 
 private:
-  Predicate pred;
+  mutable Predicate pred;
   const T new_value;
 };
 // DPCT_LABEL_END
@@ -360,8 +360,8 @@ struct transform_if_fun {
   }
 
 private:
-  Predicate pred;
-  Operator op;
+  mutable Predicate pred;
+  mutable Operator op;
 };
 // DPCT_LABEL_END
 
@@ -380,8 +380,8 @@ struct transform_if_unary_zip_mask_fun {
   }
 
 private:
-  Predicate pred;
-  Operator op;
+  mutable Predicate pred;
+  mutable Operator op;
 };
 // DPCT_LABEL_END
 
@@ -401,8 +401,8 @@ public:
   }
 
 private:
-  Predicate pred;
-  BinaryOperation op;
+  mutable Predicate pred;
+  mutable BinaryOperation op;
 };
 // DPCT_LABEL_END
 

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/functional.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/functional.h
@@ -167,7 +167,7 @@ template <typename Compare = class internal::__less> struct compare_key_fun {
   }
 
 private:
-  Compare comp;
+  mutable Compare comp;
 };
 
 // Functor evaluates second element of tied sequence with predicate.
@@ -183,7 +183,7 @@ template <typename Predicate> struct predicate_key_fun {
   }
 
 private:
-  Predicate pred;
+  mutable Predicate pred;
 };
 
 // Used by: remove_if
@@ -197,7 +197,7 @@ template <typename Predicate> struct negate_predicate_key_fun {
   }
 
 private:
-  Predicate pred;
+  mutable Predicate pred;
 };
 
 template <typename T> struct sequence_fun {
@@ -223,7 +223,7 @@ template <typename Predicate> struct unique_fun {
   }
 
 private:
-  Predicate pred;
+  mutable Predicate pred;
 };
 
 // Lambda: [pred, &new_value](Ref1 a, Ref2 s) {return pred(s) ? new_value : a;
@@ -239,7 +239,7 @@ public:
   }
 
 private:
-  Predicate pred;
+  mutable Predicate pred;
   const T new_value;
 };
 
@@ -255,8 +255,8 @@ struct transform_if_fun {
   }
 
 private:
-  Predicate pred;
-  Operator op;
+  mutable Predicate pred;
+  mutable Operator op;
 };
 
 //[pred, op](Ref1 a, Ref2 s) { return pred(s) ? op(a) : a; });
@@ -271,8 +271,8 @@ struct transform_if_unary_zip_mask_fun {
   }
 
 private:
-  Predicate pred;
-  Operator op;
+  mutable Predicate pred;
+  mutable Operator op;
 };
 
 template <typename T, typename Predicate, typename BinaryOperation>
@@ -288,8 +288,8 @@ public:
   }
 
 private:
-  Predicate pred;
-  BinaryOperation op;
+  mutable Predicate pred;
+  mutable BinaryOperation op;
 };
 
 // This following code is similar to a section of code in


### PR DESCRIPTION
Adding mutable comparators, predicates, operators in helper functors to remove hidden const requirement from public APIs.  
