### PR TITLE
[SYCLomatic] Suppress all clang warnings when using query-api-mapping.

### DIFF
--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -785,6 +785,7 @@ int runDPCT(int argc, const char **argv) {
     llvm::outs() << SourceCode.substr(StartPos, EndPos - StartPos + 1);
     llvm::outs() << "Is migrated to" << OptionMsg << ":";
 
+    Tool.appendArgumentsAdjuster(getInsertArgumentAdjuster("-w"));
     NoIncrementalMigration = true;
     // Need set a virtual path and it will used by AnalysisScope.
     InRoot = llvm::sys::path::parent_path(SourcePathList[0]).str();


### PR DESCRIPTION
Signed-off-by: Tang, Jiajun jiajun.tang@intel.com