### PR TITLE
[SYCLomatic] Add malloc, free, and temporary allocation mappings

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/memory.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/memory.h
@@ -763,21 +763,13 @@ public:
   using pointer = typename super_t::pointer;
   using reference = T &;
   using iterator_category = std::random_access_iterator_tag;
-  using is_hetero = ::std::is_same<Tag, host_sys_tag>; // required
-  using is_passed_directly = std::false_type;
+  using is_hetero = ::std::false_type;
+  using is_passed_directly = std::true_type;
 
   tagged_pointer() : super_t() {}
   tagged_pointer(T *ptr) : super_t(ptr) {}
   T &operator[](difference_type idx) { return this->m_ptr[idx]; }
   T &operator[](difference_type idx) const { return this->m_ptr[idx]; }
-  // Enable conversion to other pointer types only if it is convertible
-  template <
-      typename OtherType,
-      ::std::enable_if_t<::std::is_convertible_v<T *, OtherType *>, int> = 0>
-  operator tagged_pointer<Tag, OtherType>() {
-    return tagged_pointer<Tag, OtherType>(
-        static_cast<OtherType *>(this->m_ptr));
-  }
   tagged_pointer operator+(difference_type forward) const {
     return tagged_pointer{this->m_ptr + forward};
   }
@@ -828,9 +820,12 @@ public:
   using pointer = typename super_t::pointer;
   tagged_pointer() : super_t() {}
   tagged_pointer(pointer ptr) : super_t(ptr) {}
-  // Enable void pointer to convert to all other pointer types.
-  template <typename OtherType> operator tagged_pointer<Tag, OtherType>() {
-    return static_cast<OtherType *>(this->m_ptr);
+  // Enable tagged void pointer to convert to all other raw pointer types.
+  template <typename OtherPtr> operator OtherPtr *() const {
+    return static_cast<OtherPtr *>(this->m_ptr);
+  }
+  template <typename OtherPtr> operator OtherPtr *() {
+    return static_cast<OtherPtr *>(this->m_ptr);
   }
 };
 

--- a/clang/runtime/dpct-rt/include/dpl_extras/memory.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/memory.h
@@ -719,8 +719,9 @@ private:
 public:
   static constexpr bool is_policy_v =
       oneapi::dpl::execution::is_execution_policy_v<decayed_policy_or_tag_t>;
-  static constexpr bool is_sys_tag_v =
-      ::std::is_base_of_v<sys_tag, std::decay_t<decayed_policy_or_tag_t>>;
+  static constexpr bool is_sys_tag_v = ::std::disjunction_v<
+      ::std::is_same<decayed_policy_or_tag_t, host_sys_tag>,
+      ::std::is_same<decayed_policy_or_tag_t, device_sys_tag>>;
   static_assert(is_policy_v || is_sys_tag_v,
                 "Only oneDPL policies or system tags may be provided");
 

--- a/clang/runtime/dpct-rt/include/dpl_extras/memory.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/memory.h
@@ -776,6 +776,10 @@ public:
   tagged_pointer operator-(difference_type backward) const {
     return tagged_pointer{this->m_ptr - backward};
   }
