### PR TITLE
[SYCLomatic] Using CanonicalType when migrating cudaCreateChannelDesc

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -13231,7 +13231,11 @@ void TextureRule::runRule(const MatchFinder::MatchResult &Result) {
       if (Callee) {
         auto TemArg = Callee->template_arguments();
         if (TemArg.size() != 0) {
-          auto ChnType = TemArg[0].getArgument().getAsType().getAsString();
+          auto ChnType = TemArg[0]
+                             .getArgument()
+                             .getAsType()
+                             .getCanonicalType()
+                             .getAsString();
           if (ChnType.back() != '4') {
             report(CE->getBeginLoc(), Diagnostics::UNSUPPORTED_IMAGE_FORMAT,
                    true);

--- a/clang/test/dpct/texture_object.cu
+++ b/clang/test/dpct/texture_object.cu
@@ -93,6 +93,9 @@ __global__ void kernel(cudaTextureObject_t tex2, cudaTextureObject_t tex4) {
 }
 
 int main() {
+  using CudaRGBA = float4;
+  // CHECK: dpct::image_channel channelCudaRGBA = dpct::image_channel::create<CudaRGBA>();
+  cudaChannelFormatDesc channelCudaRGBA = cudaCreateChannelDesc<CudaRGBA>();
 
   // CHECK: sycl::float4 *d_data42;
   // CHECK-NEXT: dpct::image_matrix_p a42;


### PR DESCRIPTION
Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>