### PR TITLE
[SYCLomatic] device pointer wrapper APIs 

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -658,13 +658,13 @@ merge(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1, Iter2 keys_first2,
 }
 // DPCT_LABEL_END
 
-
 // DPCT_LABEL_BEGIN|merge_usm_none|dpct
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasAlgorithm|merge
 // DplExtrasFunctional|check_device_ptr_and_launch
 // DplExtrasFunctional|all_are_pointer_v
 // Device|get_default_queue
+// DplExtrasFunctional|__less
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
 #ifdef DPCT_USM_LEVEL_NONE
@@ -835,6 +835,7 @@ void for_each_index(Policy &&policy, Iter first, Iter last, Operator unary_op) {
 // DPCT_LABEL_BEGIN|set_intersection|dpct
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasFunctional|compare_key_fun
+// DplExtrasFunctional|enable_if_execution_policy
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
 template <class Policy, class Iter1, class Iter2, class Iter3, class Iter4,
@@ -912,6 +913,7 @@ set_intersection(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
 // DplExtrasFunctional|check_device_ptr_and_launch
 // DplExtrasFunctional|all_are_pointer_v
 // Device|get_default_queue
+// DplExtrasFunctional|__less
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
 #ifdef DPCT_USM_LEVEL_NONE
@@ -956,6 +958,7 @@ set_intersection(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
 // DPCT_LABEL_BEGIN|set_symmetric_difference|dpct
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasFunctional|compare_key_fun
+// DplExtrasFunctional|enable_if_execution_policy
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
 template <class Policy, class Iter1, class Iter2, class Iter3, class Iter4,
@@ -1037,6 +1040,7 @@ set_symmetric_difference(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
 // DplExtrasFunctional|check_device_ptr_and_launch
 // DplExtrasFunctional|all_are_pointer_v
 // Device|get_default_queue
+// DplExtrasFunctional|__less
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
 #ifdef DPCT_USM_LEVEL_NONE
@@ -1082,6 +1086,7 @@ set_symmetric_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
 // DPCT_LABEL_BEGIN|set_difference|dpct
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasFunctional|compare_key_fun
+// DplExtrasFunctional|enable_if_execution_policy
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
 template <class Policy, class Iter1, class Iter2, class Iter3, class Iter4,
@@ -1122,11 +1127,10 @@ set_difference(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
 template <class Policy, class Iter1, class Iter2, class Iter3, class Iter4,
           class Iter5, class Iter6, class Comp>
 internal::enable_if_execution_policy<Policy, std::pair<Iter5, Iter6>>
-set_difference(Policy &&policy, Iter1 keys_first1,
-                                       Iter1 keys_last1, Iter2 keys_first2,
-                                       Iter2 keys_last2, Iter3 values_first1,
-                                       Iter4 values_first2, Iter5 keys_result,
-                                       Iter6 values_result, Comp comp) {
+set_difference(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
+               Iter2 keys_first2, Iter2 keys_last2, Iter3 values_first1,
+               Iter4 values_first2, Iter5 keys_result, Iter6 values_result,
+               Comp comp) {
   static_assert(
       std::is_same<typename std::iterator_traits<Iter1>::iterator_category,
                    std::random_access_iterator_tag>::value &&
@@ -1163,6 +1167,7 @@ set_difference(Policy &&policy, Iter1 keys_first1,
 // DplExtrasFunctional|check_device_ptr_and_launch
 // DplExtrasFunctional|all_are_pointer_v
 // Device|get_default_queue
+// DplExtrasFunctional|__less
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
 #ifdef DPCT_USM_LEVEL_NONE
@@ -1208,6 +1213,7 @@ set_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
 // DPCT_LABEL_BEGIN|set_union|dpct
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasFunctional|compare_key_fun
+// DplExtrasFunctional|enable_if_execution_policy
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
 template <class Policy, class Iter1, class Iter2, class Iter3, class Iter4,
@@ -1288,6 +1294,7 @@ set_union(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
 // DplExtrasFunctional|check_device_ptr_and_launch
 // DplExtrasFunctional|all_are_pointer_v
 // Device|get_default_queue
+// DplExtrasFunctional|__less
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
 #ifdef DPCT_USM_LEVEL_NONE
@@ -1333,6 +1340,7 @@ set_union(Ptr1 keys_first1, Size size, Ptr2 keys_first2, Size size2,
 // DPCT_LABEL_BEGIN|stable_partition_copy|dpct
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasFunctional|predicate_key_fun
+// DplExtrasFunctional|enable_if_execution_policy
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
 template <typename Policy, typename Iter1, typename Iter2, typename Iter3,
@@ -1435,6 +1443,7 @@ stable_partition_copy(Ptr1 first, Size size, Ptr2 out_true, Ptr3 out_false,
 // DPCT_LABEL_BEGIN|partition_copy|dpct
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasAlgorithm|stable_partition_copy
+// DplExtrasFunctional|enable_if_execution_policy
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
 template <typename Policy, typename Iter1, typename Iter2, typename Iter3,
@@ -1551,6 +1560,7 @@ stable_partition(Policy &&policy, Iter1 first, Iter1 last, Iter2 mask, Pred p) {
 // DPCT_LABEL_BEGIN|partition|dpct
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasAlgorithm|stable_partition
+// DplExtrasFunctional|enable_if_execution_policy
 // DPCT_DEPENDENCY_END
 // DPCT_CODE
 template <typename Policy, typename Iter1, typename Iter2, typename Pred>
@@ -2417,11 +2427,15 @@ inline void reduce_argmin(_ExecutionPolicy &&policy, Iter1 input, Iter2 output,
 // DPCT_LABEL_END
 
 // DPCT_LABEL_BEGIN|equal_range|dpct
-// DPCT_DEPENDENCY_EMPTY
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasFunctional|enable_if_execution_policy
+// DplExtrasFunctional|__less
+// DPCT_DEPENDENCY_END
 // DPCT_CODE
 template <typename _ExecutionPolicy, typename Iter1,
           typename ValueLessComparable, typename StrictWeakOrdering>
-inline ::std::pair<Iter1, Iter1>
+inline dpct::internal::enable_if_execution_policy<_ExecutionPolicy,
+                                                  ::std::pair<Iter1, Iter1>>
 equal_range(_ExecutionPolicy &&policy, Iter1 start, Iter1 end,
             const ValueLessComparable &value, StrictWeakOrdering comp) {
   ::std::vector<::std::int64_t> res_lower(1);
@@ -2438,12 +2452,48 @@ equal_range(_ExecutionPolicy &&policy, Iter1 start, Iter1 end,
 
 template <typename _ExecutionPolicy, typename Iter1,
           typename ValueLessComparable>
-inline ::std::pair<Iter1, Iter1> equal_range(_ExecutionPolicy &&policy,
-                                             Iter1 start, Iter1 end,
-                                             const ValueLessComparable &value) {
+inline dpct::internal::enable_if_execution_policy<_ExecutionPolicy,
+                                                  ::std::pair<Iter1, Iter1>>
+equal_range(_ExecutionPolicy &&policy, Iter1 start, Iter1 end,
+            const ValueLessComparable &value) {
   return equal_range(::std::forward<_ExecutionPolicy>(policy), start, end,
                      value, internal::__less());
 }
+// DPCT_LABEL_END
+
+// DPCT_LABEL_BEGIN|equal_range|dpct
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasFunctional|check_device_ptr_and_launch_w_value
+// DplExtrasFunctional|__less
+// Device|get_default_queue
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+#ifdef DPCT_USM_LEVEL_NONE
+template <typename Ptr1, typename Size, typename ValueLessComparable,
+          typename StrictWeakOrdering>
+inline std::enable_if_t<std::is_pointer_v<Ptr1>, ::std::pair<Ptr1, Ptr1>>
+equal_range(Ptr1 start, Size size, const ValueLessComparable &value,
+            StrictWeakOrdering comp) {
+  return dpct::internal::check_device_ptr_and_launch_w_value(
+      oneapi::dpl::execution::par_unseq,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      value, comp, size,
+      [](auto &&policy, Ptr1 start, Ptr1 end, const ValueLessComparable &value,
+         StrictWeakOrdering comp) {
+        return dpct::equal_range(std::forward<decltype(policy)>(policy), start,
+                                 end, value, comp);
+      },
+      start, start, // return base
+      start         // all ptrs
+  );
+}
+
+template <typename _T, typename Size, typename ValueLessComparable>
+inline std::enable_if_t<std::is_pointer_v<_T>, ::std::pair<_T, _T>>
+equal_range(_T start, Size size, const ValueLessComparable &value) {
+  return dpct::equal_range(start, size, value, internal::__less());
+}
+#endif // DPCT_USM_LEVEL_NONE
 // DPCT_LABEL_END
 
 // DPCT_LABEL_BEGIN|segmented_reduce_argmin|dpct

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h.inc
@@ -221,6 +221,44 @@ std::pair<Iter1, Iter2> unique(Policy &&policy, Iter1 keys_first,
 }
 // DPCT_LABEL_END
 
+// DPCT_LABEL_BEGIN|unique_usm_none|dpct
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasAlgorithm|unique
+// DplExtrasFunctional|check_device_ptr_and_launch
+// DplExtrasFunctional|all_are_pointer_v
+// Device|get_default_queue
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+#ifdef DPCT_USM_LEVEL_NONE
+template <typename Ptr1, typename Size, typename Ptr2, typename BinaryPred>
+std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2>,
+                 std::pair<Ptr1, Ptr2>>
+unique(Ptr1 start1, Size size, Ptr2 start2, BinaryPred binary_pred) {
+  return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::par_unseq,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      binary_pred, size,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2,
+         BinaryPred binary_pred) {
+        return dpct::unique(std::forward<decltype(policy)>(policy), start1,
+                            end1, start2, binary_pred);
+      },
+      start1, start2, // return base
+      start1, start2  // all ptrs
+  );
+}
+
+template <typename Ptr1, typename Size, typename Ptr2>
+std::enable_if_t<dpct::internal::all_are_pointer_v<Ptr1, Ptr2>,
+                 std::pair<Ptr1, Ptr2>>
+unique(Ptr1 start1, Size size, Ptr2 start2) {
+  return dpct::unique(
+      start1, size, start2,
+      std::equal_to<typename std::iterator_traits<Ptr1>::value_type>());
+}
+#endif // DPCT_USM_LEVEL_NONE
+// DPCT_LABEL_END
+
 // DPCT_LABEL_BEGIN|unique_copy|dpct
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasFunctional|unique_fun
@@ -273,6 +311,49 @@ std::pair<Iter3, Iter4> unique_copy(Policy &&policy, Iter1 keys_first,
   return unique_copy(std::forward<Policy>(policy), keys_first, keys_last,
                      values_first, keys_result, values_result, comp);
 }
+// DPCT_LABEL_END
+
+// DPCT_LABEL_BEGIN|unique_copy_usm_none|dpct
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasAlgorithm|unique_copy
+// DplExtrasFunctional|check_device_ptr_and_launch
+// DplExtrasFunctional|all_are_pointer_v
+// Device|get_default_queue
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+#ifdef DPCT_USM_LEVEL_NONE
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename BinaryPred>
+
+std::enable_if_t<dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4>,
+                 std::pair<Ptr3, Ptr4>>
+unique_copy(Ptr1 keys_first, Size size, Ptr2 values_first, Ptr3 keys_result,
+            Ptr4 values_result, BinaryPred binary_pred) {
+  return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::par_unseq,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      binary_pred, size,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
+         Ptr4 start4, BinaryPred binary_pred) {
+        return dpct::unique_copy(std::forward<decltype(policy)>(policy), start1,
+                                 end1, start2, start3, start4, binary_pred);
+      },
+      keys_result, values_result,                          // return base
+      keys_first, values_first, keys_result, values_result // all ptrs
+  );
+}
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4>
+std::enable_if_t<dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4>,
+                 std::pair<Ptr3, Ptr4>>
+unique_copy(Ptr1 keys_first, Size size, Ptr2 values_first, Ptr3 keys_result,
+            Ptr4 values_result) {
+  return dpct::unique_copy(
+      keys_first, size, values_first, keys_result, values_result,
+      std::equal_to<typename std::iterator_traits<Ptr1>::value_type>());
+}
+#endif // DPCT_USM_LEVEL_NONE
 // DPCT_LABEL_END
 
 // DPCT_LABEL_BEGIN|partition_point|dpct
@@ -577,6 +658,53 @@ merge(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1, Iter2 keys_first2,
 }
 // DPCT_LABEL_END
 
+
+// DPCT_LABEL_BEGIN|merge_usm_none|dpct
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasAlgorithm|merge
+// DplExtrasFunctional|check_device_ptr_and_launch
+// DplExtrasFunctional|all_are_pointer_v
+// Device|get_default_queue
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+#ifdef DPCT_USM_LEVEL_NONE
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5, typename Ptr6, typename Comp>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
+    std::pair<Ptr5, Ptr6>>
+merge(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
+      Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
+      Ptr6 values_result, Comp comp) {
+  return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::par_unseq,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      comp, size1, size2,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
+         Ptr3 start3, Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
+        return dpct::merge(std::forward<decltype(policy)>(policy), start1, end1,
+                           start2, end2, start3, start4, start5, start6, comp);
+      },
+      keys_result, values_result, // return base
+      keys_first1, keys_first2, values_first1, values_first2, keys_result,
+      values_result); // all ptrs
+}
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5, typename Ptr6>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
+    std::pair<Ptr5, Ptr6>>
+merge(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
+      Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
+      Ptr6 values_result) {
+  return dpct::merge(keys_first1, size1, keys_first2, size2, values_first1,
+                     values_first2, keys_result, values_result,
+                     dpct::internal::__less());
+}
+#endif // DPCT_USM_LEVEL_NONE
+// DPCT_LABEL_END
+
 // DPCT_LABEL_BEGIN|iota|dpct
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasFunctional|sequence_fun
@@ -711,7 +839,7 @@ void for_each_index(Policy &&policy, Iter first, Iter last, Operator unary_op) {
 // DPCT_CODE
 template <class Policy, class Iter1, class Iter2, class Iter3, class Iter4,
           class Iter5>
-std::pair<Iter4, Iter5>
+internal::enable_if_execution_policy<Policy, std::pair<Iter4, Iter5>>
 set_intersection(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
                  Iter2 keys_first2, Iter2 keys_last2, Iter3 values_first1,
                  Iter4 keys_result, Iter5 values_result) {
@@ -745,7 +873,7 @@ set_intersection(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
 
 template <class Policy, class Iter1, class Iter2, class Iter3, class Iter4,
           class Iter5, class Comp>
-std::pair<Iter4, Iter5>
+internal::enable_if_execution_policy<Policy, std::pair<Iter4, Iter5>>
 set_intersection(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
                  Iter2 keys_first2, Iter2 keys_last2, Iter3 values_first1,
                  Iter4 keys_result, Iter5 values_result, Comp comp) {
@@ -778,6 +906,53 @@ set_intersection(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
 }
 // DPCT_LABEL_END
 
+// DPCT_LABEL_BEGIN|set_intersection_usm_none|dpct
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasAlgorithm|set_intersection
+// DplExtrasFunctional|check_device_ptr_and_launch
+// DplExtrasFunctional|all_are_pointer_v
+// Device|get_default_queue
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+#ifdef DPCT_USM_LEVEL_NONE
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5, typename Comp>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5>,
+    std::pair<Ptr4, Ptr5>>
+set_intersection(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
+                 Ptr3 values_first1, Ptr4 keys_result, Ptr5 values_result,
+                 Comp comp) {
+  return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::par,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      comp, size1, size2,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
+         Ptr3 start3, Ptr4 start4, Ptr5 start5, Comp comp) {
+        return dpct::set_intersection(std::forward<decltype(policy)>(policy),
+                                      start1, end1, start2, end2, start3,
+                                      start4, start5, comp);
+      },
+      keys_result, values_result, // return base
+      keys_first1, keys_first2, values_first1, keys_result,
+      values_result // all ptrs
+  );
+}
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5>,
+    std::pair<Ptr4, Ptr5>>
+set_intersection(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
+                 Ptr3 values_first1, Ptr4 keys_result, Ptr5 values_result) {
+  return dpct::set_intersection(keys_first1, size1, keys_first2, size2,
+                                values_first1, keys_result, values_result,
+                                dpct::internal::__less());
+}
+#endif // DPCT_USM_LEVEL_NONE
+// DPCT_LABEL_END
+
 // DPCT_LABEL_BEGIN|set_symmetric_difference|dpct
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasFunctional|compare_key_fun
@@ -785,7 +960,7 @@ set_intersection(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
 // DPCT_CODE
 template <class Policy, class Iter1, class Iter2, class Iter3, class Iter4,
           class Iter5, class Iter6>
-std::pair<Iter5, Iter6>
+internal::enable_if_execution_policy<Policy, std::pair<Iter5, Iter6>>
 set_symmetric_difference(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
                          Iter2 keys_first2, Iter2 keys_last2,
                          Iter3 values_first1, Iter4 values_first2,
@@ -821,7 +996,7 @@ set_symmetric_difference(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
 
 template <class Policy, class Iter1, class Iter2, class Iter3, class Iter4,
           class Iter5, class Iter6, class Comp>
-std::pair<Iter5, Iter6>
+internal::enable_if_execution_policy<Policy, std::pair<Iter5, Iter6>>
 set_symmetric_difference(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
                          Iter2 keys_first2, Iter2 keys_last2,
                          Iter3 values_first1, Iter4 values_first2,
@@ -856,6 +1031,54 @@ set_symmetric_difference(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
 }
 // DPCT_LABEL_END
 
+// DPCT_LABEL_BEGIN|set_symmetric_difference_usm_none|dpct
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasAlgorithm|set_symmetric_difference
+// DplExtrasFunctional|check_device_ptr_and_launch
+// DplExtrasFunctional|all_are_pointer_v
+// Device|get_default_queue
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+#ifdef DPCT_USM_LEVEL_NONE
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5, typename Ptr6, typename Comp>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
+    std::pair<Ptr5, Ptr6>>
+set_symmetric_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
+                         Size size2, Ptr3 values_first1, Ptr4 values_first2,
+                         Ptr5 keys_result, Ptr6 values_result, Comp comp) {
+  return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::par,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      comp, size1, size2,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
+         Ptr3 start3, Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
+        return dpct::set_symmetric_difference(
+            std::forward<decltype(policy)>(policy), start1, end1, start2, end2,
+            start3, start4, start5, start6);
+      },
+      keys_result, values_result, // return base
+      keys_first1, keys_first2, values_first1, values_first2, keys_result,
+      values_result // all ptrs
+  );
+}
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5, typename Ptr6>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
+    std::pair<Ptr5, Ptr6>>
+set_symmetric_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
+                         Size size2, Ptr3 values_first1, Ptr4 values_first2,
+                         Ptr5 keys_result, Ptr6 values_result) {
+  return dpct::set_symmetric_difference(
+      keys_first1, size1, keys_first2, size2, values_first1, values_first2,
+      keys_result, values_result, dpct::internal::__less());
+}
+#endif // DPCT_USM_LEVEL_NONE
+// DPCT_LABEL_END
+
 // DPCT_LABEL_BEGIN|set_difference|dpct
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasFunctional|compare_key_fun
@@ -863,7 +1086,7 @@ set_symmetric_difference(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
 // DPCT_CODE
 template <class Policy, class Iter1, class Iter2, class Iter3, class Iter4,
           class Iter5, class Iter6>
-std::pair<Iter5, Iter6>
+internal::enable_if_execution_policy<Policy, std::pair<Iter5, Iter6>>
 set_difference(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
                Iter2 keys_first2, Iter2 keys_last2, Iter3 values_first1,
                Iter4 values_first2, Iter5 keys_result, Iter6 values_result) {
@@ -898,7 +1121,8 @@ set_difference(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
 
 template <class Policy, class Iter1, class Iter2, class Iter3, class Iter4,
           class Iter5, class Iter6, class Comp>
-std::pair<Iter5, Iter6> set_difference(Policy &&policy, Iter1 keys_first1,
+internal::enable_if_execution_policy<Policy, std::pair<Iter5, Iter6>>
+set_difference(Policy &&policy, Iter1 keys_first1,
                                        Iter1 keys_last1, Iter2 keys_first2,
                                        Iter2 keys_last2, Iter3 values_first1,
                                        Iter4 values_first2, Iter5 keys_result,
@@ -931,6 +1155,54 @@ std::pair<Iter5, Iter6> set_difference(Policy &&policy, Iter1 keys_first1,
       oneapi::dpl::make_zip_iterator(keys_result, values_result), ret_val);
   return std::make_pair(keys_result + n1, values_result + n1);
 }
+// DPCT_LABEL_END
+
+// DPCT_LABEL_BEGIN|set_difference_usm_none|dpct
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasAlgorithm|set_difference
+// DplExtrasFunctional|check_device_ptr_and_launch
+// DplExtrasFunctional|all_are_pointer_v
+// Device|get_default_queue
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+#ifdef DPCT_USM_LEVEL_NONE
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5, typename Ptr6, typename Comp>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
+    std::pair<Ptr5, Ptr6>>
+set_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
+               Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
+               Ptr6 values_result, Comp comp) {
+  return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::par_unseq,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      comp, size1, size2,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
+         Ptr3 start3, Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
+        return dpct::set_difference(std::forward<decltype(policy)>(policy),
+                                    start1, end1, start2, end2, start3, start4,
+                                    start5, start6, comp);
+      },
+      keys_result, values_result, // return base
+      keys_first1, keys_first2, values_first1, values_first2, keys_result,
+      values_result // all ptrs
+  );
+}
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5, typename Ptr6>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
+    std::pair<Ptr5, Ptr6>>
+set_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
+               Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
+               Ptr6 values_result) {
+  return dpct::set_difference(keys_first1, size1, keys_first2, size2,
+                              values_first1, values_first2, keys_result,
+                              values_result, dpct::internal::__less());
+}
+#endif // DPCT_USM_LEVEL_NONE
 // DPCT_LABEL_END
 
 // DPCT_LABEL_BEGIN|set_union|dpct
@@ -1010,6 +1282,54 @@ set_union(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
 }
 // DPCT_LABEL_END
 
+// DPCT_LABEL_BEGIN|set_union_usm_none|dpct
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasAlgorithm|set_union
+// DplExtrasFunctional|check_device_ptr_and_launch
+// DplExtrasFunctional|all_are_pointer_v
+// Device|get_default_queue
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+#ifdef DPCT_USM_LEVEL_NONE
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5, typename Ptr6, typename Comp>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
+    std::pair<Ptr5, Ptr6>>
+set_union(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
+          Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
+          Ptr6 values_result, Comp comp) {
+  return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::par,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      comp, size1, size2,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
+         Ptr3 start3, Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
+        return dpct::set_union(std::forward<decltype(policy)>(policy), start1,
+                               end1, start2, end2, start3, start4, start5,
+                               start6, comp);
+      },
+      keys_result, values_result, // return base
+      keys_first1, keys_first2, values_first1, values_first2, keys_result,
+      values_result // all ptrs
+  );
+}
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5, typename Ptr6>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
+    std::pair<Ptr5, Ptr6>>
+set_union(Ptr1 keys_first1, Size size, Ptr2 keys_first2, Size size2,
+          Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
+          Ptr6 values_result) {
+  return dpct::set_union(keys_first1, size, keys_first2, size2, values_first1,
+                         values_first2, keys_result, values_result,
+                         dpct::internal::__less());
+}
+#endif // DPCT_USM_LEVEL_NONE
+// DPCT_LABEL_END
+
 // DPCT_LABEL_BEGIN|stable_partition_copy|dpct
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasFunctional|predicate_key_fun
@@ -1059,6 +1379,59 @@ stable_partition_copy(Policy &&policy, Iter1 first, Iter1 last, Iter3 out_true,
 }
 // DPCT_LABEL_END
 
+// DPCT_LABEL_BEGIN|stable_partition_copy_usm_none|dpct
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasAlgorithm|stable_partition_copy
+// DplExtrasFunctional|check_device_ptr_and_launch
+// DplExtrasFunctional|all_are_pointer_v
+// Device|get_default_queue
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+#ifdef DPCT_USM_LEVEL_NONE
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Pred>
+std::enable_if_t<dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4>,
+                 std::pair<Ptr3, Ptr4>>
+stable_partition_copy(Ptr1 first, Size size, Ptr2 mask, Ptr3 out_true,
+                      Ptr4 out_false, Pred p) {
+  return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::par_unseq,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()), p,
+      size,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
+         Ptr4 start4, Pred pred) {
+        return dpct::stable_partition_copy(
+            std::forward<decltype(policy)>(policy), start1, end1, start2,
+            start3, start4, pred);
+      },
+      out_true, out_false,             // return base
+      first, mask, out_true, out_false // all ptrs
+  );
+}
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Pred>
+std::enable_if_t<dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3>,
+                 std::pair<Ptr2, Ptr3>>
+stable_partition_copy(Ptr1 first, Size size, Ptr2 out_true, Ptr3 out_false,
+                      Pred p) {
+  return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::par_unseq,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()), p,
+      size,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
+         Pred pred) {
+        return dpct::stable_partition_copy(
+            std::forward<decltype(policy)>(policy), start1, end1, start2,
+            start3, pred);
+      },
+      out_true, out_false,       // return base
+      first, out_true, out_false // all ptrs
+  );
+}
+#endif // DPCT_USM_LEVEL_NONE
+// DPCT_LABEL_END
+
 // DPCT_LABEL_BEGIN|partition_copy|dpct
 // DPCT_DEPENDENCY_BEGIN
 // DplExtrasAlgorithm|stable_partition_copy
@@ -1082,6 +1455,37 @@ partition_copy(Policy &&policy, Iter1 first, Iter1 last, Iter2 mask,
   return stable_partition_copy(std::forward<Policy>(policy), first, last, mask,
                                out_true, out_false, p);
 }
+// DPCT_LABEL_END
+
+// DPCT_LABEL_BEGIN|partition_copy_usm_none|dpct
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasAlgorithm|partition_copy
+// DplExtrasFunctional|check_device_ptr_and_launch
+// DplExtrasFunctional|all_are_pointer_v
+// Device|get_default_queue
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+#ifdef DPCT_USM_LEVEL_NONE
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Pred>
+std::enable_if_t<dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4>,
+                 std::pair<Ptr3, Ptr4>>
+partition_copy(Ptr1 first, Size size, Ptr2 mask, Ptr3 out_true, Ptr4 out_false,
+               Pred p) {
+  return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::par_unseq,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()), p,
+      size,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
+         Ptr4 start4, Pred pred) {
+        return dpct::partition_copy(std::forward<decltype(policy)>(policy),
+                                    start1, end1, start2, start3, start4, pred);
+      },
+      out_true, out_false,             // return base
+      first, mask, out_true, out_false // all ptrs
+  );
+}
+#endif // DPCT_USM_LEVEL_NONE
 // DPCT_LABEL_END
 
 // DPCT_LABEL_BEGIN|stable_partition|dpct

--- a/clang/runtime/dpct-rt/include/dpl_extras/functional.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/functional.h.inc
@@ -406,6 +406,143 @@ private:
 };
 // DPCT_LABEL_END
 
+// DPCT_LABEL_BEGIN|all_are_pointer_v|dpct::internal
+// DPCT_DEPENDENCY_EMPTY
+// DPCT_CODE
+template <typename... T>
+constexpr inline bool all_are_pointer_v = (... & std::is_pointer_v<T>);
+// DPCT_LABEL_END
+
+// DPCT_LABEL_BEGIN|make_device_pointer_from_virtual_pointer|dpct::internal
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasMemory|device_pointer_forward_decl
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+#ifdef DPCT_USM_LEVEL_NONE
+template <typename T>
+dpct::device_pointer<typename std::iterator_traits<T>::value_type>
+make_device_pointer_from_virtual_pointer(T t) {
+  return dpct::device_pointer<typename std::iterator_traits<T>::value_type>(t);
+}
+#endif //DPCT_USM_LEVEL_NONE
+// DPCT_LABEL_END
+
+// DPCT_LABEL_BEGIN|to_virtual_pointer_space|dpct::internal
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasFunctional|make_device_pointer_from_virtual_pointer
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+#ifdef DPCT_USM_LEVEL_NONE
+template <typename InitialPtr, typename VirtPtr>
+VirtPtr to_virtual_pointer_space(InitialPtr in_ptr, VirtPtr virt_base) {
+  return virt_base +
+         (in_ptr -
+          dpct::internal::make_device_pointer_from_virtual_pointer(virt_base));
+}
+#endif //DPCT_USM_LEVEL_NONE
+// DPCT_LABEL_END
+
+// DPCT_LABEL_BEGIN|check_device_ptr_and_launch|dpct::internal
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasFunctional|make_device_pointer_from_virtual_pointer
+// DplExtrasFunctional|to_virtual_pointer_space
+// DplExtrasFunctional|all_are_pointer_v
+// Memory|is_device_ptr|UsmNone
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+#ifdef DPCT_USM_LEVEL_NONE
+template <typename ExecutionPolicyHost, typename ExecutionPolicyDevice,
+          typename Oper, typename Func, typename RetPtr1, typename RetPtr2,
+          typename Ptr1, typename Ptr2, typename... MiddlePtrs>
+inline std::enable_if_t<dpct::internal::all_are_pointer_v<
+                            Ptr1, Ptr2, RetPtr1, RetPtr2, MiddlePtrs...>,
+                        ::std::pair<RetPtr1, RetPtr2>>
+check_device_ptr_and_launch(ExecutionPolicyHost &&host_policy,
+                            ExecutionPolicyDevice &&dev_policy, Oper op,
+                            std::size_t size1, std::size_t size2, Func func,
+                            RetPtr1 ret_base1, RetPtr2 ret_base2, Ptr1 start1,
+                            Ptr2 start2, MiddlePtrs... middle_ptrs) {
+  if (dpct::is_device_ptr(start1)) {
+
+    auto ret =
+        func(std::forward<ExecutionPolicyDevice>(dev_policy),
+             dpct::internal::make_device_pointer_from_virtual_pointer(start1),
+             dpct::internal::make_device_pointer_from_virtual_pointer(start1) +
+                 size1,
+             dpct::internal::make_device_pointer_from_virtual_pointer(start2),
+             dpct::internal::make_device_pointer_from_virtual_pointer(start2) +
+                 size2,
+             dpct::internal::make_device_pointer_from_virtual_pointer(
+                 middle_ptrs)...,
+             op);
+    return ::std::pair<RetPtr1, RetPtr2>(
+        dpct::internal::to_virtual_pointer_space(ret.first, ret_base1),
+        dpct::internal::to_virtual_pointer_space(ret.second, ret_base2));
+  } else {
+    return func(std::forward<ExecutionPolicyHost>(host_policy), start1,
+                start1 + size1, start2, start2 + size2, middle_ptrs..., op);
+  }
+}
+
+template <typename ExecutionPolicyHost, typename ExecutionPolicyDevice,
+          typename Oper, typename Func, typename RetPtr1, typename RetPtr2,
+          typename Ptr1, typename... MiddlePtrs>
+inline std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, RetPtr1, RetPtr2, MiddlePtrs...>,
+    ::std::pair<RetPtr1, RetPtr2>>
+check_device_ptr_and_launch(ExecutionPolicyHost &&host_policy,
+                            ExecutionPolicyDevice &&dev_policy, Oper op,
+                            std::size_t size, Func func, RetPtr1 ret_base1,
+                            RetPtr2 ret_base2, Ptr1 start1,
+                            MiddlePtrs... middle_ptrs) {
+  if (dpct::is_device_ptr(start1)) {
+    auto ret = func(
+        std::forward<ExecutionPolicyDevice>(dev_policy),
+        dpct::internal::make_device_pointer_from_virtual_pointer(start1),
+        dpct::internal::make_device_pointer_from_virtual_pointer(start1) + size,
+        dpct::internal::make_device_pointer_from_virtual_pointer(
+            middle_ptrs)...,
+        op);
+    return ::std::pair<RetPtr1, RetPtr2>(
+        dpct::internal::to_virtual_pointer_space(ret.first, ret_base1),
+        dpct::internal::to_virtual_pointer_space(ret.second, ret_base2));
+  } else {
+    return func(std::forward<ExecutionPolicyHost>(host_policy), start1,
+                start1 + size, middle_ptrs..., op);
+  }
+}
+
+template <typename ExecutionPolicyHost, typename ExecutionPolicyDevice,
+          typename ValueType, typename Oper, typename Func, typename RetPtr1,
+          typename RetPtr2, typename Ptr1, typename... MiddlePtrs>
+inline std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, RetPtr1, RetPtr2, MiddlePtrs...>,
+    ::std::pair<RetPtr1, RetPtr2>>
+check_device_ptr_and_launch_w_value(ExecutionPolicyHost &&host_policy,
+                                    ExecutionPolicyDevice &&dev_policy,
+                                    ValueType value, Oper op, std::size_t size,
+                                    Func func, RetPtr1 ret_base1,
+                                    RetPtr2 ret_base2, Ptr1 start1,
+                                    MiddlePtrs... middle_ptrs) {
+  if (dpct::is_device_ptr(start1)) {
+    auto ret = func(
+        std::forward<ExecutionPolicyDevice>(dev_policy),
+        dpct::internal::make_device_pointer_from_virtual_pointer(start1),
+        dpct::internal::make_device_pointer_from_virtual_pointer(start1) + size,
+        dpct::internal::make_device_pointer_from_virtual_pointer(
+            middle_ptrs)...,
+        value, op);
+    return ::std::pair<RetPtr1, RetPtr2>(
+        dpct::internal::to_virtual_pointer_space(ret.first, ret_base1),
+        dpct::internal::to_virtual_pointer_space(ret.second, ret_base2));
+  } else {
+    return func(std::forward<ExecutionPolicyHost>(host_policy), start1,
+                start1 + size, middle_ptrs..., value, op);
+  }
+}
+#endif //DPCT_USM_LEVEL_NONE
+// DPCT_LABEL_END
+
 // This following code is similar to a section of code in
 // oneDPL/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
 // It has a similar approach, and could be consolidated.

--- a/clang/runtime/dpct-rt/include/dpl_extras/functional.h.inc
+++ b/clang/runtime/dpct-rt/include/dpl_extras/functional.h.inc
@@ -234,7 +234,9 @@ private:
 // DPCT_LABEL_END
 
 // DPCT_LABEL_BEGIN|compare_key_fun|dpct::internal
-// DPCT_DEPENDENCY_EMPTY
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasFunctional|__less
+// DPCT_DEPENDENCY_END
 // DPCT_CODE
 // Functor compares first element (key) from tied sequence.
 template <typename Compare = class internal::__less> struct compare_key_fun {
@@ -424,7 +426,7 @@ dpct::device_pointer<typename std::iterator_traits<T>::value_type>
 make_device_pointer_from_virtual_pointer(T t) {
   return dpct::device_pointer<typename std::iterator_traits<T>::value_type>(t);
 }
-#endif //DPCT_USM_LEVEL_NONE
+#endif // DPCT_USM_LEVEL_NONE
 // DPCT_LABEL_END
 
 // DPCT_LABEL_BEGIN|to_virtual_pointer_space|dpct::internal
@@ -439,7 +441,7 @@ VirtPtr to_virtual_pointer_space(InitialPtr in_ptr, VirtPtr virt_base) {
          (in_ptr -
           dpct::internal::make_device_pointer_from_virtual_pointer(virt_base));
 }
-#endif //DPCT_USM_LEVEL_NONE
+#endif // DPCT_USM_LEVEL_NONE
 // DPCT_LABEL_END
 
 // DPCT_LABEL_BEGIN|check_device_ptr_and_launch|dpct::internal
@@ -511,7 +513,18 @@ check_device_ptr_and_launch(ExecutionPolicyHost &&host_policy,
                 start1 + size, middle_ptrs..., op);
   }
 }