+  T &operator*() { return *this->m_ptr; }
+  const T &operator*() const { return *this->m_ptr; }
+  T *operator->() { return this->m_ptr; }
+  const T *operator->() const { return this->m_ptr; }
   tagged_pointer operator++(int) {
     tagged_pointer p(this->m_ptr);
     ++this->m_ptr;

--- a/clang/runtime/dpct-rt/include/dpl_extras/memory.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/memory.h
@@ -739,8 +739,8 @@ template <typename Tag, typename T, typename Derived>
 class tagged_pointer_base {
 public:
   using pointer = T *;
-  using difference_type = ::std::make_signed_t<std::size_t>;
-  tagged_pointer_base() = default;
+  using difference_type = ::std::ptrdiff_t;
+  tagged_pointer_base() : m_ptr(nullptr) {}
   tagged_pointer_base(T *ptr) : m_ptr(ptr) {}
   operator const T *() const { return m_ptr; }
   operator T *() { return m_ptr; }
@@ -769,7 +769,7 @@ public:
   tagged_pointer() : super_t() {}
   tagged_pointer(T *ptr) : super_t(ptr) {}
   T &operator[](difference_type idx) { return this->m_ptr[idx]; }
-  T &operator[](difference_type idx) const { return this->m_ptr[idx]; }
+  const T &operator[](difference_type idx) const { return this->m_ptr[idx]; }
   tagged_pointer operator+(difference_type forward) const {
     return tagged_pointer{this->m_ptr + forward};
   }

--- a/clang/runtime/dpct-rt/include/dpl_extras/memory.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/memory.h
@@ -742,7 +742,7 @@ public:
   using difference_type = ::std::make_signed_t<std::size_t>;
   tagged_pointer_base() = default;
   tagged_pointer_base(T *ptr) : m_ptr(ptr) {}
-  operator T *() const { return m_ptr; }
+  operator const T *() const { return m_ptr; }
   operator T *() { return m_ptr; }
 
 protected:
@@ -822,9 +822,6 @@ public:
   tagged_pointer(pointer ptr) : super_t(ptr) {}
   // Enable tagged void pointer to convert to all other raw pointer types.
   template <typename OtherPtr> operator OtherPtr *() const {
-    return static_cast<OtherPtr *>(this->m_ptr);
-  }
-  template <typename OtherPtr> operator OtherPtr *() {
     return static_cast<OtherPtr *>(this->m_ptr);
   }
 };

--- a/clang/runtime/dpct-rt/include/dpl_extras/memory.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/memory.h
@@ -735,8 +735,7 @@ using policy_or_tag_to_tag_t = typename policy_or_tag_to_tag<PolicyOrTag>::type;
 
 // TODO: Improve this pointer wrapper and make an iterator adaptor
 // once we have the Boost library dependency
-template <typename Tag, typename T, typename Derived>
-class tagged_pointer_base {
+template <typename Tag, typename T> class tagged_pointer_base {
 public:
   using pointer = T *;
   using difference_type = ::std::ptrdiff_t;
@@ -753,9 +752,8 @@ protected:
 // location of the allocated memory. Standard pointer operations are supported
 // with this class.
 template <typename Tag, typename T = void>
-class tagged_pointer
-    : public tagged_pointer_base<Tag, T, tagged_pointer<Tag, T>> {
-  using super_t = tagged_pointer_base<Tag, T, tagged_pointer<Tag, T>>;
+class tagged_pointer : public tagged_pointer_base<Tag, T> {
+  using super_t = tagged_pointer_base<Tag, T>;
 
 public:
   using value_type = T;
@@ -815,9 +813,8 @@ public:
 // conversion to other non-void tagged pointers is allowed. Pointer arithmetic
 // is disallowed with this specialization.
 template <typename Tag>
-class tagged_pointer<Tag, void>
-    : public tagged_pointer_base<Tag, void, tagged_pointer<Tag, void>> {
-  using super_t = tagged_pointer_base<Tag, void, tagged_pointer<Tag, void>>;
+class tagged_pointer<Tag, void> : public tagged_pointer_base<Tag, void> {
+  using super_t = tagged_pointer_base<Tag, void>;
 
 public:
   using difference_type = typename super_t::difference_type;


### PR DESCRIPTION
In this PR, we add the APIs for `malloc`, `free`, and temporary buffers (`get_temporary_allocation` and `release_temporary_allocation`). A `tagged_pointer` type is added that contains a template parameter of type `host_sys_tag` or `device_sys_tag` specifying the location of the allocation. This type is returned by `malloc` and `get_temporary_allocation`. `tagged_pointer` currently provides basic pointer functionality and will be improved in the future once we get access to Boost iterator adaptors.

In addition to passing execution policies to the memory allocation APIs, passing a system tag type is also supported in this PR. The implemented functionality is only supported for USM mode. Static asserts are hit if `DPCT_USM_LEVEL_NONE` is set.

There are two PRs that test this functionality:
- https://github.com/oneapi-src/SYCLomatic-test/pull/426
- https://github.com/oneapi-src/SYCLomatic-test/pull/427