### PR TITLE
[SYCLomatic] Add run length encode nontrivial runs API

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
@@ -1749,10 +1749,12 @@ segmented_reduce_argmax(Policy &&policy, Iter1 keys_in, Iter2 keys_out,
 template <typename ExecutionPolicy, typename InputIterator,
           typename OutputIterator1, typename OutputIterator2,
           typename OutputIterator3>
-::std::pair<OutputIterator1, OutputIterator2> nontrivial_run_length_encode(
-    ExecutionPolicy &&policy, InputIterator input_beg, InputIterator input_end,
-    OutputIterator1 offsets_out, OutputIterator2 lengths_out,
-    OutputIterator3 num_runs) {
+void nontrivial_run_length_encode(ExecutionPolicy &&policy,
+                                  InputIterator input_beg,
+                                  OutputIterator1 offsets_out,
+                                  OutputIterator2 lengths_out,
+                                  OutputIterator3 num_runs,
+                                  ::std::int64_t num_items) {
   using oneapi::dpl::make_transform_iterator;
   using oneapi::dpl::make_zip_iterator;
   using offsets_t =
@@ -1760,21 +1762,21 @@ template <typename ExecutionPolicy, typename InputIterator,
   using lengths_t =
       typename ::std::iterator_traits<OutputIterator2>::value_type;
 
-  auto n = ::std::distance(input_beg, input_end);
+  auto input_end = input_beg + num_items;
   // First element must be nontrivial run (start of first segment)
   auto first_adj_it = oneapi::dpl::adjacent_find(policy, input_beg, input_end);
   auto first_adj_idx = ::std::distance(input_beg, first_adj_it);
   if (first_adj_it == input_end) {
     ::std::fill(policy, num_runs, num_runs + 1, 0);
-    return ::std::make_pair(offsets_out, lengths_out);
+    return;
   }
   auto get_prev_idx_element = [first_adj_idx](const auto &idx) {
     auto out_idx = idx + first_adj_idx;
     return (out_idx == 0) ? 0 : out_idx - 1;
   };
-  auto get_next_idx_element = [first_adj_idx, n](const auto &idx) {
+  auto get_next_idx_element = [first_adj_idx, num_items](const auto &idx) {
     auto out_idx = idx + first_adj_idx;
-    return (out_idx == n - 1) ? n - 1 : out_idx + 1;
+    return (out_idx == num_items - 1) ? num_items - 1 : out_idx + 1;
   };
   // TODO: Use shifted view to pad range once oneDPL ranges is non-experimental
   auto left_shifted_input_beg =
@@ -1788,9 +1790,9 @@ template <typename ExecutionPolicy, typename InputIterator,
       oneapi::dpl::counting_iterator<offsets_t>(0));
   // Set flag at the beginning of new nontrivial run (ex: (2, 3, 3) -> 1)
   auto key_flags_beg =
-      make_transform_iterator(zipped_keys_beg, [n](const auto &zipped) {
+      make_transform_iterator(zipped_keys_beg, [num_items](const auto &zipped) {
         using ::std::get;
-        bool last_idx_mask = get<3>(zipped) != n - 1;
+        bool last_idx_mask = get<3>(zipped) != num_items - 1;
         return (get<0>(zipped) != get<1>(zipped) &&
                 get<1>(zipped) == get<2>(zipped)) &&
                last_idx_mask;
@@ -1827,12 +1829,11 @@ template <typename ExecutionPolicy, typename InputIterator,
   auto zipped_out_beg = make_zip_iterator(oneapi::dpl::discard_iterator(),
                                           offsets_out, lengths_out);
   auto [_, zipped_out_vals_end] = oneapi::dpl::reduce_by_segment(
-      policy, key_flags_beg + first_adj_idx, key_flags_beg + n,
+      policy, key_flags_beg + first_adj_idx, key_flags_beg + num_items,
       zipped_vals_beg + first_adj_idx, oneapi::dpl::discard_iterator(),
       zipped_out_beg, pred, op);
   auto ret_dist = ::std::distance(zipped_out_beg, zipped_out_vals_end);
   ::std::fill(policy, num_runs, num_runs + 1, ret_dist);
-  return ::std::make_pair(offsets_out + ret_dist, lengths_out + ret_dist);
 }
 
 } // end namespace dpct


### PR DESCRIPTION
This PR implements the run length encoding nontrivial runs API. In order for the added source code in this PR to compile, https://github.com/oneapi-src/oneDPL/pull/1019 must be first merged into oneDPL. The corresponding test PR for this implementation is provided in https://github.com/oneapi-src/SYCLomatic-test/pull/393

Nontrivial runs are a subsequence of length two or greater in a buffer that are equivalent. This API marks the start of each nontrivial run, length of each nontrivial run, and the number of nontrivial runs.