### PR TITLE
[NFC][SYCLomatic] Avoid redefinition warning of NOMINMAX

### DIFF
--- a/clang/runtime/dpct-rt/include/device.hpp
+++ b/clang/runtime/dpct-rt/include/device.hpp
@@ -25,7 +25,9 @@
 #include <sys/syscall.h>
 #endif
 #if defined(_WIN64)
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <windows.h>
 #endif
 

--- a/clang/runtime/dpct-rt/include/memory.hpp
+++ b/clang/runtime/dpct-rt/include/memory.hpp
@@ -24,7 +24,9 @@
 #if defined(__linux__)
 #include <sys/mman.h>
 #elif defined(_WIN64)
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <windows.h>
 #else
 #error "Only support Windows and Linux."


### PR DESCRIPTION
Avoid redefinition warning of NOMINMAX when the `-DNOMINMAX` option enabled.