### PR TITLE
[SYCLomatic] Add parentheses to migrated code when std::chrono::duration is assignable.

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -7997,7 +7997,7 @@ void EventAPICallRule::handleEventElapsedTime(bool IsAssigned) {
         << StmtStrArg2 << " - " << StmtStrArg1 << ").count()";
     if (IsAssigned) {
       std::ostringstream Temp;
-      Temp << "DPCT_CHECK_ERROR(" << Repl.str() << ")";
+      Temp << "DPCT_CHECK_ERROR((" << Repl.str() << "))";
       Repl = std::move(Temp);
       requestFeature(HelperFeatureEnum::Dpct_check_error_code, TimeElapsedCE);
     }

--- a/clang/test/dpct/cuda-event-api.cu
+++ b/clang/test/dpct/cuda-event-api.cu
@@ -212,7 +212,7 @@ int main(int argc, char* argv[]) {
   cudaEventSynchronize(stop);
   cudaEventElapsedTime(&elapsed_time, start, stop);
 
-  // CHECK: MY_ERROR_CHECKER(DPCT_CHECK_ERROR(elapsed_time = std::chrono::duration<float, std::milli>(stop_ct1 - start_ct1).count()));
+  // CHECK: MY_ERROR_CHECKER(DPCT_CHECK_ERROR((elapsed_time = std::chrono::duration<float, std::milli>(stop_ct1 - start_ct1).count())));
   MY_ERROR_CHECKER(cudaEventElapsedTime(&elapsed_time, start, stop));
 
   // kernel call without sync
@@ -317,7 +317,7 @@ void foo() {
 
   cudaEventSynchronize(stop);
 
-  // CHECK: MY_CHECKER(DPCT_CHECK_ERROR(elapsed_time = std::chrono::duration<float, std::milli>(stop_ct1 - start_ct1).count()));
+  // CHECK: MY_CHECKER(DPCT_CHECK_ERROR((elapsed_time = std::chrono::duration<float, std::milli>(stop_ct1 - start_ct1).count())));
   MY_CHECKER(cudaEventElapsedTime(&elapsed_time, start, stop));
 
   cudaEventDestroy(start);
@@ -359,7 +359,7 @@ void bar() {
   fun(cudaEventRecord(stop, 0));
 
   cudaEventSynchronize(stop);
-  // CHECK: fun(DPCT_CHECK_ERROR(elapsed_time = std::chrono::duration<float, std::milli>(stop_ct1 - start_ct1).count()));
+  // CHECK: fun(DPCT_CHECK_ERROR((elapsed_time = std::chrono::duration<float, std::milli>(stop_ct1 - start_ct1).count())));
   fun(cudaEventElapsedTime(&elapsed_time, start, stop));
 
   cudaEventDestroy(start);

--- a/clang/test/dpct/tm-complex.cu
+++ b/clang/test/dpct/tm-complex.cu
@@ -383,7 +383,7 @@ int foo_test_2()
 // CHECK-NEXT:    stop_ct1 = std::chrono::steady_clock::now();
 // CHECK-NEXT:    CHECK(DPCT_CHECK_ERROR(*stop = dpct::get_default_queue().ext_oneapi_submit_barrier()));
 // CHECK-NEXT:    CHECK(0);
-// CHECK-NEXT:    CHECK(DPCT_CHECK_ERROR(elapsed_time = std::chrono::duration<float, std::milli>(stop_ct1 - start_ct1).count()));
+// CHECK-NEXT:    CHECK(DPCT_CHECK_ERROR((elapsed_time = std::chrono::duration<float, std::milli>(stop_ct1 - start_ct1).count())));
     CHECK(cudaEventRecord(stop, 0));
     CHECK(cudaEventSynchronize(stop));
     CHECK(cudaEventElapsedTime(&elapsed_time, start, stop));


### PR DESCRIPTION
Signed-off-by: Chen, Sheng S <sheng.s.chen@intel.com>
