### PR TITLE
[SYCLomatic] Histogram functional implementation

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
@@ -1801,11 +1801,10 @@ __histogram_general_select_best(_ExecutionPolicy &&policy,
       policy.queue()
           .get_device()
           .template get_info<sycl::info::device::local_mem_size>();
-
-  ::std::size_t N = __last - __first;
+  constexpr ::std::uint8_t __max_registers = 16;
 
   // if bins fit into registers, use register private accumulation
-  if (num_bins < MAX_BINS_PER_WORK_ITEM) {
+  if (num_bins < __max_registers) {
     return __histogram_general_registers_local_reduction<1024, 32, 16>(
         ::std::forward<_ExecutionPolicy>(policy), __first, __last,
         __histogram_first, num_bins, __func);

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
@@ -1467,16 +1467,17 @@ struct __evenly_divided_binhash_impl<T, /* is_floating_point = */ true> {
   T __minimum;
   ::std::uint32_t __num_bins;
   T __scale;
+  T __maximum;
   __evenly_divided_binhash_impl(const T &min, const T &max,
                                 const ::std::uint32_t &num_bins)
-      : __minimum(min), __num_bins(num_bins),
+      : __minimum(min), __maximum(max), __num_bins(num_bins),
         __scale(T(num_bins) / (max - min)) {}
   template <typename T2>::std::uint32_t operator()(T2 &&value) const {
     return ::std::uint32_t((::std::forward<T2>(value) - __minimum) * __scale);
   }
 
   template <typename T2> bool is_valid(const T2 &value) const {
-    return value >= __minimum && value < __minimum + __scale * T(__num_bins);
+    return value >= __minimum && value < __maximum;
   }
 };
 

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
@@ -1866,8 +1866,8 @@ template <typename Policy, typename Iter1, typename Iter2, typename T,
     dpct::internal::is_iterator<Iter1>::value &&
     dpct::internal::is_iterator<Iter2>::value &&
     internal::is_hetero_execution_policy<::std::decay_t<Policy>>::value>
-HistogramEven(Policy &&policy, Iter1 d_samples, Iter2 d_histogram,
-              int num_levels, T lower_level, T upper_level, Size num_samples) {
+histogram_even(Policy &&policy, Iter1 d_samples, Iter2 d_histogram,
+               int num_levels, T lower_level, T upper_level, Size num_samples) {
   internal::dpl_histogram::histogram(::std::forward<Policy>(policy), d_samples,
                                      d_samples + num_samples, d_histogram,
                                      num_levels - 1, lower_level, upper_level);
@@ -1880,11 +1880,11 @@ template <typename Policy, typename Iter1, typename Iter2, typename T,
     dpct::internal::is_iterator<Iter1>::value &&
     dpct::internal::is_iterator<Iter2>::value &&
     internal::is_hetero_execution_policy<::std::decay_t<Policy>>::value>
-HistogramEven(Policy &&policy, Iter1 d_samples, Iter2 d_histogram,
-              int num_levels, T lower_level, T upper_level,
-              OffsetT num_row_samples, OffsetT num_rows,
-              ::std::size_t row_stride_bytes) {
-  return HistogramEven(
+histogram_even_roi(Policy &&policy, Iter1 d_samples, Iter2 d_histogram,
+                   int num_levels, T lower_level, T upper_level,
+                   OffsetT num_row_samples, OffsetT num_rows,
+                   ::std::size_t row_stride_bytes) {
+  return histogram_even(
       ::std::forward<Policy>(policy),
       oneapi::dpl::permutation_iterator(
           d_samples,
@@ -1903,14 +1903,14 @@ template <int NumChannels, int NumActiveChannels, typename Policy,
     dpct::internal::is_iterator<Iter1>::value &&
     dpct::internal::is_iterator<Iter2>::value &&
     internal::is_hetero_execution_policy<::std::decay_t<Policy>>::value>
-MultiHistogramEven(Policy &&policy, Iter1 d_samples,
-                   Iter2 d_histogram[NumActiveChannels],
-                   int num_levels[NumActiveChannels],
-                   T lower_level[NumActiveChannels],
-                   T upper_level[NumActiveChannels], Size num_pixels) {
+multi_histogram_even(Policy &&policy, Iter1 d_samples,
+                     Iter2 d_histogram[NumActiveChannels],
+                     int num_levels[NumActiveChannels],
+                     T lower_level[NumActiveChannels],
+                     T upper_level[NumActiveChannels], Size num_pixels) {
   for (int active_channel = 0; active_channel < NumActiveChannels;
        active_channel++) {
-    HistogramEven(
+    histogram_even(
         policy,
         oneapi::dpl::permutation_iterator(
             d_samples,
@@ -1927,15 +1927,16 @@ template <int NumChannels, int NumActiveChannels, typename Policy,
     dpct::internal::is_iterator<Iter1>::value &&
     dpct::internal::is_iterator<Iter2>::value &&
     internal::is_hetero_execution_policy<::std::decay_t<Policy>>::value>
-MultiHistogramEven(Policy &&policy, Iter1 d_samples,
-                   Iter2 d_histogram[NumActiveChannels],
-                   int num_levels[NumActiveChannels],
-                   T lower_level[NumActiveChannels],
-                   T upper_level[NumActiveChannels], OffsetT num_row_samples,
-                   OffsetT num_rows, ::std::size_t row_stride_bytes) {
+multi_histogram_even_roi(Policy &&policy, Iter1 d_samples,
+                         Iter2 d_histogram[NumActiveChannels],
+                         int num_levels[NumActiveChannels],
+                         T lower_level[NumActiveChannels],
+                         T upper_level[NumActiveChannels],
+                         OffsetT num_row_samples, OffsetT num_rows,
+                         ::std::size_t row_stride_bytes) {
   for (int active_channel = 0; active_channel < NumActiveChannels;
        active_channel++) {
-    HistogramEven(
+    histogram_even(
         policy,
         oneapi::dpl::permutation_iterator(
             d_samples,
@@ -1961,8 +1962,8 @@ template <typename Policy, typename Iter1, typename Iter2, typename Iter3,
     dpct::internal::is_iterator<Iter2>::value &&
     dpct::internal::is_iterator<Iter3>::value &&
     internal::is_hetero_execution_policy<::std::decay_t<Policy>>::value>
-HistogramRange(Policy &&policy, Iter1 d_samples, Iter2 d_histogram,
-               int num_levels, Iter3 d_levels, Size num_samples) {
+histogram_range(Policy &&policy, Iter1 d_samples, Iter2 d_histogram,
+                int num_levels, Iter3 d_levels, Size num_samples) {
   internal::dpl_histogram::histogram(::std::forward<Policy>(policy), d_samples,
                                      d_samples + num_samples, d_histogram,
                                      d_levels, d_levels + num_levels);
@@ -1976,10 +1977,10 @@ template <typename Policy, typename Iter1, typename Iter2, typename Iter3,
     dpct::internal::is_iterator<Iter2>::value &&
     dpct::internal::is_iterator<Iter3>::value &&
     internal::is_hetero_execution_policy<::std::decay_t<Policy>>::value>
-HistogramRange(Policy &&policy, Iter1 d_samples, Iter2 d_histogram,
-               int num_levels, Iter3 d_levels, OffsetT num_row_samples,
-               OffsetT num_rows, ::std::size_t row_stride_bytes) {
-  return HistogramRange(
+histogram_range_roi(Policy &&policy, Iter1 d_samples, Iter2 d_histogram,
+                    int num_levels, Iter3 d_levels, OffsetT num_row_samples,
+                    OffsetT num_rows, ::std::size_t row_stride_bytes) {
+  return histogram_range(
       ::std::forward<Policy>(policy),
       oneapi::dpl::permutation_iterator(
           d_samples,
@@ -1998,18 +1999,18 @@ template <int NumChannels, int NumActiveChannels, typename Policy,
     dpct::internal::is_iterator<Iter2>::value &&
     dpct::internal::is_iterator<Iter3>::value &&
     internal::is_hetero_execution_policy<::std::decay_t<Policy>>::value>
-MultiHistogramRange(Policy &&policy, Iter1 d_samples,
-                    Iter2 d_histogram[NumActiveChannels],
-                    int num_levels[NumActiveChannels],
-                    Iter3 d_levels[NumActiveChannels], Size num_pixels) {
+multi_histogram_range(Policy &&policy, Iter1 d_samples,
+                      Iter2 d_histogram[NumActiveChannels],
+                      int num_levels[NumActiveChannels],
+                      Iter3 d_levels[NumActiveChannels], Size num_pixels) {
   for (int active_channel = 0; active_channel < NumActiveChannels;
        active_channel++) {
-    HistogramRange(policy,
-                   oneapi::dpl::permutation_iterator(
-                       d_samples, internal::__interleaved_index_functor(
-                                      NumChannels, active_channel)),
-                   d_histogram[active_channel], num_levels[active_channel],
-                   d_levels[active_channel], num_pixels);
+    histogram_range(policy,
+                    oneapi::dpl::permutation_iterator(
+                        d_samples, internal::__interleaved_index_functor(
+                                       NumChannels, active_channel)),
+                    d_histogram[active_channel], num_levels[active_channel],
+                    d_levels[active_channel], num_pixels);
   }
 }
 
@@ -2021,14 +2022,15 @@ template <int NumChannels, int NumActiveChannels, typename Policy,
     dpct::internal::is_iterator<Iter2>::value &&
     dpct::internal::is_iterator<Iter3>::value &&
     internal::is_hetero_execution_policy<::std::decay_t<Policy>>::value>
-MultiHistogramRange(Policy &&policy, Iter1 d_samples,
-                    Iter2 d_histogram[NumActiveChannels],
-                    int num_levels[NumActiveChannels],
-                    Iter3 d_levels[NumActiveChannels], OffsetT num_row_samples,
-                    OffsetT num_rows, ::std::size_t row_stride_bytes) {
+multi_histogram_range_roi(Policy &&policy, Iter1 d_samples,
+                          Iter2 d_histogram[NumActiveChannels],
+                          int num_levels[NumActiveChannels],
+                          Iter3 d_levels[NumActiveChannels],
+                          OffsetT num_row_samples, OffsetT num_rows,
+                          ::std::size_t row_stride_bytes) {
   for (int active_channel = 0; active_channel < NumActiveChannels;
        active_channel++) {
-    HistogramRange(
+    histogram_range(
         policy,
         oneapi::dpl::permutation_iterator(
             d_samples,

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
@@ -1837,37 +1837,58 @@ __histogram_general_select_best(_ExecutionPolicy &&policy,
   }
 }
 
-} // end namespace internal
-
-template <typename _ExecutionPolicy, typename _InputIterator,
-          typename _RandomAccessIterator, typename _Size, typename _T>
-_RandomAccessIterator
-histogram_even(_ExecutionPolicy &&policy, _InputIterator __first,
-               _InputIterator __last, _RandomAccessIterator __histogram_first,
+template <typename Policy, typename Iter1,
+          typename Iter2, typename _Size, typename _T>
+inline ::std::enable_if_t<
+    dpct::internal::is_iterator<Iter1>::value &&
+    dpct::internal::is_iterator<Iter2>::value &&
+    internal::is_hetero_execution_policy<::std::decay_t<Policy>>::value, Iter2> 
+histogram(Policy &&policy, Iter1 __first,
+               Iter1 __last, Iter2 __histogram_first,
                _Size num_bins, _T __first_bin_min_val, _T __last_bin_max_val) {
   return internal::__histogram_general_select_best(
-      ::std::forward<_ExecutionPolicy>(policy), __first, __last,
+      ::std::forward<Policy>(policy), __first, __last,
       __histogram_first, num_bins,
       internal::__evenly_divided_binhash<_T>(__first_bin_min_val,
                                              __last_bin_max_val, num_bins));
 }
 
-template <typename _ExecutionPolicy, typename _InputIterator,
-          typename _RandomAccessIterator1, typename _RandomAccessIterator2>
-_RandomAccessIterator1 histogram_range(_ExecutionPolicy &&policy,
-                                       _InputIterator __first,
-                                       _InputIterator __last,
-                                       _RandomAccessIterator1 __histogram_first,
-                                       _RandomAccessIterator2 __boundary_first,
-                                       _RandomAccessIterator2 __boundary_last) {
+template <typename Policy, typename Iter1,
+          typename Iter2, typename Iter3>
+inline ::std::enable_if_t<
+    dpct::internal::is_iterator<Iter1>::value &&
+    dpct::internal::is_iterator<Iter2>::value &&
+    dpct::internal::is_iterator<Iter3>::value &&
+    internal::is_hetero_execution_policy<::std::decay_t<Policy>>::value, Iter2> 
+histogram(Policy &&policy,
+          Iter1 __first,
+          Iter1 __last,
+          Iter2 __histogram_first,
+          Iter3 __boundary_first,
+          Iter3 __boundary_last) {
   return internal::__histogram_general_select_best(
-      ::std::forward<_ExecutionPolicy>(policy), __first, __last,
+      ::std::forward<Policy>(policy), __first, __last,
       __histogram_first, (__boundary_last - __boundary_first) - 1,
       internal::__custom_range_binhash{__boundary_first, __boundary_last});
 }
 
-<<<<<<< HEAD
 } // end namespace internal
+
+template<typename Policy, typename SampleIteratorT, typename CounterT, typename LevelT, typename OffsetT>
+void 
+HistogramEven (Policy&& policy, SampleIteratorT d_samples, CounterT *d_histogram, int num_levels, LevelT lower_level, LevelT upper_level, 
+                             OffsetT num_samples)
+{
+  internal::histogram(::std::forward<Policy>(policy), d_samples, d_samples + num_samples, d_histogram, num_levels - 1, lower_level, upper_level);
+}
+
+
+template<typename SampleIteratorT , typename CounterT , typename LevelT , typename OffsetT >
+void 
+HistogramRange (Policy&& policy, SampleIteratorT d_samples, CounterT *d_histogram, int num_levels, LevelT *d_levels, OffsetT num_samples)
+{
+  internal::histogram(::std::forward<Policy>(policy), d_samples, d_samples + num_samples, d_histogram, d_levels, d_levels + num_levels);
+}
 
 template <typename Policy, typename Iter1, typename Iter2, typename Iter3,
           typename Iter4>
@@ -1883,24 +1904,7 @@ sort_pairs(Policy &&policy, Iter1 keys_in, Iter2 keys_out, Iter3 values_in,
                             end_bit);
 }
 
-template <typename Policy, typename Iter1, typename Iter2>
-=======
-template <typename _ExecutionPolicy, typename key_t, typename key_out_t,
-          typename value_t, typename value_out_t>
-inline ::std::enable_if_t<dpct::internal::is_iterator<key_t>::value &&
-                        dpct::internal::is_iterator<key_out_t>::value &&
-                        dpct::internal::is_iterator<value_t>::value &&
-                        dpct::internal::is_iterator<value_out_t>::value>
-sort_pairs(_ExecutionPolicy &&policy, key_t keys_in, key_out_t keys_out,
-                value_t values_in, value_out_t values_out, int64_t n,
-                bool descending, int begin_bit, int end_bit) {
-  internal::sort_pairs_impl(std::forward<_ExecutionPolicy>(policy), keys_in,
-                            keys_out, values_in, values_out, n, descending,
-                            begin_bit, end_bit);
-}
-
 template <typename _ExecutionPolicy, typename key_t, typename value_t>
->>>>>>> 4ce821a5e17d... improving types
 inline void sort_pairs(
     Policy &&policy, io_iterator_pair<Iter1> &keys,
     io_iterator_pair<Iter2> &values, ::std::int64_t n, bool descending = false,

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
@@ -1914,13 +1914,13 @@ MultiHistogramEven(Policy &&policy, Iter1 d_samples,
                    T upper_level[NUM_ACTIVE_CHANNELS], Size num_pixels) {
   for (int active_channel = 0; active_channel < NUM_ACTIVE_CHANNELS;
        active_channel++) {
-    HistogramEven(
-        policy,
-        oneapi::dpl::permutation_iterator(
-            d_samples,
-            internal::__interleaved_index_functor(NUM_CHANNELS, active_channel)),
-        d_histogram[active_channel], num_levels[active_channel],
-        lower_level[active_channel], upper_level[active_channel], num_pixels);
+    HistogramEven(policy,
+                  oneapi::dpl::permutation_iterator(
+                      d_samples, internal::__interleaved_index_functor(
+                                     NUM_CHANNELS, active_channel)),
+                  d_histogram[active_channel], num_levels[active_channel],
+                  lower_level[active_channel], upper_level[active_channel],
+                  num_pixels);
   }
 }
 
@@ -1949,7 +1949,7 @@ MultiHistogramEven(Policy &&policy, Iter1 d_samples,
                         (NUM_CHANNELS * sizeof(typename ::std::iterator_traits<
                                                Iter1>::value_type))),
                 internal::__interleaved_index_functor(NUM_CHANNELS,
-                                                     active_channel))),
+                                                      active_channel))),
         d_histogram[active_channel], num_levels[active_channel],
         lower_level[active_channel], upper_level[active_channel],
         num_row_samples * num_rows);
@@ -2039,7 +2039,7 @@ MultiHistogramRange(Policy &&policy, Iter1 d_samples,
                         (NUM_CHANNELS * sizeof(typename ::std::iterator_traits<
                                                Iter1>::value_type))),
                 internal::__interleaved_index_functor(NUM_CHANNELS,
-                                                     active_channel))),
+                                                      active_channel))),
         d_histogram[active_channel], num_levels[active_channel],
         d_levels[active_channel], num_row_samples * num_rows);
   }

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
@@ -12,7 +12,6 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/numeric>
-#include <oneapi/dpl/async>
 
 #include "functional.h"
 #include "iterators.h"

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
@@ -1874,18 +1874,18 @@ histogram(Policy &&policy,
 
 } // end namespace internal
 
-template<typename Policy, typename SampleIteratorT, typename CounterT, typename LevelT, typename OffsetT>
+template<typename Policy, typename Iter1, typename HistBin, typename T, typename Size>
 void 
-HistogramEven (Policy&& policy, SampleIteratorT d_samples, CounterT *d_histogram, int num_levels, LevelT lower_level, LevelT upper_level, 
-                             OffsetT num_samples)
+HistogramEven (Policy&& policy, Iter1 d_samples, HistBin *d_histogram, int num_levels, T lower_level, T upper_level, 
+                             Size num_samples)
 {
   internal::histogram(::std::forward<Policy>(policy), d_samples, d_samples + num_samples, d_histogram, num_levels - 1, lower_level, upper_level);
 }
 
 
-template<typename SampleIteratorT , typename CounterT , typename LevelT , typename OffsetT >
+template<typename Iter1 , typename HistBin , typename T , typename Size >
 void 
-HistogramRange (Policy&& policy, SampleIteratorT d_samples, CounterT *d_histogram, int num_levels, LevelT *d_levels, OffsetT num_samples)
+HistogramRange (Policy&& policy, Iter1 d_samples, HistBin *d_histogram, int num_levels, T *d_levels, Size num_samples)
 {
   internal::histogram(::std::forward<Policy>(policy), d_samples, d_samples + num_samples, d_histogram, d_levels, d_levels + num_levels);
 }

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
@@ -1514,7 +1514,7 @@ auto __async_initialize_bins(_ExecutionPolicy &&policy,
 }
 
 template <typename _HistAccessor, typename _Size, typename _SelfItem>
-void clear_wglocal_histograms(_HistAccessor local_histogram, _Size num_bins,
+void __clear_wglocal_histograms(_HistAccessor local_histogram, _Size num_bins,
                               _SelfItem self_item) {
   ::std::uint32_t gSize = self_item.get_local_range()[0];
   ::std::uint32_t self_lidx = self_item.get_local_id(0);
@@ -1536,7 +1536,7 @@ void clear_wglocal_histograms(_HistAccessor local_histogram, _Size num_bins,
 
 template <typename _HistAccessorIn, typename _HistAccessorOut, typename _Size,
           typename _SelfItem>
-void reduce_out_histograms(_HistAccessorIn in_histogram,
+void __reduce_out_histograms(_HistAccessorIn in_histogram,
                            _HistAccessorOut out_histogram, _Size num_bins,
                            _SelfItem self_item) {
   using __histo_value_type =
@@ -1569,7 +1569,7 @@ template <::std::uint16_t __work_group_size,
           ::std::uint8_t __bins_per_work_item, typename _ExecutionPolicy,
           typename _ForwardIterator, typename _RandomAccessIterator,
           typename _Size, typename _IdxHashFunc>
-_RandomAccessIterator histogram_general_registers_local_reduction(
+_RandomAccessIterator __histogram_general_registers_local_reduction(
     _ExecutionPolicy &&policy, _ForwardIterator __first,
     _ForwardIterator __last, _RandomAccessIterator __histogram_first,
     _Size num_bins, _IdxHashFunc __func) {
@@ -1604,7 +1604,7 @@ _RandomAccessIterator histogram_general_registers_local_reduction(
           const ::std::size_t __seg_start =
               __work_group_size * __iters_per_work_item * __wgroup_idx;
 
-          clear_wglocal_histograms(&(local_histogram[0]), num_bins,
+          __clear_wglocal_histograms(&(local_histogram[0]), num_bins,
                                    __self_item);
 
           // histogram bins take less storage with smaller data type
@@ -1635,7 +1635,7 @@ _RandomAccessIterator histogram_general_registers_local_reduction(
 
           __self_item.barrier(sycl::access::fence_space::local_space);
 
-          reduce_out_histograms(&(local_histogram[0]), &(hacc[0]), num_bins,
+          __reduce_out_histograms(&(local_histogram[0]), &(hacc[0]), num_bins,
                                 __self_item);
         });
   });
@@ -1648,7 +1648,7 @@ template <::std::uint16_t __work_group_size,
           ::std::uint8_t __iters_per_work_item, typename _ExecutionPolicy,
           typename _ForwardIterator, typename _RandomAccessIterator,
           typename _Size, typename _IdxHashFunc>
-_RandomAccessIterator histogram_general_local_atomics(
+_RandomAccessIterator __histogram_general_local_atomics(
     _ExecutionPolicy &&policy, _ForwardIterator __first,
     _ForwardIterator __last, _RandomAccessIterator __histogram_first,
     _Size num_bins, _IdxHashFunc __func) {
@@ -1683,7 +1683,7 @@ _RandomAccessIterator histogram_general_local_atomics(
           const ::std::size_t __seg_start =
               __work_group_size * __wgroup_idx * __iters_per_work_item;
 
-          clear_wglocal_histograms(&(local_histogram[0]), num_bins,
+          __clear_wglocal_histograms(&(local_histogram[0]), num_bins,
                                    __self_item);
 
           const ::std::size_t __seg_end = sycl::min(
@@ -1702,7 +1702,7 @@ _RandomAccessIterator histogram_general_local_atomics(
 
           __self_item.barrier(sycl::access::fence_space::local_space);
 
-          reduce_out_histograms(&(local_histogram[0]), &(hacc[0]), num_bins,
+          __reduce_out_histograms(&(local_histogram[0]), &(hacc[0]), num_bins,
                                 __self_item);
         });
   });
@@ -1715,7 +1715,7 @@ template <::std::uint16_t __work_group_size,
           ::std::uint8_t __min_iters_per_work_item, typename _ExecutionPolicy,
           typename _ForwardIterator, typename _RandomAccessIterator,
           typename _Size, typename _IdxHashFunc>
-_RandomAccessIterator histogram_general_private_global_atomics(
+_RandomAccessIterator __histogram_general_private_global_atomics(
     _ExecutionPolicy &&policy, _ForwardIterator __first,
     _ForwardIterator __last, _RandomAccessIterator __histogram_first,
     _Size num_bins, _IdxHashFunc __func) {
@@ -1760,7 +1760,7 @@ _RandomAccessIterator histogram_general_private_global_atomics(
           const ::std::size_t __seg_start =
               __work_group_size * iters_per_work_item * __wgroup_idx;
 
-          clear_wglocal_histograms(&(hacc_private[__wgroup_idx * num_bins]),
+          __clear_wglocal_histograms(&(hacc_private[__wgroup_idx * num_bins]),
                                    num_bins, __self_item);
 
           const ::std::size_t __seg_end = sycl::min(
@@ -1780,7 +1780,7 @@ _RandomAccessIterator histogram_general_private_global_atomics(
 
           __self_item.barrier(sycl::access::fence_space::local_space);
 
-          reduce_out_histograms(&(hacc_private[__wgroup_idx * num_bins]),
+          __reduce_out_histograms(&(hacc_private[__wgroup_idx * num_bins]),
                                 &(hacc[0]), num_bins, __self_item);
         });
   });
@@ -1791,7 +1791,7 @@ _RandomAccessIterator histogram_general_private_global_atomics(
 template <typename _ExecutionPolicy, typename _ForwardIterator,
           typename _RandomAccessIterator, typename _Size, typename _IdxHashFunc>
 _RandomAccessIterator
-histogram_general_select_best(_ExecutionPolicy &&policy,
+__histogram_general_select_best(_ExecutionPolicy &&policy,
                               _ForwardIterator __first, _ForwardIterator __last,
                               _RandomAccessIterator __histogram_first,
                               _Size num_bins, _IdxHashFunc __func) {
@@ -1806,18 +1806,18 @@ histogram_general_select_best(_ExecutionPolicy &&policy,
 
   // if bins fit into registers, use register private accumulation
   if (num_bins < MAX_BINS_PER_WORK_ITEM) {
-    return histogram_general_registers_local_reduction<1024, 32, 16>(
+    return __histogram_general_registers_local_reduction<1024, 32, 16>(
         ::std::forward<_ExecutionPolicy>(policy), __first, __last,
         __histogram_first, num_bins, __func);
   } else if (num_bins * sizeof(__histo_value_type) <
              __local_mem_size) // if bins fit into SLM, use local atomics
   {
-    return histogram_general_local_atomics<1024, 4>(
+    return __histogram_general_local_atomics<1024, 4>(
         ::std::forward<_ExecutionPolicy>(policy), __first, __last,
         __histogram_first, num_bins, __func);
   } else // otherwise, use global atomics (private copies per workgroup)
   {
-    return histogram_general_private_global_atomics<1024, 4>(
+    return __histogram_general_private_global_atomics<1024, 4>(
         ::std::forward<_ExecutionPolicy>(policy), __first, __last,
         __histogram_first, num_bins, __func);
   }
@@ -1831,7 +1831,7 @@ _RandomAccessIterator
 histogram_even(_ExecutionPolicy &&policy, _ForwardIterator __first,
                _ForwardIterator __last, _RandomAccessIterator __histogram_first,
                _Size num_bins, _T __first_bin_min_val, _T __last_bin_max_val) {
-  return internal::histogram_general_select_best(
+  return internal::__histogram_general_select_best(
       ::std::forward<_ExecutionPolicy>(policy), __first, __last,
       __histogram_first, num_bins,
       internal::__evenly_divided_binhash<_T>(__first_bin_min_val,
@@ -1846,7 +1846,7 @@ _RandomAccessIterator1 histogram_range(_ExecutionPolicy &&policy,
                                        _RandomAccessIterator1 __histogram_first,
                                        _RandomAccessIterator2 __boundary_first,
                                        _RandomAccessIterator2 __boundary_last) {
-  return internal::histogram_general_select_best(
+  return internal::__histogram_general_select_best(
       ::std::forward<_ExecutionPolicy>(policy), __first, __last,
       __histogram_first, (__boundary_last - __boundary_first) - 1,
       internal::__custom_range_binhash{__boundary_first, __boundary_last});

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
@@ -1540,7 +1540,7 @@ void reduce_out_histograms(_HistAccessorIn in_histogram,
                            _HistAccessorOut out_histogram, _Size num_bins,
                            _SelfItem self_item) {
   using __histo_value_type =
-      typename std::iterator_traits<_HistAccessorOut>::value_type;
+      typename ::std::iterator_traits<_HistAccessorOut>::value_type;
   ::std::uint32_t gSize = self_item.get_local_range()[0];
   ::std::uint32_t self_lidx = self_item.get_local_id(0);
   ::std::uint8_t factor = num_bins / gSize;
@@ -1573,20 +1573,20 @@ _RandomAccessIterator histogram_general_registers_local_reduction(
     _ExecutionPolicy &&policy, _ForwardIterator __first,
     _ForwardIterator __last, _RandomAccessIterator __histogram_first,
     _Size num_bins, _IdxHashFunc __func) {
-  const std::size_t N = __last - __first;
+  const ::std::size_t N = __last - __first;
   using __value_type =
-      typename std::iterator_traits<_ForwardIterator>::value_type;
+      typename ::std::iterator_traits<_ForwardIterator>::value_type;
   using __histo_value_type =
-      typename std::iterator_traits<_RandomAccessIterator>::value_type;
+      typename ::std::iterator_traits<_RandomAccessIterator>::value_type;
   //minimum type size for atomics
-  using __local_histogram_type = std::uint32_t; 
+  using __local_histogram_type = ::std::uint32_t; 
   // even though we fit into uint8_t, this is faster
-  using __private_histogram_type = std::uint16_t;
+  using __private_histogram_type = ::std::uint16_t;
   sycl::buffer<__value_type, 1> mbuf(&(*__first), sycl::range<1>(N));
   sycl::buffer<__histo_value_type, 1> hbuf(&(*__histogram_first),
                                            sycl::range<1>(num_bins));
 
-  std::size_t segments =
+  ::std::size_t segments =
       __ceiling_div(N, __work_group_size * __iters_per_work_item);
   auto init_e = __async_initialize_bins(policy, oneapi::dpl::begin(hbuf),
                                         oneapi::dpl::end(hbuf));
@@ -1653,13 +1653,13 @@ _RandomAccessIterator histogram_general_local_atomics(
     _ForwardIterator __last, _RandomAccessIterator __histogram_first,
     _Size num_bins, _IdxHashFunc __func) {
   using __value_type =
-      typename std::iterator_traits<_ForwardIterator>::value_type;
+      typename ::std::iterator_traits<_ForwardIterator>::value_type;
   using __histo_value_type =
-      typename std::iterator_traits<_RandomAccessIterator>::value_type;
+      typename ::std::iterator_traits<_RandomAccessIterator>::value_type;
   //minimum type size for atomics
-  using __local_histogram_type = std::uint32_t; 
+  using __local_histogram_type = ::std::uint32_t; 
 
-  const std::size_t N = __last - __first;
+  const ::std::size_t N = __last - __first;
 
   sycl::buffer<__value_type, 1> mbuf(&(*__first), sycl::range<1>(N));
   sycl::buffer<__histo_value_type, 1> hbuf(&(*__histogram_first),
@@ -1692,7 +1692,7 @@ _RandomAccessIterator histogram_general_local_atomics(
           for (::std::size_t __val_idx = __seg_start + __self_lidx;
                __val_idx < __seg_end; __val_idx += __work_group_size) {
             const __value_type& x = macc[__val_idx];
-            std::uint16_t y = __func(x);
+            ::std::uint16_t y = __func(x);
             sycl::atomic_ref<__local_histogram_type, sycl::memory_order::relaxed,
                              sycl::memory_scope::work_group,
                              sycl::access::address_space::local_space>
@@ -1720,22 +1720,22 @@ _RandomAccessIterator histogram_general_private_global_atomics(
     _ForwardIterator __last, _RandomAccessIterator __histogram_first,
     _Size num_bins, _IdxHashFunc __func) {
 
-  const std::size_t N = __last - __first;
+  const ::std::size_t N = __last - __first;
   using __value_type =
-      typename std::iterator_traits<_ForwardIterator>::value_type;
+      typename ::std::iterator_traits<_ForwardIterator>::value_type;
   using __histo_value_type =
-      typename std::iterator_traits<_RandomAccessIterator>::value_type;
+      typename ::std::iterator_traits<_RandomAccessIterator>::value_type;
       
   auto __global_mem_size =
       policy.queue()
           .get_device()
           .template get_info<sycl::info::device::global_mem_size>();
   const ::std::size_t max_segments =
-      std::min(__global_mem_size / (num_bins * sizeof(__histo_value_type)),
+      ::std::min(__global_mem_size / (num_bins * sizeof(__histo_value_type)),
                __ceiling_div(N, __work_group_size * __min_iters_per_work_item));
   const ::std::size_t iters_per_work_item =
       __ceiling_div(N, max_segments * __work_group_size);
-  std::size_t segments =
+  ::std::size_t segments =
       __ceiling_div(N, __work_group_size * iters_per_work_item);
 
   sycl::buffer<__value_type, 1> mbuf(&(*__first), sycl::range<1>(N));
@@ -1796,7 +1796,7 @@ histogram_general_select_best(_ExecutionPolicy &&policy,
                               _RandomAccessIterator __histogram_first,
                               _Size num_bins, _IdxHashFunc __func) {
   using __histo_value_type =
-      typename std::iterator_traits<_RandomAccessIterator>::value_type;
+      typename ::std::iterator_traits<_RandomAccessIterator>::value_type;
   auto __local_mem_size =
       policy.queue()
           .get_device()

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
@@ -1806,7 +1806,7 @@ histogram_general_select_best(_ExecutionPolicy &&policy,
 
   // if bins fit into registers, use register private accumulation
   if (num_bins < MAX_BINS_PER_WORK_ITEM) {
-    return histogram_general_registers_local_reduction<1024, 4, 16>(
+    return histogram_general_registers_local_reduction<1024, 32, 16>(
         ::std::forward<_ExecutionPolicy>(policy), __first, __last,
         __histogram_first, num_bins, __func);
   } else if (num_bins * sizeof(__histo_value_type) <

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
@@ -1578,12 +1578,10 @@ _RandomAccessIterator histogram_general_registers_local_reduction(
       typename std::iterator_traits<_ForwardIterator>::value_type;
   using __histo_value_type =
       typename std::iterator_traits<_RandomAccessIterator>::value_type;
-  using __local_histogram_type = typename std::conditional<__work_group_size * __iters_per_work_item < 65536,
-                                         std::uint16_t,
-                                         std::uint32_t>;
-  using __private_histogram_type = typename std::conditional<__iters_per_work_item < 256,
-                                         std::uint8_t,
-                                         std::uint16_t>;
+  //minimum type size for atomics
+  using __local_histogram_type = std::uint32_t; 
+  // even though we fit into uint8_t, this is faster
+  using __private_histogram_type = std::uint16_t;
   sycl::buffer<__value_type, 1> mbuf(&(*__first), sycl::range<1>(N));
   sycl::buffer<__histo_value_type, 1> hbuf(&(*__histogram_first),
                                            sycl::range<1>(num_bins));
@@ -1658,9 +1656,8 @@ _RandomAccessIterator histogram_general_local_atomics(
       typename std::iterator_traits<_ForwardIterator>::value_type;
   using __histo_value_type =
       typename std::iterator_traits<_RandomAccessIterator>::value_type;
-  using __local_histogram_type = typename std::conditional<__work_group_size * __iters_per_work_item < 65536,
-                                         std::uint16_t,
-                                         std::uint32_t>;
+  //minimum type size for atomics
+  using __local_histogram_type = std::uint32_t; 
 
   const std::size_t N = __last - __first;
 

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
@@ -1472,7 +1472,7 @@ struct __evenly_divided_binhash_impl<T, /* is_floating_point = */ true> {
                                 const ::std::uint32_t &num_bins)
       : __minimum(min), __maximum(max), __num_bins(num_bins),
         __scale(T(num_bins) / (max - min)) {}
-  template <typename T2>::std::uint32_t operator()(T2 &&value) const {
+  template <typename T2> std::uint32_t operator()(T2 &&value) const {
     return ::std::uint32_t((::std::forward<T2>(value) - __minimum) * __scale);
   }
 

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
@@ -1449,7 +1449,6 @@ inline void segmented_sort_pairs_by_two_pair_sorts(
       oneapi::dpl::begin(segments), zip_keys_vals, zip_keys_vals_out, n, false);
 }
 
-
 template <typename FunctorInner, typename FunctorOuter> struct compose_functor {
   compose_functor(FunctorInner in, FunctorOuter out) : _in(in), _out(out) {}
   template <typename T> T operator()(const T &i) const { return _out(_in(i)); }
@@ -1458,8 +1457,7 @@ template <typename FunctorInner, typename FunctorOuter> struct compose_functor {
 };
 
 template <typename OffsetT> struct roi_2d_index {
-  roi_2d_index(const OffsetT &num_cols,
-               const ::std::size_t &row_stride)
+  roi_2d_index(const OffsetT &num_cols, const ::std::size_t &row_stride)
       : _num_cols(num_cols), _row_stride(row_stride) {}
 
   template <typename Index> Index operator()(const Index &i) const {
@@ -1483,10 +1481,11 @@ template <typename OffsetT> struct interleaved_select_channel {
   OffsetT _active_channel;
 };
 
-//The dpl_histogram namespace contains a temporary preview of an upcoming oneDPL histogram API.
-//  This namespace will be removed and replaced with corresponding calls to oneapi::dpl::histogram()
-namespace dpl_histogram
-{
+// The dpl_histogram namespace contains a temporary preview of an upcoming
+// oneDPL histogram API.
+//   This namespace will be removed and replaced with corresponding calls to
+//   oneapi::dpl::histogram()
+namespace dpl_histogram {
 
 template <typename _T1, typename _T2>
 constexpr inline auto __ceiling_div(const _T1 &__number, const _T2 &__divisor) {
@@ -1503,17 +1502,15 @@ struct __evenly_divided_binhash_impl<_T, /* is_floating_point = */ true> {
   _T __scale;
   __evenly_divided_binhash_impl(const _T &min, const _T &max,
                                 const ::std::uint32_t &num_bins)
-      : __minimum(min), __num_bins(num_bins), __scale(_T(num_bins) / (max - min)) {}
+      : __minimum(min), __num_bins(num_bins),
+        __scale(_T(num_bins) / (max - min)) {}
   template <typename _T2>::std::uint32_t operator()(_T2 &&value) const {
     return ::std::uint32_t((::std::forward<_T2>(value) - __minimum) * __scale);
   }
 
-  template <typename _T2> 
-  bool is_valid(const _T2& value) const
-  {
+  template <typename _T2> bool is_valid(const _T2 &value) const {
     return value >= __minimum && value < __minimum + __scale * _T(__num_bins);
   }
-
 };
 
 // non floating point type
@@ -1531,12 +1528,9 @@ struct __evenly_divided_binhash_impl<_T, /* is_floating_point= */ false> {
         __range_size);
   }
 
-  template <typename _T2> 
-  bool is_valid(const _T2& value) const
-  {
+  template <typename _T2> bool is_valid(const _T2 &value) const {
     return value >= __minimum && value < __minimum + __range_size;
   }
-
 };
 
 template <typename _T1>
@@ -1545,19 +1539,18 @@ using __evenly_divided_binhash =
 
 template <typename _Range> struct __custom_range_binhash {
   _Range __boundaries;
-  __custom_range_binhash(_Range boundaries)
-      : __boundaries(boundaries) {}
+  __custom_range_binhash(_Range boundaries) : __boundaries(boundaries) {}
 
   template <typename _T>::std::uint32_t operator()(_T &&value) const {
-    return (::std::upper_bound(__boundaries.begin(), __boundaries.end(), ::std::forward<_T>(value)) -
+    return (::std::upper_bound(__boundaries.begin(), __boundaries.end(),
+                               ::std::forward<_T>(value)) -
             __boundaries.begin()) -
            1;
   }
 
-  template <typename _T2> 
-  bool is_valid(const _T2& value) const
-  {
-    return value >= __boundaries[0] && value < __boundaries[__boundaries.size()-1];
+  template <typename _T2> bool is_valid(const _T2 &value) const {
+    return value >= __boundaries[0] &&
+           value < __boundaries[__boundaries.size() - 1];
   }
 };
 
@@ -1600,12 +1593,11 @@ inline void __accum_local_atomics(
     ::std::size_t __val_idx = seg_start + idx * __work_group_size + self_lidx;
     if (__val_idx < N) {
 
-      const auto& x = in_acc[__val_idx];
-      if (func.is_valid(x))
-      {
+      const auto &x = in_acc[__val_idx];
+      if (func.is_valid(x)) {
         _BinIdxType c = func(x);
         sycl::atomic_ref<__histo_value_type, sycl::memory_order::relaxed,
-                        sycl::memory_scope::work_group, _AddressSpace>
+                         sycl::memory_scope::work_group, _AddressSpace>
             local_bin(wg_local_histogram[offset + c]);
         local_bin++;
       }
@@ -1646,13 +1638,12 @@ inline void __reduce_out_histograms(const _HistAccessorIn &in_histogram,
 
 template <::std::uint16_t __work_group_size,
           ::std::uint16_t __iters_per_work_item,
-          ::std::uint8_t __bins_per_work_item, 
-          typename _BinType,
-          typename Policy, typename _Range1,
-          typename _Range2, typename _Size, typename _IdxHashFunc, typename... _Range3>
+          ::std::uint8_t __bins_per_work_item, typename _BinType,
+          typename Policy, typename _Range1, typename _Range2, typename _Size,
+          typename _IdxHashFunc, typename... _Range3>
 inline void __histogram_general_registers_local_reduction(
-    Policy &&policy, _Range1&& __input, _Range2&& __bins,
-    const _Size &num_bins, _IdxHashFunc __func, _Range3&& ...__opt_range) {
+    Policy &&policy, _Range1 &&__input, _Range2 &&__bins, const _Size &num_bins,
+    _IdxHashFunc __func, _Range3 &&...__opt_range) {
   const ::std::size_t N = __input.size();
   // minimum type size for atomics
   using __local_histogram_type = ::std::uint32_t;
@@ -1662,7 +1653,8 @@ inline void __histogram_general_registers_local_reduction(
   ::std::size_t segments =
       __ceiling_div(N, __work_group_size * __iters_per_work_item);
   auto e = policy.queue().submit([&](auto &h) {
-    //temporary use of stable non-public API from oneDPL, this functionality will move into oneDPL soon.
+    // temporary use of stable non-public API from oneDPL, this functionality
+    // will move into oneDPL soon.
     oneapi::dpl::__ranges::__require_access(h, __input, __bins, __opt_range...);
     sycl::local_accessor<__local_histogram_type, 1> local_histogram(
         sycl::range(num_bins), h);
@@ -1687,9 +1679,8 @@ inline void __histogram_general_registers_local_reduction(
             ::std::size_t __val_idx =
                 __seg_start + idx * __work_group_size + __self_lidx;
             if (__val_idx < N) {
-              const auto& x = __input[__val_idx];
-              if (__func.is_valid(x))
-              {
+              const auto &x = __input[__val_idx];
+              if (__func.is_valid(x)) {
                 ::std::uint8_t c = __func(x);
                 histogram[c]++;
               }
@@ -1707,26 +1698,26 @@ inline void __histogram_general_registers_local_reduction(
 
           __self_item.barrier(sycl::access::fence_space::local_space);
 
-          __reduce_out_histograms<_BinType>(local_histogram, 0, __bins, num_bins,
-                                  __self_item);
+          __reduce_out_histograms<_BinType>(local_histogram, 0, __bins,
+                                            num_bins, __self_item);
         });
   });
   e.wait();
 }
 
 template <::std::uint16_t __work_group_size,
-          ::std::uint16_t __iters_per_work_item, 
-          typename _BinType, typename Policy, 
-          typename _Range1, typename _Range2, typename _Size,
+          ::std::uint16_t __iters_per_work_item, typename _BinType,
+          typename Policy, typename _Range1, typename _Range2, typename _Size,
           typename _IdxHashFunc, typename... _Range3>
-inline void
-__histogram_general_local_atomics(Policy &&policy, _Range1&& __input, _Range2&& __bins,
-                                  const _Size &num_bins, _IdxHashFunc __func, _Range3&& ...__opt_range) {
+inline void __histogram_general_local_atomics(
+    Policy &&policy, _Range1 &&__input, _Range2 &&__bins, const _Size &num_bins,
+    _IdxHashFunc __func, _Range3 &&...__opt_range) {
   const ::std::size_t N = __input.size();
   std::size_t segments =
       __ceiling_div(N, __work_group_size * __iters_per_work_item);
   auto e = policy.queue().submit([&](auto &h) {
-    //temporary use of stable non-public API from oneDPL, this functionality will move into oneDPL soon.
+    // temporary use of stable non-public API from oneDPL, this functionality
+    // will move into oneDPL soon.
     oneapi::dpl::__ranges::__require_access(h, __input, __bins, __opt_range...);
     // minimum type size for atomics
     sycl::local_accessor<::std::uint32_t, 1> local_histogram(
@@ -1746,8 +1737,8 @@ __histogram_general_local_atomics(Policy &&policy, _Range1&& __input, _Range2&& 
               __input, __seg_start, N, __self_lidx, local_histogram, 0, __func,
               __self_item, __iters_per_work_item);
 
-          __reduce_out_histograms<_BinType>(local_histogram, 0, __bins, num_bins,
-                                  __self_item);
+          __reduce_out_histograms<_BinType>(local_histogram, 0, __bins,
+                                            num_bins, __self_item);
         });
   });
 
@@ -1755,14 +1746,12 @@ __histogram_general_local_atomics(Policy &&policy, _Range1&& __input, _Range2&& 
 }
 
 template <::std::uint16_t __work_group_size,
-          ::std::uint16_t __min_iters_per_work_item, 
-          typename _BinType,
-          typename Policy, 
-          typename _Range1, typename _Range2, typename _Size,
+          ::std::uint16_t __min_iters_per_work_item, typename _BinType,
+          typename Policy, typename _Range1, typename _Range2, typename _Size,
           typename _IdxHashFunc, typename... _Range3>
 inline void __histogram_general_private_global_atomics(
-    Policy &&policy, _Range1&& __input, _Range2&& __bins,
-    const _Size &num_bins, _IdxHashFunc __func, _Range3&& ...__opt_range) {
+    Policy &&policy, _Range1 &&__input, _Range2 &&__bins, const _Size &num_bins,
+    _IdxHashFunc __func, _Range3 &&...__opt_range) {
 
   const ::std::size_t N = __input.size();
   auto __global_mem_size =
@@ -1781,7 +1770,8 @@ inline void __histogram_general_private_global_atomics(
       sycl::range<1>(segments * num_bins));
 
   auto e = policy.queue().submit([&](auto &h) {
-    //temporary use of stable non-public API from oneDPL, this functionality will move into oneDPL soon.
+    // temporary use of stable non-public API from oneDPL, this functionality
+    // will move into oneDPL soon.
     oneapi::dpl::__ranges::__require_access(h, __input, __bins, __opt_range...);
     sycl::accessor hacc_private(private_histograms, h, sycl::read_write,
                                 sycl::no_init);
@@ -1801,8 +1791,9 @@ inline void __histogram_general_private_global_atomics(
               __wgroup_idx * num_bins, __func, __self_item,
               iters_per_work_item);
 
-          __reduce_out_histograms<_BinType>(hacc_private, __wgroup_idx * num_bins, __bins,
-                                  num_bins, __self_item);
+          __reduce_out_histograms<_BinType>(hacc_private,
+                                            __wgroup_idx * num_bins, __bins,
+                                            num_bins, __self_item);
         });
   });
   e.wait();
@@ -1813,52 +1804,64 @@ template <typename Policy, typename _Iter1, typename _Iter2, typename _Size,
 inline _Iter2
 __histogram_general_select_best(Policy &&policy, _Iter1 __first, _Iter1 __last,
                                 _Iter2 __histogram_first, const _Size &num_bins,
-                                _IdxHashFunc __func, _Range&&... __opt_range) {
-  using __histo_value_type = typename ::std::iterator_traits<_Iter2>::value_type;
+                                _IdxHashFunc __func, _Range &&...__opt_range) {
+  using __histo_value_type =
+      typename ::std::iterator_traits<_Iter2>::value_type;
   auto __local_mem_size =
       policy.queue()
           .get_device()
           .template get_info<sycl::info::device::local_mem_size>();
   constexpr ::std::uint8_t __max_registers = 16;
 
-  //temporary use of stable non-public API from oneDPL, this functionality will move into oneDPL soon.
-  auto keep_input = oneapi::dpl::__ranges::__get_sycl_range<oneapi::dpl::__par_backend_hetero::access_mode::read, _Iter1>();
+  // temporary use of stable non-public API from oneDPL, this functionality will
+  // move into oneDPL soon.
+  auto keep_input = oneapi::dpl::__ranges::__get_sycl_range<
+      oneapi::dpl::__par_backend_hetero::access_mode::read, _Iter1>();
   auto input_buf = keep_input(__first, __last);
-  //temporary use of stable non-public API from oneDPL, this functionality will move into oneDPL soon.
-  auto keep_bins = oneapi::dpl::__ranges::__get_sycl_range<oneapi::dpl::__par_backend_hetero::access_mode::write, _Iter2>();
+  // temporary use of stable non-public API from oneDPL, this functionality will
+  // move into oneDPL soon.
+  auto keep_bins = oneapi::dpl::__ranges::__get_sycl_range<
+      oneapi::dpl::__par_backend_hetero::access_mode::write, _Iter2>();
   auto bins_buf = keep_bins(__histogram_first, __histogram_first + num_bins);
-  
-  //synchronous to avoid experimental oneDPL API
-  oneapi::dpl::fill(std::forward<Policy>(policy), bins_buf.all_view().begin(),  bins_buf.all_view().end(), __histo_value_type(0));
+
+  // synchronous to avoid experimental oneDPL API
+  oneapi::dpl::fill(std::forward<Policy>(policy), bins_buf.all_view().begin(),
+                    bins_buf.all_view().end(), __histo_value_type(0));
   auto N = __last - __first;
   // if bins fit into registers, use register private accumulation
   if (num_bins < __max_registers) {
-    __histogram_general_registers_local_reduction<1024, 32, 16, __histo_value_type>(
-        ::std::forward<Policy>(policy), input_buf.all_view(), bins_buf.all_view(),
-        num_bins, __func, std::forward<_Range...>(__opt_range)...);
+    __histogram_general_registers_local_reduction<1024, 32, 16,
+                                                  __histo_value_type>(
+        ::std::forward<Policy>(policy), input_buf.all_view(),
+        bins_buf.all_view(), num_bins, __func,
+        std::forward<_Range...>(__opt_range)...);
   } else if (num_bins * sizeof(__histo_value_type) <
              __local_mem_size) // if bins fit into SLM, use local atomics
   {
     if (N <= 524288) {
       __histogram_general_local_atomics<1024, 4, __histo_value_type>(
-          ::std::forward<Policy>(policy), input_buf.all_view(), bins_buf.all_view(),
-          num_bins, __func, std::forward<_Range...>(__opt_range)...);
+          ::std::forward<Policy>(policy), input_buf.all_view(),
+          bins_buf.all_view(), num_bins, __func,
+          std::forward<_Range...>(__opt_range)...);
     } else {
       __histogram_general_local_atomics<1024, 32, __histo_value_type>(
-          ::std::forward<Policy>(policy), input_buf.all_view(), bins_buf.all_view(),
-          num_bins, __func, std::forward<_Range...>(__opt_range)...);
+          ::std::forward<Policy>(policy), input_buf.all_view(),
+          bins_buf.all_view(), num_bins, __func,
+          std::forward<_Range...>(__opt_range)...);
     }
   } else // otherwise, use global atomics (private copies per workgroup)
   {
 
     if (N <= 524288) {
       __histogram_general_private_global_atomics<1024, 4, __histo_value_type>(
-          ::std::forward<Policy>(policy), input_buf.all_view(), bins_buf.all_view(),
-          num_bins, __func, std::forward<_Range...>(__opt_range)...);
+          ::std::forward<Policy>(policy), input_buf.all_view(),
+          bins_buf.all_view(), num_bins, __func,
+          std::forward<_Range...>(__opt_range)...);
     } else {
       __histogram_general_private_global_atomics<1024, 32, __histo_value_type>(
-          ::std::forward<Policy>(policy), input_buf.all_view(), bins_buf.all_view(),
-          num_bins, __func, std::forward<_Range...>(__opt_range)...);
+          ::std::forward<Policy>(policy), input_buf.all_view(),
+          bins_buf.all_view(), num_bins, __func,
+          std::forward<_Range...>(__opt_range)...);
     }
   }
   return __histogram_first + num_bins;
@@ -1877,8 +1880,8 @@ histogram(Policy &&policy, Iter1 __first, Iter1 __last, Iter2 __histogram_first,
   return __histogram_general_select_best(
       ::std::forward<Policy>(policy), __first, __last, __histogram_first,
       num_bins,
-      __evenly_divided_binhash<_T>(__first_bin_min_val,
-                                             __last_bin_max_val, num_bins));
+      __evenly_divided_binhash<_T>(__first_bin_min_val, __last_bin_max_val,
+                                   num_bins));
 }
 
 template <typename Policy, typename Iter1, typename Iter2, typename Iter3>
@@ -1890,8 +1893,10 @@ inline ::std::enable_if_t<
     Iter2>
 histogram(Policy &&policy, Iter1 __first, Iter1 __last, Iter2 __histogram_first,
           Iter3 __boundary_first, Iter3 __boundary_last) {
-  //temporary use of stable non-public API from oneDPL,  this function will be replaced with oneDPL call soon.
-  auto keep_boundaries = oneapi::dpl::__ranges::__get_sycl_range<oneapi::dpl::__par_backend_hetero::access_mode::read, Iter3>();
+  // temporary use of stable non-public API from oneDPL,  this function will be
+  // replaced with oneDPL call soon.
+  auto keep_boundaries = oneapi::dpl::__ranges::__get_sycl_range<
+      oneapi::dpl::__par_backend_hetero::access_mode::read, Iter3>();
   auto boundary_buf = keep_boundaries(__boundary_first, __boundary_last);
 
   return __histogram_general_select_best(
@@ -1899,7 +1904,7 @@ histogram(Policy &&policy, Iter1 __first, Iter1 __last, Iter2 __histogram_first,
       (__boundary_last - __boundary_first) - 1,
       __custom_range_binhash{boundary_buf.all_view()}, boundary_buf.all_view());
 }
-} //end namespace dpl_histogram
+} // end namespace dpl_histogram
 
 } // end namespace internal
 
@@ -1909,22 +1914,24 @@ void HistogramEven(Policy &&policy, Iter1 d_samples, Iter2 d_histogram,
                    int num_levels, T lower_level, T upper_level,
                    Size num_samples) {
   internal::dpl_histogram::histogram(::std::forward<Policy>(policy), d_samples,
-                      d_samples + num_samples, d_histogram, num_levels - 1,
-                      lower_level, upper_level);
+                                     d_samples + num_samples, d_histogram,
+                                     num_levels - 1, lower_level, upper_level);
 }
 
 template <typename Policy, typename Iter1, typename Iter2, typename T,
           typename OffsetT>
 void HistogramEven(Policy &&policy, Iter1 d_samples, Iter2 d_histogram,
-                       int num_levels, T lower_level, T upper_level,
-                       OffsetT num_row_samples, OffsetT num_rows,
-                       ::std::size_t row_stride_bytes) {
+                   int num_levels, T lower_level, T upper_level,
+                   OffsetT num_row_samples, OffsetT num_rows,
+                   ::std::size_t row_stride_bytes) {
   return HistogramEven(
       ::std::forward<Policy>(policy),
       oneapi::dpl::permutation_iterator(
-          d_samples, internal::roi_2d_index(
-                         num_row_samples, row_stride_bytes /
-                             sizeof(typename ::std::iterator_traits<Iter1>::value_type))),
+          d_samples,
+          internal::roi_2d_index(
+              num_row_samples,
+              row_stride_bytes /
+                  sizeof(typename ::std::iterator_traits<Iter1>::value_type))),
       d_histogram, num_levels, lower_level, upper_level,
       num_row_samples * num_rows);
 }
@@ -1965,9 +1972,12 @@ void MultiHistogramEven(Policy &&policy, Iter1 d_samples,
             d_samples,
             internal::compose_functor(
                 internal::roi_2d_index(
-                    num_row_samples, row_stride_bytes /
-                        (NUM_CHANNELS * sizeof(typename ::std::iterator_traits<Iter1>::value_type))),
-            internal::interleaved_select_channel(NUM_CHANNELS, active_channel))),
+                    num_row_samples,
+                    row_stride_bytes /
+                        (NUM_CHANNELS * sizeof(typename ::std::iterator_traits<
+                                               Iter1>::value_type))),
+                internal::interleaved_select_channel(NUM_CHANNELS,
+                                                     active_channel))),
         d_histogram[active_channel], num_levels[active_channel],
         lower_level[active_channel], upper_level[active_channel],
         num_row_samples * num_rows);
@@ -1979,21 +1989,23 @@ template <typename Policy, typename Iter1, typename Iter2, typename Iter3,
 void HistogramRange(Policy &&policy, Iter1 d_samples, Iter2 d_histogram,
                     int num_levels, Iter3 d_levels, Size num_samples) {
   internal::dpl_histogram::histogram(::std::forward<Policy>(policy), d_samples,
-                      d_samples + num_samples, d_histogram, d_levels,
-                      d_levels + num_levels);
+                                     d_samples + num_samples, d_histogram,
+                                     d_levels, d_levels + num_levels);
 }
 
 template <typename Policy, typename Iter1, typename Iter2, typename Iter3,
           typename OffsetT>
 void HistogramRange(Policy &&policy, Iter1 d_samples, Iter2 d_histogram,
-                        int num_levels, Iter3 d_levels, OffsetT num_row_samples,
-                        OffsetT num_rows, ::std::size_t row_stride_bytes) {
+                    int num_levels, Iter3 d_levels, OffsetT num_row_samples,
+                    OffsetT num_rows, ::std::size_t row_stride_bytes) {
   return HistogramRange(
       ::std::forward<Policy>(policy),
       oneapi::dpl::permutation_iterator(
-          d_samples, internal::roi_2d_index(
-                         num_row_samples, row_stride_bytes /
-                             sizeof(typename ::std::iterator_traits<Iter1>::value_type))),
+          d_samples,
+          internal::roi_2d_index(
+              num_row_samples,
+              row_stride_bytes /
+                  sizeof(typename ::std::iterator_traits<Iter1>::value_type))),
       d_histogram, num_levels, d_levels, num_row_samples * num_rows);
 }
 
@@ -2032,8 +2044,10 @@ void MultiHistogramRange(Policy &&policy, Iter1 d_samples,
                 internal::roi_2d_index(
                     num_row_samples,
                     row_stride_bytes /
-                         (NUM_CHANNELS * sizeof(typename ::std::iterator_traits<Iter1>::value_type))),
-                internal::interleaved_select_channel(NUM_CHANNELS, active_channel))),
+                        (NUM_CHANNELS * sizeof(typename ::std::iterator_traits<
+                                               Iter1>::value_type))),
+                internal::interleaved_select_channel(NUM_CHANNELS,
+                                                     active_channel))),
         d_histogram[active_channel], num_levels[active_channel],
         d_levels[active_channel], num_row_samples * num_rows);
   }

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
@@ -2054,7 +2054,7 @@ sort_pairs(Policy &&policy, Iter1 keys_in, Iter2 keys_out, Iter3 values_in,
                             end_bit);
 }
 
-template <typename _ExecutionPolicy, typename key_t, typename value_t>
+template <typename Policy, typename Iter1, typename Iter2>
 inline void sort_pairs(
     Policy &&policy, io_iterator_pair<Iter1> &keys,
     io_iterator_pair<Iter2> &values, ::std::int64_t n, bool descending = false,

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
@@ -1491,7 +1491,7 @@ struct __evenly_divided_binhash_impl<T, /* is_floating_point= */ false> {
       : __minimum(min), __num_bins(num_bins), __range_size(max - min) {}
   template <typename T2>::std::uint32_t operator()(T2 &&value) const {
     return ::std::uint32_t(
-        ((T(::std::forward<T2>(value)) - __minimum) * T(__num_bins)) /
+        ((std::uint64_t(::std::forward<T2>(value)) - __minimum) * std::uint64_t(__num_bins)) /
         __range_size);
   }
 

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
@@ -1450,28 +1450,23 @@ inline void segmented_sort_pairs_by_two_pair_sorts(
 }
 
 template <typename _T1, typename _T2>
-constexpr inline auto __ceiling_div(const _T1& __number, const _T2& __divisor) {
+constexpr inline auto __ceiling_div(const _T1 &__number, const _T2 &__divisor) {
   return (__number - 1) / __divisor + 1;
 }
 
-template <typename FunctorInner, typename FunctorOuter>
-struct compose_functor{
-  compose_functor(FunctorInner in, FunctorOuter out): _in(in), _out(out){}
-  template<typename T>
-  T operator()(const T& i) const{
-    return _out(_in(i));
-  }
+template <typename FunctorInner, typename FunctorOuter> struct compose_functor {
+  compose_functor(FunctorInner in, FunctorOuter out) : _in(in), _out(out) {}
+  template <typename T> T operator()(const T &i) const { return _out(_in(i)); }
   FunctorInner _in;
   FunctorOuter _out;
 };
 
-template <typename OffsetT>
-struct roi_2d_index{
-  roi_2d_index(const OffsetT& num_cols, const OffsetT&  num_rows, const ::std::size_t& row_stride) : _num_cols(num_cols), _num_rows(num_rows), _row_stride(row_stride)
-  {}
+template <typename OffsetT> struct roi_2d_index {
+  roi_2d_index(const OffsetT &num_cols, const OffsetT &num_rows,
+               const ::std::size_t &row_stride)
+      : _num_cols(num_cols), _num_rows(num_rows), _row_stride(row_stride) {}
 
-  template <typename Index>
-  Index operator()(const Index& i) const{
+  template <typename Index> Index operator()(const Index &i) const {
     return _row_stride * (i / _num_cols) + (i % _num_cols);
   }
 
@@ -1480,21 +1475,18 @@ struct roi_2d_index{
   ::std::size_t _row_stride;
 };
 
-template <typename OffsetT>
-struct interleaved_select_channel{
-  interleaved_select_channel(const OffsetT& total_channels, const OffsetT&  active_channel) : _total_channels(total_channels), _active_channel(active_channel)
-  {}
+template <typename OffsetT> struct interleaved_select_channel {
+  interleaved_select_channel(const OffsetT &total_channels,
+                             const OffsetT &active_channel)
+      : _total_channels(total_channels), _active_channel(active_channel) {}
 
-  template <typename Index>
-  Index operator()(const Index& i) const{
+  template <typename Index> Index operator()(const Index &i) const {
     return i * _total_channels + _active_channel;
   }
 
   OffsetT _total_channels;
   OffsetT _active_channel;
 };
-
-
 
 template <typename _T1, bool _IsFloatingPoint>
 struct __evenly_divided_binhash_impl {};
@@ -1546,16 +1538,19 @@ template <typename _ForwardIterator> struct __custom_range_binhash {
 
 template <typename Policy, typename Iter2>
 inline auto __async_initialize_bins(Policy &&policy, Iter2 __histogram_first,
-                             Iter2 __histogram_last) {
+                                    Iter2 __histogram_last) {
   using __histo_value_type = typename std::iterator_traits<Iter2>::value_type;
   return oneapi::dpl::experimental::fill_async(
       std::forward<Policy>(policy), __histogram_first, __histogram_last,
       __histo_value_type(0));
 }
 
-template <typename _HistAccessor, typename _OffsetT, typename _Size, typename _SelfItem>
-inline void __clear_wglocal_histograms(const _HistAccessor& local_histogram, const _OffsetT& offset, const _Size& num_bins,
-                                const _SelfItem& self_item) {
+template <typename _HistAccessor, typename _OffsetT, typename _Size,
+          typename _SelfItem>
+inline void __clear_wglocal_histograms(const _HistAccessor &local_histogram,
+                                       const _OffsetT &offset,
+                                       const _Size &num_bins,
+                                       const _SelfItem &self_item) {
   ::std::uint32_t gSize = self_item.get_local_range()[0];
   ::std::uint32_t self_lidx = self_item.get_local_id(0);
   ::std::uint8_t factor = __ceiling_div(num_bins, gSize);
@@ -1574,29 +1569,26 @@ inline void __clear_wglocal_histograms(const _HistAccessor& local_histogram, con
   self_item.barrier(sycl::access::fence_space::local_space);
 }
 
-template <::std::uint16_t __work_group_size,
-          typename _BinIdxType,
-          sycl::access::address_space _AddressSpace,
-          typename _Iter1, typename _HistAccessor, typename _OffsetT,
-          typename _BinFunc, typename _SelfItem, typename _T>
-inline void __accum_local_atomics(const _Iter1& in_acc, const ::std::size_t &seg_start,
-                           const ::std::size_t &N,
-                           const ::std::uint32_t &self_lidx,
-                           const _HistAccessor& wg_local_histogram, const _OffsetT& offset,
-                           _BinFunc func, 
-                           const _SelfItem& self_item, const _T& iters_per_work_item) {
+template <::std::uint16_t __work_group_size, typename _BinIdxType,
+          sycl::access::address_space _AddressSpace, typename _Iter1,
+          typename _HistAccessor, typename _OffsetT, typename _BinFunc,
+          typename _SelfItem, typename _T>
+inline void __accum_local_atomics(
+    const _Iter1 &in_acc, const ::std::size_t &seg_start,
+    const ::std::size_t &N, const ::std::uint32_t &self_lidx,
+    const _HistAccessor &wg_local_histogram, const _OffsetT &offset,
+    _BinFunc func, const _SelfItem &self_item, const _T &iters_per_work_item) {
   using __histo_value_type = typename _HistAccessor::value_type;
   using __value_type = typename _Iter1::value_type;
 #pragma unroll
   for (::std::uint8_t idx = 0; idx < iters_per_work_item; idx++) {
     ::std::size_t __val_idx = seg_start + idx * __work_group_size + self_lidx;
-    if (__val_idx < N)
-    {
+    if (__val_idx < N) {
       const __value_type &x = in_acc[__val_idx];
       _BinIdxType c = func(x);
 
       sycl::atomic_ref<__histo_value_type, sycl::memory_order::relaxed,
-                     sycl::memory_scope::work_group, _AddressSpace>
+                       sycl::memory_scope::work_group, _AddressSpace>
           local_bin(wg_local_histogram[offset + c]);
       local_bin++;
     }
@@ -1604,11 +1596,13 @@ inline void __accum_local_atomics(const _Iter1& in_acc, const ::std::size_t &seg
   self_item.barrier(sycl::access::fence_space::local_space);
 }
 
-template <typename _HistAccessorIn, typename _OffsetT, typename _HistAccessorOut, typename _Size,
-          typename _SelfItem>
-inline void __reduce_out_histograms(const _HistAccessorIn& in_histogram, const _OffsetT& offset,
-                             const _HistAccessorOut& out_histogram, const _Size& num_bins,
-                             const _SelfItem& self_item) {
+template <typename _HistAccessorIn, typename _OffsetT,
+          typename _HistAccessorOut, typename _Size, typename _SelfItem>
+inline void __reduce_out_histograms(const _HistAccessorIn &in_histogram,
+                                    const _OffsetT &offset,
+                                    const _HistAccessorOut &out_histogram,
+                                    const _Size &num_bins,
+                                    const _SelfItem &self_item) {
   using __histo_value_type = typename _HistAccessorOut::value_type;
   ::std::uint32_t gSize = self_item.get_local_range()[0];
   ::std::uint32_t self_lidx = self_item.get_local_id(0);
@@ -1639,7 +1633,7 @@ template <::std::uint16_t __work_group_size,
           typename Iter2, typename _Size, typename _IdxHashFunc>
 inline Iter2 __histogram_general_registers_local_reduction(
     Policy &&policy, _Iter1 __first, _Iter1 __last, Iter2 __histogram_first,
-    const _Size& num_bins, _IdxHashFunc __func) {
+    const _Size &num_bins, _IdxHashFunc __func) {
   const ::std::size_t N = __last - __first;
   using __value_type = typename ::std::iterator_traits<_Iter1>::value_type;
   using __histo_value_type = typename ::std::iterator_traits<Iter2>::value_type;
@@ -1669,8 +1663,7 @@ inline Iter2 __histogram_general_registers_local_reduction(
           const ::std::size_t __seg_start =
               __work_group_size * __iters_per_work_item * __wgroup_idx;
 
-          __clear_wglocal_histograms(local_histogram, 0, num_bins,
-                                     __self_item);
+          __clear_wglocal_histograms(local_histogram, 0, num_bins, __self_item);
           // histogram bins take less storage with smaller data type
           __private_histogram_type histogram[__bins_per_work_item];
 #pragma unroll
@@ -1680,12 +1673,12 @@ inline Iter2 __histogram_general_registers_local_reduction(
 
 #pragma unroll
           for (::std::uint8_t idx = 0; idx < __iters_per_work_item; idx++) {
-            ::std::size_t __val_idx = __seg_start + idx * __work_group_size + __self_lidx;
-            if (__val_idx < N)
-            {
+            ::std::size_t __val_idx =
+                __seg_start + idx * __work_group_size + __self_lidx;
+            if (__val_idx < N) {
               const __value_type &x = macc[__val_idx];
               ::std::uint8_t c = __func(x);
-              histogram[c] ++;
+              histogram[c]++;
             }
           }
 #pragma unroll
@@ -1713,9 +1706,10 @@ template <::std::uint16_t __work_group_size,
           ::std::uint16_t __iters_per_work_item, typename Policy,
           typename _Iter1, typename Iter2, typename _Size,
           typename _IdxHashFunc>
-inline Iter2 __histogram_general_local_atomics(Policy &&policy, _Iter1 __first,
-                                        _Iter1 __last, Iter2 __histogram_first,
-                                        const _Size& num_bins, _IdxHashFunc __func) {
+inline Iter2
+__histogram_general_local_atomics(Policy &&policy, _Iter1 __first,
+                                  _Iter1 __last, Iter2 __histogram_first,
+                                  const _Size &num_bins, _IdxHashFunc __func) {
   using __value_type = typename ::std::iterator_traits<_Iter1>::value_type;
   using __histo_value_type = typename ::std::iterator_traits<Iter2>::value_type;
   // minimum type size for atomics
@@ -1745,14 +1739,12 @@ inline Iter2 __histogram_general_local_atomics(Policy &&policy, _Iter1 __first,
           const ::std::size_t __seg_start =
               __work_group_size * __wgroup_idx * __iters_per_work_item;
 
-          __clear_wglocal_histograms(local_histogram, 0, num_bins,
-                                     __self_item);
+          __clear_wglocal_histograms(local_histogram, 0, num_bins, __self_item);
 
-          __accum_local_atomics<__work_group_size,
-                                ::std::uint16_t, 
+          __accum_local_atomics<__work_group_size, ::std::uint16_t,
                                 sycl::access::address_space::local_space>(
-              macc, __seg_start, N, __self_lidx, local_histogram, 0,
-              __func, __self_item, __iters_per_work_item);
+              macc, __seg_start, N, __self_lidx, local_histogram, 0, __func,
+              __self_item, __iters_per_work_item);
 
           __reduce_out_histograms(local_histogram, 0, hacc, num_bins,
                                   __self_item);
@@ -1767,11 +1759,9 @@ template <::std::uint16_t __work_group_size,
           ::std::uint16_t __min_iters_per_work_item, typename Policy,
           typename _Iter1, typename Iter2, typename _Size,
           typename _IdxHashFunc>
-inline Iter2 __histogram_general_private_global_atomics(Policy &&policy,
-                                                 _Iter1 __first, _Iter1 __last,
-                                                 Iter2 __histogram_first,
-                                                 const _Size& num_bins,
-                                                 _IdxHashFunc __func) {
+inline Iter2 __histogram_general_private_global_atomics(
+    Policy &&policy, _Iter1 __first, _Iter1 __last, Iter2 __histogram_first,
+    const _Size &num_bins, _IdxHashFunc __func) {
 
   const ::std::size_t N = __last - __first;
   using __value_type = typename ::std::iterator_traits<_Iter1>::value_type;
@@ -1813,16 +1803,14 @@ inline Iter2 __histogram_general_private_global_atomics(Policy &&policy,
 
           __clear_wglocal_histograms(hacc_private, __wgroup_idx * num_bins,
                                      num_bins, __self_item);
-          __accum_local_atomics<__work_group_size,
-                                ::std::uint32_t, 
+          __accum_local_atomics<__work_group_size, ::std::uint32_t,
                                 sycl::access::address_space::global_space>(
-              macc, __seg_start, N, __self_lidx,
-              hacc_private, __wgroup_idx * num_bins,
-              __func, __self_item,
+              macc, __seg_start, N, __self_lidx, hacc_private,
+              __wgroup_idx * num_bins, __func, __self_item,
               iters_per_work_item);
 
-          __reduce_out_histograms(hacc_private, __wgroup_idx * num_bins,
-                                  hacc, num_bins, __self_item);
+          __reduce_out_histograms(hacc_private, __wgroup_idx * num_bins, hacc,
+                                  num_bins, __self_item);
         });
   });
   e.wait();
@@ -1831,9 +1819,10 @@ inline Iter2 __histogram_general_private_global_atomics(Policy &&policy,
 
 template <typename Policy, typename Iter1, typename Iter2, typename _Size,
           typename _IdxHashFunc>
-inline Iter2 __histogram_general_select_best(Policy &&policy, Iter1 __first,
-                                      Iter1 __last, Iter2 __histogram_first,
-                                      const _Size& num_bins, _IdxHashFunc __func) {
+inline Iter2
+__histogram_general_select_best(Policy &&policy, Iter1 __first, Iter1 __last,
+                                Iter2 __histogram_first, const _Size &num_bins,
+                                _IdxHashFunc __func) {
   using __histo_value_type = typename ::std::iterator_traits<Iter2>::value_type;
   auto __local_mem_size =
       policy.queue()
@@ -1850,28 +1839,22 @@ inline Iter2 __histogram_general_select_best(Policy &&policy, Iter1 __first,
   } else if (num_bins * sizeof(__histo_value_type) <
              __local_mem_size) // if bins fit into SLM, use local atomics
   {
-    if (N <= 524288)
-    {
+    if (N <= 524288) {
       return __histogram_general_local_atomics<1024, 4>(
           ::std::forward<Policy>(policy), __first, __last, __histogram_first,
           num_bins, __func);
-    }
-    else
-    {
+    } else {
       return __histogram_general_local_atomics<1024, 32>(
           ::std::forward<Policy>(policy), __first, __last, __histogram_first,
           num_bins, __func);
     }
   } else // otherwise, use global atomics (private copies per workgroup)
   {
-    if (N <= 524288)
-    {
+    if (N <= 524288) {
       return __histogram_general_private_global_atomics<1024, 4>(
           ::std::forward<Policy>(policy), __first, __last, __histogram_first,
           num_bins, __func);
-    }
-    else
-    {
+    } else {
       return __histogram_general_private_global_atomics<1024, 32>(
           ::std::forward<Policy>(policy), __first, __last, __histogram_first,
           num_bins, __func);
@@ -1887,7 +1870,8 @@ inline ::std::enable_if_t<
         internal::is_hetero_execution_policy<::std::decay_t<Policy>>::value,
     Iter2>
 histogram(Policy &&policy, Iter1 __first, Iter1 __last, Iter2 __histogram_first,
-          const _Size& num_bins, const _T& __first_bin_min_val, const _T& __last_bin_max_val) {
+          const _Size &num_bins, const _T &__first_bin_min_val,
+          const _T &__last_bin_max_val) {
   return internal::__histogram_general_select_best(
       ::std::forward<Policy>(policy), __first, __last, __histogram_first,
       num_bins,
@@ -1922,35 +1906,72 @@ void HistogramEven(Policy &&policy, Iter1 d_samples, HistBin *d_histogram,
                       lower_level, upper_level);
 }
 
-template<typename Policy, typename Iter1 , typename HistBin , typename T , typename OffsetT >
-HistBin* HistogramEven (Policy &&policy, Iter1 d_samples, HistBin *d_histogram, int num_levels,
-                             T lower_level, T upper_level, 
-                             OffsetT num_row_samples, OffsetT num_rows, ::std::size_t row_stride_bytes)
-{
-  return HistogramEven(::std::forward<Policy>(policy), oneapi::dpl::permutation_iterator(d_samples, internal::roi_2d_index(num_row_samples, num_rows, row_stride_bytes / sizeof(std::iterator_traits<Iter1>::value_type))), d_histogram, num_levels, lower_level, upper_level, num_row_samples*num_rows);
+template <typename Policy, typename Iter1, typename HistBin, typename T,
+          typename OffsetT>
+HistBin *HistogramEven(Policy &&policy, Iter1 d_samples, HistBin *d_histogram,
+                       int num_levels, T lower_level, T upper_level,
+                       OffsetT num_row_samples, OffsetT num_rows,
+                       ::std::size_t row_stride_bytes) {
+  return HistogramEven(
+      ::std::forward<Policy>(policy),
+      oneapi::dpl::permutation_iterator(
+          d_samples, internal::roi_2d_index(
+                         num_row_samples, num_rows,
+                         row_stride_bytes /
+                             sizeof(std::iterator_traits<Iter1>::value_type))),
+      d_histogram, num_levels, lower_level, upper_level,
+      num_row_samples * num_rows);
 }
 
-template<int NUM_CHANNELS, int NUM_ACTIVE_CHANNELS, typename Policy, typename Iter1 , typename HistBin , typename T , typename Size>
-void MultiHistogramEven(Policy &&policy, Iter1 d_samples, HistBin * d_histogram[NUM_ACTIVE_CHANNELS], int num_levels[NUM_ACTIVE_CHANNELS],
-                             T lower_level[NUM_ACTIVE_CHANNELS], T upper_level[NUM_ACTIVE_CHANNELS], Size num_pixels)
-{
-  for (int active_channel=0; active_channel < NUM_ACTIVE_CHANNELS; active_channel++)
-  {
-    HistogramEven(policy, oneapi::dpl::permutation_iterator(d_samples,internal::interleaved_select_channel(NUM_CHANNELS, active_channel)), d_histogram[active_channel], num_levels[active_channel], lower_level[active_channel], upper_level[active_channel], num_pixels);
+template <int NUM_CHANNELS, int NUM_ACTIVE_CHANNELS, typename Policy,
+          typename Iter1, typename HistBin, typename T, typename Size>
+void MultiHistogramEven(Policy &&policy, Iter1 d_samples,
+                        HistBin *d_histogram[NUM_ACTIVE_CHANNELS],
+                        int num_levels[NUM_ACTIVE_CHANNELS],
+                        T lower_level[NUM_ACTIVE_CHANNELS],
+                        T upper_level[NUM_ACTIVE_CHANNELS], Size num_pixels) {
+  for (int active_channel = 0; active_channel < NUM_ACTIVE_CHANNELS;
+       active_channel++) {
+    HistogramEven(
+        policy,
+        oneapi::dpl::permutation_iterator(
+            d_samples,
+            internal::interleaved_select_channel(NUM_CHANNELS, active_channel)),
+        d_histogram[active_channel], num_levels[active_channel],
+        lower_level[active_channel], upper_level[active_channel], num_pixels);
   }
 }
 
-template<int NUM_CHANNELS, int NUM_ACTIVE_CHANNELS, typename Policy, typename Iter1 , typename HistBin , typename T , typename OffsetT >
-void MultiHistogramEven(Policy &&policy, Iter1 d_samples, HistBin * d_histogram[NUM_ACTIVE_CHANNELS], int num_levels[NUM_ACTIVE_CHANNELS],
-                             T lower_level[NUM_ACTIVE_CHANNELS], T upper_level[NUM_ACTIVE_CHANNELS], OffsetT num_row_samples, OffsetT num_rows, ::std::size_t row_stride_bytes)
-{
-  for (int active_channel=0; active_channel < NUM_ACTIVE_CHANNELS; active_channel++)
-  {
-    HistogramEven(policy, oneapi::dpl::permutation_iterator(d_samples,internal::compose_functor(internal::interleaved_select_channel(NUM_CHANNELS, active_channel), internal::roi_2d_index(num_row_samples,num_rows, row_stride_bytes / sizeof(::std::iterator_traits<Iter1>::value_type)))), d_histogram[active_channel], num_levels[active_channel], lower_level[active_channel], upper_level[active_channel], num_row_samples, num_rows, row_stride_bytes);
+template <int NUM_CHANNELS, int NUM_ACTIVE_CHANNELS, typename Policy,
+          typename Iter1, typename HistBin, typename T, typename OffsetT>
+void MultiHistogramEven(Policy &&policy, Iter1 d_samples,
+                        HistBin *d_histogram[NUM_ACTIVE_CHANNELS],
+                        int num_levels[NUM_ACTIVE_CHANNELS],
+                        T lower_level[NUM_ACTIVE_CHANNELS],
+                        T upper_level[NUM_ACTIVE_CHANNELS],
+                        OffsetT num_row_samples, OffsetT num_rows,
+                        ::std::size_t row_stride_bytes) {
+  for (int active_channel = 0; active_channel < NUM_ACTIVE_CHANNELS;
+       active_channel++) {
+    HistogramEven(
+        policy,
+        oneapi::dpl::permutation_iterator(
+            d_samples,
+            internal::compose_functor(
+                internal::interleaved_select_channel(NUM_CHANNELS,
+                                                     active_channel),
+                internal::roi_2d_index(
+                    num_row_samples, num_rows,
+                    row_stride_bytes /
+                        sizeof(::std::iterator_traits<Iter1>::value_type)))),
+        d_histogram[active_channel], num_levels[active_channel],
+        lower_level[active_channel], upper_level[active_channel],
+        num_row_samples, num_rows, row_stride_bytes);
   }
 }
 
-template <typename Policy, typename Iter1, typename HistBin, typename T, typename Size>
+template <typename Policy, typename Iter1, typename HistBin, typename T,
+          typename Size>
 void HistogramRange(Policy &&policy, Iter1 d_samples, HistBin *d_histogram,
                     int num_levels, T *d_levels, Size num_samples) {
   internal::histogram(::std::forward<Policy>(policy), d_samples,
@@ -1958,34 +1979,61 @@ void HistogramRange(Policy &&policy, Iter1 d_samples, HistBin *d_histogram,
                       d_levels + num_levels);
 }
 
-template <typename Policy, typename Iter1, typename HistBin, typename T, typename OffsetT>
-HistBin* HistogramRange(Policy &&policy, Iter1 d_samples, HistBin *d_histogram,
-                    int num_levels, T *d_levels, OffsetT num_row_samples, OffsetT num_rows, ::std::size_t row_stride_bytes) {
-  return HistogramRange(::std::forward<Policy>(policy), 
-                 oneapi::dpl::permutation_iterator(d_samples, 
-                                                      internal::roi_2d_index(num_row_samples,
-                                                                             num_rows,
-                                                                             row_stride_bytes / sizeof(std::iterator_traits<Iter1>::value_type))),
-                 d_histogram, num_levels, d_levels, num_row_samples*num_rows);
+template <typename Policy, typename Iter1, typename HistBin, typename T,
+          typename OffsetT>
+HistBin *HistogramRange(Policy &&policy, Iter1 d_samples, HistBin *d_histogram,
+                        int num_levels, T *d_levels, OffsetT num_row_samples,
+                        OffsetT num_rows, ::std::size_t row_stride_bytes) {
+  return HistogramRange(
+      ::std::forward<Policy>(policy),
+      oneapi::dpl::permutation_iterator(
+          d_samples, internal::roi_2d_index(
+                         num_row_samples, num_rows,
+                         row_stride_bytes /
+                             sizeof(std::iterator_traits<Iter1>::value_type))),
+      d_histogram, num_levels, d_levels, num_row_samples * num_rows);
 }
 
-template<int NUM_CHANNELS, int NUM_ACTIVE_CHANNELS, typename Policy, typename Iter1 , typename HistBin , typename T , typename Size>
-void MultiHistogramRange(Policy &&policy, Iter1 d_samples, HistBin * d_histogram[NUM_ACTIVE_CHANNELS], int num_levels[NUM_ACTIVE_CHANNELS],
-                             T* d_levels[NUM_ACTIVE_CHANNELS], Size num_pixels)
-{
-  for (int active_channel=0; active_channel < NUM_ACTIVE_CHANNELS; active_channel++)
-  {
-    HistogramRange(policy, oneapi::dpl::permutation_iterator(d_samples,internal::interleaved_select_channel(NUM_CHANNELS, active_channel)), d_histogram[active_channel], num_levels[active_channel], d_levels[active_channel], num_pixels);
+template <int NUM_CHANNELS, int NUM_ACTIVE_CHANNELS, typename Policy,
+          typename Iter1, typename HistBin, typename T, typename Size>
+void MultiHistogramRange(Policy &&policy, Iter1 d_samples,
+                         HistBin *d_histogram[NUM_ACTIVE_CHANNELS],
+                         int num_levels[NUM_ACTIVE_CHANNELS],
+                         T *d_levels[NUM_ACTIVE_CHANNELS], Size num_pixels) {
+  for (int active_channel = 0; active_channel < NUM_ACTIVE_CHANNELS;
+       active_channel++) {
+    HistogramRange(policy,
+                   oneapi::dpl::permutation_iterator(
+                       d_samples, internal::interleaved_select_channel(
+                                      NUM_CHANNELS, active_channel)),
+                   d_histogram[active_channel], num_levels[active_channel],
+                   d_levels[active_channel], num_pixels);
   }
 }
 
-template<int NUM_CHANNELS, int NUM_ACTIVE_CHANNELS, typename Policy, typename Iter1 , typename HistBin , typename T , typename OffsetT >
-void MultiHistogramRange(Policy &&policy, Iter1 d_samples, HistBin * d_histogram[NUM_ACTIVE_CHANNELS], int num_levels[NUM_ACTIVE_CHANNELS],
-                             T* d_levels[NUM_ACTIVE_CHANNELS], OffsetT num_row_samples, OffsetT num_rows, ::std::size_t row_stride_bytes)
-{
-  for (int active_channel=0; active_channel < NUM_ACTIVE_CHANNELS; active_channel++)
-  {
-    HistogramRange(policy, oneapi::dpl::permutation_iterator(d_samples,internal::compose_functor(internal::interleaved_select_channel(NUM_CHANNELS, active_channel), internal::roi_2d_index(num_row_samples,num_rows, row_stride_bytes / sizeof(::std::iterator_traits<Iter1>::value_type)))), d_histogram[active_channel], num_levels[active_channel], d_levels[active_channel], num_row_samples, num_rows, row_stride_bytes);
+template <int NUM_CHANNELS, int NUM_ACTIVE_CHANNELS, typename Policy,
+          typename Iter1, typename HistBin, typename T, typename OffsetT>
+void MultiHistogramRange(Policy &&policy, Iter1 d_samples,
+                         HistBin *d_histogram[NUM_ACTIVE_CHANNELS],
+                         int num_levels[NUM_ACTIVE_CHANNELS],
+                         T *d_levels[NUM_ACTIVE_CHANNELS],
+                         OffsetT num_row_samples, OffsetT num_rows,
+                         ::std::size_t row_stride_bytes) {
+  for (int active_channel = 0; active_channel < NUM_ACTIVE_CHANNELS;
+       active_channel++) {
+    HistogramRange(
+        policy,
+        oneapi::dpl::permutation_iterator(
+            d_samples,
+            internal::compose_functor(
+                internal::interleaved_select_channel(NUM_CHANNELS,
+                                                     active_channel),
+                internal::roi_2d_index(
+                    num_row_samples, num_rows,
+                    row_stride_bytes /
+                        sizeof(::std::iterator_traits<Iter1>::value_type)))),
+        d_histogram[active_channel], num_levels[active_channel],
+        d_levels[active_channel], num_row_samples, num_rows, row_stride_bytes);
   }
 }
 

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
@@ -1932,30 +1932,29 @@ void MultiHistogramEven(Policy &&policy, Iter1 d_samples,
         oneapi::dpl::permutation_iterator(
             d_samples,
             internal::compose_functor(
-                internal::interleaved_select_channel(NUM_CHANNELS,
-                                                     active_channel),
                 internal::roi_2d_index(
                     num_row_samples, row_stride_bytes /
-                        sizeof(typename ::std::iterator_traits<Iter1>::value_type)))),
+                        (NUM_CHANNELS * sizeof(typename ::std::iterator_traits<Iter1>::value_type))),
+            internal::interleaved_select_channel(NUM_CHANNELS, active_channel))),
         d_histogram[active_channel], num_levels[active_channel],
         lower_level[active_channel], upper_level[active_channel],
-        num_row_samples, num_rows, row_stride_bytes);
+        num_row_samples * num_rows);
   }
 }
 
-template <typename Policy, typename Iter1, typename Iter2, typename T,
+template <typename Policy, typename Iter1, typename Iter2, typename Iter3,
           typename Size>
 void HistogramRange(Policy &&policy, Iter1 d_samples, Iter2 d_histogram,
-                    int num_levels, T *d_levels, Size num_samples) {
+                    int num_levels, Iter3 d_levels, Size num_samples) {
   internal::histogram(::std::forward<Policy>(policy), d_samples,
                       d_samples + num_samples, d_histogram, d_levels,
                       d_levels + num_levels);
 }
 
-template <typename Policy, typename Iter1, typename Iter2, typename T,
+template <typename Policy, typename Iter1, typename Iter2, typename Iter3,
           typename OffsetT>
 void HistogramRange(Policy &&policy, Iter1 d_samples, Iter2 d_histogram,
-                        int num_levels, T *d_levels, OffsetT num_row_samples,
+                        int num_levels, Iter3 d_levels, OffsetT num_row_samples,
                         OffsetT num_rows, ::std::size_t row_stride_bytes) {
   return HistogramRange(
       ::std::forward<Policy>(policy),
@@ -1967,11 +1966,11 @@ void HistogramRange(Policy &&policy, Iter1 d_samples, Iter2 d_histogram,
 }
 
 template <int NUM_CHANNELS, int NUM_ACTIVE_CHANNELS, typename Policy,
-          typename Iter1, typename Iter2, typename T, typename Size>
+          typename Iter1, typename Iter2, typename Iter3, typename Size>
 void MultiHistogramRange(Policy &&policy, Iter1 d_samples,
                          Iter2 d_histogram[NUM_ACTIVE_CHANNELS],
                          int num_levels[NUM_ACTIVE_CHANNELS],
-                         T *d_levels[NUM_ACTIVE_CHANNELS], Size num_pixels) {
+                         Iter3 d_levels[NUM_ACTIVE_CHANNELS], Size num_pixels) {
   for (int active_channel = 0; active_channel < NUM_ACTIVE_CHANNELS;
        active_channel++) {
     HistogramRange(policy,
@@ -1984,11 +1983,11 @@ void MultiHistogramRange(Policy &&policy, Iter1 d_samples,
 }
 
 template <int NUM_CHANNELS, int NUM_ACTIVE_CHANNELS, typename Policy,
-          typename Iter1, typename Iter2, typename T, typename OffsetT>
+          typename Iter1, typename Iter2, typename Iter3, typename OffsetT>
 void MultiHistogramRange(Policy &&policy, Iter1 d_samples,
                          Iter2 d_histogram[NUM_ACTIVE_CHANNELS],
                          int num_levels[NUM_ACTIVE_CHANNELS],
-                         T *d_levels[NUM_ACTIVE_CHANNELS],
+                         Iter3 d_levels[NUM_ACTIVE_CHANNELS],
                          OffsetT num_row_samples, OffsetT num_rows,
                          ::std::size_t row_stride_bytes) {
   for (int active_channel = 0; active_channel < NUM_ACTIVE_CHANNELS;
@@ -1998,14 +1997,13 @@ void MultiHistogramRange(Policy &&policy, Iter1 d_samples,
         oneapi::dpl::permutation_iterator(
             d_samples,
             internal::compose_functor(
-                internal::interleaved_select_channel(NUM_CHANNELS,
-                                                     active_channel),
                 internal::roi_2d_index(
                     num_row_samples,
                     row_stride_bytes /
-                        sizeof(typename ::std::iterator_traits<Iter1>::value_type)))),
+                         (NUM_CHANNELS * sizeof(typename ::std::iterator_traits<Iter1>::value_type))),
+                internal::interleaved_select_channel(NUM_CHANNELS, active_channel))),
         d_histogram[active_channel], num_levels[active_channel],
-        d_levels[active_channel], num_row_samples, num_rows, row_stride_bytes);
+        d_levels[active_channel], num_row_samples * num_rows);
   }
 }
 

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
@@ -1449,38 +1449,6 @@ inline void segmented_sort_pairs_by_two_pair_sorts(
       oneapi::dpl::begin(segments), zip_keys_vals, zip_keys_vals_out, n, false);
 }
 
-template <typename FunctorInner, typename FunctorOuter> struct __composition_functor {
-  __composition_functor(FunctorInner in, FunctorOuter out) : _in(in), _out(out) {}
-  template <typename T> T operator()(T&& i) const { return _out(_in(::std::forward<T>(i))); }
-  FunctorInner _in;
-  FunctorOuter _out;
-};
-
-template <typename OffsetT> struct __roi_2d_index_functor {
-  __roi_2d_index_functor(const OffsetT &num_cols, const ::std::size_t &row_stride)
-      : _num_cols(num_cols), _row_stride(row_stride) {}
-
-  template <typename Index> Index operator()(const Index &i) const {
-    return _row_stride * (i / _num_cols) + (i % _num_cols);
-  }
-
-  OffsetT _num_cols;
-  ::std::size_t _row_stride;
-};
-
-template <typename OffsetT> struct __interleaved_index_functor {
-  __interleaved_index_functor(const OffsetT &total_channels,
-                             const OffsetT &active_channel)
-      : _total_channels(total_channels), _active_channel(active_channel) {}
-
-  template <typename Index> Index operator()(const Index &i) const {
-    return i * _total_channels + _active_channel;
-  }
-
-  OffsetT _total_channels;
-  OffsetT _active_channel;
-};
-
 // The dpl_histogram namespace contains a temporary preview of an upcoming
 // oneDPL histogram API.  This namespace will be removed and replaced with
 // corresponding calls to oneapi::dpl::histogram()

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
@@ -2160,11 +2160,11 @@ segmented_reduce_argmax(Policy &&policy, Iter1 keys_in, Iter2 keys_out,
   policy.queue().wait();
 }
 
-template <typename ExecutionPolicy, typename Iter1,
+template <typename ExecutionPolicy, typename InputIterator,
           typename OutputIterator1, typename OutputIterator2,
           typename OutputIterator3>
 void nontrivial_run_length_encode(ExecutionPolicy &&policy,
-                                  Iter1 input_beg,
+                                  InputIterator input_beg,
                                   OutputIterator1 offsets_out,
                                   OutputIterator2 lengths_out,
                                   OutputIterator3 num_runs,

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
@@ -1859,6 +1859,7 @@ histogram(Policy &&policy, Iter1 first, Iter1 last, Iter2 histogram_first,
 
 } // end namespace internal
 
+// Evenly Divided Histogram of a 1-D array
 template <typename Policy, typename Iter1, typename Iter2, typename T,
           typename Size>
 ::std::enable_if_t<
@@ -1872,6 +1873,7 @@ HistogramEven(Policy &&policy, Iter1 d_samples, Iter2 d_histogram,
                                      num_levels - 1, lower_level, upper_level);
 }
 
+// Evenly Divided Histogram of a 2-D ROI in a flattened 2-D array
 template <typename Policy, typename Iter1, typename Iter2, typename T,
           typename OffsetT>
 ::std::enable_if_t<
@@ -1894,6 +1896,7 @@ HistogramEven(Policy &&policy, Iter1 d_samples, Iter2 d_histogram,
       num_row_samples * num_rows);
 }
 
+// Evenly Divided Multi-Channel Histogram of a 1-D array
 template <int NumChannels, int NumActiveChannels, typename Policy,
           typename Iter1, typename Iter2, typename T, typename Size>
 ::std::enable_if_t<
@@ -1917,6 +1920,7 @@ MultiHistogramEven(Policy &&policy, Iter1 d_samples,
   }
 }
 
+// Evenly Divided Multi-Channel Histogram of a 2-D ROI in a flattened 2-D array
 template <int NumChannels, int NumActiveChannels, typename Policy,
           typename Iter1, typename Iter2, typename T, typename OffsetT>
 ::std::enable_if_t<
@@ -1949,6 +1953,7 @@ MultiHistogramEven(Policy &&policy, Iter1 d_samples,
   }
 }
 
+// Custom Range Histogram of a 1-D array
 template <typename Policy, typename Iter1, typename Iter2, typename Iter3,
           typename Size>
 ::std::enable_if_t<
@@ -1963,6 +1968,7 @@ HistogramRange(Policy &&policy, Iter1 d_samples, Iter2 d_histogram,
                                      d_levels, d_levels + num_levels);
 }
 
+// Custom Range Histogram of a 2-D ROI in a flattened 2-D Array
 template <typename Policy, typename Iter1, typename Iter2, typename Iter3,
           typename OffsetT>
 ::std::enable_if_t<
@@ -1984,6 +1990,7 @@ HistogramRange(Policy &&policy, Iter1 d_samples, Iter2 d_histogram,
       d_histogram, num_levels, d_levels, num_row_samples * num_rows);
 }
 
+// Custom Range Multi-Channel Histogram of a 1-D array
 template <int NumChannels, int NumActiveChannels, typename Policy,
           typename Iter1, typename Iter2, typename Iter3, typename Size>
 ::std::enable_if_t<
@@ -2006,6 +2013,7 @@ MultiHistogramRange(Policy &&policy, Iter1 d_samples,
   }
 }
 
+// Custom Range Multi-Channel Histogram of a 2-D ROI in a flattened 2-D array
 template <int NumChannels, int NumActiveChannels, typename Policy,
           typename Iter1, typename Iter2, typename Iter3, typename OffsetT>
 ::std::enable_if_t<

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
@@ -9,8 +9,8 @@
 #ifndef __DPCT_ALGORITHM_H__
 #define __DPCT_ALGORITHM_H__
 
-#include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/execution>
+#include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/numeric>
 
 #include "functional.h"

--- a/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/algorithm.h
@@ -1580,7 +1580,7 @@ _RandomAccessIterator __histogram_general_registers_local_reduction(
       typename ::std::iterator_traits<_RandomAccessIterator>::value_type;
   //minimum type size for atomics
   using __local_histogram_type = ::std::uint32_t; 
-  // even though we fit into uint8_t, this is faster
+  // even though we fit into uint8_t, uint16_t is faster
   using __private_histogram_type = ::std::uint16_t;
   sycl::buffer<__value_type, 1> mbuf(&(*__first), sycl::range<1>(N));
   sycl::buffer<__histo_value_type, 1> hbuf(&(*__histogram_first),

--- a/clang/runtime/dpct-rt/include/dpl_extras/functional.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/functional.h
@@ -379,17 +379,23 @@ struct no_op_fun {
   }
 };
 
-//Unary functor which composes a pair of functors by calling them in succession on an input
-template <typename FunctorInner, typename FunctorOuter> struct __composition_functor {
-  __composition_functor(FunctorInner in, FunctorOuter out) : _in(in), _out(out) {}
-  template <typename T> T operator()(T&& i) const { return _out(_in(::std::forward<T>(i))); }
+// Unary functor which composes a pair of functors by calling them in succession
+// on an input
+template <typename FunctorInner, typename FunctorOuter>
+struct __composition_functor {
+  __composition_functor(FunctorInner in, FunctorOuter out)
+      : _in(in), _out(out) {}
+  template <typename T> T operator()(T &&i) const {
+    return _out(_in(::std::forward<T>(i)));
+  }
   FunctorInner _in;
   FunctorOuter _out;
 };
 
-//Unary functor which maps an index of a ROI into a 2D flattened array
+// Unary functor which maps an index of a ROI into a 2D flattened array
 template <typename OffsetT> struct __roi_2d_index_functor {
-  __roi_2d_index_functor(const OffsetT &num_cols, const ::std::size_t &row_stride)
+  __roi_2d_index_functor(const OffsetT &num_cols,
+                         const ::std::size_t &row_stride)
       : _num_cols(num_cols), _row_stride(row_stride) {}
 
   template <typename Index> Index operator()(const Index &i) const {
@@ -400,10 +406,11 @@ template <typename OffsetT> struct __roi_2d_index_functor {
   ::std::size_t _row_stride;
 };
 
-//Unary functor which maps and index into an interleaved array by its active channel
+// Unary functor which maps and index into an interleaved array by its active
+// channel
 template <typename OffsetT> struct __interleaved_index_functor {
   __interleaved_index_functor(const OffsetT &total_channels,
-                             const OffsetT &active_channel)
+                              const OffsetT &active_channel)
       : _total_channels(total_channels), _active_channel(active_channel) {}
 
   template <typename Index> Index operator()(const Index &i) const {
@@ -413,7 +420,6 @@ template <typename OffsetT> struct __interleaved_index_functor {
   OffsetT _total_channels;
   OffsetT _active_channel;
 };
-
 
 } // end namespace internal
 

--- a/clang/runtime/dpct-rt/include/dpl_extras/functional.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/functional.h
@@ -21,6 +21,23 @@
 #include <utility>
 
 #include "../dpct.hpp"
+#define _DPCT_GCC_VERSION                                                      \
+  (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+
+// Portability "#pragma" definition
+#ifdef _MSC_VER
+#define _DPCT_PRAGMA(x) __pragma(x)
+#else
+#define _DPCT_PRAGMA(x) _Pragma(#x)
+#endif
+
+// Enable loop unrolling pragmas where supported
+#if (__INTEL_COMPILER ||                                                       \
+     (!defined(__INTEL_COMPILER) && _DPCT_GCC_VERSION >= 80000))
+#define _DPCT_PRAGMA_UNROLL _DPCT_PRAGMA(unroll)
+#else // no pragma unroll
+#define _DPCT_PRAGMA_UNROLL
+#endif
 
 namespace dpct {
 

--- a/clang/runtime/dpct-rt/include/dpl_extras/functional.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/functional.h
@@ -385,8 +385,8 @@ template <typename FunctorInner, typename FunctorOuter>
 struct __composition_functor {
   __composition_functor(FunctorInner in, FunctorOuter out)
       : _in(in), _out(out) {}
-  template <typename T> T operator()(T &&i) const {
-    return _out(_in(::std::forward<T>(i)));
+  template <typename T> T operator()(const T &i) const {
+    return _out(_in(i));
   }
   FunctorInner _in;
   FunctorOuter _out;


### PR DESCRIPTION
Provides reasonable performance functional implementation of Histogram APIs:

`dpct::histogram_even` - Evenly Divided Histogram of a 1-D array
`dpct::histogram_even_roi` - Evenly Divided Histogram of a 2-D ROI in a flattened 2-D array
`dpct::multi_histogram_even` -  Evenly Divided Multi-Channel Histogram of a 1-D array
`dpct::multi_histogram_even_roi` - Evenly Divided Multi-Channel Histogram of a 2-D ROI in a flattened 2-D array
`dpct::histogram_range` - Custom Range Histogram of a 1-D array
`dpct::histogram_range_roi` - Custom Range Histogram of a 2-D ROI in a flattened 2-D Array
`dpct::multi_histogram_range` -  Custom Range Multi-Channel Histogram of a 1-D array
`dpct::multi_histogram_range_roi` - Custom Range Multi-Channel Histogram of a 2-D ROI in a flattened 2-D array

note:
This PR includes the `dpct::internal::dpl_histogram` namespace which provides a prototype implementation of functionality intended to be provided by oneDPL.  In a future PR, this namespace will be removed and references to it will be replaced by calls to `oneapi::dpl::histogram`.  There are two instances of non-public oneDPL APIs used in this namespace to enable full functionality without large amounts or redundant code coming into the SYCLomatic headers.  These will be removed with the namespace when the histogram API is available from oneDPL.  These non-public APIs used are stable and should not be expected to change in the timeframe where this code should exist.

Tested by https://github.com/oneapi-src/SYCLomatic-test/pull/429

