### PR TITLE
[SYCLomatic] Refine the migration of cub::WarpScan<T>

### DIFF
--- a/clang/lib/DPCT/CUBAPIMigration.cpp
+++ b/clang/lib/DPCT/CUBAPIMigration.cpp
@@ -764,9 +764,9 @@ void CubRule::processCubTypeDef(const TypedefDecl *TD) {
     auto EndLoc =
         SM.getExpansionLoc(TD->getTypeSourceInfo()->getTypeLoc().getEndLoc());
     if (CanonicalTypeStr.find("Warp") != std::string::npos) {
-      emplaceTransformation(replaceText(
-          BeginLoc, EndLoc.getLocWithOffset(1),
-          MapNames::getClNamespace() + "ext::oneapi::sub_group", SM));
+      emplaceTransformation(
+          replaceText(BeginLoc, EndLoc.getLocWithOffset(1),
+                      MapNames::getClNamespace() + "sub_group", SM));
     } else if (CanonicalTypeStr.find("Block") != std::string::npos) {
       auto DeviceFuncDecl = DpctGlobalInfo::findAncestor<FunctionDecl>(TD);
       if (DeviceFuncDecl && (DeviceFuncDecl->hasAttr<CUDADeviceAttr>() ||
@@ -1313,9 +1313,9 @@ void CubRule::processTypeLoc(const TypeLoc *TL) {
   std::string TypeName = TL->getType().getCanonicalType().getAsString();
   if (TypeName.find("class cub::WarpScan") == 0 ||
       TypeName.find("class cub::WarpReduce") == 0) {
-    emplaceTransformation(
-        replaceText(BeginLoc, EndLoc.getLocWithOffset(1),
-                    MapNames::getClNamespace() + "ext::oneapi::sub_group", SM));
+    emplaceTransformation(replaceText(BeginLoc, EndLoc.getLocWithOffset(1),
+                                      MapNames::getClNamespace() + "sub_group",
+                                      SM));
   } else if (TypeName.find("class cub::BlockScan") == 0 ||
              TypeName.find("class cub::BlockReduce") == 0) {
     auto DeviceFuncDecl = DpctGlobalInfo::findAncestor<FunctionDecl>(TL);

--- a/clang/test/dpct/cub/warplevel/warpscan.cu
+++ b/clang/test/dpct/cub/warplevel/warpscan.cu
@@ -270,16 +270,16 @@ __device__ void Scan1(ScanTy &s) {
   s.InclusiveSum(d, d);
 }
 
-//CHECK: void TemplateKernel1(int* data,
-//CHECK-NEXT:   const sycl::nd_item<3> &item_ct1) {
-//CHECK-NEXT:  typedef sycl::ext::oneapi::sub_group WarpScan;
-//CHECK-NEXT:  typedef sycl::group<3> BlockScan;
-//CHECK-EMPTY:
-//CHECK-NEXT:  WarpScan ws(item_ct1.get_sub_group());
-//CHECK-NEXT:  BlockScan bs(item_ct1.get_group());
-//CHECK-NEXT:  Scan1<WarpScan, int>(ws);
-//CHECK-NEXT:  Scan1<BlockScan, int>(bs);
-//CHECK-NEXT:}
+// CHECK: void TemplateKernel1(int* data,
+// CHECK-NEXT:   const sycl::nd_item<3> &item_ct1) {
+// CHECK-NEXT:  typedef sycl::sub_group WarpScan;
+// CHECK-NEXT:  typedef sycl::group<3> BlockScan;
+// CHECK-EMPTY:
+// CHECK-NEXT:  WarpScan ws(item_ct1.get_sub_group());
+// CHECK-NEXT:  BlockScan bs(item_ct1.get_group());
+// CHECK-NEXT:  Scan1<WarpScan, int>(ws);
+// CHECK-NEXT:  Scan1<BlockScan, int>(bs);
+// CHECK-NEXT:}
 __global__ void TemplateKernel1(int* data) {
   typedef cub::WarpScan<int> WarpScan;
   typedef cub::BlockScan<int, 8> BlockScan;

--- a/clang/test/dpct/cub/warplevel/warpscan1d.cu
+++ b/clang/test/dpct/cub/warplevel/warpscan1d.cu
@@ -36,16 +36,16 @@ __device__ void Scan1(ScanTy &s) {
   s.InclusiveSum(d, d);
 }
 
-//CHECK: void TemplateKernel1(int* data,
-//CHECK-NEXT:  const sycl::nd_item<1> &item_ct1) {
-//CHECK-NEXT:  typedef sycl::ext::oneapi::sub_group WarpScan;
-//CHECK-NEXT:  typedef sycl::group<1> BlockScan;
-//CHECK-EMPTY:
-//CHECK-NEXT:  WarpScan ws(item_ct1.get_sub_group());
-//CHECK-NEXT:  BlockScan bs(item_ct1.get_group());
-//CHECK-NEXT:  Scan1<WarpScan, int>(ws);
-//CHECK-NEXT:  Scan1<BlockScan, int>(bs);
-//CHECK-NEXT:}
+// CHECK: void TemplateKernel1(int* data,
+// CHECK-NEXT:  const sycl::nd_item<1> &item_ct1) {
+// CHECK-NEXT:  typedef sycl::sub_group WarpScan;
+// CHECK-NEXT:  typedef sycl::group<1> BlockScan;
+// CHECK-EMPTY:
+// CHECK-NEXT:  WarpScan ws(item_ct1.get_sub_group());
+// CHECK-NEXT:  BlockScan bs(item_ct1.get_group());
+// CHECK-NEXT:  Scan1<WarpScan, int>(ws);
+// CHECK-NEXT:  Scan1<BlockScan, int>(bs);
+// CHECK-NEXT:}
 __global__ void TemplateKernel1(int* data) {
   typedef cub::WarpScan<int> WarpScan;
   typedef cub::BlockScan<int, 8> BlockScan;


### PR DESCRIPTION
Refine the migration of `cub::WarpScan<T>`, use `sycl::sub_group`  instead of `sycl::ext::oneapi::sub_group` , because  `sycl::ext::oneapi::sub_group`  was deprecated , and also `sycl::sub_group` was supported in SYCL 2020.

https://github.com/intel-restricted/applications.compilers.llvm-project/blob/91f9ca4618031f394bdd45c9f554d93fbf8b84de/sycl/include/sycl/sub_group.hpp#L17