### PR TITLE
[SYCLomatic] Support migration of %warpid and WARP_SZ in inline asm

### DIFF
--- a/clang/lib/DPCT/Asm/AsmIdentifierTable.cpp
+++ b/clang/lib/DPCT/Asm/AsmIdentifierTable.cpp
@@ -16,11 +16,7 @@ InlineAsmIdentifierInfoLookup::~InlineAsmIdentifierInfoLookup() = default;
 InlineAsmIdentifierTable::InlineAsmIdentifierTable(
     InlineAsmIdentifierInfoLookup *ExternalLookup)
     : HashTable(128), // Start with space for 8K identifiers.
-      ExternalLookup(ExternalLookup) {
-  // Populate the identifier table with info about keywords for the current
-  // language.
-  AddKeywords();
-}
+      ExternalLookup(ExternalLookup) {}
 
 void InlineAsmIdentifierTable::AddKeywords() {
 #define KEYWORD(X, Y) get(Y, asmtok::kw_##X);

--- a/clang/lib/DPCT/Asm/AsmIdentifierTable.h
+++ b/clang/lib/DPCT/Asm/AsmIdentifierTable.h
@@ -90,9 +90,6 @@ class InlineAsmIdentifierTable {
 
   InlineAsmIdentifierInfoLookup *ExternalLookup;
 
-  /// Populate the identifier table with info about the asm keywords.
-  void AddKeywords();
-
 public:
   /// Create the identifier table.
   explicit InlineAsmIdentifierTable(
@@ -153,6 +150,9 @@ public:
   iterator find(StringRef Name) const { return HashTable.find(Name); }
 
   bool contains(StringRef Name) const { return HashTable.contains(Name); }
+
+  /// Populate the identifier table with info about the asm keywords.
+  void AddKeywords();
 };
 
 } // namespace clang::dpct

--- a/clang/lib/DPCT/Asm/AsmLexer.cpp
+++ b/clang/lib/DPCT/Asm/AsmLexer.cpp
@@ -24,7 +24,11 @@ using namespace clang::dpct;
 
 InlineAsmLexer::InlineAsmLexer(llvm::MemoryBufferRef Input)
     : BufferStart(Input.getBufferStart()), BufferEnd(Input.getBufferEnd()),
-      BufferPtr(Input.getBufferStart()) {}
+      BufferPtr(Input.getBufferStart()) {
+  // Populate the identifier table with info about keywords for the current
+  // language.
+  Identifiers.AddKeywords();
+}
 
 InlineAsmLexer::~InlineAsmLexer() = default;
 

--- a/clang/lib/DPCT/Asm/AsmTokenKinds.def
+++ b/clang/lib/DPCT/Asm/AsmTokenKinds.def
@@ -245,6 +245,8 @@ INSTRUCTION(wmma)
 INSTRUCTION(xor)
 
 BUILTIN_ID(laneid, "%laneid", s64)
+BUILTIN_ID(warpid, "%warpid", s64)
+BUILTIN_ID(WARP_SZ, "WARP_SZ", s64)
 
 BUILTIN_TYPE(b8,      ".b8")
 BUILTIN_TYPE(b16,     ".b16")

--- a/clang/lib/DPCT/AsmMigration.cpp
+++ b/clang/lib/DPCT/AsmMigration.cpp
@@ -47,7 +47,8 @@ namespace {
 inline bool SYCLGenError() { return true; }
 inline bool SYCLGenSuccess() { return false; }
 
-/// This is used to handle all the AST nodes (except specific instructions).
+/// This is used to handle all the AST nodes (except specific instructions, Eg.
+/// mov/setp), and generate functionally equivalent SYCL code.
 class SYCLGenBase {
   bool IsInMacroDef = false;
   bool EmitNewLine = true;
@@ -354,6 +355,12 @@ bool SYCLGenBase::emitDeclRefExpression(const InlineAsmDeclRefExpr *E) {
     switch (E->getDecl().getDeclName()->getTokenID()) {
     case asmtok::bi_laneid:
       OS() << getItemName() << ".get_sub_group().get_local_linear_id()";
+      break;
+    case asmtok::bi_warpid:
+      OS() << getItemName() << ".get_sub_group().get_group_linear_id()";
+      break;
+    case asmtok::bi_WARP_SZ:
+      OS() << getItemName() << ".get_local_range().get(0)";
       break;
     default:
       return SYCLGenError();

--- a/clang/test/dpct/asm.cu
+++ b/clang/test/dpct/asm.cu
@@ -12,13 +12,21 @@ __global__ void gpu_ptx(int *d_ptr, int length) {
     if (elemID < length) {
       unsigned int laneid;
       unsigned int warpid;
+      unsigned int WARP_SZ;
       // CHECK: laneid = item_ct1.get_sub_group().get_local_linear_id();
       asm("mov.u32 %0, %%laneid;" : "=r"(laneid));
 
+      // CHECK: warpid = item_ct1.get_sub_group().get_group_linear_id();
+      asm("mov.u32 %0, %%warpid;" : "=r"(warpid));
+
+      // CHECK: WARP_SZ = item_ct1.get_local_range().get(0);
+      asm("mov.u32 %0, WARP_SZ;" : "=r"(WARP_SZ));
+      
+      // ill-formed inline asm, missing ';' at the end of mov instruction.
       // CHECK: /*
       // CHECK-NEXT: DPCT1053:{{.*}} Migration of device assembly code is not supported.
       // CHECK-NEXT: */
-      asm("mov.u32 %0, %%warpid;" : "=r"(warpid));
+      asm("mov.u32 %0, WARP_SZ" : "=r"(WARP_SZ));
       d_ptr[elemID] = laneid;
     }
   }


### PR DESCRIPTION
Signed-off-by: Wang, Yihan [yihan.wang@intel.com](mailto:yihan.wang@intel.com)