### PR TITLE
[SYCLomatic] Skip the cooperative_groups_block_tile_memory.cu test case when using lower versions of CUDA header files.

### DIFF
--- a/clang/test/dpct/cooperative_groups_block_tile_memory.cu
+++ b/clang/test/dpct/cooperative_groups_block_tile_memory.cu
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.8
+// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.1, cuda-11.2, cuda-11.3, cuda-11.4, cuda-11.5, cuda-11.6, cuda-11.7, cuda-11.8
 // UNSUPPORTED: v8.0, v9.0, v9.1, v9.2, v10.0, v10.1, v10.2, v11.0, v11.1, v11.2, v11.3, v11.4, v11.5, v11.6, v11.7, v11.8
 // RUN: dpct --format-range=none -out-root %T/cooperative_groups_block_tile_memory %s --cuda-include-path="%cuda-path/include" -use-experimental-features=free-function-queries,logical-group -- -x cuda --cuda-host-only -std=c++14
 // RUN: FileCheck %s --match-full-lines --input-file %T/cooperative_groups_block_tile_memory/cooperative_groups_block_tile_memory.dp.cpp


### PR DESCRIPTION
Signed-off-by: Chen, Sheng S <sheng.s.chen@intel.com>
