### PR TITLE
SYCLomatic] Add functor workaround which const-ifys functors

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/functional.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/functional.h
@@ -26,6 +26,21 @@ namespace dpct {
 
 struct null_type {};
 
+// Function object to wrap user defined functors to provide compile time "const"
+// workaround for user function objects.
+// The SYCL spec (4.12) states that writing to a function object during a SYCL
+// kernel is undefined behavior.  This wrapper is provided as a compile-time
+// work around, but functors used in SYCL kernels must be `const` in practice.
+template <typename _Op> struct mark_functor_const {
+  mutable _Op op;
+  mark_functor_const() : op() {}
+  mark_functor_const(const _Op &__op) : op(__op) {}
+  mark_functor_const(_Op &&__op) : op(::std::move(__op)) {}
+  template <typename... _T> auto operator()(_T &&...x) const {
+    return op(std::forward<_T>(x)...);
+  }
+};
+
 template <typename T>
 __dpct_inline__ ::std::enable_if_t<::std::is_unsigned_v<T>, T>
 bfe(T source, uint32_t bit_start, uint32_t num_bits) {


### PR DESCRIPTION
The intention for this PR is provide a workaround wrapper to allow user code to function when no `const` function call operator is provided.  
This provided function object should wrap incoming user function objects when calling oneDPL or dpct algorithms with an appropriate message stating that use within SYCL kernels of function objects which modify themselves during their functional call operators results in undefined behavior.  The user should be prompted via a comment to check that their function object is in fact const, mark it as such, then remove this workaround wrapper function.

Here is the proposed addition to oneDPL's documentation which adds this requirement: https://github.com/oneapi-src/oneDPL/pull/1083