+#endif // DPCT_USM_LEVEL_NONE
+// DPCT_LABEL_END
 
+// DPCT_LABEL_BEGIN|check_device_ptr_and_launch_w_value|dpct::internal
+// DPCT_DEPENDENCY_BEGIN
+// DplExtrasFunctional|make_device_pointer_from_virtual_pointer
+// DplExtrasFunctional|to_virtual_pointer_space
+// DplExtrasFunctional|all_are_pointer_v
+// Memory|is_device_ptr|UsmNone
+// DPCT_DEPENDENCY_END
+// DPCT_CODE
+#ifdef DPCT_USM_LEVEL_NONE
 template <typename ExecutionPolicyHost, typename ExecutionPolicyDevice,
           typename ValueType, typename Oper, typename Func, typename RetPtr1,
           typename RetPtr2, typename Ptr1, typename... MiddlePtrs>
@@ -540,7 +553,7 @@ check_device_ptr_and_launch_w_value(ExecutionPolicyHost &&host_policy,
                 start1 + size, middle_ptrs..., value, op);
   }
 }
-#endif //DPCT_USM_LEVEL_NONE
+#endif // DPCT_USM_LEVEL_NONE
 // DPCT_LABEL_END
 
 // This following code is similar to a section of code in

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1698,61 +1698,80 @@ equal_range(_ExecutionPolicy &&policy,
 
 #ifdef DPCT_USM_LEVEL_NONE
 
-template <typename Ptr1, typename Size, typename ValueLessComparable, typename StrictWeakOrdering>
+template <typename Ptr1, typename Size, typename ValueLessComparable,
+          typename StrictWeakOrdering>
 inline std::enable_if_t<std::is_pointer_v<Ptr1>, ::std::pair<Ptr1, Ptr1>>
-equal_range(Ptr1 start, Size size, const ValueLessComparable& value, StrictWeakOrdering comp)
-{
-    return dpct::internal::check_device_ptr_and_launch(
-        oneapi::dpl::execution::seq, oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-        start, size, 
-        [](auto policy, Ptr1 start, Ptr1 end, const ValueLessComparable& value, StrictWeakOrdering comp){return dpct::equal_range(policy, start, end, value, comp);}, 
-        value, comp);
+equal_range(Ptr1 start, Size size, const ValueLessComparable &value,
+            StrictWeakOrdering comp) {
+  return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::seq,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      start, size,
+      [](auto policy, Ptr1 start, Ptr1 end, const ValueLessComparable &value,
+         StrictWeakOrdering comp) {
+        return dpct::equal_range(policy, start, end, value, comp);
+      },
+      value, comp);
 }
 
 template <typename _T, typename Size, typename ValueLessComparable>
-inline
-std::enable_if_t<std::is_pointer_v<_T>, ::std::pair<_T, _T>>
-equal_range(_T start, Size size, const ValueLessComparable& value)
-{
+inline std::enable_if_t<std::is_pointer_v<_T>, ::std::pair<_T, _T>>
+equal_range(_T start, Size size, const ValueLessComparable &value) {
   return dpct::equal_range(start, size, value, internal::__less());
 }
 
 template <typename Ptr1, typename Size, typename Ptr2, typename BinaryPred>
-std::pair<Ptr1, Ptr2> unique(Ptr1 start1, Size size, Ptr2 start2, BinaryPred binary_pred)
-{
-    return dpct::internal::check_device_ptr_and_launch(
-        oneapi::dpl::execution::seq, oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-        start1, size, start2,
-        [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, BinaryPred binary_pred){return dpct::unique(policy, start1, end1, start2, binary_pred);},
-        binary_pred);
+std::pair<Ptr1, Ptr2> unique(Ptr1 start1, Size size, Ptr2 start2,
+                             BinaryPred binary_pred) {
+  return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::seq,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      start1, size, start2,
+      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2,
+         BinaryPred binary_pred) {
+        return dpct::unique(policy, start1, end1, start2, binary_pred);
+      },
+      binary_pred);
 }
 
 template <typename Ptr1, typename Size, typename Ptr2>
-std::pair<Ptr1, Ptr2> unique(Ptr1 start1, Size size, Ptr2 start2) 
-{
-  return dpct::unique(start1, size, start2, std::equal_to<typename std::iterator_traits<Ptr1>::value_type>());
+std::pair<Ptr1, Ptr2> unique(Ptr1 start1, Size size, Ptr2 start2) {
+  return dpct::unique(
+      start1, size, start2,
+      std::equal_to<typename std::iterator_traits<Ptr1>::value_type>());
 }
 
-template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
-          typename BinaryPred>
-std::pair<Ptr3, Ptr4> unique_copy(Ptr1 keys_first, Size size,  Ptr2 values_first,
-                                    Ptr3 keys_result, Ptr4 values_result,
-                                    BinaryPred binary_pred) 
-{
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename BinaryPred>
+std::pair<Ptr3, Ptr4> unique_copy(Ptr1 keys_first, Size size, Ptr2 values_first,
+                                  Ptr3 keys_result, Ptr4 values_result,
+                                  BinaryPred binary_pred) {
   return dpct::internal::check_device_ptr_and_launch(
-    oneapi::dpl::execution::seq, oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-    keys_first, size, values_first, keys_result, values_result,
-    [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3, Ptr4 start4, BinaryPred binary_pred){return dpct::unique_copy(policy, start1, end1, start2, start3, start4, binary_pred);},
-    binary_pred);
+      oneapi::dpl::execution::seq,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      keys_first, size, values_first, keys_result, values_result,
+      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
+         Ptr4 start4, BinaryPred binary_pred) {
+        return dpct::unique_copy(policy, start1, end1, start2, start3, start4,
+                                 binary_pred);
+      },
+      binary_pred);
 }
 
-template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4>
-std::pair<Ptr3, Ptr4> unique_copy(Ptr1 keys_first, Size size, Ptr2 values_first, Ptr3 keys_result, Ptr4 values_result)
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4>
+std::pair<Ptr3, Ptr4> unique_copy(Ptr1 keys_first, Size size, Ptr2 values_first,
+                                  Ptr3 keys_result, Ptr4 values_result) {
+  return dpct::unique_copy(
+      keys_first, size, values_first, keys_result, values_result,
+      std::equal_to<typename std::iterator_traits<Ptr1>::value_type>());
+}
+
 {
   return dpct::unique_copy(keys_first, size, values_first, keys_result, values_result, std::equal_to<typename std::iterator_traits<Ptr1>::value_type>());
 }
 
-#endif //#DPCT_USM_LEVEL_NONE
+#endif // #DPCT_USM_LEVEL_NONE
 
 template <typename Policy, typename Iter1, typename Iter2, typename Iter3>
 inline ::std::enable_if_t<

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1779,16 +1779,18 @@ std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
 merge(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
       Size size2, Ptr3 values_first1, Ptr4 values_first2,
       Ptr5 keys_result, Ptr6 values_result, Comp comp)
-{
+{ 
     return dpct::internal::check_device_ptr_and_launch(
       oneapi::dpl::execution::seq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      comp, keys_first1, size1, keys_first2, size2, 
+      comp, size1, size2, 
       [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2, Ptr3 start3,
          Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
         return dpct::merge(policy, start1, end1, start2, end2, start3, start4, start5, 
                                  start6, comp);
-      }, keys_result, values_result, values_first1, values_first2);
+      }, 
+      keys_result, values_result, //return base
+      keys_first1, keys_first2, values_first1, values_first2, keys_result, values_result); //all ptrs
 }
 
 
@@ -1817,12 +1819,14 @@ set_intersection(Ptr1 keys_first1, Size size1,
     return dpct::internal::check_device_ptr_and_launch(
       oneapi::dpl::execution::seq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      comp, keys_first1, size1, keys_first2, size2,
+      comp, size1, size2,
       [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2, Ptr3 start3,
          Ptr4 start4, Ptr5 start5, Comp comp) {
         return dpct::set_intersection(policy, start1, end1, start2, end2, start3, start4, start5,
                                  comp);
-      }, keys_result, values_result, values_first1);
+      }, 
+      keys_result, values_result,
+      keys_first1, keys_first2, values_first1, keys_result, values_result);
 
 }
 
@@ -1854,12 +1858,13 @@ set_symmetric_difference(Ptr1 keys_first1, Size size1,
     return dpct::internal::check_device_ptr_and_launch(
       oneapi::dpl::execution::seq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      comp, keys_first1, size1, keys_first2, size2,
+      comp, size1, size2,
       [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2, Ptr3 start3,
          Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
         return dpct::set_symmetric_difference(policy, start1, end1, start2, end2, start3, start4, start5, 
                                  start6);
-      }, keys_result, values_result,values_first1, values_first2);
+      }, keys_result, values_result,
+      keys_first1, keys_first2, values_first1, values_first2, keys_result, values_result);
 }
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
@@ -1892,12 +1897,13 @@ set_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
     return dpct::internal::check_device_ptr_and_launch(
       oneapi::dpl::execution::seq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      comp, keys_first1, size1, keys_first2, size2,
+      comp, size1, size2,
       [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2, Ptr3 start3,
          Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
         return dpct::set_difference(policy, start1, end1, start2, end2, start3, start4, start5, 
                                  start6, comp);
-      },  keys_result, values_result,values_first1, values_first2);
+      },  keys_result, values_result,
+      keys_first1, keys_first2, values_first1, values_first2, keys_result, values_result);
 }
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
@@ -1927,12 +1933,13 @@ set_union(Ptr1 keys_first1, Size size1,
     return dpct::internal::check_device_ptr_and_launch(
       oneapi::dpl::execution::seq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      comp, keys_first1, size1, keys_first2, size2, 
+      comp, size1, size2, 
       [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2, Ptr3 start3,
          Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
         return dpct::set_union(policy, start1, end1, start2, end2, start3, start4, start5, 
                                  start6, comp);
-      }, keys_result, values_result, values_first1, values_first2);
+      }, keys_result, values_result,
+      keys_first1, keys_first2, values_first1, values_first2, keys_result, values_result);
 }
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1698,15 +1698,15 @@ equal_range(_ExecutionPolicy &&policy,
 
 #ifdef DPCT_USM_LEVEL_NONE
 
-template <typename _T, typename Size, typename ValueLessComparable, typename StrictWeakOrdering>
-inline std::enable_if_t<std::is_pointer_v<_T>, ::std::pair<_T, _T>>
-equal_range(_T start, Size size, const ValueLessComparable& value, StrictWeakOrdering comp)
+template <typename Ptr1, typename Size, typename ValueLessComparable, typename StrictWeakOrdering>
+inline std::enable_if_t<std::is_pointer_v<Ptr1>, ::std::pair<Ptr1, Ptr1>>
+equal_range(Ptr1 start, Size size, const ValueLessComparable& value, StrictWeakOrdering comp)
 {
     return dpct::internal::check_device_ptr_and_launch(
         oneapi::dpl::execution::seq, oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
         start, size, 
-        [](auto policy, auto start, auto end, auto value, auto comp){return dpct::equal_range(policy, start, end, value, comp);}, 
-        5, comp);
+        [](auto policy, Ptr1 start, Ptr1 end, const ValueLessComparable& value, StrictWeakOrdering comp){return dpct::equal_range(policy, start, end, value, comp);}, 
+        value, comp);
 }
 
 template <typename _T, typename Size, typename ValueLessComparable>
@@ -1717,6 +1717,40 @@ equal_range(_T start, Size size, const ValueLessComparable& value)
   return dpct::equal_range(start, size, value, internal::__less());
 }
 
