### PR TITLE
[SYCLomatic] Implement migration for cub::DeviceSegmentedSort::{StableSortKeys, StableSortKeysDescending}

### DIFF
--- a/clang/lib/DPCT/APINamesCUB.inc
+++ b/clang/lib/DPCT/APINamesCUB.inc
@@ -2078,6 +2078,108 @@ MEMBER_CALL_FACTORY_ENTRY("cub::LaneId", MEMBER_CALL(NDITEM, false, LITERAL("get
 // cub::WarpId
 MEMBER_CALL_FACTORY_ENTRY("cub::WarpId", MEMBER_CALL(NDITEM, false, LITERAL("get_sub_group")), false, "get_group_linear_id")
 
+// cub::DeviceSegmentedSort::StableSortKeys
+CASE_FACTORY_ENTRY(
+    CASE(CheckCubRedundantFunctionCall(),
+         REMOVE_API_FACTORY_ENTRY("cub::DeviceSegmentedSort::StableSortKeys")),
+    OTHERWISE(FEATURE_REQUEST_FACTORY(
+        HelperFeatureEnum::DplExtrasAlgorithm_sort_keys,
+        HEADER_INSERT_FACTORY(
+            HeaderType::HT_DPCT_DPL_Utils,
+            REMOVE_CUB_TEMP_STORAGE_FACTORY(CASE_FACTORY_ENTRY(
+                CASE(CheckArgType(2, "cub::DoubleBuffer"),
+                     CASE_FACTORY_ENTRY(
+                         CASE(makeCheckAnd(
+                                  CheckArgCount(8, std::greater_equal<>(),
+                                                /* IncludeDefaultArg */ false),
+                                  makeCheckNot(CheckArgIsDefaultCudaStream(7))),
+                              CALL_FACTORY_ENTRY(
+                                  "cub::DeviceSegmentedSort::StableSortKeys",
+                                  CALL("dpct::segmented_sort_keys",
+                                       CALL("oneapi::dpl::execution::device_"
+                                            "policy",
+                                            STREAM(7)),
+                                       ARG(2), ARG(3), ARG(4), ARG(5), ARG(6),
+                                       LITERAL("false"), LITERAL("true")))),
+                         OTHERWISE(CALL_FACTORY_ENTRY(
+                             "cub::DeviceSegmentedSort::StableSortKeys",
+                             CALL("dpct::segmented_sort_keys",
+                                  CALL("oneapi::dpl::execution::device_policy",
+                                       QUEUESTR),
+                                  ARG(2), ARG(3), ARG(4), ARG(5), ARG(6),
+                                  LITERAL("false"), LITERAL("true")))))),
+                OTHERWISE(CASE_FACTORY_ENTRY(
+                    CASE(makeCheckAnd(
+                             CheckArgCount(9, std::greater_equal<>(),
+                                           /* IncludeDefaultArg */ false),
+                             makeCheckNot(CheckArgIsDefaultCudaStream(8))),
+                         CALL_FACTORY_ENTRY(
+                             "cub::DeviceSegmentedSort::StableSortKeys",
+                             CALL("dpct::segmented_sort_keys",
+                                  CALL("oneapi::dpl::execution::device_policy",
+                                       STREAM(8)),
+                                  ARG(2), ARG(3), ARG(4), ARG(5), ARG(6),
+                                  ARG(7), LITERAL("false")))),
+                    OTHERWISE(CALL_FACTORY_ENTRY(
+                        "cub::DeviceSegmentedSort::StableSortKeys",
+                        CALL("dpct::segmented_sort_keys",
+                             CALL("oneapi::dpl::execution::device_policy",
+                                  QUEUESTR),
+                             ARG(2), ARG(3), ARG(4), ARG(5), ARG(6), ARG(7),
+                             LITERAL("false"))))))))))))
+
+// cub::DeviceSegmentedSort::StableSortKeysDescending
+CASE_FACTORY_ENTRY(
+    CASE(CheckCubRedundantFunctionCall(),
+         REMOVE_API_FACTORY_ENTRY(
+             "cub::DeviceSegmentedSort::StableSortKeysDescending")),
+    OTHERWISE(FEATURE_REQUEST_FACTORY(
+        HelperFeatureEnum::DplExtrasAlgorithm_sort_keys,
+        HEADER_INSERT_FACTORY(
+            HeaderType::HT_DPCT_DPL_Utils,
+            REMOVE_CUB_TEMP_STORAGE_FACTORY(CASE_FACTORY_ENTRY(
+                CASE(
+                    CheckArgType(2, "cub::DoubleBuffer"),
+                    CASE_FACTORY_ENTRY(
+                        CASE(makeCheckAnd(
+                                 CheckArgCount(8, std::greater_equal<>(),
+                                               /* IncludeDefaultArg */ false),
+                                 makeCheckNot(CheckArgIsDefaultCudaStream(7))),
+                             CALL_FACTORY_ENTRY(
+                                 "cub::DeviceSegmentedSort::StableSortKeysDescending",
+                                 CALL("dpct::segmented_sort_keys",
+                                      CALL("oneapi::dpl::execution::device_"
+                                           "policy",
+                                           STREAM(7)),
+                                      ARG(2), ARG(3), ARG(4), ARG(5), ARG(6),
+                                      LITERAL("true"), LITERAL("true")))),
+                        OTHERWISE(CALL_FACTORY_ENTRY(
+                            "cub::DeviceSegmentedSort::StableSortKeysDescending",
+                            CALL("dpct::segmented_sort_keys",
+                                 CALL("oneapi::dpl::execution::device_policy",
+                                      QUEUESTR),
+                                 ARG(2), ARG(3), ARG(4), ARG(5), ARG(6),
+                                 LITERAL("true"), LITERAL("true")))))),
+                OTHERWISE(CASE_FACTORY_ENTRY(
+                    CASE(makeCheckAnd(
+                             CheckArgCount(9, std::greater_equal<>(),
+                                           /* IncludeDefaultArg */ false),
+                             makeCheckNot(CheckArgIsDefaultCudaStream(8))),
+                         CALL_FACTORY_ENTRY(
+                             "cub::DeviceSegmentedSort::StableSortKeysDescending",
+                             CALL("dpct::segmented_sort_keys",
+                                  CALL("oneapi::dpl::execution::device_policy",
+                                       STREAM(8)),
+                                  ARG(2), ARG(3), ARG(4), ARG(5), ARG(6),
+                                  ARG(7), LITERAL("true")))),
+                    OTHERWISE(CALL_FACTORY_ENTRY(
+                        "cub::DeviceSegmentedSort::StableSortKeysDescending",
+                        CALL("dpct::segmented_sort_keys",
+                             CALL("oneapi::dpl::execution::device_policy",
+                                  QUEUESTR),
+                             ARG(2), ARG(3), ARG(4), ARG(5), ARG(6), ARG(7),
+                             LITERAL("true"))))))))))))
+
 // cub::DeviceSegmentedSort::StableSortPairs
 CONDITIONAL_FACTORY_ENTRY(
     CheckCubRedundantFunctionCall(),

--- a/clang/lib/DPCT/APINames_CUB.inc
+++ b/clang/lib/DPCT/APINames_CUB.inc
@@ -178,12 +178,12 @@ ENTRY_MEMBER_FUNCTION(cub::DeviceSegmentedReduce, Max, Max, true, NO_FLAG, P4, "
 ENTRY_MEMBER_FUNCTION(cub::DeviceSegmentedReduce, ArgMax, ArgMax, false, NO_FLAG, P4, "Comment")
 ENTRY_MEMBER_FUNCTION(cub::DeviceSegmentedSort, SortKeys, SortKeys, true, NO_FLAG, P4, "Successful: DPCT1026/DPCT1027")
 ENTRY_MEMBER_FUNCTION(cub::DeviceSegmentedSort, SortKeysDescending, SortKeysDescending, true, NO_FLAG, P4, "Successful: DPCT1026/DPCT1027")
-ENTRY_MEMBER_FUNCTION(cub::DeviceSegmentedSort, StableSortKeys, StableSortKeys, false, NO_FLAG, P4, "Comment")
-ENTRY_MEMBER_FUNCTION(cub::DeviceSegmentedSort, StableSortKeysDescending, StableSortKeysDescending, false, NO_FLAG, P4, "Comment")
+ENTRY_MEMBER_FUNCTION(cub::DeviceSegmentedSort, StableSortKeys, StableSortKeys, true, NO_FLAG, P4, "Successful: DPCT1026/DPCT1027")
+ENTRY_MEMBER_FUNCTION(cub::DeviceSegmentedSort, StableSortKeysDescending, StableSortKeysDescending, true, NO_FLAG, P4, "Successful: DPCT1026/DPCT1027")
 ENTRY_MEMBER_FUNCTION(cub::DeviceSegmentedSort, SortPairs, SortPairs, true, NO_FLAG, P4, "Successful: DPCT1026/DPCT1027")
 ENTRY_MEMBER_FUNCTION(cub::DeviceSegmentedSort, SortPairsDescending, SortPairsDescending, true, NO_FLAG, P4, "Successful: DPCT1026/DPCT1027")
-ENTRY_MEMBER_FUNCTION(cub::DeviceSegmentedSort, StableSortPairs, StableSortPairs, false, NO_FLAG, P4, "Comment")
-ENTRY_MEMBER_FUNCTION(cub::DeviceSegmentedSort, StableSortPairsDescending, StableSortPairsDescending, false, NO_FLAG, P4, "Comment")
+ENTRY_MEMBER_FUNCTION(cub::DeviceSegmentedSort, StableSortPairs, StableSortPairs, true, NO_FLAG, P4, "Successful: DPCT1026/DPCT1027")
+ENTRY_MEMBER_FUNCTION(cub::DeviceSegmentedSort, StableSortPairsDescending, StableSortPairsDescending, true, NO_FLAG, P4, "Successful: DPCT1026/DPCT1027")
 
 // Thread and thread block I/O
 ENTRY(cub::ThreadLoad, cub::ThreadLoad, true, NO_FLAG, P4, "Successful")

--- a/clang/lib/DPCT/CUBAPIMigration.cpp
+++ b/clang/lib/DPCT/CUBAPIMigration.cpp
@@ -51,7 +51,8 @@ auto isDeviceFuncCallExpr = []() {
         "InclusiveScanByKey", "InclusiveSumByKey", "ExclusiveScanByKey",
         "ExclusiveSumByKey", "Flagged", "Unique", "UniqueByKey", "Encode",
         "SortKeys", "SortKeysDescending", "SortPairs", "SortPairsDescending",
-        "If", "StableSortPairs", "StableSortPairsDescending");
+        "If", "StableSortKeys", "StableSortKeysDescending", "StableSortPairs",
+        "StableSortPairsDescending");
   };
   auto hasDeviceRecordName = []() {
     return hasAnyName("DeviceSegmentedReduce", "DeviceReduce", "DeviceScan",

--- a/clang/test/dpct/cub/devicelevel/device_segmented_stable_sort_keys.cu
+++ b/clang/test/dpct/cub/devicelevel/device_segmented_stable_sort_keys.cu
@@ -1,0 +1,148 @@
+// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.2, cuda-11.4
+// UNSUPPORTED: v8.0, v9.0, v9.1, v9.2, v10.0, v10.1, v10.2, v11.0, v11.2, v11.4
+// RUN: dpct --format-range=none -in-root %S -out-root %T/devicelevel/device_segmented_stable_sort_keys %S/device_segmented_stable_sort_keys.cu --cuda-include-path="%cuda-path/include" -- -std=c++14 -x cuda --cuda-host-only
+// RUN: FileCheck --input-file %T/devicelevel/device_segmented_stable_sort_keys/device_segmented_stable_sort_keys.dp.cpp %s
+
+// CHECK:#include <oneapi/dpl/execution>
+// CHECK:#include <oneapi/dpl/algorithm>
+// CHECK:#include <dpct/dpl_utils.hpp>
+#include <cstdint>
+#include <cub/cub.cuh>
+
+int n, num_segments, *d_keys_in, *d_keys_out, *d_offsets;
+
+// CHECK:dpct::io_iterator_pair<int *> d_keys(d_keys_in, d_keys_out);
+cub::DoubleBuffer<int> d_keys(d_keys_in, d_keys_out);
+
+// CHECK: void test1(void) {
+// CHECK:   dpct::device_ext &dev_ct1 = dpct::get_current_device();
+// CHECK:   sycl::queue &q_ct1 = dev_ct1.default_queue();
+// CHECK:   /*
+// CHECK:   DPCT1026:0: The call to cub::DeviceSegmentedSort::StableSortKeys was removed because this call is redundant in SYCL.
+// CHECK:   */
+// CHECK:   dpct::segmented_sort_keys(oneapi::dpl::execution::device_policy(q_ct1), d_keys_in, d_keys_out, n, num_segments, d_offsets, d_offsets + 1, false);
+// CHECK: }
+void test1(void) {
+  void *temp_storage;
+  size_t temp_storage_size;
+  cub::DeviceSegmentedSort::StableSortKeys(nullptr, temp_storage_size, d_keys_in, d_keys_out, n, num_segments, d_offsets, d_offsets + 1);
+  cudaMalloc(&temp_storage, temp_storage_size);
+  cub::DeviceSegmentedSort::StableSortKeys(temp_storage, temp_storage_size, d_keys_in, d_keys_out, n, num_segments, d_offsets, d_offsets + 1);
+}
+
+// CHECK: void test2(void) {
+// CHECK:   dpct::device_ext &dev_ct1 = dpct::get_current_device();
+// CHECK:   sycl::queue &q_ct1 = dev_ct1.default_queue();
+// CHECK:   /*
+// CHECK:   DPCT1026:1: The call to cub::DeviceSegmentedSort::StableSortKeys was removed because this call is redundant in SYCL.
+// CHECK:   */
+// CHECK:   dpct::segmented_sort_keys(oneapi::dpl::execution::device_policy(q_ct1), d_keys, n, num_segments, d_offsets, d_offsets + 1, false, true);
+// CHECK: }
+void test2(void) {
+  void *temp_storage;
+  size_t temp_storage_size;
+  cub::DeviceSegmentedSort::StableSortKeys(nullptr, temp_storage_size, d_keys, n, num_segments, d_offsets, d_offsets + 1);
+  cudaMalloc(&temp_storage, temp_storage_size);
+  cub::DeviceSegmentedSort::StableSortKeys(temp_storage, temp_storage_size, d_keys, n, num_segments, d_offsets, d_offsets + 1);
+}
+
+// CHECK: void test3(void) {
+// CHECK:   dpct::device_ext &dev_ct1 = dpct::get_current_device();
+// CHECK:   sycl::queue &q_ct1 = dev_ct1.default_queue();
+// CHECK:   dpct::queue_ptr s = &q_ct1;
+// CHECK:   /*
+// CHECK:   DPCT1026:2: The call to cub::DeviceSegmentedSort::StableSortKeys was removed because this call is redundant in SYCL.
+// CHECK:   */
+// CHECK:   dpct::segmented_sort_keys(oneapi::dpl::execution::device_policy(*s), d_keys, n, num_segments, d_offsets, d_offsets + 1, false, true);
+// CHECK: }
+void test3(void) {
+  void *temp_storage;
+  size_t temp_storage_size;
+  cudaStream_t s = 0;
+  cub::DeviceSegmentedSort::StableSortKeys(nullptr, temp_storage_size, d_keys, n, num_segments, d_offsets, d_offsets + 1, s);
+  cudaMalloc(&temp_storage, temp_storage_size);
+  cub::DeviceSegmentedSort::StableSortKeys(temp_storage, temp_storage_size, d_keys, n, num_segments, d_offsets, d_offsets + 1, s);
+}
+
+// CHECK: void test4(void) {
+// CHECK:   dpct::queue_ptr s = (dpct::queue_ptr)(void *)(uintptr_t)0xFF;
+// CHECK:   /*
+// CHECK:   DPCT1026:3: The call to cub::DeviceSegmentedSort::StableSortKeys was removed because this call is redundant in SYCL.
+// CHECK:   */
+// CHECK:   dpct::segmented_sort_keys(oneapi::dpl::execution::device_policy(*s), d_keys_in, d_keys_out, n, num_segments, d_offsets, d_offsets + 1, false);
+// CHECK: }
+void test4(void) {
+  void *temp_storage;
+  size_t temp_storage_size;
+  cudaStream_t s = (cudaStream_t)(void *)(uintptr_t)0xFF;
+  cub::DeviceSegmentedSort::StableSortKeys(nullptr, temp_storage_size, d_keys_in, d_keys_out, n, num_segments, d_offsets, d_offsets + 1, s);
+  cudaMalloc(&temp_storage, temp_storage_size);
+  cub::DeviceSegmentedSort::StableSortKeys(temp_storage, temp_storage_size, d_keys_in, d_keys_out, n, num_segments, d_offsets, d_offsets + 1, s);
+}
+
+// CHECK: void test5(void) {
+// CHECK:   dpct::device_ext &dev_ct1 = dpct::get_current_device();
+// CHECK:   sycl::queue &q_ct1 = dev_ct1.default_queue();
+// CHECK:   /*
+// CHECK:   DPCT1026:4: The call to cub::DeviceSegmentedSort::StableSortKeysDescending was removed because this call is redundant in SYCL.
+// CHECK:   */
+// CHECK:   dpct::segmented_sort_keys(oneapi::dpl::execution::device_policy(q_ct1), d_keys_in, d_keys_out, n, num_segments, d_offsets, d_offsets + 1, true);
+// CHECK: }
+void test5(void) {
+  void *temp_storage;
+  size_t temp_storage_size;
+  cub::DeviceSegmentedSort::StableSortKeysDescending(nullptr, temp_storage_size, d_keys_in, d_keys_out, n, num_segments, d_offsets, d_offsets + 1);
+  cudaMalloc(&temp_storage, temp_storage_size);
+  cub::DeviceSegmentedSort::StableSortKeysDescending(temp_storage, temp_storage_size, d_keys_in, d_keys_out, n, num_segments, d_offsets, d_offsets + 1);
+}
+
+// CHECK: void test6(void) {
+// CHECK:   dpct::device_ext &dev_ct1 = dpct::get_current_device();
+// CHECK:   sycl::queue &q_ct1 = dev_ct1.default_queue();
+// CHECK:   /*
+// CHECK:   DPCT1026:5: The call to cub::DeviceSegmentedSort::StableSortKeysDescending was removed because this call is redundant in SYCL.
+// CHECK:   */
+// CHECK:   dpct::segmented_sort_keys(oneapi::dpl::execution::device_policy(q_ct1), d_keys, n, num_segments, d_offsets, d_offsets + 1, true, true);
+// CHECK: }
+void test6(void) {
+  void *temp_storage;
+  size_t temp_storage_size;
+  cub::DeviceSegmentedSort::StableSortKeysDescending(nullptr, temp_storage_size, d_keys, n, num_segments, d_offsets, d_offsets + 1);
+  cudaMalloc(&temp_storage, temp_storage_size);
+  cub::DeviceSegmentedSort::StableSortKeysDescending(temp_storage, temp_storage_size, d_keys, n, num_segments, d_offsets, d_offsets + 1);
+}
+
+// CHECK: void test7(void) {
+// CHECK:   dpct::device_ext &dev_ct1 = dpct::get_current_device();
+// CHECK:   sycl::queue &q_ct1 = dev_ct1.default_queue();
+// CHECK:   dpct::queue_ptr s = &q_ct1;
+// CHECK:   /*
+// CHECK:   DPCT1026:6: The call to cub::DeviceSegmentedSort::StableSortKeysDescending was removed because this call is redundant in SYCL.
+// CHECK:   */
+// CHECK:   dpct::segmented_sort_keys(oneapi::dpl::execution::device_policy(*s), d_keys, n, num_segments, d_offsets, d_offsets + 1, true, true);
+// CHECK: }
+void test7(void) {
+  void *temp_storage;
+  size_t temp_storage_size;
+  cudaStream_t s = 0;
+  cub::DeviceSegmentedSort::StableSortKeysDescending(nullptr, temp_storage_size, d_keys, n, num_segments, d_offsets, d_offsets + 1, s);
+  cudaMalloc(&temp_storage, temp_storage_size);
+  cub::DeviceSegmentedSort::StableSortKeysDescending(temp_storage, temp_storage_size, d_keys, n, num_segments, d_offsets, d_offsets + 1, s);
+}
+
+// CHECK: void test8(void) {
+// CHECK:   dpct::queue_ptr s = (dpct::queue_ptr)(void *)(uintptr_t)0xFF;;
+// CHECK:   /*
+// CHECK:   DPCT1026:7: The call to cub::DeviceSegmentedSort::StableSortKeysDescending was removed because this call is redundant in SYCL.
+// CHECK:   */
+// CHECK:   dpct::segmented_sort_keys(oneapi::dpl::execution::device_policy(*s), d_keys_in, d_keys_out, n, num_segments, d_offsets, d_offsets + 1, true);
+// CHECK: }
+void test8(void) {
+  void *temp_storage;
+  size_t temp_storage_size;
+  cudaStream_t s = (cudaStream_t)(void *)(uintptr_t)0xFF;
+  ;
+  cub::DeviceSegmentedSort::StableSortKeysDescending(nullptr, temp_storage_size, d_keys_in, d_keys_out, n, num_segments, d_offsets, d_offsets + 1, s);
+  cudaMalloc(&temp_storage, temp_storage_size);
+  cub::DeviceSegmentedSort::StableSortKeysDescending(temp_storage, temp_storage_size, d_keys_in, d_keys_out, n, num_segments, d_offsets, d_offsets + 1, s);
+}


### PR DESCRIPTION
Signed-off-by: Wang, Yihan [yihan.wang@intel.com](mailto:yihan.wang@intel.com)