### PR TITLE
[SYCLomatic] Save length of macro instead of SourceLocation to avoid internal error when SourceManager switched

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -371,7 +371,9 @@ void IncludesCallbacks::MacroExpands(const Token &MacroNameTok,
       dpct::DpctGlobalInfo::getEndOfEmptyMacros()[getHashStrFromLoc(
           Tok.getLocation())] = Range.getBegin();
       dpct::DpctGlobalInfo::getBeginOfEmptyMacros()[getHashStrFromLoc(
-          Range.getBegin())] = Range.getEnd();
+          Range.getBegin())] =
+          dpct::DpctGlobalInfo::getLocInfo(Range.getEnd()).second -
+          dpct::DpctGlobalInfo::getLocInfo(Range.getBegin()).second;
     }
   }
 

--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -12220,6 +12220,8 @@ void RecognizeAPINameRule::processFuncCall(const CallExpr *CE) {
                            ->getType()
                            .getCanonicalType();
     ND = getNamedDecl(ObjType.getTypePtr());
+    if (!ND)
+      return;
     ObjName = ND->getNameAsString();
   } else {
     // Match the static member function call, like: A a; a.staticCall();

--- a/clang/lib/DPCT/AnalysisInfo.cpp
+++ b/clang/lib/DPCT/AnalysisInfo.cpp
@@ -87,7 +87,7 @@ std::map<std::string, std::shared_ptr<DpctGlobalInfo::MacroDefRecord>>
 std::map<std::string, std::string>
     DpctGlobalInfo::FunctionCallInMacroMigrateRecord;
 std::map<std::string, SourceLocation> DpctGlobalInfo::EndOfEmptyMacros;
-std::map<std::string, SourceLocation> DpctGlobalInfo::BeginOfEmptyMacros;
+std::map<std::string, unsigned int> DpctGlobalInfo::BeginOfEmptyMacros;
 std::map<std::string, bool> DpctGlobalInfo::MacroDefines;
 std::set<std::string> DpctGlobalInfo::IncludingFileSet;
 std::set<std::string> DpctGlobalInfo::FileSetInCompiationDB;

--- a/clang/lib/DPCT/AnalysisInfo.h
+++ b/clang/lib/DPCT/AnalysisInfo.h
@@ -1658,7 +1658,7 @@ public:
     return ConditionalCompilationLoc;
   }
 
-  static std::map<std::string, SourceLocation> &getBeginOfEmptyMacros() {
+  static std::map<std::string, unsigned int> &getBeginOfEmptyMacros() {
     return BeginOfEmptyMacros;
   }
   static std::map<std::string, SourceLocation> &getEndOfEmptyMacros() {
@@ -2037,7 +2037,7 @@ private:
   static std::map<std::string, SourceLocation> EndOfEmptyMacros;
   // key: The hash string of the begin location of the macro expansion
   // value: The end location of the macro expansion
-  static std::map<std::string, SourceLocation> BeginOfEmptyMacros;
+  static std::map<std::string, unsigned int> BeginOfEmptyMacros;
   static std::unordered_map<std::string,
                             std::vector<clang::tooling::Replacement>>
       FileRelpsMap;

--- a/clang/lib/DPCT/ExprAnalysis.cpp
+++ b/clang/lib/DPCT/ExprAnalysis.cpp
@@ -321,9 +321,7 @@ std::pair<size_t, size_t> ExprAnalysis::getOffsetAndLength(const Expr *E, Source
                              SM.getCharacterData(BeginLoc);
 
   auto EndLocWithoutPostfix = SM.getExpansionLoc(EndLoc);
-  EndLoc = SM.getExpansionLoc(getEndLocOfFollowingEmptyMacro(EndLoc));
-  auto RewritePostfixLength =
-      SM.getCharacterData(EndLoc) - SM.getCharacterData(EndLocWithoutPostfix);
+  unsigned int RewritePostfixLength = getEndLocOfFollowingEmptyMacro(EndLoc);
 
   if (Loc)
     *Loc = BeginLoc;

--- a/clang/lib/DPCT/Utility.cpp
+++ b/clang/lib/DPCT/Utility.cpp
@@ -1980,7 +1980,7 @@ SourceLocation getBeginLocOfPreviousEmptyMacro(SourceLocation Loc) {
   return Loc;
 }
 
-SourceLocation getEndLocOfFollowingEmptyMacro(SourceLocation Loc) {
+unsigned int getEndLocOfFollowingEmptyMacro(SourceLocation Loc) {
   auto &SM = dpct::DpctGlobalInfo::getSourceManager();
   auto &Map = dpct::DpctGlobalInfo::getBeginOfEmptyMacros();
   Token Tok;
@@ -1989,7 +1989,7 @@ SourceLocation getEndLocOfFollowingEmptyMacro(SourceLocation Loc) {
           Loc, SM, dpct::DpctGlobalInfo::getContext().getLangOpts())),
       Tok, SM, dpct::DpctGlobalInfo::getContext().getLangOpts(), true);
   if (Ret)
-    return Loc;
+    return 0;
 
   SourceLocation EndOfToken = SM.getExpansionLoc(Tok.getLocation());
   while (Tok.isNot(tok::eof) && Tok.is(tok::comment)) {
@@ -2001,11 +2001,16 @@ SourceLocation getEndLocOfFollowingEmptyMacro(SourceLocation Loc) {
     ;
   }
 
-  auto It = Map.find(getHashStrFromLoc(EndOfToken));
+  auto EndOfTokenLocInfo = dpct::DpctGlobalInfo::getLocInfo(EndOfToken);
+  std::string EndOfTokenKey = std::to_string(std::hash<std::string>()(
+      dpct::buildString(EndOfTokenLocInfo.first, EndOfTokenLocInfo.second)));
+  auto OriginalLocInfo = dpct::DpctGlobalInfo::getLocInfo(Loc);
+
+  auto It = Map.find(EndOfTokenKey);
   if (It != Map.end()) {
-    return It->second;
+    return It->second + EndOfTokenLocInfo.second - OriginalLocInfo.second;
   }
-  return Loc;
+  return 0;
 }
 
 std::string

--- a/clang/lib/DPCT/Utility.h
+++ b/clang/lib/DPCT/Utility.h
@@ -448,7 +448,7 @@ const clang::CXXRecordDecl *getParentRecordDecl(const clang::ValueDecl *DD);
 bool IsTypeChangedToPointer(const clang::DeclRefExpr *DRE);
 clang::SourceLocation
 getBeginLocOfPreviousEmptyMacro(clang::SourceLocation Loc);
-clang::SourceLocation getEndLocOfFollowingEmptyMacro(clang::SourceLocation Loc);
+unsigned int getEndLocOfFollowingEmptyMacro(clang::SourceLocation Loc);
 
 std::string getNestedNameSpecifierString(const clang::NestedNameSpecifier *);
 std::string getNestedNameSpecifierString(const clang::NestedNameSpecifierLoc &);


### PR DESCRIPTION
Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>