+template <typename Ptr1, typename Size, typename Ptr2, typename BinaryPred>
+std::pair<Ptr1, Ptr2> unique(Ptr1 start1, Size size, Ptr2 start2, BinaryPred binary_pred)
+{
+    return dpct::internal::check_device_ptr_and_launch(
+        oneapi::dpl::execution::seq, oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+        start1, size, start2,
+        [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, BinaryPred binary_pred){return dpct::unique(policy, start1, end1, start2, binary_pred);},
+        binary_pred);
+}
+
+template <typename Ptr1, typename Size, typename Ptr2>
+std::pair<Ptr1, Ptr2> unique(Ptr1 start1, Size size, Ptr2 start2) 
+{
+  return dpct::unique(start1, size, start2, std::equal_to<typename std::iterator_traits<Ptr1>::value_type>());
+}
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
+          typename BinaryPred>
+std::pair<Ptr3, Ptr4> unique_copy(Ptr1 keys_first, Size size,  Ptr2 values_first,
+                                    Ptr3 keys_result, Ptr4 values_result,
+                                    BinaryPred binary_pred) 
+{
+  return dpct::internal::check_device_ptr_and_launch(
+    oneapi::dpl::execution::seq, oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+    keys_first, size, values_first, keys_result, values_result,
+    [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3, Ptr4 start4, BinaryPred binary_pred){return dpct::unique_copy(policy, start1, end1, start2, start3, start4, binary_pred);},
+    binary_pred);
+}
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4>
+std::pair<Ptr3, Ptr4> unique_copy(Ptr1 keys_first, Size size, Ptr2 values_first, Ptr3 keys_result, Ptr4 values_result)
+{
+  return dpct::unique_copy(keys_first, size, values_first, keys_result, values_result, std::equal_to<typename std::iterator_traits<Ptr1>::value_type>());
+}
 
 #endif //#DPCT_USM_LEVEL_NONE
 

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -566,7 +566,7 @@ void for_each_index(Policy &&policy, Iter first, Iter last, Operator unary_op) {
 
 template <class Policy, class Iter1, class Iter2, class Iter3, class Iter4,
           class Iter5>
-std::pair<Iter4, Iter5>
+internal::enable_if_execution_policy<Policy, std::pair<Iter4, Iter5>>
 set_intersection(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
                  Iter2 keys_first2, Iter2 keys_last2, Iter3 values_first1,
                  Iter4 keys_result, Iter5 values_result) {
@@ -600,7 +600,7 @@ set_intersection(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
 
 template <class Policy, class Iter1, class Iter2, class Iter3, class Iter4,
           class Iter5, class Comp>
-std::pair<Iter4, Iter5>
+internal::enable_if_execution_policy<Policy, std::pair<Iter4, Iter5>>
 set_intersection(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
                  Iter2 keys_first2, Iter2 keys_last2, Iter3 values_first1,
                  Iter4 keys_result, Iter5 values_result, Comp comp) {
@@ -634,7 +634,7 @@ set_intersection(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
 
 template <class Policy, class Iter1, class Iter2, class Iter3, class Iter4,
           class Iter5, class Iter6>
-std::pair<Iter5, Iter6>
+internal::enable_if_execution_policy<Policy, std::pair<Iter5, Iter6>>
 set_symmetric_difference(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
                          Iter2 keys_first2, Iter2 keys_last2,
                          Iter3 values_first1, Iter4 values_first2,
@@ -670,7 +670,7 @@ set_symmetric_difference(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
 
 template <class Policy, class Iter1, class Iter2, class Iter3, class Iter4,
           class Iter5, class Iter6, class Comp>
-std::pair<Iter5, Iter6>
+internal::enable_if_execution_policy<Policy, std::pair<Iter5, Iter6>>
 set_symmetric_difference(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
                          Iter2 keys_first2, Iter2 keys_last2,
                          Iter3 values_first1, Iter4 values_first2,
@@ -706,7 +706,7 @@ set_symmetric_difference(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
 
 template <class Policy, class Iter1, class Iter2, class Iter3, class Iter4,
           class Iter5, class Iter6>
-std::pair<Iter5, Iter6>
+internal::enable_if_execution_policy<Policy, std::pair<Iter5, Iter6>>
 set_difference(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
                Iter2 keys_first2, Iter2 keys_last2, Iter3 values_first1,
                Iter4 values_first2, Iter5 keys_result, Iter6 values_result) {
@@ -741,7 +741,7 @@ set_difference(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
 
 template <class Policy, class Iter1, class Iter2, class Iter3, class Iter4,
           class Iter5, class Iter6, class Comp>
-std::pair<Iter5, Iter6> set_difference(Policy &&policy, Iter1 keys_first1,
+internal::enable_if_execution_policy<Policy, std::pair<Iter5, Iter6>> set_difference(Policy &&policy, Iter1 keys_first1,
                                        Iter1 keys_last1, Iter2 keys_first2,
                                        Iter2 keys_last2, Iter3 values_first1,
                                        Iter4 values_first2, Iter5 keys_result,
@@ -1721,7 +1721,8 @@ equal_range(_T start, Size size, const ValueLessComparable &value) {
 }
 
 template <typename Ptr1, typename Size, typename Ptr2, typename BinaryPred>
-std::pair<Ptr1, Ptr2> unique(Ptr1 start1, Size size, Ptr2 start2,
+std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2>, std::pair<Ptr1, Ptr2>>
+unique(Ptr1 start1, Size size, Ptr2 start2,
                              BinaryPred binary_pred) {
   return dpct::internal::check_device_ptr_and_launch(
       oneapi::dpl::execution::seq,
@@ -1735,7 +1736,8 @@ std::pair<Ptr1, Ptr2> unique(Ptr1 start1, Size size, Ptr2 start2,
 }
 
 template <typename Ptr1, typename Size, typename Ptr2>
-std::pair<Ptr1, Ptr2> unique(Ptr1 start1, Size size, Ptr2 start2) {
+std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2>,std::pair<Ptr1, Ptr2>>
+                  unique(Ptr1 start1, Size size, Ptr2 start2) {
   return dpct::unique(
       start1, size, start2,
       std::equal_to<typename std::iterator_traits<Ptr1>::value_type>());
@@ -1760,7 +1762,9 @@ std::pair<Ptr3, Ptr4> unique_copy(Ptr1 keys_first, Size size, Ptr2 values_first,
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
           typename Ptr4>
-std::pair<Ptr3, Ptr4> unique_copy(Ptr1 keys_first, Size size, Ptr2 values_first,
+std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
+                 std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4>, std::pair<Ptr3, Ptr4>>
+unique_copy(Ptr1 keys_first, Size size, Ptr2 values_first,
                                   Ptr3 keys_result, Ptr4 values_result) {
   return dpct::unique_copy(
       keys_first, size, values_first, keys_result, values_result,
@@ -1769,7 +1773,9 @@ std::pair<Ptr3, Ptr4> unique_copy(Ptr1 keys_first, Size size, Ptr2 values_first,
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
           typename Ptr4, typename Ptr5, typename Ptr6, typename Comp>
-std::pair<Ptr5, Ptr6>
+std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
+                 std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
+                 std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>,std::pair<Ptr5, Ptr6>>
 merge(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
       Size size2, Ptr3 values_first1, Ptr4 values_first2,
       Ptr5 keys_result, Ptr6 values_result, Comp comp)
@@ -1777,18 +1783,20 @@ merge(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
     return dpct::internal::check_device_ptr_and_launch(
       oneapi::dpl::execution::seq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      keys_first1, size1, keys_first2, size2, values_first1, values_first2, keys_result, values_result,
+      comp, keys_first1, size1, keys_first2, size2, 
       [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2, Ptr3 start3,
          Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
         return dpct::merge(policy, start1, end1, start2, end2, start3, start4, start5, 
                                  start6, comp);
-      }, comp);
+      }, keys_result, values_result, values_first1, values_first2);
 }
 
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
           typename Ptr4, typename Ptr5, typename Ptr6>
-std::pair<Ptr5, Ptr6>
+std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
+                 std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
+                 std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>,std::pair<Ptr5, Ptr6>>
 merge(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
       Size size2, Ptr3 values_first1, Ptr4 values_first2,
       Ptr5 keys_result, Ptr6 values_result)
@@ -1799,7 +1807,9 @@ merge(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
           typename Ptr5, typename Comp>
-std::pair<Ptr4, Ptr5>
+std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
+                 std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
+                 std::is_pointer_v<Ptr5>,std::pair<Ptr4, Ptr5>>
 set_intersection(Ptr1 keys_first1, Size size1,
                  Ptr2 keys_first2, Size size2, Ptr3 values_first1,
                  Ptr4 keys_result, Ptr5 values_result, Comp comp)
@@ -1807,18 +1817,20 @@ set_intersection(Ptr1 keys_first1, Size size1,
     return dpct::internal::check_device_ptr_and_launch(
       oneapi::dpl::execution::seq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      keys_first1, size1, keys_first2, size2, values_first1, keys_result, values_result,
+      comp, keys_first1, size1, keys_first2, size2,
       [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2, Ptr3 start3,
          Ptr4 start4, Ptr5 start5, Comp comp) {
         return dpct::set_intersection(policy, start1, end1, start2, end2, start3, start4, start5,
                                  comp);
-      }, comp);
+      }, keys_result, values_result, values_first1);
 
 }
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
           typename Ptr5>
-std::pair<Ptr4, Ptr5>
+std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
+                 std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
+                 std::is_pointer_v<Ptr5>,std::pair<Ptr4, Ptr5>>
 set_intersection(Ptr1 keys_first1, Size size1,
                  Ptr2 keys_first2, Size size2, Ptr3 values_first1,
                  Ptr4 keys_result, Ptr5 values_result)
@@ -1831,7 +1843,9 @@ set_intersection(Ptr1 keys_first1, Size size1,
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
           typename Ptr5, typename Ptr6, typename Comp>
-std::pair<Ptr5, Ptr6>
+std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
+                 std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
+                 std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6> ,std::pair<Ptr5, Ptr6>>
 set_symmetric_difference(Ptr1 keys_first1, Size size1,
                          Ptr2 keys_first2, Size size2,
                          Ptr3 values_first1, Ptr4 values_first2,
@@ -1840,17 +1854,19 @@ set_symmetric_difference(Ptr1 keys_first1, Size size1,
     return dpct::internal::check_device_ptr_and_launch(
       oneapi::dpl::execution::seq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      keys_first1, size1, keys_first2, size2, values_first1, values_first2, keys_result, values_result,
+      comp, keys_first1, size1, keys_first2, size2,
       [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2, Ptr3 start3,
          Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
         return dpct::set_symmetric_difference(policy, start1, end1, start2, end2, start3, start4, start5, 
-                                 start6, comp);
-      }, comp);
+                                 start6);
+      }, keys_result, values_result,values_first1, values_first2);
 }
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
           typename Ptr5, typename Ptr6>
-std::pair<Ptr5, Ptr6>
+std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
+                 std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
+                 std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>, std::pair<Ptr5, Ptr6>>
 set_symmetric_difference(Ptr1 keys_first1, Size size1,
                          Ptr2 keys_first2, Size size2,
                          Ptr3 values_first1, Ptr4 values_first2,
@@ -1864,7 +1880,11 @@ set_symmetric_difference(Ptr1 keys_first1, Size size1,
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
           typename Ptr5, typename Ptr6, typename Comp>
-std::pair<Ptr5, Ptr6> set_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
+std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
+                 std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
+                 std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>, 
+                 std::pair<Ptr5, Ptr6>>
+set_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
                                        Size size2, Ptr3 values_first1,
                                        Ptr4 values_first2, Ptr5 keys_result,
                                        Ptr6 values_result, Comp comp)
@@ -1872,17 +1892,19 @@ std::pair<Ptr5, Ptr6> set_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_fir
     return dpct::internal::check_device_ptr_and_launch(
       oneapi::dpl::execution::seq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      keys_first1, size1, keys_first2, size2, values_first1, values_first2, keys_result, values_result,
+      comp, keys_first1, size1, keys_first2, size2,
       [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2, Ptr3 start3,
          Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
         return dpct::set_difference(policy, start1, end1, start2, end2, start3, start4, start5, 
                                  start6, comp);
-      }, comp);
+      },  keys_result, values_result,values_first1, values_first2);
 }
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
           typename Ptr5, typename Ptr6>
-std::pair<Ptr5, Ptr6>
+std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
+                 std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
+                 std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>, std::pair<Ptr5, Ptr6>>
 set_difference(Ptr1 keys_first1, Size size1,
                Ptr2 keys_first2, Size size2, Ptr3 values_first1,
                Ptr4 values_first2, Ptr5 keys_result, Ptr6 values_result)
@@ -1894,7 +1916,9 @@ set_difference(Ptr1 keys_first1, Size size1,
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
           typename Ptr5, typename Ptr6, typename Comp>
-std::pair<Ptr5, Ptr6>
+std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
+                 std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
+                 std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>, std::pair<Ptr5, Ptr6>>
 set_union(Ptr1 keys_first1, Size size1,
           Ptr2 keys_first2, Size size2, Ptr3 values_first1,
           Ptr4 values_first2, Ptr5 keys_result, Ptr6 values_result,
@@ -1903,17 +1927,19 @@ set_union(Ptr1 keys_first1, Size size1,
     return dpct::internal::check_device_ptr_and_launch(
       oneapi::dpl::execution::seq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      keys_first1, size1, keys_first2, size2, values_first1, values_first2, keys_result, values_result,
+      comp, keys_first1, size1, keys_first2, size2, 
       [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2, Ptr3 start3,
          Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
         return dpct::set_union(policy, start1, end1, start2, end2, start3, start4, start5, 
                                  start6, comp);
-      }, comp);
+      }, keys_result, values_result, values_first1, values_first2);
 }
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
           typename Ptr5, typename Ptr6>
-std::pair<Ptr5, Ptr6>
+std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
+                 std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
+                 std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>, std::pair<Ptr5, Ptr6>>
 set_union(Ptr1 keys_first1, Size size,
           Ptr2 keys_first2, Size size2, Ptr3 values_first1,
           Ptr4 values_first2, Ptr5 keys_result, Ptr6 values_result)
@@ -1925,7 +1951,8 @@ set_union(Ptr1 keys_first1, Size size,
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
           typename Ptr4, typename Pred>
-std::pair<Ptr3, Ptr4>
+std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
+                 std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4>, std::pair<Ptr3, Ptr4>>
 stable_partition_copy(Ptr1 first, Size size, Ptr2 mask,
                       Ptr3 out_true, Ptr4 out_false, Pred p)
 {
@@ -1943,7 +1970,8 @@ stable_partition_copy(Ptr1 first, Size size, Ptr2 mask,
 }
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
           typename Pred>
-std::pair<Ptr2, Ptr3>
+std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
+                 std::is_pointer_v<Ptr3>, std::pair<Ptr2, Ptr3>>
 stable_partition_copy(Ptr1 first, Size size, Ptr2 out_true,
                       Ptr3 out_false, Pred p)
 {
@@ -1961,7 +1989,8 @@ stable_partition_copy(Ptr1 first, Size size, Ptr2 out_true,
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
           typename Ptr4, typename Pred>
-std::pair<Ptr3, Ptr4>
+std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
+                 std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4>,std::pair<Ptr3, Ptr4>>
 partition_copy(Ptr1 first, Size size, Ptr2 mask,
                Ptr3 out_true, Ptr4 out_false, Pred p)
 {

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1767,8 +1767,214 @@ std::pair<Ptr3, Ptr4> unique_copy(Ptr1 keys_first, Size size, Ptr2 values_first,
       std::equal_to<typename std::iterator_traits<Ptr1>::value_type>());
 }
 
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5, typename Ptr6, typename Comp>
+std::pair<Ptr5, Ptr6>
+merge(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
+      Size size2, Ptr3 values_first1, Ptr4 values_first2,
+      Ptr5 keys_result, Ptr6 values_result, Comp comp)
 {
-  return dpct::unique_copy(keys_first, size, values_first, keys_result, values_result, std::equal_to<typename std::iterator_traits<Ptr1>::value_type>());
+    return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::seq,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      keys_first1, size1, keys_first2, size2, values_first1, values_first2, keys_result, values_result,
+      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2, Ptr3 start3,
+         Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
+        return dpct::merge(policy, start1, end1, start2, end2, start3, start4, start5, 
+                                 start6, comp);
+      }, comp);
+}
+
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5, typename Ptr6>
+std::pair<Ptr5, Ptr6>
+merge(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
+      Size size2, Ptr3 values_first1, Ptr4 values_first2,
+      Ptr5 keys_result, Ptr6 values_result)
+{
+  return dpct::merge(keys_first1, size1, keys_first2, size2, values_first1, values_first2, keys_result, values_result, dpct::internal::__less());
+}
+
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
+          typename Ptr5, typename Comp>
+std::pair<Ptr4, Ptr5>
+set_intersection(Ptr1 keys_first1, Size size1,
+                 Ptr2 keys_first2, Size size2, Ptr3 values_first1,
+                 Ptr4 keys_result, Ptr5 values_result, Comp comp)
+{
+    return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::seq,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      keys_first1, size1, keys_first2, size2, values_first1, keys_result, values_result,
+      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2, Ptr3 start3,
+         Ptr4 start4, Ptr5 start5, Comp comp) {
+        return dpct::set_intersection(policy, start1, end1, start2, end2, start3, start4, start5,
+                                 comp);
+      }, comp);
+
+}
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
+          typename Ptr5>
+std::pair<Ptr4, Ptr5>
+set_intersection(Ptr1 keys_first1, Size size1,
+                 Ptr2 keys_first2, Size size2, Ptr3 values_first1,
+                 Ptr4 keys_result, Ptr5 values_result)
+{
+  return dpct::set_intersection(keys_first1, size1,
+                 keys_first2, size2, values_first1,
+                 keys_result, values_result, dpct::internal::__less());
+}
+
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
+          typename Ptr5, typename Ptr6, typename Comp>
+std::pair<Ptr5, Ptr6>
+set_symmetric_difference(Ptr1 keys_first1, Size size1,
+                         Ptr2 keys_first2, Size size2,
+                         Ptr3 values_first1, Ptr4 values_first2,
+                         Ptr5 keys_result, Ptr6 values_result, Comp comp)
+{
+    return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::seq,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      keys_first1, size1, keys_first2, size2, values_first1, values_first2, keys_result, values_result,
+      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2, Ptr3 start3,
+         Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
+        return dpct::set_symmetric_difference(policy, start1, end1, start2, end2, start3, start4, start5, 
+                                 start6, comp);
+      }, comp);
+}
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
+          typename Ptr5, typename Ptr6>
+std::pair<Ptr5, Ptr6>
+set_symmetric_difference(Ptr1 keys_first1, Size size1,
+                         Ptr2 keys_first2, Size size2,
+                         Ptr3 values_first1, Ptr4 values_first2,
+                         Ptr5 keys_result, Ptr6 values_result)
+{
+    return dpct::set_symmetric_difference(keys_first1, size1,
+                 keys_first2, size2, values_first1, values_first2,
+                 keys_result, values_result, dpct::internal::__less());
+}
+
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
+          typename Ptr5, typename Ptr6, typename Comp>
+std::pair<Ptr5, Ptr6> set_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
+                                       Size size2, Ptr3 values_first1,
+                                       Ptr4 values_first2, Ptr5 keys_result,
+                                       Ptr6 values_result, Comp comp)
+{
+    return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::seq,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      keys_first1, size1, keys_first2, size2, values_first1, values_first2, keys_result, values_result,
+      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2, Ptr3 start3,
+         Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
+        return dpct::set_difference(policy, start1, end1, start2, end2, start3, start4, start5, 
+                                 start6, comp);
+      }, comp);
+}
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
+          typename Ptr5, typename Ptr6>
+std::pair<Ptr5, Ptr6>
+set_difference(Ptr1 keys_first1, Size size1,
+               Ptr2 keys_first2, Size size2, Ptr3 values_first1,
+               Ptr4 values_first2, Ptr5 keys_result, Ptr6 values_result)
+{
+   return dpct::set_difference(keys_first1, size1,
+          keys_first2, size2, values_first1,
+          values_first2, keys_result, values_result, dpct::internal::__less()); 
+}
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
+          typename Ptr5, typename Ptr6, typename Comp>
+std::pair<Ptr5, Ptr6>
+set_union(Ptr1 keys_first1, Size size1,
+          Ptr2 keys_first2, Size size2, Ptr3 values_first1,
+          Ptr4 values_first2, Ptr5 keys_result, Ptr6 values_result,
+          Comp comp)
+{
+    return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::seq,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      keys_first1, size1, keys_first2, size2, values_first1, values_first2, keys_result, values_result,
+      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2, Ptr3 start3,
+         Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
+        return dpct::set_union(policy, start1, end1, start2, end2, start3, start4, start5, 
+                                 start6, comp);
+      }, comp);
+}
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
+          typename Ptr5, typename Ptr6>
+std::pair<Ptr5, Ptr6>
+set_union(Ptr1 keys_first1, Size size,
+          Ptr2 keys_first2, Size size2, Ptr3 values_first1,
+          Ptr4 values_first2, Ptr5 keys_result, Ptr6 values_result)
+{
+  return dpct::set_union(keys_first1, size,
+          keys_first2, size2, values_first1,
+          values_first2, keys_result, values_result, dpct::internal::__less());
+}
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Pred>
+std::pair<Ptr3, Ptr4>
+stable_partition_copy(Ptr1 first, Size size, Ptr2 mask,
+                      Ptr3 out_true, Ptr4 out_false, Pred p)
+{
+  return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::seq,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      first, size, mask, out_true, out_false,
+      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
+         Ptr4 start4, Pred pred) {
+        return dpct::stable_partition_copy(policy, start1, end1, start2, start3, start4,
+                                 pred);
+      },
+      p);
+
+}
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Pred>
+std::pair<Ptr2, Ptr3>
+stable_partition_copy(Ptr1 first, Size size, Ptr2 out_true,
+                      Ptr3 out_false, Pred p)
+{
+  return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::seq,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      first, size, out_true, out_false,
+      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
+         Pred pred) {
+        return dpct::stable_partition_copy(policy, start1, end1, start2, start3,
+                                 pred);
+      },
+      p);
+}
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Pred>
+std::pair<Ptr3, Ptr4>
+partition_copy(Ptr1 first, Size size, Ptr2 mask,
+               Ptr3 out_true, Ptr4 out_false, Pred p)
+{
+  return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::seq,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      first, size, mask, out_true, out_false,
+      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
+         Ptr4 start4, Pred pred) {
+        return dpct::partition_copy(policy, start1, end1, start2, start3, start4,
+                                 pred);
+      },
+      p);
 }
 
 #endif // #DPCT_USM_LEVEL_NONE

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1703,15 +1703,17 @@ template <typename Ptr1, typename Size, typename ValueLessComparable,
 inline std::enable_if_t<std::is_pointer_v<Ptr1>, ::std::pair<Ptr1, Ptr1>>
 equal_range(Ptr1 start, Size size, const ValueLessComparable &value,
             StrictWeakOrdering comp) {
-  return dpct::internal::check_device_ptr_and_launch(
+  return dpct::internal::check_device_ptr_and_launch_w_value(
       oneapi::dpl::execution::seq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      start, size,
+      value, comp, size,
       [](auto policy, Ptr1 start, Ptr1 end, const ValueLessComparable &value,
          StrictWeakOrdering comp) {
         return dpct::equal_range(policy, start, end, value, comp);
       },
-      value, comp);
+      start, start, //return base
+      start //all ptrs
+      );
 }
 
 template <typename _T, typename Size, typename ValueLessComparable>
@@ -1727,12 +1729,14 @@ unique(Ptr1 start1, Size size, Ptr2 start2,
   return dpct::internal::check_device_ptr_and_launch(
       oneapi::dpl::execution::seq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      start1, size, start2,
+      binary_pred, size,
       [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2,
          BinaryPred binary_pred) {
         return dpct::unique(policy, start1, end1, start2, binary_pred);
       },
-      binary_pred);
+      start1, start2, //return base
+      start1, start2 //all ptrs
+      );
 }
 
 template <typename Ptr1, typename Size, typename Ptr2>
@@ -1751,13 +1755,15 @@ std::pair<Ptr3, Ptr4> unique_copy(Ptr1 keys_first, Size size, Ptr2 values_first,
   return dpct::internal::check_device_ptr_and_launch(
       oneapi::dpl::execution::seq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      keys_first, size, values_first, keys_result, values_result,
+      binary_pred, size,
       [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
          Ptr4 start4, BinaryPred binary_pred) {
         return dpct::unique_copy(policy, start1, end1, start2, start3, start4,
                                  binary_pred);
       },
-      binary_pred);
+      keys_result, values_result, //return base
+      keys_first, values_first, keys_result, values_result //all ptrs
+      );
 }
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
@@ -1825,8 +1831,9 @@ set_intersection(Ptr1 keys_first1, Size size1,
         return dpct::set_intersection(policy, start1, end1, start2, end2, start3, start4, start5,
                                  comp);
       }, 
-      keys_result, values_result,
-      keys_first1, keys_first2, values_first1, keys_result, values_result);
+      keys_result, values_result, //return base
+      keys_first1, keys_first2, values_first1, keys_result, values_result //all ptrs
+      );
 
 }
 
@@ -1863,8 +1870,10 @@ set_symmetric_difference(Ptr1 keys_first1, Size size1,
          Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
         return dpct::set_symmetric_difference(policy, start1, end1, start2, end2, start3, start4, start5, 
                                  start6);
-      }, keys_result, values_result,
-      keys_first1, keys_first2, values_first1, values_first2, keys_result, values_result);
+      }, 
+      keys_result, values_result, //return base
+      keys_first1, keys_first2, values_first1, values_first2, keys_result, values_result // all ptrs
+      );
 }
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
@@ -1902,8 +1911,10 @@ set_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
          Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
         return dpct::set_difference(policy, start1, end1, start2, end2, start3, start4, start5, 
                                  start6, comp);
