### PR TITLE
[SYCLomatic] device_pointer allocation using shared memory

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/memory.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/memory.h
@@ -358,7 +358,7 @@ public:
   device_pointer_base(ValueType *p) : ptr(p) {}
   device_pointer_base(const std::size_t count) {
     sycl::queue default_queue = dpct::get_default_queue();
-    ptr = static_cast<ValueType *>(sycl::malloc_device(
+    ptr = static_cast<ValueType *>(sycl::malloc_shared(
         count, default_queue.get_device(), default_queue.get_context()));
   }
   device_pointer_base() {}


### PR DESCRIPTION
`device_pointer` used shared USM memory or sycl::buffers to allow seamless host and device access.  
This is consistent for `device_vector`, and this PR makes this `device_pointer` constructor consistent with that strategy.  This constructor is also used by `dpct::malloc_device()`.  

Making this a shared USM allocation resolves an issue with subsequent uses of this `device_pointer` from the host.

