### PR TITLE
[SYCLomatic] Add device_read_only property when malloc for constant_memory

### DIFF
--- a/clang/runtime/dpct-rt/include/memory.hpp
+++ b/clang/runtime/dpct-rt/include/memory.hpp
@@ -1259,6 +1259,14 @@ private:
           _size, q.get_device(), q.get_context());
       return;
     }
+#ifdef SYCL_EXT_ONEAPI_USM_DEVICE_READ_ONLY
+    if (Memory == constant) {
+      _device_ptr = (value_t *)sycl::malloc_device(
+          _size, q.get_device(), q.get_context(),
+          sycl::ext::oneapi::property::usm::device_read_only());
+      return;
+    }
+#endif
 #endif
     _device_ptr = (value_t *)detail::dpct_malloc(_size, q);
   }


### PR DESCRIPTION
Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>