-      },  keys_result, values_result,
-      keys_first1, keys_first2, values_first1, values_first2, keys_result, values_result);
+      },
+      keys_result, values_result, //return base
+      keys_first1, keys_first2, values_first1, values_first2, keys_result, values_result //all ptrs
+      ); 
 }
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
@@ -1938,8 +1949,10 @@ set_union(Ptr1 keys_first1, Size size1,
          Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
         return dpct::set_union(policy, start1, end1, start2, end2, start3, start4, start5, 
                                  start6, comp);
-      }, keys_result, values_result,
-      keys_first1, keys_first2, values_first1, values_first2, keys_result, values_result);
+      }, 
+      keys_result, values_result, //return base
+      keys_first1, keys_first2, values_first1, values_first2, keys_result, values_result //all ptrs
+      );
 }
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
@@ -1966,13 +1979,15 @@ stable_partition_copy(Ptr1 first, Size size, Ptr2 mask,
   return dpct::internal::check_device_ptr_and_launch(
       oneapi::dpl::execution::seq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      first, size, mask, out_true, out_false,
+      p, size,
       [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
          Ptr4 start4, Pred pred) {
         return dpct::stable_partition_copy(policy, start1, end1, start2, start3, start4,
                                  pred);
       },
-      p);
+      out_true, out_false, //return base
+      first, mask, out_true, out_false //all ptrs
+      );
 
 }
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
@@ -1985,13 +2000,15 @@ stable_partition_copy(Ptr1 first, Size size, Ptr2 out_true,
   return dpct::internal::check_device_ptr_and_launch(
       oneapi::dpl::execution::seq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      first, size, out_true, out_false,
+      p, size,
       [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
          Pred pred) {
         return dpct::stable_partition_copy(policy, start1, end1, start2, start3,
                                  pred);
       },
-      p);
+      out_true, out_false, //return base
+      first, out_true, out_false // all ptrs
+      );
 }
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
@@ -2004,13 +2021,15 @@ partition_copy(Ptr1 first, Size size, Ptr2 mask,
   return dpct::internal::check_device_ptr_and_launch(
       oneapi::dpl::execution::seq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      first, size, mask, out_true, out_false,
+      p, size,
       [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
          Ptr4 start4, Pred pred) {
         return dpct::partition_copy(policy, start1, end1, start2, start3, start4,
                                  pred);
       },
-      p);
+      out_true, out_false, //return base
+      first, mask, out_true, out_false // all ptrs
+      );
 }
 
 #endif // #DPCT_USM_LEVEL_NONE

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1741,7 +1741,7 @@ unique(Ptr1 start1, Size size, Ptr2 start2, BinaryPred binary_pred) {
 }
 
 template <typename Ptr1, typename Size, typename Ptr2>
