### PR TITLE
[SYCLomatic] Add missing scatter_if and gather_if APIs

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
@@ -375,7 +375,7 @@ template <typename Policy, typename InputIter1, typename InputIter2,
 void scatter_if(Policy &&policy, InputIter1 first, InputIter1 last,
                 InputIter2 map, InputIter3 mask, OutputIter result) {
   scatter_if(::std::forward<Policy>(policy), first, last, map, mask, result,
-             [=](auto &&mask_element) { return mask_element; });
+             internal::no_op_fun());
 }
 
 template <typename Policy, typename InputIter1, typename InputIter2,
@@ -411,8 +411,7 @@ OutputIter gather_if(Policy &&policy, InputIter1 map_first, InputIter1 map_last,
                      InputIter2 mask, InputIter3 input_first,
                      OutputIter result) {
   return gather_if(::std::forward<Policy>(policy), map_first, map_last, mask,
-                   input_first, result,
-                   [](auto &&mask_element) { return mask_element; });
+                   input_first, result, internal::no_op_fun());
 }
 
 template <typename Policy, typename Iter1, typename Iter2, typename Iter3,

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
@@ -371,6 +371,14 @@ void scatter_if(Policy &&policy, InputIter1 first, InputIter1 last,
 }
 
 template <typename Policy, typename InputIter1, typename InputIter2,
+          typename InputIter3, typename OutputIter>
+void scatter_if(Policy &&policy, InputIter1 first, InputIter1 last,
+                InputIter2 map, InputIter3 mask, OutputIter result) {
+  scatter_if(::std::forward<Policy>(policy), first, last, map, mask, result,
+             [=](auto &&mask_element) { return mask_element; });
+}
+
+template <typename Policy, typename InputIter1, typename InputIter2,
           typename InputIter3, typename OutputIter, typename Predicate>
 OutputIter gather_if(Policy &&policy, InputIter1 map_first, InputIter1 map_last,
                      InputIter2 mask, InputIter3 input_first, OutputIter result,
@@ -395,6 +403,16 @@ OutputIter gather_if(Policy &&policy, InputIter1 map_first, InputIter1 map_last,
   return transform_if(policy, perm_begin, perm_begin + n, mask, result,
                       [=](auto &&v) { return v; },
                       [=](auto &&m) { return pred(m); });
+}
+
+template <typename Policy, typename InputIter1, typename InputIter2,
+          typename InputIter3, typename OutputIter>
+OutputIter gather_if(Policy &&policy, InputIter1 map_first, InputIter1 map_last,
+                     InputIter2 mask, InputIter3 input_first,
+                     OutputIter result) {
+  return gather_if(::std::forward<Policy>(policy), map_first, map_last, mask,
+                   input_first, result,
+                   [](auto &&mask_element) { return mask_element; });
 }
 
 template <typename Policy, typename Iter1, typename Iter2, typename Iter3,

--- a/clang/runtime/dpct-rt/include/dpl_extras/functional.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/functional.h
@@ -362,6 +362,14 @@ private:
   uint_type_t flip_key;
 };
 
+// Unary operator that returns reference to its argument. Ported from
+// oneDPL: oneapi/dpl/pstl/utils.h
+struct no_op_fun {
+  template <typename Tp> Tp &&operator()(Tp &&a) const {
+    return ::std::forward<Tp>(a);
+  }
+};
+
 } // end namespace internal
 
 } // end namespace dpct


### PR DESCRIPTION
This PR adds the missing `scatter_if` and `gather_if` APIs where no user defined unary predicate is provided. In this scenario, the mask value is assumed to be convertible to `bool` and directly used as the predicate value.

These APIs are added to the `dpct` namespace in the `algorithm.h` header.