-std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2>,
+std::enable_if_t<dpct::internal::all_are_pointer_v<Ptr1, Ptr2>,
                  std::pair<Ptr1, Ptr2>>
 unique(Ptr1 start1, Size size, Ptr2 start2) {
   return dpct::unique(
@@ -1751,9 +1751,11 @@ unique(Ptr1 start1, Size size, Ptr2 start2) {
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
           typename Ptr4, typename BinaryPred>
-std::pair<Ptr3, Ptr4> unique_copy(Ptr1 keys_first, Size size, Ptr2 values_first,
-                                  Ptr3 keys_result, Ptr4 values_result,
-                                  BinaryPred binary_pred) {
+
+std::enable_if_t<dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4>,
+                 std::pair<Ptr3, Ptr4>>
+unique_copy(Ptr1 keys_first, Size size, Ptr2 values_first, Ptr3 keys_result,
+            Ptr4 values_result, BinaryPred binary_pred) {
   return dpct::internal::check_device_ptr_and_launch(
       oneapi::dpl::execution::par_unseq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
@@ -1770,8 +1772,7 @@ std::pair<Ptr3, Ptr4> unique_copy(Ptr1 keys_first, Size size, Ptr2 values_first,
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
           typename Ptr4>
-std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                     std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4>,
+std::enable_if_t<dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4>,
                  std::pair<Ptr3, Ptr4>>
 unique_copy(Ptr1 keys_first, Size size, Ptr2 values_first, Ptr3 keys_result,
             Ptr4 values_result) {
@@ -1782,10 +1783,9 @@ unique_copy(Ptr1 keys_first, Size size, Ptr2 values_first, Ptr3 keys_result,
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
           typename Ptr4, typename Ptr5, typename Ptr6, typename Comp>
-std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                     std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
-                     std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>,
-                 std::pair<Ptr5, Ptr6>>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
+    std::pair<Ptr5, Ptr6>>
 merge(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
       Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
       Ptr6 values_result, Comp comp) {
@@ -1805,10 +1805,9 @@ merge(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
           typename Ptr4, typename Ptr5, typename Ptr6>
-std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                     std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
-                     std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>,
-                 std::pair<Ptr5, Ptr6>>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
+    std::pair<Ptr5, Ptr6>>
 merge(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
       Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
       Ptr6 values_result) {
@@ -1819,10 +1818,9 @@ merge(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
           typename Ptr4, typename Ptr5, typename Comp>
-std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                     std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
-                     std::is_pointer_v<Ptr5>,
-                 std::pair<Ptr4, Ptr5>>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5>,
+    std::pair<Ptr4, Ptr5>>
 set_intersection(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
                  Ptr3 values_first1, Ptr4 keys_result, Ptr5 values_result,
                  Comp comp) {
@@ -1844,10 +1842,9 @@ set_intersection(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
           typename Ptr4, typename Ptr5>
-std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                     std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
-                     std::is_pointer_v<Ptr5>,
-                 std::pair<Ptr4, Ptr5>>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5>,
+    std::pair<Ptr4, Ptr5>>
 set_intersection(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
                  Ptr3 values_first1, Ptr4 keys_result, Ptr5 values_result) {
   return dpct::set_intersection(keys_first1, size1, keys_first2, size2,
@@ -1857,10 +1854,9 @@ set_intersection(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
           typename Ptr4, typename Ptr5, typename Ptr6, typename Comp>
-std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                     std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
-                     std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>,
-                 std::pair<Ptr5, Ptr6>>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
+    std::pair<Ptr5, Ptr6>>
 set_symmetric_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
                          Size size2, Ptr3 values_first1, Ptr4 values_first2,
                          Ptr5 keys_result, Ptr6 values_result, Comp comp) {
@@ -1882,10 +1878,9 @@ set_symmetric_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
           typename Ptr4, typename Ptr5, typename Ptr6>
-std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                     std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
-                     std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>,
-                 std::pair<Ptr5, Ptr6>>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
+    std::pair<Ptr5, Ptr6>>
 set_symmetric_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
                          Size size2, Ptr3 values_first1, Ptr4 values_first2,
                          Ptr5 keys_result, Ptr6 values_result) {
@@ -1896,10 +1891,9 @@ set_symmetric_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
           typename Ptr4, typename Ptr5, typename Ptr6, typename Comp>
-std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                     std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
-                     std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>,
-                 std::pair<Ptr5, Ptr6>>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
+    std::pair<Ptr5, Ptr6>>
 set_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
                Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
                Ptr6 values_result, Comp comp) {
@@ -1921,10 +1915,9 @@ set_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
           typename Ptr4, typename Ptr5, typename Ptr6>
-std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                     std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
-                     std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>,
-                 std::pair<Ptr5, Ptr6>>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
+    std::pair<Ptr5, Ptr6>>
 set_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
                Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
                Ptr6 values_result) {
@@ -1935,10 +1928,9 @@ set_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
           typename Ptr4, typename Ptr5, typename Ptr6, typename Comp>
-std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                     std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
-                     std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>,
-                 std::pair<Ptr5, Ptr6>>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
+    std::pair<Ptr5, Ptr6>>
 set_union(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
           Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
           Ptr6 values_result, Comp comp) {
@@ -1960,10 +1952,9 @@ set_union(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
           typename Ptr4, typename Ptr5, typename Ptr6>
-std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                     std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
-                     std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>,
-                 std::pair<Ptr5, Ptr6>>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
+    std::pair<Ptr5, Ptr6>>
 set_union(Ptr1 keys_first1, Size size, Ptr2 keys_first2, Size size2,
           Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
           Ptr6 values_result) {
@@ -1974,8 +1965,7 @@ set_union(Ptr1 keys_first1, Size size, Ptr2 keys_first2, Size size2,
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
           typename Ptr4, typename Pred>
-std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                     std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4>,
+std::enable_if_t<dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4>,
                  std::pair<Ptr3, Ptr4>>
 stable_partition_copy(Ptr1 first, Size size, Ptr2 mask, Ptr3 out_true,
                       Ptr4 out_false, Pred p) {
@@ -1995,8 +1985,7 @@ stable_partition_copy(Ptr1 first, Size size, Ptr2 mask, Ptr3 out_true,
 }
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
           typename Pred>
-std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                     std::is_pointer_v<Ptr3>,
+std::enable_if_t<dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3>,
                  std::pair<Ptr2, Ptr3>>
 stable_partition_copy(Ptr1 first, Size size, Ptr2 out_true, Ptr3 out_false,
                       Pred p) {
@@ -2017,8 +2006,7 @@ stable_partition_copy(Ptr1 first, Size size, Ptr2 out_true, Ptr3 out_false,
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
           typename Ptr4, typename Pred>
-std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                     std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4>,
+std::enable_if_t<dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4>,
                  std::pair<Ptr3, Ptr4>>
 partition_copy(Ptr1 first, Size size, Ptr2 mask, Ptr3 out_true, Ptr4 out_false,
                Pred p) {

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1703,12 +1703,12 @@ inline std::enable_if_t<std::is_pointer_v<Ptr1>, ::std::pair<Ptr1, Ptr1>>
 equal_range(Ptr1 start, Size size, const ValueLessComparable &value,
             StrictWeakOrdering comp) {
   return dpct::internal::check_device_ptr_and_launch_w_value(
-      oneapi::dpl::execution::seq,
+      oneapi::dpl::execution::par_unseq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
       value, comp, size,
-      [](auto policy, Ptr1 start, Ptr1 end, const ValueLessComparable &value,
+      [](auto&& policy, Ptr1 start, Ptr1 end, const ValueLessComparable &value,
          StrictWeakOrdering comp) {
-        return dpct::equal_range(policy, start, end, value, comp);
+        return dpct::equal_range(std::forward<decltype(policy)>(policy), start, end, value, comp);
       },
       start, start, // return base
       start         // all ptrs
@@ -1726,12 +1726,12 @@ std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2>,
                  std::pair<Ptr1, Ptr2>>
 unique(Ptr1 start1, Size size, Ptr2 start2, BinaryPred binary_pred) {
   return dpct::internal::check_device_ptr_and_launch(
-      oneapi::dpl::execution::seq,
+      oneapi::dpl::execution::par_unseq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
       binary_pred, size,
-      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2,
+      [](auto&& policy, Ptr1 start1, Ptr1 end1, Ptr2 start2,
          BinaryPred binary_pred) {
-        return dpct::unique(policy, start1, end1, start2, binary_pred);
+        return dpct::unique(std::forward<decltype(policy)>(policy), start1, end1, start2, binary_pred);
       },
       start1, start2, // return base
       start1, start2  // all ptrs
@@ -1753,12 +1753,12 @@ std::pair<Ptr3, Ptr4> unique_copy(Ptr1 keys_first, Size size, Ptr2 values_first,
                                   Ptr3 keys_result, Ptr4 values_result,
                                   BinaryPred binary_pred) {
   return dpct::internal::check_device_ptr_and_launch(
-      oneapi::dpl::execution::seq,
+      oneapi::dpl::execution::par_unseq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
       binary_pred, size,
-      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
+      [](auto&& policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
          Ptr4 start4, BinaryPred binary_pred) {
-        return dpct::unique_copy(policy, start1, end1, start2, start3, start4,
+        return dpct::unique_copy(std::forward<decltype(policy)>(policy), start1, end1, start2, start3, start4,
                                  binary_pred);
       },
       keys_result, values_result,                          // return base
@@ -1788,12 +1788,12 @@ merge(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
       Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
       Ptr6 values_result, Comp comp) {
   return dpct::internal::check_device_ptr_and_launch(
-      oneapi::dpl::execution::seq,
+      oneapi::dpl::execution::par_unseq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
       comp, size1, size2,
-      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
+      [](auto&& policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
          Ptr3 start3, Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
-        return dpct::merge(policy, start1, end1, start2, end2, start3, start4,
+        return dpct::merge(std::forward<decltype(policy)>(policy), start1, end1, start2, end2, start3, start4,
                            start5, start6, comp);
       },
       keys_result, values_result, // return base
@@ -1825,12 +1825,12 @@ set_intersection(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
                  Ptr3 values_first1, Ptr4 keys_result, Ptr5 values_result,
                  Comp comp) {
   return dpct::internal::check_device_ptr_and_launch(
-      oneapi::dpl::execution::seq,
+      oneapi::dpl::execution::par,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
       comp, size1, size2,
-      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
+      [](auto&& policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
          Ptr3 start3, Ptr4 start4, Ptr5 start5, Comp comp) {
-        return dpct::set_intersection(policy, start1, end1, start2, end2,
+        return dpct::set_intersection(std::forward<decltype(policy)>(policy), start1, end1, start2, end2,
                                       start3, start4, start5, comp);
       },
       keys_result, values_result, // return base
@@ -1862,13 +1862,13 @@ set_symmetric_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
                          Size size2, Ptr3 values_first1, Ptr4 values_first2,
                          Ptr5 keys_result, Ptr6 values_result, Comp comp) {
   return dpct::internal::check_device_ptr_and_launch(
-      oneapi::dpl::execution::seq,
+      oneapi::dpl::execution::par,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
       comp, size1, size2,
-      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
+      [](auto&& policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
          Ptr3 start3, Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
         return dpct::set_symmetric_difference(
-            policy, start1, end1, start2, end2, start3, start4, start5, start6);
+            std::forward<decltype(policy)>(policy), start1, end1, start2, end2, start3, start4, start5, start6);
       },
       keys_result, values_result, // return base
       keys_first1, keys_first2, values_first1, values_first2, keys_result,
@@ -1900,12 +1900,12 @@ set_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
                Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
                Ptr6 values_result, Comp comp) {
   return dpct::internal::check_device_ptr_and_launch(
-      oneapi::dpl::execution::seq,
+      oneapi::dpl::execution::par_unseq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
       comp, size1, size2,
-      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
+      [](auto&& policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
          Ptr3 start3, Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
-        return dpct::set_difference(policy, start1, end1, start2, end2, start3,
+        return dpct::set_difference(std::forward<decltype(policy)>(policy), start1, end1, start2, end2, start3,
                                     start4, start5, start6, comp);
       },
       keys_result, values_result, // return base
@@ -1938,12 +1938,12 @@ set_union(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
           Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
           Ptr6 values_result, Comp comp) {
   return dpct::internal::check_device_ptr_and_launch(
-      oneapi::dpl::execution::seq,
+      oneapi::dpl::execution::par,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
       comp, size1, size2,
-      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
          Ptr3 start3, Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
-        return dpct::set_union(policy, start1, end1, start2, end2, start3,
+        return dpct::set_union(std::forward<decltype(policy)>(policy), start1, end1, start2, end2, start3,
                                start4, start5, start6, comp);
       },
       keys_result, values_result, // return base
@@ -1974,12 +1974,12 @@ std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
 stable_partition_copy(Ptr1 first, Size size, Ptr2 mask, Ptr3 out_true,
                       Ptr4 out_false, Pred p) {
   return dpct::internal::check_device_ptr_and_launch(
-      oneapi::dpl::execution::seq,
+      oneapi::dpl::execution::par_unseq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()), p,
       size,
-      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
+      [](auto&& policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
          Ptr4 start4, Pred pred) {
-        return dpct::stable_partition_copy(policy, start1, end1, start2, start3,
+        return dpct::stable_partition_copy(std::forward<decltype(policy)>(policy), start1, end1, start2, start3,
                                            start4, pred);
       },
       out_true, out_false,             // return base
@@ -1994,12 +1994,12 @@ std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
 stable_partition_copy(Ptr1 first, Size size, Ptr2 out_true, Ptr3 out_false,
                       Pred p) {
   return dpct::internal::check_device_ptr_and_launch(
-      oneapi::dpl::execution::seq,
+      oneapi::dpl::execution::par_unseq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()), p,
       size,
-      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
+      [](auto&& policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
          Pred pred) {
-        return dpct::stable_partition_copy(policy, start1, end1, start2, start3,
+        return dpct::stable_partition_copy(std::forward<decltype(policy)>(policy), start1, end1, start2, start3,
                                            pred);
       },
       out_true, out_false,       // return base
@@ -2015,12 +2015,12 @@ std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
 partition_copy(Ptr1 first, Size size, Ptr2 mask, Ptr3 out_true, Ptr4 out_false,
                Pred p) {
   return dpct::internal::check_device_ptr_and_launch(
-      oneapi::dpl::execution::seq,
+      oneapi::dpl::execution::par_unseq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()), p,
       size,
-      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
+      [](auto&& policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
          Ptr4 start4, Pred pred) {
-        return dpct::partition_copy(policy, start1, end1, start2, start3,
+        return dpct::partition_copy(std::forward<decltype(policy)>(policy), start1, end1, start2, start3,
                                     start4, pred);
       },
       out_true, out_false,             // return base

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1706,9 +1706,10 @@ equal_range(Ptr1 start, Size size, const ValueLessComparable &value,
       oneapi::dpl::execution::par_unseq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
       value, comp, size,
-      [](auto&& policy, Ptr1 start, Ptr1 end, const ValueLessComparable &value,
+      [](auto &&policy, Ptr1 start, Ptr1 end, const ValueLessComparable &value,
          StrictWeakOrdering comp) {
-        return dpct::equal_range(std::forward<decltype(policy)>(policy), start, end, value, comp);
+        return dpct::equal_range(std::forward<decltype(policy)>(policy), start,
+                                 end, value, comp);
       },
       start, start, // return base
       start         // all ptrs
@@ -1729,9 +1730,10 @@ unique(Ptr1 start1, Size size, Ptr2 start2, BinaryPred binary_pred) {
       oneapi::dpl::execution::par_unseq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
       binary_pred, size,
-      [](auto&& policy, Ptr1 start1, Ptr1 end1, Ptr2 start2,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2,
          BinaryPred binary_pred) {
-        return dpct::unique(std::forward<decltype(policy)>(policy), start1, end1, start2, binary_pred);
+        return dpct::unique(std::forward<decltype(policy)>(policy), start1,
+                            end1, start2, binary_pred);
       },
       start1, start2, // return base
       start1, start2  // all ptrs
@@ -1756,10 +1758,10 @@ std::pair<Ptr3, Ptr4> unique_copy(Ptr1 keys_first, Size size, Ptr2 values_first,
       oneapi::dpl::execution::par_unseq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
       binary_pred, size,
-      [](auto&& policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
          Ptr4 start4, BinaryPred binary_pred) {
-        return dpct::unique_copy(std::forward<decltype(policy)>(policy), start1, end1, start2, start3, start4,
-                                 binary_pred);
+        return dpct::unique_copy(std::forward<decltype(policy)>(policy), start1,
+                                 end1, start2, start3, start4, binary_pred);
       },
       keys_result, values_result,                          // return base
       keys_first, values_first, keys_result, values_result // all ptrs
@@ -1791,10 +1793,10 @@ merge(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
       oneapi::dpl::execution::par_unseq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
       comp, size1, size2,
-      [](auto&& policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
          Ptr3 start3, Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
-        return dpct::merge(std::forward<decltype(policy)>(policy), start1, end1, start2, end2, start3, start4,
-                           start5, start6, comp);
+        return dpct::merge(std::forward<decltype(policy)>(policy), start1, end1,
+                           start2, end2, start3, start4, start5, start6, comp);
       },
       keys_result, values_result, // return base
       keys_first1, keys_first2, values_first1, values_first2, keys_result,
@@ -1828,10 +1830,11 @@ set_intersection(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
       oneapi::dpl::execution::par,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
       comp, size1, size2,
-      [](auto&& policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
          Ptr3 start3, Ptr4 start4, Ptr5 start5, Comp comp) {
-        return dpct::set_intersection(std::forward<decltype(policy)>(policy), start1, end1, start2, end2,
-                                      start3, start4, start5, comp);
+        return dpct::set_intersection(std::forward<decltype(policy)>(policy),
+                                      start1, end1, start2, end2, start3,
+                                      start4, start5, comp);
       },
       keys_result, values_result, // return base
       keys_first1, keys_first2, values_first1, keys_result,
@@ -1865,10 +1868,11 @@ set_symmetric_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
       oneapi::dpl::execution::par,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
       comp, size1, size2,
-      [](auto&& policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
          Ptr3 start3, Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
         return dpct::set_symmetric_difference(
-            std::forward<decltype(policy)>(policy), start1, end1, start2, end2, start3, start4, start5, start6);
+            std::forward<decltype(policy)>(policy), start1, end1, start2, end2,
+            start3, start4, start5, start6);
       },
       keys_result, values_result, // return base
       keys_first1, keys_first2, values_first1, values_first2, keys_result,
@@ -1903,10 +1907,11 @@ set_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
       oneapi::dpl::execution::par_unseq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
       comp, size1, size2,
-      [](auto&& policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
          Ptr3 start3, Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
-        return dpct::set_difference(std::forward<decltype(policy)>(policy), start1, end1, start2, end2, start3,
-                                    start4, start5, start6, comp);
+        return dpct::set_difference(std::forward<decltype(policy)>(policy),
+                                    start1, end1, start2, end2, start3, start4,
+                                    start5, start6, comp);
       },
       keys_result, values_result, // return base
       keys_first1, keys_first2, values_first1, values_first2, keys_result,
@@ -1943,8 +1948,9 @@ set_union(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
       comp, size1, size2,
       [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
          Ptr3 start3, Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
-        return dpct::set_union(std::forward<decltype(policy)>(policy), start1, end1, start2, end2, start3,
-                               start4, start5, start6, comp);
+        return dpct::set_union(std::forward<decltype(policy)>(policy), start1,
+                               end1, start2, end2, start3, start4, start5,
+                               start6, comp);
       },
       keys_result, values_result, // return base
       keys_first1, keys_first2, values_first1, values_first2, keys_result,
@@ -1977,10 +1983,11 @@ stable_partition_copy(Ptr1 first, Size size, Ptr2 mask, Ptr3 out_true,
       oneapi::dpl::execution::par_unseq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()), p,
       size,
-      [](auto&& policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
          Ptr4 start4, Pred pred) {
-        return dpct::stable_partition_copy(std::forward<decltype(policy)>(policy), start1, end1, start2, start3,
-                                           start4, pred);
+        return dpct::stable_partition_copy(
+            std::forward<decltype(policy)>(policy), start1, end1, start2,
+            start3, start4, pred);
       },
       out_true, out_false,             // return base
       first, mask, out_true, out_false // all ptrs
@@ -1997,10 +2004,11 @@ stable_partition_copy(Ptr1 first, Size size, Ptr2 out_true, Ptr3 out_false,
       oneapi::dpl::execution::par_unseq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()), p,
       size,
-      [](auto&& policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
          Pred pred) {
-        return dpct::stable_partition_copy(std::forward<decltype(policy)>(policy), start1, end1, start2, start3,
-                                           pred);
+        return dpct::stable_partition_copy(
+            std::forward<decltype(policy)>(policy), start1, end1, start2,
+            start3, pred);
       },
       out_true, out_false,       // return base
       first, out_true, out_false // all ptrs
@@ -2018,10 +2026,10 @@ partition_copy(Ptr1 first, Size size, Ptr2 mask, Ptr3 out_true, Ptr4 out_false,
       oneapi::dpl::execution::par_unseq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()), p,
       size,
-      [](auto&& policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
          Ptr4 start4, Pred pred) {
-        return dpct::partition_copy(std::forward<decltype(policy)>(policy), start1, end1, start2, start3,
-                                    start4, pred);
+        return dpct::partition_copy(std::forward<decltype(policy)>(policy),
+                                    start1, end1, start2, start3, start4, pred);
       },
       out_true, out_false,             // return base
       first, mask, out_true, out_false // all ptrs

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -155,6 +155,35 @@ std::pair<Iter1, Iter2> unique(Policy &&policy, Iter1 keys_first,
                 values_first, std::equal_to<T>());
 }
 
+#ifdef DPCT_USM_LEVEL_NONE
+template <typename Ptr1, typename Size, typename Ptr2, typename BinaryPred>
+std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2>,
+                 std::pair<Ptr1, Ptr2>>
+unique(Ptr1 start1, Size size, Ptr2 start2, BinaryPred binary_pred) {
+  return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::par_unseq,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      binary_pred, size,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2,
+         BinaryPred binary_pred) {
+        return dpct::unique(std::forward<decltype(policy)>(policy), start1,
+                            end1, start2, binary_pred);
+      },
+      start1, start2, // return base
+      start1, start2  // all ptrs
+  );
+}
+
+template <typename Ptr1, typename Size, typename Ptr2>
+std::enable_if_t<dpct::internal::all_are_pointer_v<Ptr1, Ptr2>,
+                 std::pair<Ptr1, Ptr2>>
+unique(Ptr1 start1, Size size, Ptr2 start2) {
+  return dpct::unique(
+      start1, size, start2,
+      std::equal_to<typename std::iterator_traits<Ptr1>::value_type>());
+}
+#endif // DPCT_USM_LEVEL_NONE
+
 template <class Policy, class Iter1, class Iter2, class Iter3, class Iter4,
           class BinaryPred>
 std::pair<Iter3, Iter4> unique_copy(Policy &&policy, Iter1 keys_first,
@@ -202,6 +231,40 @@ std::pair<Iter3, Iter4> unique_copy(Policy &&policy, Iter1 keys_first,
   return unique_copy(std::forward<Policy>(policy), keys_first, keys_last,
                      values_first, keys_result, values_result, comp);
 }
+
+#ifdef DPCT_USM_LEVEL_NONE
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename BinaryPred>
+
+std::enable_if_t<dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4>,
+                 std::pair<Ptr3, Ptr4>>
+unique_copy(Ptr1 keys_first, Size size, Ptr2 values_first, Ptr3 keys_result,
+            Ptr4 values_result, BinaryPred binary_pred) {
+  return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::par_unseq,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      binary_pred, size,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
+         Ptr4 start4, BinaryPred binary_pred) {
+        return dpct::unique_copy(std::forward<decltype(policy)>(policy), start1,
+                                 end1, start2, start3, start4, binary_pred);
+      },
+      keys_result, values_result,                          // return base
+      keys_first, values_first, keys_result, values_result // all ptrs
+  );
+}
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4>
+std::enable_if_t<dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4>,
+                 std::pair<Ptr3, Ptr4>>
+unique_copy(Ptr1 keys_first, Size size, Ptr2 values_first, Ptr3 keys_result,
+            Ptr4 values_result) {
+  return dpct::unique_copy(
+      keys_first, size, values_first, keys_result, values_result,
+      std::equal_to<typename std::iterator_traits<Ptr1>::value_type>());
+}
+#endif // DPCT_USM_LEVEL_NONE
 
 template <typename Policy, typename Iter, typename Pred>
 Iter partition_point(Policy &&policy, Iter first, Iter last, Pred p) {
@@ -461,6 +524,43 @@ merge(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1, Iter2 keys_first2,
   return std::make_pair(keys_result + n1 + n2, values_result + n1 + n2);
 }
 
+#ifdef DPCT_USM_LEVEL_NONE
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5, typename Ptr6, typename Comp>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
+    std::pair<Ptr5, Ptr6>>
+merge(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
+      Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
+      Ptr6 values_result, Comp comp) {
+  return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::par_unseq,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      comp, size1, size2,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
+         Ptr3 start3, Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
+        return dpct::merge(std::forward<decltype(policy)>(policy), start1, end1,
+                           start2, end2, start3, start4, start5, start6, comp);
+      },
+      keys_result, values_result, // return base
+      keys_first1, keys_first2, values_first1, values_first2, keys_result,
+      values_result); // all ptrs
+}
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5, typename Ptr6>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
+    std::pair<Ptr5, Ptr6>>
+merge(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
+      Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
+      Ptr6 values_result) {
+  return dpct::merge(keys_first1, size1, keys_first2, size2, values_first1,
+                     values_first2, keys_result, values_result,
+                     dpct::internal::__less());
+}
+#endif // DPCT_USM_LEVEL_NONE
+
 template <class Policy, class Iter, class T>
 void iota(Policy &&policy, Iter first, Iter last, T init, T step) {
   static_assert(
@@ -632,6 +732,44 @@ set_intersection(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
   return std::make_pair(keys_result + n1, values_result + n1);
 }
 
+#ifdef DPCT_USM_LEVEL_NONE
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5, typename Comp>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5>,
+    std::pair<Ptr4, Ptr5>>
+set_intersection(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
+                 Ptr3 values_first1, Ptr4 keys_result, Ptr5 values_result,
+                 Comp comp) {
+  return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::par,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      comp, size1, size2,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
+         Ptr3 start3, Ptr4 start4, Ptr5 start5, Comp comp) {
+        return dpct::set_intersection(std::forward<decltype(policy)>(policy),
+                                      start1, end1, start2, end2, start3,
+                                      start4, start5, comp);
+      },
+      keys_result, values_result, // return base
+      keys_first1, keys_first2, values_first1, keys_result,
+      values_result // all ptrs
+  );
+}
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5>,
+    std::pair<Ptr4, Ptr5>>
+set_intersection(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
+                 Ptr3 values_first1, Ptr4 keys_result, Ptr5 values_result) {
+  return dpct::set_intersection(keys_first1, size1, keys_first2, size2,
+                                values_first1, keys_result, values_result,
+                                dpct::internal::__less());
+}
+#endif // DPCT_USM_LEVEL_NONE
+
 template <class Policy, class Iter1, class Iter2, class Iter3, class Iter4,
           class Iter5, class Iter6>
 internal::enable_if_execution_policy<Policy, std::pair<Iter5, Iter6>>
@@ -704,6 +842,45 @@ set_symmetric_difference(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
   return std::make_pair(keys_result + n1, values_result + n1);
 }
 
+#ifdef DPCT_USM_LEVEL_NONE
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5, typename Ptr6, typename Comp>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
+    std::pair<Ptr5, Ptr6>>
+set_symmetric_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
+                         Size size2, Ptr3 values_first1, Ptr4 values_first2,
+                         Ptr5 keys_result, Ptr6 values_result, Comp comp) {
+  return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::par,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      comp, size1, size2,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
+         Ptr3 start3, Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
+        return dpct::set_symmetric_difference(
+            std::forward<decltype(policy)>(policy), start1, end1, start2, end2,
+            start3, start4, start5, start6);
+      },
+      keys_result, values_result, // return base
+      keys_first1, keys_first2, values_first1, values_first2, keys_result,
+      values_result // all ptrs
+  );
+}
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5, typename Ptr6>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
+    std::pair<Ptr5, Ptr6>>
+set_symmetric_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
+                         Size size2, Ptr3 values_first1, Ptr4 values_first2,
+                         Ptr5 keys_result, Ptr6 values_result) {
+  return dpct::set_symmetric_difference(
+      keys_first1, size1, keys_first2, size2, values_first1, values_first2,
+      keys_result, values_result, dpct::internal::__less());
+}
+#endif // DPCT_USM_LEVEL_NONE
+
 template <class Policy, class Iter1, class Iter2, class Iter3, class Iter4,
           class Iter5, class Iter6>
 internal::enable_if_execution_policy<Policy, std::pair<Iter5, Iter6>>
@@ -741,11 +918,11 @@ set_difference(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
 
 template <class Policy, class Iter1, class Iter2, class Iter3, class Iter4,
           class Iter5, class Iter6, class Comp>
-internal::enable_if_execution_policy<Policy, std::pair<Iter5, Iter6>> set_difference(Policy &&policy, Iter1 keys_first1,
-                                       Iter1 keys_last1, Iter2 keys_first2,
-                                       Iter2 keys_last2, Iter3 values_first1,
-                                       Iter4 values_first2, Iter5 keys_result,
-                                       Iter6 values_result, Comp comp) {
+internal::enable_if_execution_policy<Policy, std::pair<Iter5, Iter6>>
+set_difference(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
+               Iter2 keys_first2, Iter2 keys_last2, Iter3 values_first1,
+               Iter4 values_first2, Iter5 keys_result, Iter6 values_result,
+               Comp comp) {
   static_assert(
       std::is_same<typename std::iterator_traits<Iter1>::iterator_category,
                    std::random_access_iterator_tag>::value &&
@@ -774,6 +951,45 @@ internal::enable_if_execution_policy<Policy, std::pair<Iter5, Iter6>> set_differ
       oneapi::dpl::make_zip_iterator(keys_result, values_result), ret_val);
   return std::make_pair(keys_result + n1, values_result + n1);
 }
+
+#ifdef DPCT_USM_LEVEL_NONE
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5, typename Ptr6, typename Comp>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
+    std::pair<Ptr5, Ptr6>>
+set_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
+               Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
+               Ptr6 values_result, Comp comp) {
+  return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::par_unseq,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      comp, size1, size2,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
+         Ptr3 start3, Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
+        return dpct::set_difference(std::forward<decltype(policy)>(policy),
+                                    start1, end1, start2, end2, start3, start4,
+                                    start5, start6, comp);
+      },
+      keys_result, values_result, // return base
+      keys_first1, keys_first2, values_first1, values_first2, keys_result,
+      values_result // all ptrs
+  );
+}
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5, typename Ptr6>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
+    std::pair<Ptr5, Ptr6>>
+set_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
+               Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
+               Ptr6 values_result) {
+  return dpct::set_difference(keys_first1, size1, keys_first2, size2,
+                              values_first1, values_first2, keys_result,
+                              values_result, dpct::internal::__less());
+}
+#endif // DPCT_USM_LEVEL_NONE
 
 template <class Policy, class Iter1, class Iter2, class Iter3, class Iter4,
           class Iter5, class Iter6>
@@ -846,6 +1062,45 @@ set_union(Policy &&policy, Iter1 keys_first1, Iter1 keys_last1,
   return std::make_pair(keys_result + n1, values_result + n1);
 }
 
+#ifdef DPCT_USM_LEVEL_NONE
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5, typename Ptr6, typename Comp>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
+    std::pair<Ptr5, Ptr6>>
+set_union(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
+          Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
+          Ptr6 values_result, Comp comp) {
+  return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::par,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      comp, size1, size2,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
+         Ptr3 start3, Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
+        return dpct::set_union(std::forward<decltype(policy)>(policy), start1,
+                               end1, start2, end2, start3, start4, start5,
+                               start6, comp);
+      },
+      keys_result, values_result, // return base
+      keys_first1, keys_first2, values_first1, values_first2, keys_result,
+      values_result // all ptrs
+  );
+}
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5, typename Ptr6>
+std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
+    std::pair<Ptr5, Ptr6>>
+set_union(Ptr1 keys_first1, Size size, Ptr2 keys_first2, Size size2,
+          Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
+          Ptr6 values_result) {
+  return dpct::set_union(keys_first1, size, keys_first2, size2, values_first1,
+                         values_first2, keys_result, values_result,
+                         dpct::internal::__less());
+}
+#endif // DPCT_USM_LEVEL_NONE
+
 template <typename Policy, typename Iter1, typename Iter2, typename Iter3,
           typename Iter4, typename Pred>
 internal::enable_if_execution_policy<Policy, std::pair<Iter3, Iter4>>
@@ -889,6 +1144,50 @@ stable_partition_copy(Policy &&policy, Iter1 first, Iter1 last, Iter3 out_true,
                              out_true, out_false, p);
 }
 
+#ifdef DPCT_USM_LEVEL_NONE
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Pred>
+std::enable_if_t<dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4>,
+                 std::pair<Ptr3, Ptr4>>
+stable_partition_copy(Ptr1 first, Size size, Ptr2 mask, Ptr3 out_true,
+                      Ptr4 out_false, Pred p) {
+  return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::par_unseq,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()), p,
+      size,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
+         Ptr4 start4, Pred pred) {
+        return dpct::stable_partition_copy(
+            std::forward<decltype(policy)>(policy), start1, end1, start2,
+            start3, start4, pred);
+      },
+      out_true, out_false,             // return base
+      first, mask, out_true, out_false // all ptrs
+  );
+}
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Pred>
+std::enable_if_t<dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3>,
+                 std::pair<Ptr2, Ptr3>>
+stable_partition_copy(Ptr1 first, Size size, Ptr2 out_true, Ptr3 out_false,
+                      Pred p) {
+  return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::par_unseq,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()), p,
+      size,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
+         Pred pred) {
+        return dpct::stable_partition_copy(
+            std::forward<decltype(policy)>(policy), start1, end1, start2,
+            start3, pred);
+      },
+      out_true, out_false,       // return base
+      first, out_true, out_false // all ptrs
+  );
+}
+#endif // DPCT_USM_LEVEL_NONE
+
 template <typename Policy, typename Iter1, typename Iter2, typename Iter3,
           typename Iter4, typename Pred>
 internal::enable_if_execution_policy<Policy, std::pair<Iter3, Iter4>>
@@ -907,6 +1206,28 @@ partition_copy(Policy &&policy, Iter1 first, Iter1 last, Iter2 mask,
   return stable_partition_copy(std::forward<Policy>(policy), first, last, mask,
                                out_true, out_false, p);
 }
+
+#ifdef DPCT_USM_LEVEL_NONE
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Pred>
+std::enable_if_t<dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4>,
+                 std::pair<Ptr3, Ptr4>>
+partition_copy(Ptr1 first, Size size, Ptr2 mask, Ptr3 out_true, Ptr4 out_false,
+               Pred p) {
+  return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::par_unseq,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()), p,
+      size,
+      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
+         Ptr4 start4, Pred pred) {
+        return dpct::partition_copy(std::forward<decltype(policy)>(policy),
+                                    start1, end1, start2, start3, start4, pred);
+      },
+      out_true, out_false,             // return base
+      first, mask, out_true, out_false // all ptrs
+  );
+}
+#endif // DPCT_USM_LEVEL_NONE
 
 template <typename Policy, typename Iter1, typename Iter2, typename Pred>
 internal::enable_if_hetero_execution_policy<Policy, Iter1>
@@ -1696,7 +2017,6 @@ equal_range(_ExecutionPolicy &&policy, Iter1 start, Iter1 end,
 }
 
 #ifdef DPCT_USM_LEVEL_NONE
-
 template <typename Ptr1, typename Size, typename ValueLessComparable,
           typename StrictWeakOrdering>
 inline std::enable_if_t<std::is_pointer_v<Ptr1>, ::std::pair<Ptr1, Ptr1>>
@@ -1721,310 +2041,7 @@ inline std::enable_if_t<std::is_pointer_v<_T>, ::std::pair<_T, _T>>
 equal_range(_T start, Size size, const ValueLessComparable &value) {
   return dpct::equal_range(start, size, value, internal::__less());
 }
-
-template <typename Ptr1, typename Size, typename Ptr2, typename BinaryPred>
-std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2>,
-                 std::pair<Ptr1, Ptr2>>
-unique(Ptr1 start1, Size size, Ptr2 start2, BinaryPred binary_pred) {
-  return dpct::internal::check_device_ptr_and_launch(
-      oneapi::dpl::execution::par_unseq,
-      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      binary_pred, size,
-      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2,
-         BinaryPred binary_pred) {
-        return dpct::unique(std::forward<decltype(policy)>(policy), start1,
-                            end1, start2, binary_pred);
-      },
-      start1, start2, // return base
-      start1, start2  // all ptrs
-  );
-}
-
-template <typename Ptr1, typename Size, typename Ptr2>
-std::enable_if_t<dpct::internal::all_are_pointer_v<Ptr1, Ptr2>,
-                 std::pair<Ptr1, Ptr2>>
-unique(Ptr1 start1, Size size, Ptr2 start2) {
-  return dpct::unique(
-      start1, size, start2,
-      std::equal_to<typename std::iterator_traits<Ptr1>::value_type>());
-}
-
-template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
-          typename Ptr4, typename BinaryPred>
-
-std::enable_if_t<dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4>,
-                 std::pair<Ptr3, Ptr4>>
-unique_copy(Ptr1 keys_first, Size size, Ptr2 values_first, Ptr3 keys_result,
-            Ptr4 values_result, BinaryPred binary_pred) {
-  return dpct::internal::check_device_ptr_and_launch(
-      oneapi::dpl::execution::par_unseq,
-      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      binary_pred, size,
-      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
-         Ptr4 start4, BinaryPred binary_pred) {
-        return dpct::unique_copy(std::forward<decltype(policy)>(policy), start1,
-                                 end1, start2, start3, start4, binary_pred);
-      },
-      keys_result, values_result,                          // return base
-      keys_first, values_first, keys_result, values_result // all ptrs
-  );
-}
-
-template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
-          typename Ptr4>
-std::enable_if_t<dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4>,
-                 std::pair<Ptr3, Ptr4>>
-unique_copy(Ptr1 keys_first, Size size, Ptr2 values_first, Ptr3 keys_result,
-            Ptr4 values_result) {
-  return dpct::unique_copy(
-      keys_first, size, values_first, keys_result, values_result,
-      std::equal_to<typename std::iterator_traits<Ptr1>::value_type>());
-}
-
-template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
-          typename Ptr4, typename Ptr5, typename Ptr6, typename Comp>
-std::enable_if_t<
-    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
-    std::pair<Ptr5, Ptr6>>
-merge(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
-      Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
-      Ptr6 values_result, Comp comp) {
-  return dpct::internal::check_device_ptr_and_launch(
-      oneapi::dpl::execution::par_unseq,
-      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      comp, size1, size2,
-      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
-         Ptr3 start3, Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
-        return dpct::merge(std::forward<decltype(policy)>(policy), start1, end1,
-                           start2, end2, start3, start4, start5, start6, comp);
-      },
-      keys_result, values_result, // return base
-      keys_first1, keys_first2, values_first1, values_first2, keys_result,
-      values_result); // all ptrs
-}
-
-template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
-          typename Ptr4, typename Ptr5, typename Ptr6>
-std::enable_if_t<
-    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
-    std::pair<Ptr5, Ptr6>>
-merge(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
-      Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
-      Ptr6 values_result) {
-  return dpct::merge(keys_first1, size1, keys_first2, size2, values_first1,
-                     values_first2, keys_result, values_result,
-                     dpct::internal::__less());
-}
-
-template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
-          typename Ptr4, typename Ptr5, typename Comp>
-std::enable_if_t<
-    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5>,
-    std::pair<Ptr4, Ptr5>>
-set_intersection(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
-                 Ptr3 values_first1, Ptr4 keys_result, Ptr5 values_result,
-                 Comp comp) {
-  return dpct::internal::check_device_ptr_and_launch(
-      oneapi::dpl::execution::par,
-      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      comp, size1, size2,
-      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
-         Ptr3 start3, Ptr4 start4, Ptr5 start5, Comp comp) {
-        return dpct::set_intersection(std::forward<decltype(policy)>(policy),
-                                      start1, end1, start2, end2, start3,
-                                      start4, start5, comp);
-      },
-      keys_result, values_result, // return base
-      keys_first1, keys_first2, values_first1, keys_result,
-      values_result // all ptrs
-  );
-}
-
-template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
-          typename Ptr4, typename Ptr5>
-std::enable_if_t<
-    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5>,
-    std::pair<Ptr4, Ptr5>>
-set_intersection(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
-                 Ptr3 values_first1, Ptr4 keys_result, Ptr5 values_result) {
-  return dpct::set_intersection(keys_first1, size1, keys_first2, size2,
-                                values_first1, keys_result, values_result,
-                                dpct::internal::__less());
-}
-
-template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
-          typename Ptr4, typename Ptr5, typename Ptr6, typename Comp>
-std::enable_if_t<
-    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
-    std::pair<Ptr5, Ptr6>>
-set_symmetric_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
-                         Size size2, Ptr3 values_first1, Ptr4 values_first2,
-                         Ptr5 keys_result, Ptr6 values_result, Comp comp) {
-  return dpct::internal::check_device_ptr_and_launch(
-      oneapi::dpl::execution::par,
-      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      comp, size1, size2,
-      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
-         Ptr3 start3, Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
-        return dpct::set_symmetric_difference(
-            std::forward<decltype(policy)>(policy), start1, end1, start2, end2,
-            start3, start4, start5, start6);
-      },
-      keys_result, values_result, // return base
-      keys_first1, keys_first2, values_first1, values_first2, keys_result,
-      values_result // all ptrs
-  );
-}
-
-template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
-          typename Ptr4, typename Ptr5, typename Ptr6>
-std::enable_if_t<
-    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
-    std::pair<Ptr5, Ptr6>>
-set_symmetric_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
-                         Size size2, Ptr3 values_first1, Ptr4 values_first2,
-                         Ptr5 keys_result, Ptr6 values_result) {
-  return dpct::set_symmetric_difference(
-      keys_first1, size1, keys_first2, size2, values_first1, values_first2,
-      keys_result, values_result, dpct::internal::__less());
-}
-
-template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
-          typename Ptr4, typename Ptr5, typename Ptr6, typename Comp>
-std::enable_if_t<
-    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
-    std::pair<Ptr5, Ptr6>>
-set_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
-               Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
-               Ptr6 values_result, Comp comp) {
-  return dpct::internal::check_device_ptr_and_launch(
-      oneapi::dpl::execution::par_unseq,
-      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      comp, size1, size2,
-      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
-         Ptr3 start3, Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
-        return dpct::set_difference(std::forward<decltype(policy)>(policy),
-                                    start1, end1, start2, end2, start3, start4,
-                                    start5, start6, comp);
-      },
-      keys_result, values_result, // return base
-      keys_first1, keys_first2, values_first1, values_first2, keys_result,
-      values_result // all ptrs
-  );
-}
-
-template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
-          typename Ptr4, typename Ptr5, typename Ptr6>
-std::enable_if_t<
-    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
-    std::pair<Ptr5, Ptr6>>
-set_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
-               Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
-               Ptr6 values_result) {
-  return dpct::set_difference(keys_first1, size1, keys_first2, size2,
-                              values_first1, values_first2, keys_result,
-                              values_result, dpct::internal::__less());
-}
-
-template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
-          typename Ptr4, typename Ptr5, typename Ptr6, typename Comp>
-std::enable_if_t<
-    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
-    std::pair<Ptr5, Ptr6>>
-set_union(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
-          Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
-          Ptr6 values_result, Comp comp) {
-  return dpct::internal::check_device_ptr_and_launch(
-      oneapi::dpl::execution::par,
-      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      comp, size1, size2,
-      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
-         Ptr3 start3, Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
-        return dpct::set_union(std::forward<decltype(policy)>(policy), start1,
-                               end1, start2, end2, start3, start4, start5,
-                               start6, comp);
-      },
-      keys_result, values_result, // return base
-      keys_first1, keys_first2, values_first1, values_first2, keys_result,
-      values_result // all ptrs
-  );
-}
-
-template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
-          typename Ptr4, typename Ptr5, typename Ptr6>
-std::enable_if_t<
-    dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4, Ptr5, Ptr6>,
-    std::pair<Ptr5, Ptr6>>
-set_union(Ptr1 keys_first1, Size size, Ptr2 keys_first2, Size size2,
-          Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
-          Ptr6 values_result) {
-  return dpct::set_union(keys_first1, size, keys_first2, size2, values_first1,
-                         values_first2, keys_result, values_result,
-                         dpct::internal::__less());
-}
-
-template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
-          typename Ptr4, typename Pred>
-std::enable_if_t<dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4>,
-                 std::pair<Ptr3, Ptr4>>
-stable_partition_copy(Ptr1 first, Size size, Ptr2 mask, Ptr3 out_true,
-                      Ptr4 out_false, Pred p) {
-  return dpct::internal::check_device_ptr_and_launch(
-      oneapi::dpl::execution::par_unseq,
-      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()), p,
-      size,
-      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
-         Ptr4 start4, Pred pred) {
-        return dpct::stable_partition_copy(
-            std::forward<decltype(policy)>(policy), start1, end1, start2,
-            start3, start4, pred);
-      },
-      out_true, out_false,             // return base
-      first, mask, out_true, out_false // all ptrs
-  );
-}
-template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
-          typename Pred>
-std::enable_if_t<dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3>,
-                 std::pair<Ptr2, Ptr3>>
-stable_partition_copy(Ptr1 first, Size size, Ptr2 out_true, Ptr3 out_false,
-                      Pred p) {
-  return dpct::internal::check_device_ptr_and_launch(
-      oneapi::dpl::execution::par_unseq,
-      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()), p,
-      size,
-      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
-         Pred pred) {
-        return dpct::stable_partition_copy(
-            std::forward<decltype(policy)>(policy), start1, end1, start2,
-            start3, pred);
-      },
-      out_true, out_false,       // return base
-      first, out_true, out_false // all ptrs
-  );
-}
-
-template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
-          typename Ptr4, typename Pred>
-std::enable_if_t<dpct::internal::all_are_pointer_v<Ptr1, Ptr2, Ptr3, Ptr4>,
-                 std::pair<Ptr3, Ptr4>>
-partition_copy(Ptr1 first, Size size, Ptr2 mask, Ptr3 out_true, Ptr4 out_false,
-               Pred p) {
-  return dpct::internal::check_device_ptr_and_launch(
-      oneapi::dpl::execution::par_unseq,
-      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()), p,
-      size,
-      [](auto &&policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
-         Ptr4 start4, Pred pred) {
-        return dpct::partition_copy(std::forward<decltype(policy)>(policy),
-                                    start1, end1, start2, start3, start4, pred);
-      },
-      out_true, out_false,             // return base
-      first, mask, out_true, out_false // all ptrs
-  );
-}
-
-#endif // #DPCT_USM_LEVEL_NONE
+#endif // DPCT_USM_LEVEL_NONE
 
 template <typename Policy, typename Iter1, typename Iter2, typename Iter3>
 inline ::std::enable_if_t<

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/algorithm.h
@@ -1669,8 +1669,8 @@ inline void reduce_argmin(_ExecutionPolicy &&policy, Iter1 input, Iter2 output,
 
 template <typename _ExecutionPolicy, typename Iter1,
           typename ValueLessComparable, typename StrictWeakOrdering>
-inline 
-dpct::internal::enable_if_execution_policy<_ExecutionPolicy, ::std::pair<Iter1,Iter1>>
+inline dpct::internal::enable_if_execution_policy<_ExecutionPolicy,
+                                                  ::std::pair<Iter1, Iter1>>
 equal_range(_ExecutionPolicy &&policy, Iter1 start, Iter1 end,
             const ValueLessComparable &value, StrictWeakOrdering comp) {
   ::std::vector<::std::int64_t> res_lower(1);
@@ -1687,11 +1687,10 @@ equal_range(_ExecutionPolicy &&policy, Iter1 start, Iter1 end,
 
 template <typename _ExecutionPolicy, typename Iter1,
           typename ValueLessComparable>
-inline
-dpct::internal::enable_if_execution_policy<_ExecutionPolicy, ::std::pair<Iter1,Iter1>>
-equal_range(_ExecutionPolicy &&policy,
-                                             Iter1 start, Iter1 end,
-                                             const ValueLessComparable &value) {
+inline dpct::internal::enable_if_execution_policy<_ExecutionPolicy,
+                                                  ::std::pair<Iter1, Iter1>>
+equal_range(_ExecutionPolicy &&policy, Iter1 start, Iter1 end,
+            const ValueLessComparable &value) {
   return equal_range(::std::forward<_ExecutionPolicy>(policy), start, end,
                      value, internal::__less());
 }
@@ -1711,9 +1710,9 @@ equal_range(Ptr1 start, Size size, const ValueLessComparable &value,
          StrictWeakOrdering comp) {
         return dpct::equal_range(policy, start, end, value, comp);
       },
-      start, start, //return base
-      start //all ptrs
-      );
+      start, start, // return base
+      start         // all ptrs
+  );
 }
 
 template <typename _T, typename Size, typename ValueLessComparable>
@@ -1723,9 +1722,9 @@ equal_range(_T start, Size size, const ValueLessComparable &value) {
 }
 
 template <typename Ptr1, typename Size, typename Ptr2, typename BinaryPred>
-std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2>, std::pair<Ptr1, Ptr2>>
-unique(Ptr1 start1, Size size, Ptr2 start2,
-                             BinaryPred binary_pred) {
+std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2>,
+                 std::pair<Ptr1, Ptr2>>
+unique(Ptr1 start1, Size size, Ptr2 start2, BinaryPred binary_pred) {
   return dpct::internal::check_device_ptr_and_launch(
       oneapi::dpl::execution::seq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
@@ -1734,14 +1733,15 @@ unique(Ptr1 start1, Size size, Ptr2 start2,
          BinaryPred binary_pred) {
         return dpct::unique(policy, start1, end1, start2, binary_pred);
       },
-      start1, start2, //return base
-      start1, start2 //all ptrs
-      );
+      start1, start2, // return base
+      start1, start2  // all ptrs
+  );
 }
 
 template <typename Ptr1, typename Size, typename Ptr2>
-std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2>,std::pair<Ptr1, Ptr2>>
-                  unique(Ptr1 start1, Size size, Ptr2 start2) {
+std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2>,
+                 std::pair<Ptr1, Ptr2>>
+unique(Ptr1 start1, Size size, Ptr2 start2) {
   return dpct::unique(
       start1, size, start2,
       std::equal_to<typename std::iterator_traits<Ptr1>::value_type>());
@@ -1761,17 +1761,18 @@ std::pair<Ptr3, Ptr4> unique_copy(Ptr1 keys_first, Size size, Ptr2 values_first,
         return dpct::unique_copy(policy, start1, end1, start2, start3, start4,
                                  binary_pred);
       },
-      keys_result, values_result, //return base
-      keys_first, values_first, keys_result, values_result //all ptrs
-      );
+      keys_result, values_result,                          // return base
+      keys_first, values_first, keys_result, values_result // all ptrs
+  );
 }
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
           typename Ptr4>
 std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                 std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4>, std::pair<Ptr3, Ptr4>>
-unique_copy(Ptr1 keys_first, Size size, Ptr2 values_first,
-                                  Ptr3 keys_result, Ptr4 values_result) {
+                     std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4>,
+                 std::pair<Ptr3, Ptr4>>
+unique_copy(Ptr1 keys_first, Size size, Ptr2 values_first, Ptr3 keys_result,
+            Ptr4 values_result) {
   return dpct::unique_copy(
       keys_first, size, values_first, keys_result, values_result,
       std::equal_to<typename std::iterator_traits<Ptr1>::value_type>());
@@ -1780,256 +1781,251 @@ unique_copy(Ptr1 keys_first, Size size, Ptr2 values_first,
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
           typename Ptr4, typename Ptr5, typename Ptr6, typename Comp>
 std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                 std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
-                 std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>,std::pair<Ptr5, Ptr6>>
-merge(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
-      Size size2, Ptr3 values_first1, Ptr4 values_first2,
-      Ptr5 keys_result, Ptr6 values_result, Comp comp)
-{ 
-    return dpct::internal::check_device_ptr_and_launch(
+                     std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
+                     std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>,
+                 std::pair<Ptr5, Ptr6>>
+merge(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
+      Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
+      Ptr6 values_result, Comp comp) {
+  return dpct::internal::check_device_ptr_and_launch(
       oneapi::dpl::execution::seq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      comp, size1, size2, 
-      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2, Ptr3 start3,
-         Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
-        return dpct::merge(policy, start1, end1, start2, end2, start3, start4, start5, 
-                                 start6, comp);
-      }, 
-      keys_result, values_result, //return base
-      keys_first1, keys_first2, values_first1, values_first2, keys_result, values_result); //all ptrs
+      comp, size1, size2,
+      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
+         Ptr3 start3, Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
+        return dpct::merge(policy, start1, end1, start2, end2, start3, start4,
+                           start5, start6, comp);
+      },
+      keys_result, values_result, // return base
+      keys_first1, keys_first2, values_first1, values_first2, keys_result,
+      values_result); // all ptrs
 }
-
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
           typename Ptr4, typename Ptr5, typename Ptr6>
 std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                 std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
-                 std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>,std::pair<Ptr5, Ptr6>>
-merge(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
-      Size size2, Ptr3 values_first1, Ptr4 values_first2,
-      Ptr5 keys_result, Ptr6 values_result)
-{
-  return dpct::merge(keys_first1, size1, keys_first2, size2, values_first1, values_first2, keys_result, values_result, dpct::internal::__less());
-}
-
-
-template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
-          typename Ptr5, typename Comp>
-std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                 std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
-                 std::is_pointer_v<Ptr5>,std::pair<Ptr4, Ptr5>>
-set_intersection(Ptr1 keys_first1, Size size1,
-                 Ptr2 keys_first2, Size size2, Ptr3 values_first1,
-                 Ptr4 keys_result, Ptr5 values_result, Comp comp)
-{
-    return dpct::internal::check_device_ptr_and_launch(
-      oneapi::dpl::execution::seq,
-      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      comp, size1, size2,
-      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2, Ptr3 start3,
-         Ptr4 start4, Ptr5 start5, Comp comp) {
-        return dpct::set_intersection(policy, start1, end1, start2, end2, start3, start4, start5,
-                                 comp);
-      }, 
-      keys_result, values_result, //return base
-      keys_first1, keys_first2, values_first1, keys_result, values_result //all ptrs
-      );
-
-}
-
-template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
-          typename Ptr5>
-std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                 std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
-                 std::is_pointer_v<Ptr5>,std::pair<Ptr4, Ptr5>>
-set_intersection(Ptr1 keys_first1, Size size1,
-                 Ptr2 keys_first2, Size size2, Ptr3 values_first1,
-                 Ptr4 keys_result, Ptr5 values_result)
-{
-  return dpct::set_intersection(keys_first1, size1,
-                 keys_first2, size2, values_first1,
-                 keys_result, values_result, dpct::internal::__less());
-}
-
-
-template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
-          typename Ptr5, typename Ptr6, typename Comp>
-std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                 std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
-                 std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6> ,std::pair<Ptr5, Ptr6>>
-set_symmetric_difference(Ptr1 keys_first1, Size size1,
-                         Ptr2 keys_first2, Size size2,
-                         Ptr3 values_first1, Ptr4 values_first2,
-                         Ptr5 keys_result, Ptr6 values_result, Comp comp)
-{
-    return dpct::internal::check_device_ptr_and_launch(
-      oneapi::dpl::execution::seq,
-      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      comp, size1, size2,
-      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2, Ptr3 start3,
-         Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
-        return dpct::set_symmetric_difference(policy, start1, end1, start2, end2, start3, start4, start5, 
-                                 start6);
-      }, 
-      keys_result, values_result, //return base
-      keys_first1, keys_first2, values_first1, values_first2, keys_result, values_result // all ptrs
-      );
-}
-
-template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
-          typename Ptr5, typename Ptr6>
-std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                 std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
-                 std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>, std::pair<Ptr5, Ptr6>>
-set_symmetric_difference(Ptr1 keys_first1, Size size1,
-                         Ptr2 keys_first2, Size size2,
-                         Ptr3 values_first1, Ptr4 values_first2,
-                         Ptr5 keys_result, Ptr6 values_result)
-{
-    return dpct::set_symmetric_difference(keys_first1, size1,
-                 keys_first2, size2, values_first1, values_first2,
-                 keys_result, values_result, dpct::internal::__less());
-}
-
-
-template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
-          typename Ptr5, typename Ptr6, typename Comp>
-std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                 std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
-                 std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>, 
+                     std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
+                     std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>,
                  std::pair<Ptr5, Ptr6>>
-set_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
-                                       Size size2, Ptr3 values_first1,
-                                       Ptr4 values_first2, Ptr5 keys_result,
-                                       Ptr6 values_result, Comp comp)
-{
-    return dpct::internal::check_device_ptr_and_launch(
+merge(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
+      Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
+      Ptr6 values_result) {
+  return dpct::merge(keys_first1, size1, keys_first2, size2, values_first1,
+                     values_first2, keys_result, values_result,
+                     dpct::internal::__less());
+}
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5, typename Comp>
+std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
+                     std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
+                     std::is_pointer_v<Ptr5>,
+                 std::pair<Ptr4, Ptr5>>
+set_intersection(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
+                 Ptr3 values_first1, Ptr4 keys_result, Ptr5 values_result,
+                 Comp comp) {
+  return dpct::internal::check_device_ptr_and_launch(
       oneapi::dpl::execution::seq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
       comp, size1, size2,
-      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2, Ptr3 start3,
-         Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
-        return dpct::set_difference(policy, start1, end1, start2, end2, start3, start4, start5, 
-                                 start6, comp);
+      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
+         Ptr3 start3, Ptr4 start4, Ptr5 start5, Comp comp) {
+        return dpct::set_intersection(policy, start1, end1, start2, end2,
+                                      start3, start4, start5, comp);
       },
-      keys_result, values_result, //return base
-      keys_first1, keys_first2, values_first1, values_first2, keys_result, values_result //all ptrs
-      ); 
+      keys_result, values_result, // return base
+      keys_first1, keys_first2, values_first1, keys_result,
+      values_result // all ptrs
+  );
 }
 
-template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
-          typename Ptr5, typename Ptr6>
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5>
 std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                 std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
-                 std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>, std::pair<Ptr5, Ptr6>>
-set_difference(Ptr1 keys_first1, Size size1,
-               Ptr2 keys_first2, Size size2, Ptr3 values_first1,
-               Ptr4 values_first2, Ptr5 keys_result, Ptr6 values_result)
-{
-   return dpct::set_difference(keys_first1, size1,
-          keys_first2, size2, values_first1,
-          values_first2, keys_result, values_result, dpct::internal::__less()); 
+                     std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
+                     std::is_pointer_v<Ptr5>,
+                 std::pair<Ptr4, Ptr5>>
+set_intersection(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
+                 Ptr3 values_first1, Ptr4 keys_result, Ptr5 values_result) {
+  return dpct::set_intersection(keys_first1, size1, keys_first2, size2,
+                                values_first1, keys_result, values_result,
+                                dpct::internal::__less());
 }
 
-template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
-          typename Ptr5, typename Ptr6, typename Comp>
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5, typename Ptr6, typename Comp>
 std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                 std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
-                 std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>, std::pair<Ptr5, Ptr6>>
-set_union(Ptr1 keys_first1, Size size1,
-          Ptr2 keys_first2, Size size2, Ptr3 values_first1,
-          Ptr4 values_first2, Ptr5 keys_result, Ptr6 values_result,
-          Comp comp)
-{
-    return dpct::internal::check_device_ptr_and_launch(
+                     std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
+                     std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>,
+                 std::pair<Ptr5, Ptr6>>
+set_symmetric_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
+                         Size size2, Ptr3 values_first1, Ptr4 values_first2,
+                         Ptr5 keys_result, Ptr6 values_result, Comp comp) {
+  return dpct::internal::check_device_ptr_and_launch(
       oneapi::dpl::execution::seq,
       oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      comp, size1, size2, 
-      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2, Ptr3 start3,
-         Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
-        return dpct::set_union(policy, start1, end1, start2, end2, start3, start4, start5, 
-                                 start6, comp);
-      }, 
-      keys_result, values_result, //return base
-      keys_first1, keys_first2, values_first1, values_first2, keys_result, values_result //all ptrs
-      );
+      comp, size1, size2,
+      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
+         Ptr3 start3, Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
+        return dpct::set_symmetric_difference(
+            policy, start1, end1, start2, end2, start3, start4, start5, start6);
+      },
+      keys_result, values_result, // return base
+      keys_first1, keys_first2, values_first1, values_first2, keys_result,
+      values_result // all ptrs
+  );
 }
 
-template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3, typename Ptr4,
-          typename Ptr5, typename Ptr6>
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5, typename Ptr6>
 std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                 std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
-                 std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>, std::pair<Ptr5, Ptr6>>
-set_union(Ptr1 keys_first1, Size size,
-          Ptr2 keys_first2, Size size2, Ptr3 values_first1,
-          Ptr4 values_first2, Ptr5 keys_result, Ptr6 values_result)
-{
-  return dpct::set_union(keys_first1, size,
-          keys_first2, size2, values_first1,
-          values_first2, keys_result, values_result, dpct::internal::__less());
+                     std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
+                     std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>,
+                 std::pair<Ptr5, Ptr6>>
+set_symmetric_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2,
+                         Size size2, Ptr3 values_first1, Ptr4 values_first2,
+                         Ptr5 keys_result, Ptr6 values_result) {
+  return dpct::set_symmetric_difference(
+      keys_first1, size1, keys_first2, size2, values_first1, values_first2,
+      keys_result, values_result, dpct::internal::__less());
+}
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5, typename Ptr6, typename Comp>
+std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
+                     std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
+                     std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>,
+                 std::pair<Ptr5, Ptr6>>
+set_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
+               Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
+               Ptr6 values_result, Comp comp) {
+  return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::seq,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      comp, size1, size2,
+      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
+         Ptr3 start3, Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
+        return dpct::set_difference(policy, start1, end1, start2, end2, start3,
+                                    start4, start5, start6, comp);
+      },
+      keys_result, values_result, // return base
+      keys_first1, keys_first2, values_first1, values_first2, keys_result,
+      values_result // all ptrs
+  );
+}
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5, typename Ptr6>
+std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
+                     std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
+                     std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>,
+                 std::pair<Ptr5, Ptr6>>
+set_difference(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
+               Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
+               Ptr6 values_result) {
+  return dpct::set_difference(keys_first1, size1, keys_first2, size2,
+                              values_first1, values_first2, keys_result,
+                              values_result, dpct::internal::__less());
+}
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5, typename Ptr6, typename Comp>
+std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
+                     std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
+                     std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>,
+                 std::pair<Ptr5, Ptr6>>
+set_union(Ptr1 keys_first1, Size size1, Ptr2 keys_first2, Size size2,
+          Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
+          Ptr6 values_result, Comp comp) {
+  return dpct::internal::check_device_ptr_and_launch(
+      oneapi::dpl::execution::seq,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      comp, size1, size2,
+      [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr2 end2,
+         Ptr3 start3, Ptr4 start4, Ptr5 start5, Ptr6 start6, Comp comp) {
+        return dpct::set_union(policy, start1, end1, start2, end2, start3,
+                               start4, start5, start6, comp);
+      },
+      keys_result, values_result, // return base
+      keys_first1, keys_first2, values_first1, values_first2, keys_result,
+      values_result // all ptrs
+  );
+}
+
+template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Ptr5, typename Ptr6>
+std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
+                     std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4> &&
+                     std::is_pointer_v<Ptr5> && std::is_pointer_v<Ptr6>,
+                 std::pair<Ptr5, Ptr6>>
+set_union(Ptr1 keys_first1, Size size, Ptr2 keys_first2, Size size2,
+          Ptr3 values_first1, Ptr4 values_first2, Ptr5 keys_result,
+          Ptr6 values_result) {
+  return dpct::set_union(keys_first1, size, keys_first2, size2, values_first1,
+                         values_first2, keys_result, values_result,
+                         dpct::internal::__less());
 }
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
           typename Ptr4, typename Pred>
 std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                 std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4>, std::pair<Ptr3, Ptr4>>
-stable_partition_copy(Ptr1 first, Size size, Ptr2 mask,
-                      Ptr3 out_true, Ptr4 out_false, Pred p)
-{
+                     std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4>,
+                 std::pair<Ptr3, Ptr4>>
+stable_partition_copy(Ptr1 first, Size size, Ptr2 mask, Ptr3 out_true,
+                      Ptr4 out_false, Pred p) {
   return dpct::internal::check_device_ptr_and_launch(
       oneapi::dpl::execution::seq,
-      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      p, size,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()), p,
+      size,
       [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
          Ptr4 start4, Pred pred) {
-        return dpct::stable_partition_copy(policy, start1, end1, start2, start3, start4,
-                                 pred);
+        return dpct::stable_partition_copy(policy, start1, end1, start2, start3,
+                                           start4, pred);
       },
-      out_true, out_false, //return base
-      first, mask, out_true, out_false //all ptrs
-      );
-
+      out_true, out_false,             // return base
+      first, mask, out_true, out_false // all ptrs
+  );
 }
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
           typename Pred>
 std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                 std::is_pointer_v<Ptr3>, std::pair<Ptr2, Ptr3>>
-stable_partition_copy(Ptr1 first, Size size, Ptr2 out_true,
-                      Ptr3 out_false, Pred p)
-{
+                     std::is_pointer_v<Ptr3>,
+                 std::pair<Ptr2, Ptr3>>
+stable_partition_copy(Ptr1 first, Size size, Ptr2 out_true, Ptr3 out_false,
+                      Pred p) {
   return dpct::internal::check_device_ptr_and_launch(
       oneapi::dpl::execution::seq,
-      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      p, size,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()), p,
+      size,
       [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
          Pred pred) {
         return dpct::stable_partition_copy(policy, start1, end1, start2, start3,
-                                 pred);
+                                           pred);
       },
-      out_true, out_false, //return base
+      out_true, out_false,       // return base
       first, out_true, out_false // all ptrs
-      );
+  );
 }
 
 template <typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
           typename Ptr4, typename Pred>
 std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                 std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4>,std::pair<Ptr3, Ptr4>>
-partition_copy(Ptr1 first, Size size, Ptr2 mask,
-               Ptr3 out_true, Ptr4 out_false, Pred p)
-{
+                     std::is_pointer_v<Ptr3> && std::is_pointer_v<Ptr4>,
+                 std::pair<Ptr3, Ptr4>>
+partition_copy(Ptr1 first, Size size, Ptr2 mask, Ptr3 out_true, Ptr4 out_false,
+               Pred p) {
   return dpct::internal::check_device_ptr_and_launch(
       oneapi::dpl::execution::seq,
-      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-      p, size,
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()), p,
+      size,
       [](auto policy, Ptr1 start1, Ptr1 end1, Ptr2 start2, Ptr3 start3,
          Ptr4 start4, Pred pred) {
-        return dpct::partition_copy(policy, start1, end1, start2, start3, start4,
-                                 pred);
+        return dpct::partition_copy(policy, start1, end1, start2, start3,
+                                    start4, pred);
       },
-      out_true, out_false, //return base
+      out_true, out_false,             // return base
       first, mask, out_true, out_false // all ptrs
-      );
+  );
 }
 
 #endif // #DPCT_USM_LEVEL_NONE

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/functional.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/functional.h
@@ -294,23 +294,109 @@ private:
 
 #ifdef DPCT_USM_LEVEL_NONE
 
+
 template <typename _ExecutionPolicyHost, typename _ExecutionPolicyDevice,
-          typename _T, typename Size, typename _Func, typename... _Args>
+          typename _Ptr1, typename Size, typename _Ptr2, typename _Ptr3, typename _Ptr4, typename _Ptr5, typename _Ptr6, typename _Func, typename... _Args>
 inline
-std::enable_if_t<std::is_pointer_v<_T>, ::std::pair<_T, _T>>
-check_device_ptr_and_launch(_ExecutionPolicyHost&& host_policy, _ExecutionPolicyDevice&& dev_policy, _T start,
+std::enable_if_t<std::is_pointer_v<_Ptr1> && std::is_pointer_v<_Ptr2> && std::is_pointer_v<_Ptr3> && std::is_pointer_v<_Ptr4> && std::is_pointer_v<_Ptr5> && std::is_pointer_v<_Ptr6>, ::std::pair<_Ptr5, _Ptr6>>
+check_device_ptr_and_launch(_ExecutionPolicyHost&& host_policy, _ExecutionPolicyDevice&& dev_policy, _Ptr1 start1,
+                       Size size, _Ptr2 start2, _Ptr3 start3, _Ptr4 start4, _Ptr5 start5, _Ptr6 start6, _Func func, _Args... args)
+{
+    if (dpct::is_device_ptr(start1)) {
+      using value_type1 = typename std::iterator_traits<_Ptr1>::value_type;
+      using value_type2 = typename std::iterator_traits<_Ptr2>::value_type;
+      using value_type3 = typename std::iterator_traits<_Ptr3>::value_type;
+      using value_type4 = typename std::iterator_traits<_Ptr4>::value_type;
+      using value_type5 = typename std::iterator_traits<_Ptr5>::value_type;
+      using value_type6 = typename std::iterator_traits<_Ptr6>::value_type;
+      auto dev_start1 = dpct::device_pointer<value_type1>(start1);
+      auto dev_end1 = dpct::device_pointer<value_type1>(start1) + size;
+      auto dev_start2 = dpct::device_pointer<value_type2>(start2);
+      auto dev_end2 = dpct::device_pointer<value_type2>(start2) + size;
+      auto dev_start3 = dpct::device_pointer<value_type3>(start3);
+      auto dev_end3 = dpct::device_pointer<value_type3>(start3) + size;
+      auto dev_start4 = dpct::device_pointer<value_type4>(start4);
+      auto dev_end4 = dpct::device_pointer<value_type4>(start4) + size;
+      auto dev_start5 = dpct::device_pointer<value_type5>(start5);
+      auto dev_end5 = dpct::device_pointer<value_type5>(start5) + size;
+      auto dev_start6 = dpct::device_pointer<value_type6>(start6);
+      auto dev_end6 = dpct::device_pointer<value_type6>(start6) + size;
+      auto ret = func(std::forward<_ExecutionPolicyDevice>(dev_policy), dev_start1, dev_end1, dev_start2, dev_start3, dev_start4, dev_start5, dev_start6, args...);
+      return ::std::pair<_Ptr5, _Ptr6>(start5 + (ret.first - dev_start5), start6 + (ret.second - dev_start6));
+    } else {
+      return func(std::forward<_ExecutionPolicyHost>(host_policy), start1, start1 + size, start2, start3, start4, start5, start6, args...);
+    }
+}
+
+
+template <typename _ExecutionPolicyHost, typename _ExecutionPolicyDevice,
+          typename _Ptr1, typename Size, typename _Ptr2, typename _Ptr3, typename _Ptr4, typename _Func, typename... _Args>
+inline
+std::enable_if_t<std::is_pointer_v<_Ptr1> && std::is_pointer_v<_Ptr2> && std::is_pointer_v<_Ptr3> && std::is_pointer_v<_Ptr4>, ::std::pair<_Ptr3, _Ptr4>>
+check_device_ptr_and_launch(_ExecutionPolicyHost&& host_policy, _ExecutionPolicyDevice&& dev_policy, _Ptr1 start1,
+                       Size size, _Ptr2 start2, _Ptr3 start3, _Ptr4 start4, _Func func, _Args... args)
+{
+    if (dpct::is_device_ptr(start1)) {
+      using value_type1 = typename std::iterator_traits<_Ptr1>::value_type;
+      using value_type2 = typename std::iterator_traits<_Ptr2>::value_type;
+      using value_type3 = typename std::iterator_traits<_Ptr3>::value_type;
+      using value_type4 = typename std::iterator_traits<_Ptr4>::value_type;
+      auto dev_start1 = dpct::device_pointer<value_type1>(start1);
+      auto dev_end1 = dpct::device_pointer<value_type1>(start1) + size;
+      auto dev_start2 = dpct::device_pointer<value_type2>(start2);
+      auto dev_end2 = dpct::device_pointer<value_type2>(start2) + size;
+      auto dev_start3 = dpct::device_pointer<value_type3>(start3);
+      auto dev_end3 = dpct::device_pointer<value_type3>(start3) + size;
+      auto dev_start4 = dpct::device_pointer<value_type4>(start4);
+      auto dev_end4 = dpct::device_pointer<value_type4>(start4) + size;
+      auto ret = func(std::forward<_ExecutionPolicyDevice>(dev_policy), dev_start1, dev_end1, dev_start2, dev_start3, dev_start4, args...);
+      return ::std::pair<_Ptr3, _Ptr4>(start3 + (ret.first - dev_start3), start4 + (ret.second - dev_start4));
+    } else {
+      return func(std::forward<_ExecutionPolicyHost>(host_policy), start1, start1 + size, start2, start3, start4, args...);
+    }
+}
+
+
+
+template <typename _ExecutionPolicyHost, typename _ExecutionPolicyDevice,
+          typename _Ptr1, typename Size, typename _Ptr2, typename _Func, typename... _Args>
+inline
+std::enable_if_t<std::is_pointer_v<_Ptr1> && std::is_pointer_v<_Ptr2>, ::std::pair<_Ptr1, _Ptr2>>
+check_device_ptr_and_launch(_ExecutionPolicyHost&& host_policy, _ExecutionPolicyDevice&& dev_policy, _Ptr1 start1,
+                       Size size, _Ptr2 start2, _Func func, _Args... args)
+{
+    if (dpct::is_device_ptr(start1)) {
+      using value_type1 = typename std::iterator_traits<_Ptr1>::value_type;
+      using value_type2 = typename std::iterator_traits<_Ptr2>::value_type;
+      auto dev_start1 = dpct::device_pointer<value_type1>(start1);
+      auto dev_end1 = dpct::device_pointer<value_type1>(start1) + size;
+      auto dev_start2 = dpct::device_pointer<value_type2>(start2);
+      auto dev_end2 = dpct::device_pointer<value_type2>(start2) + size;
+      auto ret = func(std::forward<_ExecutionPolicyDevice>(dev_policy), dev_start1, dev_end1, dev_start2, args...);
+      return ::std::pair<_Ptr1, _Ptr2>(start1 + (ret.first - dev_start1), start2 + (ret.second - dev_start2));
+    } else {
+      return func(std::forward<_ExecutionPolicyHost>(host_policy), start1, start1 + size, start2, args...);
+    }
+}
+
+template <typename _ExecutionPolicyHost, typename _ExecutionPolicyDevice,
+          typename _PtrT, typename Size, typename _Func, typename... _Args>
+inline
+std::enable_if_t<std::is_pointer_v<_PtrT>, ::std::pair<_PtrT, _PtrT>>
+check_device_ptr_and_launch(_ExecutionPolicyHost&& host_policy, _ExecutionPolicyDevice&& dev_policy, _PtrT start,
                        Size size, _Func func, _Args... args)
 {
     if (dpct::is_device_ptr(start)) {
-      using value_type = typename std::iterator_traits<_T>::value_type;
+      using value_type = typename std::iterator_traits<_PtrT>::value_type;
       auto dev_start = dpct::device_pointer<value_type>(start);
       auto dev_end = dpct::device_pointer<value_type>(start) + size;
       auto ret = func(std::forward<_ExecutionPolicyDevice>(dev_policy), dev_start, dev_end, args...);
-      return ::std::pair<_T, _T>(start + (ret.first - dev_start), start + (ret.second - dev_start));
+      return ::std::pair<_PtrT, _PtrT>(start + (ret.first - dev_start), start + (ret.second - dev_start));
     } else {
       return func(std::forward<_ExecutionPolicyHost>(host_policy), start, start + size, args...);
     }
 }
+
 #endif //DPCT_USM_LEVEL_NONE
 
 // This following code is similar to a section of code in

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/functional.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/functional.h
@@ -294,110 +294,132 @@ private:
 
 #ifdef DPCT_USM_LEVEL_NONE
 
-
 template <typename _ExecutionPolicyHost, typename _ExecutionPolicyDevice,
-          typename _Ptr1, typename Size, typename _Ptr2, typename _Ptr3, typename _Ptr4, typename _Ptr5, typename _Ptr6, typename _Func, typename... _Args>
-inline
-std::enable_if_t<std::is_pointer_v<_Ptr1> && std::is_pointer_v<_Ptr2> && std::is_pointer_v<_Ptr3> && std::is_pointer_v<_Ptr4> && std::is_pointer_v<_Ptr5> && std::is_pointer_v<_Ptr6>, ::std::pair<_Ptr5, _Ptr6>>
-check_device_ptr_and_launch(_ExecutionPolicyHost&& host_policy, _ExecutionPolicyDevice&& dev_policy, _Ptr1 start1,
-                       Size size, _Ptr2 start2, _Ptr3 start3, _Ptr4 start4, _Ptr5 start5, _Ptr6 start6, _Func func, _Args... args)
-{
-    if (dpct::is_device_ptr(start1)) {
-      using value_type1 = typename std::iterator_traits<_Ptr1>::value_type;
-      using value_type2 = typename std::iterator_traits<_Ptr2>::value_type;
-      using value_type3 = typename std::iterator_traits<_Ptr3>::value_type;
-      using value_type4 = typename std::iterator_traits<_Ptr4>::value_type;
-      using value_type5 = typename std::iterator_traits<_Ptr5>::value_type;
-      using value_type6 = typename std::iterator_traits<_Ptr6>::value_type;
-      auto dev_start1 = dpct::device_pointer<value_type1>(start1);
-      auto dev_end1 = dpct::device_pointer<value_type1>(start1) + size;
-      auto dev_start2 = dpct::device_pointer<value_type2>(start2);
-      auto dev_end2 = dpct::device_pointer<value_type2>(start2) + size;
-      auto dev_start3 = dpct::device_pointer<value_type3>(start3);
-      auto dev_end3 = dpct::device_pointer<value_type3>(start3) + size;
-      auto dev_start4 = dpct::device_pointer<value_type4>(start4);
-      auto dev_end4 = dpct::device_pointer<value_type4>(start4) + size;
-      auto dev_start5 = dpct::device_pointer<value_type5>(start5);
-      auto dev_end5 = dpct::device_pointer<value_type5>(start5) + size;
-      auto dev_start6 = dpct::device_pointer<value_type6>(start6);
-      auto dev_end6 = dpct::device_pointer<value_type6>(start6) + size;
-      auto ret = func(std::forward<_ExecutionPolicyDevice>(dev_policy), dev_start1, dev_end1, dev_start2, dev_start3, dev_start4, dev_start5, dev_start6, args...);
-      return ::std::pair<_Ptr5, _Ptr6>(start5 + (ret.first - dev_start5), start6 + (ret.second - dev_start6));
-    } else {
-      return func(std::forward<_ExecutionPolicyHost>(host_policy), start1, start1 + size, start2, start3, start4, start5, start6, args...);
-    }
+          typename _Ptr1, typename Size, typename _Ptr2, typename _Ptr3,
+          typename _Ptr4, typename _Ptr5, typename _Ptr6, typename _Func,
+          typename... _Args>
+inline std::enable_if_t<
+    std::is_pointer_v<_Ptr1> && std::is_pointer_v<_Ptr2> &&
+        std::is_pointer_v<_Ptr3> && std::is_pointer_v<_Ptr4> &&
+        std::is_pointer_v<_Ptr5> && std::is_pointer_v<_Ptr6>,
+    ::std::pair<_Ptr5, _Ptr6>>
+check_device_ptr_and_launch(_ExecutionPolicyHost &&host_policy,
+                            _ExecutionPolicyDevice &&dev_policy, _Ptr1 start1,
+                            Size size, _Ptr2 start2, _Ptr3 start3, _Ptr4 start4,
+                            _Ptr5 start5, _Ptr6 start6, _Func func,
+                            _Args... args) {
+  if (dpct::is_device_ptr(start1)) {
+    using value_type1 = typename std::iterator_traits<_Ptr1>::value_type;
+    using value_type2 = typename std::iterator_traits<_Ptr2>::value_type;
+    using value_type3 = typename std::iterator_traits<_Ptr3>::value_type;
+    using value_type4 = typename std::iterator_traits<_Ptr4>::value_type;
+    using value_type5 = typename std::iterator_traits<_Ptr5>::value_type;
+    using value_type6 = typename std::iterator_traits<_Ptr6>::value_type;
+    auto dev_start1 = dpct::device_pointer<value_type1>(start1);
+    auto dev_end1 = dpct::device_pointer<value_type1>(start1) + size;
+    auto dev_start2 = dpct::device_pointer<value_type2>(start2);
+    auto dev_end2 = dpct::device_pointer<value_type2>(start2) + size;
+    auto dev_start3 = dpct::device_pointer<value_type3>(start3);
+    auto dev_end3 = dpct::device_pointer<value_type3>(start3) + size;
+    auto dev_start4 = dpct::device_pointer<value_type4>(start4);
+    auto dev_end4 = dpct::device_pointer<value_type4>(start4) + size;
+    auto dev_start5 = dpct::device_pointer<value_type5>(start5);
+    auto dev_end5 = dpct::device_pointer<value_type5>(start5) + size;
+    auto dev_start6 = dpct::device_pointer<value_type6>(start6);
+    auto dev_end6 = dpct::device_pointer<value_type6>(start6) + size;
+    auto ret = func(std::forward<_ExecutionPolicyDevice>(dev_policy),
+                    dev_start1, dev_end1, dev_start2, dev_start3, dev_start4,
+                    dev_start5, dev_start6, args...);
+    return ::std::pair<_Ptr5, _Ptr6>(start5 + (ret.first - dev_start5),
+                                     start6 + (ret.second - dev_start6));
+  } else {
+    return func(std::forward<_ExecutionPolicyHost>(host_policy), start1,
+                start1 + size, start2, start3, start4, start5, start6, args...);
+  }
 }
 
-
 template <typename _ExecutionPolicyHost, typename _ExecutionPolicyDevice,
-          typename _Ptr1, typename Size, typename _Ptr2, typename _Ptr3, typename _Ptr4, typename _Func, typename... _Args>
-inline
-std::enable_if_t<std::is_pointer_v<_Ptr1> && std::is_pointer_v<_Ptr2> && std::is_pointer_v<_Ptr3> && std::is_pointer_v<_Ptr4>, ::std::pair<_Ptr3, _Ptr4>>
-check_device_ptr_and_launch(_ExecutionPolicyHost&& host_policy, _ExecutionPolicyDevice&& dev_policy, _Ptr1 start1,
-                       Size size, _Ptr2 start2, _Ptr3 start3, _Ptr4 start4, _Func func, _Args... args)
-{
-    if (dpct::is_device_ptr(start1)) {
-      using value_type1 = typename std::iterator_traits<_Ptr1>::value_type;
-      using value_type2 = typename std::iterator_traits<_Ptr2>::value_type;
-      using value_type3 = typename std::iterator_traits<_Ptr3>::value_type;
-      using value_type4 = typename std::iterator_traits<_Ptr4>::value_type;
-      auto dev_start1 = dpct::device_pointer<value_type1>(start1);
-      auto dev_end1 = dpct::device_pointer<value_type1>(start1) + size;
-      auto dev_start2 = dpct::device_pointer<value_type2>(start2);
-      auto dev_end2 = dpct::device_pointer<value_type2>(start2) + size;
-      auto dev_start3 = dpct::device_pointer<value_type3>(start3);
-      auto dev_end3 = dpct::device_pointer<value_type3>(start3) + size;
-      auto dev_start4 = dpct::device_pointer<value_type4>(start4);
-      auto dev_end4 = dpct::device_pointer<value_type4>(start4) + size;
-      auto ret = func(std::forward<_ExecutionPolicyDevice>(dev_policy), dev_start1, dev_end1, dev_start2, dev_start3, dev_start4, args...);
-      return ::std::pair<_Ptr3, _Ptr4>(start3 + (ret.first - dev_start3), start4 + (ret.second - dev_start4));
-    } else {
-      return func(std::forward<_ExecutionPolicyHost>(host_policy), start1, start1 + size, start2, start3, start4, args...);
-    }
+          typename _Ptr1, typename Size, typename _Ptr2, typename _Ptr3,
+          typename _Ptr4, typename _Func, typename... _Args>
+inline std::enable_if_t<std::is_pointer_v<_Ptr1> && std::is_pointer_v<_Ptr2> &&
+                            std::is_pointer_v<_Ptr3> &&
+                            std::is_pointer_v<_Ptr4>,
+                        ::std::pair<_Ptr3, _Ptr4>>
+check_device_ptr_and_launch(_ExecutionPolicyHost &&host_policy,
+                            _ExecutionPolicyDevice &&dev_policy, _Ptr1 start1,
+                            Size size, _Ptr2 start2, _Ptr3 start3, _Ptr4 start4,
+                            _Func func, _Args... args) {
+  if (dpct::is_device_ptr(start1)) {
+    using value_type1 = typename std::iterator_traits<_Ptr1>::value_type;
+    using value_type2 = typename std::iterator_traits<_Ptr2>::value_type;
+    using value_type3 = typename std::iterator_traits<_Ptr3>::value_type;
+    using value_type4 = typename std::iterator_traits<_Ptr4>::value_type;
+    auto dev_start1 = dpct::device_pointer<value_type1>(start1);
+    auto dev_end1 = dpct::device_pointer<value_type1>(start1) + size;
+    auto dev_start2 = dpct::device_pointer<value_type2>(start2);
+    auto dev_end2 = dpct::device_pointer<value_type2>(start2) + size;
+    auto dev_start3 = dpct::device_pointer<value_type3>(start3);
+    auto dev_end3 = dpct::device_pointer<value_type3>(start3) + size;
+    auto dev_start4 = dpct::device_pointer<value_type4>(start4);
+    auto dev_end4 = dpct::device_pointer<value_type4>(start4) + size;
+    auto ret =
+        func(std::forward<_ExecutionPolicyDevice>(dev_policy), dev_start1,
+             dev_end1, dev_start2, dev_start3, dev_start4, args...);
+    return ::std::pair<_Ptr3, _Ptr4>(start3 + (ret.first - dev_start3),
+                                     start4 + (ret.second - dev_start4));
+  } else {
+    return func(std::forward<_ExecutionPolicyHost>(host_policy), start1,
+                start1 + size, start2, start3, start4, args...);
+  }
 }
 
-
-
 template <typename _ExecutionPolicyHost, typename _ExecutionPolicyDevice,
-          typename _Ptr1, typename Size, typename _Ptr2, typename _Func, typename... _Args>
-inline
-std::enable_if_t<std::is_pointer_v<_Ptr1> && std::is_pointer_v<_Ptr2>, ::std::pair<_Ptr1, _Ptr2>>
-check_device_ptr_and_launch(_ExecutionPolicyHost&& host_policy, _ExecutionPolicyDevice&& dev_policy, _Ptr1 start1,
-                       Size size, _Ptr2 start2, _Func func, _Args... args)
-{
-    if (dpct::is_device_ptr(start1)) {
-      using value_type1 = typename std::iterator_traits<_Ptr1>::value_type;
-      using value_type2 = typename std::iterator_traits<_Ptr2>::value_type;
-      auto dev_start1 = dpct::device_pointer<value_type1>(start1);
-      auto dev_end1 = dpct::device_pointer<value_type1>(start1) + size;
-      auto dev_start2 = dpct::device_pointer<value_type2>(start2);
-      auto dev_end2 = dpct::device_pointer<value_type2>(start2) + size;
-      auto ret = func(std::forward<_ExecutionPolicyDevice>(dev_policy), dev_start1, dev_end1, dev_start2, args...);
-      return ::std::pair<_Ptr1, _Ptr2>(start1 + (ret.first - dev_start1), start2 + (ret.second - dev_start2));
-    } else {
-      return func(std::forward<_ExecutionPolicyHost>(host_policy), start1, start1 + size, start2, args...);
-    }
+          typename _Ptr1, typename Size, typename _Ptr2, typename _Func,
+          typename... _Args>
+inline std::enable_if_t<std::is_pointer_v<_Ptr1> && std::is_pointer_v<_Ptr2>,
+                        ::std::pair<_Ptr1, _Ptr2>>
+check_device_ptr_and_launch(_ExecutionPolicyHost &&host_policy,
+                            _ExecutionPolicyDevice &&dev_policy, _Ptr1 start1,
+                            Size size, _Ptr2 start2, _Func func,
+                            _Args... args) {
+  if (dpct::is_device_ptr(start1)) {
+    using value_type1 = typename std::iterator_traits<_Ptr1>::value_type;
+    using value_type2 = typename std::iterator_traits<_Ptr2>::value_type;
+    auto dev_start1 = dpct::device_pointer<value_type1>(start1);
+    auto dev_end1 = dpct::device_pointer<value_type1>(start1) + size;
+    auto dev_start2 = dpct::device_pointer<value_type2>(start2);
+    auto dev_end2 = dpct::device_pointer<value_type2>(start2) + size;
+    auto ret = func(std::forward<_ExecutionPolicyDevice>(dev_policy),
+                    dev_start1, dev_end1, dev_start2, args...);
+    return ::std::pair<_Ptr1, _Ptr2>(start1 + (ret.first - dev_start1),
+                                     start2 + (ret.second - dev_start2));
+  } else {
+    return func(std::forward<_ExecutionPolicyHost>(host_policy), start1,
+                start1 + size, start2, args...);
+  }
 }
 
 template <typename _ExecutionPolicyHost, typename _ExecutionPolicyDevice,
           typename _PtrT, typename Size, typename _Func, typename... _Args>
-inline
-std::enable_if_t<std::is_pointer_v<_PtrT>, ::std::pair<_PtrT, _PtrT>>
-check_device_ptr_and_launch(_ExecutionPolicyHost&& host_policy, _ExecutionPolicyDevice&& dev_policy, _PtrT start,
-                       Size size, _Func func, _Args... args)
-{
-    if (dpct::is_device_ptr(start)) {
-      using value_type = typename std::iterator_traits<_PtrT>::value_type;
-      auto dev_start = dpct::device_pointer<value_type>(start);
-      auto dev_end = dpct::device_pointer<value_type>(start) + size;
-      auto ret = func(std::forward<_ExecutionPolicyDevice>(dev_policy), dev_start, dev_end, args...);
-      return ::std::pair<_PtrT, _PtrT>(start + (ret.first - dev_start), start + (ret.second - dev_start));
-    } else {
-      return func(std::forward<_ExecutionPolicyHost>(host_policy), start, start + size, args...);
-    }
+inline std::enable_if_t<std::is_pointer_v<_PtrT>, ::std::pair<_PtrT, _PtrT>>
+check_device_ptr_and_launch(_ExecutionPolicyHost &&host_policy,
+                            _ExecutionPolicyDevice &&dev_policy, _PtrT start,
+                            Size size, _Func func, _Args... args) {
+  if (dpct::is_device_ptr(start)) {
+    using value_type = typename std::iterator_traits<_PtrT>::value_type;
+    auto dev_start = dpct::device_pointer<value_type>(start);
+    auto dev_end = dpct::device_pointer<value_type>(start) + size;
+    auto ret = func(std::forward<_ExecutionPolicyDevice>(dev_policy), dev_start,
+                    dev_end, args...);
+    return ::std::pair<_PtrT, _PtrT>(start + (ret.first - dev_start),
+                                     start + (ret.second - dev_start));
+  } else {
+    return func(std::forward<_ExecutionPolicyHost>(host_policy), start,
+                start + size, args...);
+  }
 }
 
-#endif //DPCT_USM_LEVEL_NONE
+#endif // DPCT_USM_LEVEL_NONE
 
 // This following code is similar to a section of code in
 // oneDPL/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/functional.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/functional.h
@@ -304,20 +304,20 @@ make_device_pointer_from_pointer(T t)
 template<typename... Args>
 inline constexpr bool __are_all_pointer_v= (... && std::is_pointer_v<Args>);
 
-template <typename _ExecutionPolicyHost, typename _ExecutionPolicyDevice, 
+template <typename ExecutionPolicyHost, typename ExecutionPolicyDevice, 
           typename Oper, typename Ptr1, typename Ptr2,  
-          typename _Func, typename RetPtr1, typename RetPtr2, typename... MiddlePtrs>
+          typename Func, typename RetPtr1, typename RetPtr2, typename... MiddlePtrs>
 inline std::enable_if_t<
     std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> && std::is_pointer_v<RetPtr1> && std::is_pointer_v<RetPtr2> && dpct::internal::__are_all_pointer_v<MiddlePtrs...>,
     ::std::pair<RetPtr1, RetPtr2>>
-check_device_ptr_and_launch(_ExecutionPolicyHost &&host_policy,
-                            _ExecutionPolicyDevice &&dev_policy, Oper op, std::size_t size1, std::size_t size2, _Func func,
+check_device_ptr_and_launch(ExecutionPolicyHost &&host_policy,
+                            ExecutionPolicyDevice &&dev_policy, Oper op, std::size_t size1, std::size_t size2, Func func,
                             RetPtr1 ret_base1, RetPtr2 ret_base2,
                             Ptr1 start1, Ptr2 start2,  
                             MiddlePtrs... middle_ptrs) {
   if (dpct::is_device_ptr(start1)) {
     
-    auto ret = func(std::forward<_ExecutionPolicyDevice>(dev_policy),
+    auto ret = func(std::forward<ExecutionPolicyDevice>(dev_policy),
                     dpct::internal::make_device_pointer_from_pointer(start1),
                     dpct::internal::make_device_pointer_from_pointer(start1) + size1,
                     dpct::internal::make_device_pointer_from_pointer(start2),
@@ -327,114 +327,114 @@ check_device_ptr_and_launch(_ExecutionPolicyHost &&host_policy,
     return ::std::pair<RetPtr1, RetPtr2>(ret_base1 + (ret.first - dpct::internal::make_device_pointer_from_pointer(ret_base1)),
                                      ret_base2 + (ret.second - dpct::internal::make_device_pointer_from_pointer(ret_base2)));
   } else {
-    return func(std::forward<_ExecutionPolicyHost>(host_policy), start1,
+    return func(std::forward<ExecutionPolicyHost>(host_policy), start1,
                 start1 + size1, start2, start2 + size2, middle_ptrs..., op);
   }
 }
 
 
-template <typename _ExecutionPolicyHost, typename _ExecutionPolicyDevice,
-          typename _Ptr1, typename Size, typename _Ptr2, typename _Ptr3,
-          typename _Ptr4, typename _Func, typename... _Args>
-inline std::enable_if_t<std::is_pointer_v<_Ptr1> && std::is_pointer_v<_Ptr2> &&
-                            std::is_pointer_v<_Ptr3> &&
-                            std::is_pointer_v<_Ptr4>,
-                        ::std::pair<_Ptr3, _Ptr4>>
-check_device_ptr_and_launch(_ExecutionPolicyHost &&host_policy,
-                            _ExecutionPolicyDevice &&dev_policy, _Ptr1 start1,
-                            Size size, _Ptr2 start2, _Ptr3 start3, _Ptr4 start4,
-                            _Func func, _Args... args) {
+template <typename ExecutionPolicyHost, typename ExecutionPolicyDevice,
+          typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Ptr4, typename Func, typename... _Args>
+inline std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
+                            std::is_pointer_v<Ptr3> &&
+                            std::is_pointer_v<Ptr4>,
+                        ::std::pair<Ptr3, Ptr4>>
+check_device_ptr_and_launch(ExecutionPolicyHost &&host_policy,
+                            ExecutionPolicyDevice &&dev_policy, Ptr1 start1,
+                            Size size, Ptr2 start2, Ptr3 start3, Ptr4 start4,
+                            Func func, _Args... args) {
   if (dpct::is_device_ptr(start1)) {
-    using value_type1 = typename std::iterator_traits<_Ptr1>::value_type;
-    using value_type2 = typename std::iterator_traits<_Ptr2>::value_type;
-    using value_type3 = typename std::iterator_traits<_Ptr3>::value_type;
-    using value_type4 = typename std::iterator_traits<_Ptr4>::value_type;
+    using value_type1 = typename std::iterator_traits<Ptr1>::value_type;
+    using value_type2 = typename std::iterator_traits<Ptr2>::value_type;
+    using value_type3 = typename std::iterator_traits<Ptr3>::value_type;
+    using value_type4 = typename std::iterator_traits<Ptr4>::value_type;
     auto dev_start1 = dpct::device_pointer<value_type1>(start1);
     auto dev_end1 = dpct::device_pointer<value_type1>(start1) + size;
     auto dev_start2 = dpct::device_pointer<value_type2>(start2);
     auto dev_start3 = dpct::device_pointer<value_type3>(start3);
     auto dev_start4 = dpct::device_pointer<value_type4>(start4);
     auto ret =
-        func(std::forward<_ExecutionPolicyDevice>(dev_policy), dev_start1,
+        func(std::forward<ExecutionPolicyDevice>(dev_policy), dev_start1,
              dev_end1, dev_start2, dev_start3, dev_start4, args...);
-    return ::std::pair<_Ptr3, _Ptr4>(start3 + (ret.first - dev_start3),
+    return ::std::pair<Ptr3, Ptr4>(start3 + (ret.first - dev_start3),
                                      start4 + (ret.second - dev_start4));
   } else {
-    return func(std::forward<_ExecutionPolicyHost>(host_policy), start1,
+    return func(std::forward<ExecutionPolicyHost>(host_policy), start1,
                 start1 + size, start2, start3, start4, args...);
   }
 }
 
-template <typename _ExecutionPolicyHost, typename _ExecutionPolicyDevice,
-          typename _Ptr1, typename Size, typename _Ptr2, typename _Ptr3,
-          typename _Func, typename... _Args>
-inline std::enable_if_t<std::is_pointer_v<_Ptr1> && std::is_pointer_v<_Ptr2> &&
-                            std::is_pointer_v<_Ptr3> ,
-                        ::std::pair<_Ptr2, _Ptr3>>
-check_device_ptr_and_launch(_ExecutionPolicyHost &&host_policy,
-                            _ExecutionPolicyDevice &&dev_policy, _Ptr1 start1,
-                            Size size, _Ptr2 start2, _Ptr3 start3,
-                            _Func func, _Args... args) {
+template <typename ExecutionPolicyHost, typename ExecutionPolicyDevice,
+          typename Ptr1, typename Size, typename Ptr2, typename Ptr3,
+          typename Func, typename... _Args>
+inline std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
+                            std::is_pointer_v<Ptr3> ,
+                        ::std::pair<Ptr2, Ptr3>>
+check_device_ptr_and_launch(ExecutionPolicyHost &&host_policy,
+                            ExecutionPolicyDevice &&dev_policy, Ptr1 start1,
+                            Size size, Ptr2 start2, Ptr3 start3,
+                            Func func, _Args... args) {
   if (dpct::is_device_ptr(start1)) {
-    using value_type1 = typename std::iterator_traits<_Ptr1>::value_type;
-    using value_type2 = typename std::iterator_traits<_Ptr2>::value_type;
-    using value_type3 = typename std::iterator_traits<_Ptr3>::value_type;
+    using value_type1 = typename std::iterator_traits<Ptr1>::value_type;
+    using value_type2 = typename std::iterator_traits<Ptr2>::value_type;
+    using value_type3 = typename std::iterator_traits<Ptr3>::value_type;
     auto dev_start1 = dpct::device_pointer<value_type1>(start1);
     auto dev_end1 = dpct::device_pointer<value_type1>(start1) + size;
     auto dev_start2 = dpct::device_pointer<value_type2>(start2);
     auto dev_start3 = dpct::device_pointer<value_type3>(start3);
     auto ret =
-        func(std::forward<_ExecutionPolicyDevice>(dev_policy), dev_start1,
+        func(std::forward<ExecutionPolicyDevice>(dev_policy), dev_start1,
              dev_end1, dev_start2, dev_start3, args...);
-    return ::std::pair<_Ptr2, _Ptr3>(start2 + (ret.first - dev_start2),
+    return ::std::pair<Ptr2, Ptr3>(start2 + (ret.first - dev_start2),
                                      start3 + (ret.second - dev_start3));
   } else {
-    return func(std::forward<_ExecutionPolicyHost>(host_policy), start1,
+    return func(std::forward<ExecutionPolicyHost>(host_policy), start1,
                 start1 + size, start2, start3, args...);
   }
 }
 
-template <typename _ExecutionPolicyHost, typename _ExecutionPolicyDevice,
-          typename _Ptr1, typename Size, typename _Ptr2, typename _Func,
+template <typename ExecutionPolicyHost, typename ExecutionPolicyDevice,
+          typename Ptr1, typename Size, typename Ptr2, typename Func,
           typename... _Args>
-inline std::enable_if_t<std::is_pointer_v<_Ptr1> && std::is_pointer_v<_Ptr2>,
-                        ::std::pair<_Ptr1, _Ptr2>>
-check_device_ptr_and_launch(_ExecutionPolicyHost &&host_policy,
-                            _ExecutionPolicyDevice &&dev_policy, _Ptr1 start1,
-                            Size size, _Ptr2 start2, _Func func,
+inline std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2>,
+                        ::std::pair<Ptr1, Ptr2>>
+check_device_ptr_and_launch(ExecutionPolicyHost &&host_policy,
+                            ExecutionPolicyDevice &&dev_policy, Ptr1 start1,
+                            Size size, Ptr2 start2, Func func,
                             _Args... args) {
   if (dpct::is_device_ptr(start1)) {
-    using value_type1 = typename std::iterator_traits<_Ptr1>::value_type;
-    using value_type2 = typename std::iterator_traits<_Ptr2>::value_type;
+    using value_type1 = typename std::iterator_traits<Ptr1>::value_type;
+    using value_type2 = typename std::iterator_traits<Ptr2>::value_type;
     auto dev_start1 = dpct::device_pointer<value_type1>(start1);
     auto dev_end1 = dpct::device_pointer<value_type1>(start1) + size;
     auto dev_start2 = dpct::device_pointer<value_type2>(start2);
-    auto ret = func(std::forward<_ExecutionPolicyDevice>(dev_policy),
+    auto ret = func(std::forward<ExecutionPolicyDevice>(dev_policy),
                     dev_start1, dev_end1, dev_start2, args...);
-    return ::std::pair<_Ptr1, _Ptr2>(start1 + (ret.first - dev_start1),
+    return ::std::pair<Ptr1, Ptr2>(start1 + (ret.first - dev_start1),
                                      start2 + (ret.second - dev_start2));
   } else {
-    return func(std::forward<_ExecutionPolicyHost>(host_policy), start1,
+    return func(std::forward<ExecutionPolicyHost>(host_policy), start1,
                 start1 + size, start2, args...);
   }
 }
 
-template <typename _ExecutionPolicyHost, typename _ExecutionPolicyDevice,
-          typename _PtrT, typename Size, typename _Func, typename... _Args>
-inline std::enable_if_t<std::is_pointer_v<_PtrT>, ::std::pair<_PtrT, _PtrT>>
-check_device_ptr_and_launch(_ExecutionPolicyHost &&host_policy,
-                            _ExecutionPolicyDevice &&dev_policy, _PtrT start,
-                            Size size, _Func func, _Args... args) {
+template <typename ExecutionPolicyHost, typename ExecutionPolicyDevice,
+          typename PtrT, typename Size, typename Func, typename... _Args>
+inline std::enable_if_t<std::is_pointer_v<PtrT>, ::std::pair<PtrT, PtrT>>
+check_device_ptr_and_launch(ExecutionPolicyHost &&host_policy,
+                            ExecutionPolicyDevice &&dev_policy, PtrT start,
+                            Size size, Func func, _Args... args) {
   if (dpct::is_device_ptr(start)) {
-    using value_type = typename std::iterator_traits<_PtrT>::value_type;
+    using value_type = typename std::iterator_traits<PtrT>::value_type;
     auto dev_start = dpct::device_pointer<value_type>(start);
     auto dev_end = dpct::device_pointer<value_type>(start) + size;
-    auto ret = func(std::forward<_ExecutionPolicyDevice>(dev_policy), dev_start,
+    auto ret = func(std::forward<ExecutionPolicyDevice>(dev_policy), dev_start,
                     dev_end, args...);
-    return ::std::pair<_PtrT, _PtrT>(start + (ret.first - dev_start),
+    return ::std::pair<PtrT, PtrT>(start + (ret.first - dev_start),
                                      start + (ret.second - dev_start));
   } else {
-    return func(std::forward<_ExecutionPolicyHost>(host_policy), start,
+    return func(std::forward<ExecutionPolicyHost>(host_policy), start,
                 start + size, args...);
   }
 }

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/functional.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/functional.h
@@ -301,11 +301,14 @@ make_device_pointer_from_pointer(T t)
   return dpct::device_pointer<typename std::iterator_traits<T>::value_type>(t);
 }
 
+template<typename... Args>
+inline constexpr bool __are_all_pointer_v= (... && std::is_pointer_v<Args>);
+
 template <typename _ExecutionPolicyHost, typename _ExecutionPolicyDevice, 
           typename Oper, typename Ptr1, typename Ptr2,  
           typename _Func, typename RetPtr1, typename RetPtr2, typename... MiddlePtrs>
 inline std::enable_if_t<
-    std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> && std::is_pointer_v<RetPtr1> && std::is_pointer_v<RetPtr2>,
+    std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> && std::is_pointer_v<RetPtr1> && std::is_pointer_v<RetPtr2> && dpct::internal::__are_all_pointer_v<MiddlePtrs...>,
     ::std::pair<RetPtr1, RetPtr2>>
 check_device_ptr_and_launch(_ExecutionPolicyHost &&host_policy,
                             _ExecutionPolicyDevice &&dev_policy, Oper op, std::size_t size1, std::size_t size2, _Func func,

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/functional.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/functional.h
@@ -305,7 +305,7 @@ inline std::enable_if_t<
     ::std::pair<_Ptr5, _Ptr6>>
 check_device_ptr_and_launch(_ExecutionPolicyHost &&host_policy,
                             _ExecutionPolicyDevice &&dev_policy, _Ptr1 start1,
-                            Size size, _Ptr2 start2, _Ptr3 start3, _Ptr4 start4,
+                            Size size1, _Ptr2 start2, Size size2, _Ptr3 start3, _Ptr4 start4,
                             _Ptr5 start5, _Ptr6 start6, _Func func,
                             _Args... args) {
   if (dpct::is_device_ptr(start1)) {
@@ -316,25 +316,59 @@ check_device_ptr_and_launch(_ExecutionPolicyHost &&host_policy,
     using value_type5 = typename std::iterator_traits<_Ptr5>::value_type;
     using value_type6 = typename std::iterator_traits<_Ptr6>::value_type;
     auto dev_start1 = dpct::device_pointer<value_type1>(start1);
-    auto dev_end1 = dpct::device_pointer<value_type1>(start1) + size;
+    auto dev_end1 = dpct::device_pointer<value_type1>(start1) + size1;
     auto dev_start2 = dpct::device_pointer<value_type2>(start2);
-    auto dev_end2 = dpct::device_pointer<value_type2>(start2) + size;
+    auto dev_end2 = dpct::device_pointer<value_type2>(start2) + size2;
     auto dev_start3 = dpct::device_pointer<value_type3>(start3);
-    auto dev_end3 = dpct::device_pointer<value_type3>(start3) + size;
     auto dev_start4 = dpct::device_pointer<value_type4>(start4);
-    auto dev_end4 = dpct::device_pointer<value_type4>(start4) + size;
     auto dev_start5 = dpct::device_pointer<value_type5>(start5);
-    auto dev_end5 = dpct::device_pointer<value_type5>(start5) + size;
     auto dev_start6 = dpct::device_pointer<value_type6>(start6);
-    auto dev_end6 = dpct::device_pointer<value_type6>(start6) + size;
     auto ret = func(std::forward<_ExecutionPolicyDevice>(dev_policy),
-                    dev_start1, dev_end1, dev_start2, dev_start3, dev_start4,
+                    dev_start1, dev_end1, dev_start2, dev_end2, dev_start3, dev_start4,
                     dev_start5, dev_start6, args...);
     return ::std::pair<_Ptr5, _Ptr6>(start5 + (ret.first - dev_start5),
                                      start6 + (ret.second - dev_start6));
   } else {
     return func(std::forward<_ExecutionPolicyHost>(host_policy), start1,
-                start1 + size, start2, start3, start4, start5, start6, args...);
+                start1 + size1, start2, start2 + size2, start3, start4, start5, start6, args...);
+  }
+}
+
+template <typename _ExecutionPolicyHost, typename _ExecutionPolicyDevice,
+          typename _Ptr1, typename Size, typename _Ptr2, typename _Ptr3,
+          typename _Ptr4, typename _Ptr5, typename _Func,
+          typename... _Args>
+inline std::enable_if_t<
+    std::is_pointer_v<_Ptr1> && std::is_pointer_v<_Ptr2> &&
+        std::is_pointer_v<_Ptr3> && std::is_pointer_v<_Ptr4> &&
+        std::is_pointer_v<_Ptr5>,
+    ::std::pair<_Ptr4, _Ptr5>>
+check_device_ptr_and_launch(_ExecutionPolicyHost &&host_policy,
+                            _ExecutionPolicyDevice &&dev_policy, _Ptr1 start1,
+                            Size size1, _Ptr2 start2, Size size2, _Ptr3 start3, _Ptr4 start4,
+                            _Ptr5 start5, _Func func,
+                            _Args... args) {
+  if (dpct::is_device_ptr(start1)) {
+    using value_type1 = typename std::iterator_traits<_Ptr1>::value_type;
+    using value_type2 = typename std::iterator_traits<_Ptr2>::value_type;
+    using value_type3 = typename std::iterator_traits<_Ptr3>::value_type;
+    using value_type4 = typename std::iterator_traits<_Ptr4>::value_type;
+    using value_type5 = typename std::iterator_traits<_Ptr5>::value_type;
+    auto dev_start1 = dpct::device_pointer<value_type1>(start1);
+    auto dev_end1 = dpct::device_pointer<value_type1>(start1) + size1;
+    auto dev_start2 = dpct::device_pointer<value_type2>(start2);
+    auto dev_end2 = dpct::device_pointer<value_type2>(start2) + size2;
+    auto dev_start3 = dpct::device_pointer<value_type3>(start3);
+    auto dev_start4 = dpct::device_pointer<value_type4>(start4);
+    auto dev_start5 = dpct::device_pointer<value_type5>(start5);
+    auto ret = func(std::forward<_ExecutionPolicyDevice>(dev_policy),
+                    dev_start1, dev_end1, dev_start2, dev_end2, dev_start3, dev_start4,
+                    dev_start5, args...);
+    return ::std::pair<_Ptr4, _Ptr5>(start4 + (ret.first - dev_start4),
+                                     start5 + (ret.second - dev_start5));
+  } else {
+    return func(std::forward<_ExecutionPolicyHost>(host_policy), start1,
+                start1 + size1, start2, start2 + size2, start3, start4, start5, args...);
   }
 }
 
@@ -357,11 +391,8 @@ check_device_ptr_and_launch(_ExecutionPolicyHost &&host_policy,
     auto dev_start1 = dpct::device_pointer<value_type1>(start1);
     auto dev_end1 = dpct::device_pointer<value_type1>(start1) + size;
     auto dev_start2 = dpct::device_pointer<value_type2>(start2);
-    auto dev_end2 = dpct::device_pointer<value_type2>(start2) + size;
     auto dev_start3 = dpct::device_pointer<value_type3>(start3);
-    auto dev_end3 = dpct::device_pointer<value_type3>(start3) + size;
     auto dev_start4 = dpct::device_pointer<value_type4>(start4);
-    auto dev_end4 = dpct::device_pointer<value_type4>(start4) + size;
     auto ret =
         func(std::forward<_ExecutionPolicyDevice>(dev_policy), dev_start1,
              dev_end1, dev_start2, dev_start3, dev_start4, args...);
@@ -370,6 +401,35 @@ check_device_ptr_and_launch(_ExecutionPolicyHost &&host_policy,
   } else {
     return func(std::forward<_ExecutionPolicyHost>(host_policy), start1,
                 start1 + size, start2, start3, start4, args...);
+  }
+}
+
+template <typename _ExecutionPolicyHost, typename _ExecutionPolicyDevice,
+          typename _Ptr1, typename Size, typename _Ptr2, typename _Ptr3,
+          typename _Func, typename... _Args>
+inline std::enable_if_t<std::is_pointer_v<_Ptr1> && std::is_pointer_v<_Ptr2> &&
+                            std::is_pointer_v<_Ptr3> ,
+                        ::std::pair<_Ptr2, _Ptr3>>
+check_device_ptr_and_launch(_ExecutionPolicyHost &&host_policy,
+                            _ExecutionPolicyDevice &&dev_policy, _Ptr1 start1,
+                            Size size, _Ptr2 start2, _Ptr3 start3,
+                            _Func func, _Args... args) {
+  if (dpct::is_device_ptr(start1)) {
+    using value_type1 = typename std::iterator_traits<_Ptr1>::value_type;
+    using value_type2 = typename std::iterator_traits<_Ptr2>::value_type;
+    using value_type3 = typename std::iterator_traits<_Ptr3>::value_type;
+    auto dev_start1 = dpct::device_pointer<value_type1>(start1);
+    auto dev_end1 = dpct::device_pointer<value_type1>(start1) + size;
+    auto dev_start2 = dpct::device_pointer<value_type2>(start2);
+    auto dev_start3 = dpct::device_pointer<value_type3>(start3);
+    auto ret =
+        func(std::forward<_ExecutionPolicyDevice>(dev_policy), dev_start1,
+             dev_end1, dev_start2, dev_start3, args...);
+    return ::std::pair<_Ptr2, _Ptr3>(start2 + (ret.first - dev_start2),
+                                     start3 + (ret.second - dev_start3));
+  } else {
+    return func(std::forward<_ExecutionPolicyHost>(host_policy), start1,
+                start1 + size, start2, start3, args...);
   }
 }
 
@@ -388,7 +448,6 @@ check_device_ptr_and_launch(_ExecutionPolicyHost &&host_policy,
     auto dev_start1 = dpct::device_pointer<value_type1>(start1);
     auto dev_end1 = dpct::device_pointer<value_type1>(start1) + size;
     auto dev_start2 = dpct::device_pointer<value_type2>(start2);
-    auto dev_end2 = dpct::device_pointer<value_type2>(start2) + size;
     auto ret = func(std::forward<_ExecutionPolicyDevice>(dev_policy),
                     dev_start1, dev_end1, dev_start2, args...);
     return ::std::pair<_Ptr1, _Ptr2>(start1 + (ret.first - dev_start1),

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/functional.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/functional.h
@@ -296,20 +296,23 @@ template <typename... T>
 constexpr inline bool all_are_pointer_v = (... & std::is_pointer_v<T>);
 
 #ifdef DPCT_USM_LEVEL_NONE
-
 template <typename T>
 dpct::device_pointer<typename std::iterator_traits<T>::value_type>
 make_device_pointer_from_virtual_pointer(T t) {
   return dpct::device_pointer<typename std::iterator_traits<T>::value_type>(t);
 }
+#endif // DPCT_USM_LEVEL_NONE
 
+#ifdef DPCT_USM_LEVEL_NONE
 template <typename InitialPtr, typename VirtPtr>
 VirtPtr to_virtual_pointer_space(InitialPtr in_ptr, VirtPtr virt_base) {
   return virt_base +
          (in_ptr -
           dpct::internal::make_device_pointer_from_virtual_pointer(virt_base));
 }
+#endif // DPCT_USM_LEVEL_NONE
 
+#ifdef DPCT_USM_LEVEL_NONE
 template <typename ExecutionPolicyHost, typename ExecutionPolicyDevice,
           typename Oper, typename Func, typename RetPtr1, typename RetPtr2,
           typename Ptr1, typename Ptr2, typename... MiddlePtrs>
@@ -399,7 +402,6 @@ check_device_ptr_and_launch_w_value(ExecutionPolicyHost &&host_policy,
                 start1 + size, middle_ptrs..., value, op);
   }
 }
-
 #endif // DPCT_USM_LEVEL_NONE
 
 // This following code is similar to a section of code in

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/functional.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/functional.h
@@ -373,7 +373,9 @@ check_device_ptr_and_launch(ExecutionPolicyHost &&host_policy,
                 start1 + size, middle_ptrs..., op);
   }
 }
+#endif // DPCT_USM_LEVEL_NONE
 
+#ifdef DPCT_USM_LEVEL_NONE
 template <typename ExecutionPolicyHost, typename ExecutionPolicyDevice,
           typename ValueType, typename Oper, typename Func, typename RetPtr1,
           typename RetPtr2, typename Ptr1, typename... MiddlePtrs>

--- a/clang/test/dpct/helper_files_ref/include/dpl_extras/functional.h
+++ b/clang/test/dpct/helper_files_ref/include/dpl_extras/functional.h
@@ -292,6 +292,9 @@ private:
   mutable BinaryOperation op;
 };
 
+template <typename... T>
+constexpr inline bool all_are_pointer_v = (... & std::is_pointer_v<T>);
+
 #ifdef DPCT_USM_LEVEL_NONE
 
 template <typename T>
@@ -310,10 +313,8 @@ VirtPtr to_virtual_pointer_space(InitialPtr in_ptr, VirtPtr virt_base) {
 template <typename ExecutionPolicyHost, typename ExecutionPolicyDevice,
           typename Oper, typename Func, typename RetPtr1, typename RetPtr2,
           typename Ptr1, typename Ptr2, typename... MiddlePtrs>
-inline std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<Ptr2> &&
-                            std::is_pointer_v<RetPtr1> &&
-                            std::is_pointer_v<RetPtr2> &&
-                            (... && std::is_pointer_v<MiddlePtrs>),
+inline std::enable_if_t<dpct::internal::all_are_pointer_v<
+                            Ptr1, Ptr2, RetPtr1, RetPtr2, MiddlePtrs...>,
                         ::std::pair<RetPtr1, RetPtr2>>
 check_device_ptr_and_launch(ExecutionPolicyHost &&host_policy,
                             ExecutionPolicyDevice &&dev_policy, Oper op,
@@ -345,10 +346,9 @@ check_device_ptr_and_launch(ExecutionPolicyHost &&host_policy,
 template <typename ExecutionPolicyHost, typename ExecutionPolicyDevice,
           typename Oper, typename Func, typename RetPtr1, typename RetPtr2,
           typename Ptr1, typename... MiddlePtrs>
-inline std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<RetPtr1> &&
-                            std::is_pointer_v<RetPtr2> &&
-                            (... && std::is_pointer_v<MiddlePtrs>),
-                        ::std::pair<RetPtr1, RetPtr2>>
+inline std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, RetPtr1, RetPtr2, MiddlePtrs...>,
+    ::std::pair<RetPtr1, RetPtr2>>
 check_device_ptr_and_launch(ExecutionPolicyHost &&host_policy,
                             ExecutionPolicyDevice &&dev_policy, Oper op,
                             std::size_t size, Func func, RetPtr1 ret_base1,
@@ -374,10 +374,9 @@ check_device_ptr_and_launch(ExecutionPolicyHost &&host_policy,
 template <typename ExecutionPolicyHost, typename ExecutionPolicyDevice,
           typename ValueType, typename Oper, typename Func, typename RetPtr1,
           typename RetPtr2, typename Ptr1, typename... MiddlePtrs>
-inline std::enable_if_t<std::is_pointer_v<Ptr1> && std::is_pointer_v<RetPtr1> &&
-                            std::is_pointer_v<RetPtr2> &&
-                            (... && std::is_pointer_v<MiddlePtrs>),
-                        ::std::pair<RetPtr1, RetPtr2>>
+inline std::enable_if_t<
+    dpct::internal::all_are_pointer_v<Ptr1, RetPtr1, RetPtr2, MiddlePtrs...>,
+    ::std::pair<RetPtr1, RetPtr2>>
 check_device_ptr_and_launch_w_value(ExecutionPolicyHost &&host_policy,
                                     ExecutionPolicyDevice &&dev_policy,
                                     ValueType value, Oper op, std::size_t size,


### PR DESCRIPTION
Draft PR:
Extra APIs in NO-USM mode to launch algorithm on the device if the incoming input iterator is a pointer.  If the input pointers are pointers in the virtual memory space describing a `device_pointer`, it launches with a device policy, otherwise it launches on the host.

Adds helper function(s) to enable this pattern with minimal code duplication between APIs.

APIs for the following:
`unique`
`unique_copy`
`merge`
`set_intersection`
`set_symmetric_difference`
`set_difference`
`set_union`
`stable_partition_copy`
`partition_copy`
`equal_range`