### PR TITLE
[SYCLomatic] Fix inline asm migration

### DIFF
--- a/clang/lib/DPCT/AsmMigration.cpp
+++ b/clang/lib/DPCT/AsmMigration.cpp
@@ -930,6 +930,10 @@ protected:
            Type->getKind() == InlineAsmBuiltinType::TK_u64;
   }
 
+  std::string Cast(StringRef Type, StringRef Op) const {
+    return llvm::Twine("(").concat(Type).concat(")").concat(Op).str();
+  }
+
   bool handle_mul(const InlineAsmInstruction *Inst) override {
     if (Inst->getNumInputOperands() != 2 || Inst->getNumTypes() != 1)
       return SYCLGenError();
@@ -954,19 +958,23 @@ protected:
       if (tryEmitStmt(Op[I], Inst->getInputOperand(I)))
         return SYCLGenError();
 
+    std::string TypeStr;
+    if (tryEmitType(TypeStr, Type))
+      return SYCLGenError();
+
+    // mul.hi
     if (Inst->hasAttr(InstAttr::hi)) {
-      OS() << "sycl::mul_hi(" << Op[0] << ", " << Op[1] << ")";
+      OS() << "sycl::mul_hi<" << TypeStr << ">(" << Op[0] << ", " << Op[1]
+           << ")";
+      // mul.wide
     } else if (Inst->hasAttr(InstAttr::wide)) {
-      auto Cast = [&](StringRef Str) {
-        return llvm::Twine("(")
-            .concat(GetWiderTypeAsString(Type))
-            .concat(")")
-            .concat(Str)
-            .str();
-      };
-      OS() << Cast(Op[0]) << " * " << Cast(Op[1]);
+      OS() << Cast(GetWiderTypeAsString(Type), Op[0]) << " * "
+           << Cast(GetWiderTypeAsString(Type), Op[1]);
+      // mul.lo
     } else {
-      OS() << Op[0] << " * " << Op[1];
+      // Need to add a new help function.
+      // OS() << Op[0] << " * " << Op[1];
+      return SYCLGenError();
     }
 
     endstmt();
@@ -1003,20 +1011,29 @@ protected:
       if (tryEmitStmt(Op[I], Inst->getInputOperand(I)))
         return SYCLGenError();
 
+    std::string TypeStr;
+    if (tryEmitType(TypeStr, Type))
+      return SYCLGenError();
+
     // mad.hi.sat
     if (Inst->hasAttr(InstAttr::sat))
-      OS() << "sycl::clamp<int64_t>(sycl::mad_hi(" << Op[0] << ", " << Op[1]
-           << ", " << Op[2] << "), "
-           << "std::numeric_limits<int32_t>::min()"
-           << ", "
-           << "std::numeric_limits<int32_t>::max())";
+      OS() << llvm::formatv(
+          "sycl::add_sat<{0}>(sycl::mul_hi<{0}>({1}, {2}), {3})", TypeStr,
+          Op[0], Op[1], Op[2]);
+    // mad.hi
     else if (Inst->hasAttr(InstAttr::hi))
-      OS() << "sycl::mad_hi(" << Op[0] << ", " << Op[1] << ", " << Op[2] << ")";
+      OS() << "sycl::mad_hi<" << TypeStr << ">(" << Op[0] << ", " << Op[1]
+           << ", " << Op[2] << ")";
+    // mad.wide
     else if (Inst->hasAttr(InstAttr::wide))
       OS() << llvm::formatv("({3}){0} * ({3}){1} + ({3}){2}", Op[0], Op[1],
                             Op[2], GetWiderTypeAsString(Type));
-    else
-      OS() << Op[0] << " * " << Op[1] << " + " << Op[2];
+    // mad.lo
+    else {
+      // Need to add a new help function.
+      // OS() << Op[0] << " * " << Op[1] << " + " << Op[2];
+      return SYCLGenError();
+    }
 
     endstmt();
     return SYCLGenSuccess();
@@ -1046,9 +1063,8 @@ protected:
     return HandleDivRem(Inst, '%');
   }
 
-  bool HandleMul24Mad24(const InlineAsmInstruction *Inst) {
-    bool IsMad = Inst->is(asmtok::op_mad24);
-    if (Inst->getNumInputOperands() != 2 + IsMad || Inst->getNumTypes() != 1)
+  bool HandleMul24Mad24(const InlineAsmInstruction *Inst, bool isMad) {
+    if (Inst->getNumInputOperands() != 2 + isMad || Inst->getNumTypes() != 1)
       return SYCLGenError();
 
     const auto *Type = dyn_cast<InlineAsmBuiltinType>(Inst->getType(0));
@@ -1070,21 +1086,28 @@ protected:
       if (tryEmitStmt(Op[I], Inst->getInputOperand(I)))
         return SYCLGenError();
 
-    if (IsMad)
-      OS() << "sycl::mad24(" << Op[0] << ", " << Op[1] << ", " << Op[2] << ")";
-    else
-      OS() << "sycl::mul24(" << Op[0] << ", " << Op[1] << ")";
+    std::string TypeStr;
+    if (tryEmitType(TypeStr, Type))
+      return SYCLGenError();
+
+    if (isMad) {
+      OS() << "sycl::mad24<" << TypeStr << ">(" << Op[0] << ", " << Op[1]
+           << ", " << Op[2] << ")";
+    } else {
+      OS() << "sycl::mul24<" << TypeStr << ">(" << Op[0] << ", " << Op[1]
+           << ")";
+    }
 
     endstmt();
     return SYCLGenSuccess();
   }
 
   bool handle_mul24(const InlineAsmInstruction *Inst) override {
-    return HandleMul24Mad24(Inst);
+    return HandleMul24Mad24(Inst, /*isMad=*/false);
   }
 
   bool handle_mad24(const InlineAsmInstruction *Inst) override {
-    return HandleMul24Mad24(Inst);
+    return HandleMul24Mad24(Inst, /*isMad=*/true);
   }
 
   bool HandleAbsNeg(const InlineAsmInstruction *Inst) {
@@ -1110,8 +1133,12 @@ protected:
     if (tryEmitStmt(Op, Inst->getInputOperand(0)))
       return SYCLGenError();
 
+    std::string TypeStr;
+    if (tryEmitType(TypeStr, Type))
+      return SYCLGenError();
+
     if (Inst->is(asmtok::op_abs))
-      OS() << "sycl::abs(" << Op << ")";
+      OS() << llvm::formatv("sycl::abs<{0}>({1})", TypeStr, Op);
     else
       OS() << "-" << Op;
 
@@ -1162,7 +1189,7 @@ protected:
     return HandlePopcClz(Inst);
   }
 
-  bool HandleMinMax(const InlineAsmInstruction *Inst) {
+  bool HandleMinMax(const InlineAsmInstruction *Inst, StringRef Fn) {
     if (Inst->getNumInputOperands() != 2 || Inst->getNumTypes() != 1)
       return SYCLGenError();
 
@@ -1203,14 +1230,13 @@ protected:
     };
 
     if (Inst->hasAttr(InstAttr::relu)) {
-      std::string str = llvm::formatv(
-          "sycl::clamp<{0}>(sycl::{5}<{0}>({1}, {2}), {3}, {4})", TypeRepl,
-          Op[0], Op[1], GenZeroVal(), GenMaxVal(),
-          Inst->is(asmtok::op_min) ? "min" : "max").str();
+      std::string str =
+          llvm::formatv("sycl::clamp<{0}>({5}<{0}>({1}, {2}), {3}, {4})",
+                        TypeRepl, Op[0], Op[1], GenZeroVal(), GenMaxVal(), Fn)
+              .str();
       OS() << str;
     } else {
-      OS() << llvm::formatv("sycl::{3}<{0}>({1}, {2})", TypeRepl, Op[0], Op[1],
-                            Inst->is(asmtok::op_min) ? "min" : "max");
+      OS() << llvm::formatv("{3}<{0}>({1}, {2})", TypeRepl, Op[0], Op[1], Fn);
     }
 
     endstmt();
@@ -1218,11 +1244,11 @@ protected:
   }
 
   bool handle_min(const InlineAsmInstruction *Inst) override {
-    return HandleMinMax(Inst);
+    return HandleMinMax(Inst, "sycl::min");
   }
 
   bool handle_max(const InlineAsmInstruction *Inst) override {
-    return HandleMinMax(Inst);
+    return HandleMinMax(Inst, "sycl::max");
   }
 
   bool HandleBitwiseBinaryOp(const InlineAsmInstruction *Inst,
@@ -1378,25 +1404,30 @@ void AsmRule::doMigrateInternel(const GCCAsmStmt *GAS) {
   } while (!Parser.getCurToken().is(asmtok::eof));
 
   StringRef Ref = ReplaceString;
-  if (CodeGen.isInMacroDefine()) {
-    if (Ref.ends_with("\\\n")) {
-      ReplaceString.erase(ReplaceString.end() - 2);
-    } else if (Ref.ends_with("\\\r\n")) {
-      ReplaceString.erase(ReplaceString.end() - 3);
+
+  // Trim the trailing whitspace and ';'.
+  Ref = Ref.trim();
+  if (Ref.back() == ';')
+    Ref = Ref.drop_back();
+
+  if (CodeGen.isInMacroDefine() && Ref.ends_with("\\"))
+    Ref = Ref.drop_back();
+
+  // If the generated SYCL code in '{...}', we should remove ';' after AsmStmt.
+  if (Ref.front() == '{' && Ref.back() == '}') {
+    auto Tok = Lexer::findNextToken(GAS->getEndLoc(), SM, C.getLangOpts());
+
+    if (Tok.has_value() && Tok->is(tok::semi) &&
+        (!CodeGen.isInMacroDefine() ||
+         isInMacroDefinition(Tok->getLocation(), Tok->getEndLoc()))) {
+      emplaceTransformation(new ReplaceToken(Tok->getLocation(), ""));
     }
   }
 
-  auto *Repl = new ReplaceStmt(GAS, std::move(ReplaceString));
+  auto *Repl = new ReplaceStmt(GAS, std::move(Ref.str()));
   Repl->setBlockLevelFormatFlag();
   emplaceTransformation(Repl);
 
-  auto Tok = Lexer::findNextToken(GAS->getEndLoc(), SM, C.getLangOpts());
-
-  if (Tok.has_value() && Tok->is(tok::semi) &&
-      (!CodeGen.isInMacroDefine() ||
-       isInMacroDefinition(Tok->getLocation(), Tok->getEndLoc()))) {
-    emplaceTransformation(new ReplaceToken(Tok->getLocation(), ""));
-  }
   return;
 }
 

--- a/clang/lib/DPCT/Utility.cpp
+++ b/clang/lib/DPCT/Utility.cpp
@@ -2264,8 +2264,12 @@ getRangeInRange(SourceRange Range, SourceLocation SearchRangeBegin,
         auto InnerResult = getRangeInRange(Range, MacroDefBegin, MacroDefEnd, false);
         // If the new range covers the entire macro, use the original range,
         // otherwise, use the inner range.
-        if(!isSameLocation(It->second.getBegin(), InnerResult.first) ||
-           !isSameLocation(It->second.getEnd(), InnerResult.second)){
+        if (isInRange(It->second.getBegin(), It->second.getEnd(),
+                      InnerResult.first) &&
+            isInRange(It->second.getBegin(), It->second.getEnd(),
+                      InnerResult.second) &&
+            (!isSameLocation(It->second.getBegin(), InnerResult.first) ||
+             !isSameLocation(It->second.getEnd(), InnerResult.second))) {
           ResultBegin = InnerResult.first;
           ResultEnd = InnerResult.second;
         }

--- a/clang/test/dpct/asm.cu
+++ b/clang/test/dpct/asm.cu
@@ -35,7 +35,6 @@ __global__ void gpu_ptx(int *d_ptr, int length) {
 // CHECK: void asm_only(const sycl::nd_item<3> &item_ct1) {
 // CHECK-NEXT:  unsigned laneid;
 // CHECK-NEXT:  laneid = item_ct1.get_sub_group().get_local_linear_id();
-// CHECK-EMPTY:
 // CHECK-MEXT: }
 __global__ void asm_only() {
   unsigned laneid;

--- a/clang/test/dpct/asm_arith.cu
+++ b/clang/test/dpct/asm_arith.cu
@@ -118,40 +118,22 @@ __global__ void mul() {
   int64_t i64;
   uint64_t u64;
 
-  // CHECK: i16 = x * y;
-  asm("mul.lo.s16 %0, %1, %2;" : "=r"(i16) : "r"(x), "r"(y));
-
-  // CHECK: u16 = x * y;
-  asm("mul.lo.u16 %0, %1, %2;" : "=r"(u16) : "r"(x), "r"(y));
-
-  // CHECK: i32 = x * y;
-  asm("mul.lo.s32 %0, %1, %2;" : "=r"(i32) : "r"(x), "r"(y));
-
-  // CHECK: u32 = x * y;
-  asm("mul.lo.u32 %0, %1, %2;" : "=r"(u32) : "r"(x), "r"(y));
-
-  // CHECK: i64 = x * y;
-  asm("mul.lo.s64 %0, %1, %2;" : "=r"(i64) : "r"(x), "r"(y));
-
-  // CHECK: u64 = x * y;
-  asm("mul.lo.u64 %0, %1, %2;" : "=r"(u64) : "r"(x), "r"(y));
-
-  // CHECK: i16 = sycl::mul_hi(x, y);
+  // CHECK: i16 = sycl::mul_hi<int16_t>(x, y);
   asm("mul.hi.s16 %0, %1, %2;" : "=r"(i16) : "r"(x), "r"(y));
 
-  // CHECK: u16 = sycl::mul_hi(x, y);
+  // CHECK: u16 = sycl::mul_hi<uint16_t>(x, y);
   asm("mul.hi.u16 %0, %1, %2;" : "=r"(u16) : "r"(x), "r"(y));
 
-  // CHECK: i32 = sycl::mul_hi(x, y);
+  // CHECK: i32 = sycl::mul_hi<int32_t>(x, y);
   asm("mul.hi.s32 %0, %1, %2;" : "=r"(i32) : "r"(x), "r"(y));
 
-  // CHECK: u32 = sycl::mul_hi(x, y);
+  // CHECK: u32 = sycl::mul_hi<uint32_t>(x, y);
   asm("mul.hi.u32 %0, %1, %2;" : "=r"(u32) : "r"(x), "r"(y));
 
-  // CHECK: i64 = sycl::mul_hi(x, y);
+  // CHECK: i64 = sycl::mul_hi<int64_t>(x, y);
   asm("mul.hi.s64 %0, %1, %2;" : "=r"(i64) : "r"(x), "r"(y));
 
-  // CHECK: u64 = sycl::mul_hi(x, y);
+  // CHECK: u64 = sycl::mul_hi<uint64_t>(x, y);
   asm("mul.hi.u64 %0, %1, %2;" : "=r"(u64) : "r"(x), "r"(y));
 
   // CHECK: i16 = (int32_t)x * (int32_t)y;
@@ -182,40 +164,22 @@ __global__ void mad() {
   int64_t i64;
   uint64_t u64;
 
-  // CHECK: i16 = x * y + 3;
-  asm("mad.lo.s16 %0, %1, %2, %3;" : "=r"(i16) : "r"(x), "r"(y), "r"(3));
-
-  // CHECK: u16 = x * y + 3;
-  asm("mad.lo.u16 %0, %1, %2, %3;" : "=r"(u16) : "r"(x), "r"(y), "r"(3));
-
-  // CHECK: i32 = x * y + 3;
-  asm("mad.lo.s32 %0, %1, %2, %3;" : "=r"(i32) : "r"(x), "r"(y), "r"(3));
-
-  // CHECK: u32 = x * y + 3;
-  asm("mad.lo.u32 %0, %1, %2, %3;" : "=r"(u32) : "r"(x), "r"(y), "r"(3));
-
-  // CHECK: i64 = x * y + 3;
-  asm("mad.lo.s64 %0, %1, %2, %3;" : "=r"(i64) : "r"(x), "r"(y), "r"(3));
-
-  // CHECK: u64 = x * y + 3;
-  asm("mad.lo.u64 %0, %1, %2, %3;" : "=r"(u64) : "r"(x), "r"(y), "r"(3));
-
-  // CHECK: i16 = sycl::mad_hi(x, y, 3);
+  // CHECK: i16 = sycl::mad_hi<int16_t>(x, y, 3);
   asm("mad.hi.s16 %0, %1, %2, %3;" : "=r"(i16) : "r"(x), "r"(y), "r"(3));
 
-  // CHECK: u16 = sycl::mad_hi(x, y, 3);
+  // CHECK: u16 = sycl::mad_hi<uint16_t>(x, y, 3);
   asm("mad.hi.u16 %0, %1, %2, %3;" : "=r"(u16) : "r"(x), "r"(y), "r"(3));
 
-  // CHECK: i32 = sycl::mad_hi(x, y, 3);
+  // CHECK: i32 = sycl::mad_hi<int32_t>(x, y, 3);
   asm("mad.hi.s32 %0, %1, %2, %3;" : "=r"(i32) : "r"(x), "r"(y), "r"(3));
 
-  // CHECK: u32 = sycl::mad_hi(x, y, 3);
+  // CHECK: u32 = sycl::mad_hi<uint32_t>(x, y, 3);
   asm("mad.hi.u32 %0, %1, %2, %3;" : "=r"(u32) : "r"(x), "r"(y), "r"(3));
 
-  // CHECK: i64 = sycl::mad_hi(x, y, 3);
+  // CHECK: i64 = sycl::mad_hi<int64_t>(x, y, 3);
   asm("mad.hi.s64 %0, %1, %2, %3;" : "=r"(i64) : "r"(x), "r"(y), "r"(3));
 
-  // CHECK: u64 = sycl::mad_hi(x, y, 3);
+  // CHECK: u64 = sycl::mad_hi<uint64_t>(x, y, 3);
   asm("mad.hi.u64 %0, %1, %2, %3;" : "=r"(u64) : "r"(x), "r"(y), "r"(3));
 
   // CHECK: i16 = (int32_t)x * (int32_t)y + (int32_t)3;
@@ -242,10 +206,10 @@ __global__ void mul24() {
   int32_t i32;
   uint32_t u32;
 
-  // CHECK: i32 = sycl::mul24(x, y);
+  // CHECK: i32 = sycl::mul24<int32_t>(x, y);
   asm("mul24.lo.s32 %0, %1, %2;" : "=r"(i32) : "r"(x), "r"(y));
 
-  // CHECK: u32 = sycl::mul24(x, y);
+  // CHECK: u32 = sycl::mul24<uint32_t>(x, y);
   asm("mul24.lo.u32 %0, %1, %2;" : "=r"(u32) : "r"(x), "r"(y));
 
   // CHECK: DPCT1053:{{.*}}: Migration of device assembly code is not supported.
@@ -260,10 +224,10 @@ __global__ void mad24() {
   int32_t i32;
   uint32_t u32;
 
-  // CHECK: i32 = sycl::mad24(x, y, 3);
+  // CHECK: i32 = sycl::mad24<int32_t>(x, y, 3);
   asm("mad24.lo.s32 %0, %1, %2, %3;" : "=r"(i32) : "r"(x), "r"(y), "r"(3));
 
-  // CHECK: u32 = sycl::mad24(x, y, 3);
+  // CHECK: u32 = sycl::mad24<uint32_t>(x, y, 3);
   asm("mad24.lo.u32 %0, %1, %2, %3;" : "=r"(u32) : "r"(x), "r"(y), "r"(3));
 
   // CHECK: DPCT1053:{{.*}}: Migration of device assembly code is not supported.
@@ -334,13 +298,13 @@ __global__ void abs() {
   int32_t i32;
   int64_t i64;
 
-  // CHECK: i16 = sycl::abs(x);
+  // CHECK: i16 = sycl::abs<int16_t>(x);
   asm("abs.s16 %0, %1;" : "=r"(i16) : "r"(x));
 
-  // CHECK: i32 = sycl::abs(x);
+  // CHECK: i32 = sycl::abs<int32_t>(x);
   asm("abs.s32 %0, %1;" : "=r"(i32) : "r"(x));
 
-  // CHECK: i64 = sycl::abs(x);
+  // CHECK: i64 = sycl::abs<int64_t>(x);
   asm("abs.s64 %0, %1;" : "=r"(i64) : "r"(x));
 }
 

--- a/clang/test/dpct/builtin_macro.cu
+++ b/clang/test/dpct/builtin_macro.cu
@@ -1,0 +1,20 @@
+// RUN: dpct --format-range=none -out-root %T/builtin_macro %s --cuda-include-path="%cuda-path/include" -- -x cuda --cuda-host-only
+// RUN: FileCheck --input-file %T/builtin_macro/builtin_macro.dp.cpp --match-full-lines %s
+
+#define MACRO(ID, CMP, S) \
+  {                       \
+    S;                    \
+    if (!(CMP)) {         \
+      return ID;          \
+    }                     \
+  }
+
+// clang-format off
+__device__ int f() {
+  int s32 = 0, s32x = 1;
+  // CHECK:MACRO(7, s32 == INT_MAX, s32 = sycl::add_sat<int32_t>(s32x, INT_MAX));
+  MACRO(7, s32 == INT_MAX, asm("add.s32.sat %0, %1, %2;" : "=r"(s32) : "r"(s32x), "r"(INT_MAX)));
+
+  return 0;
+}
+// clang-format on


### PR DESCRIPTION
1. Fix migration of inline asm integer arithmetic instructions.
2. Fix migration of compiler builtin macro which is function-like macro argument.

Signed-off-by: Wang, Yihan <yihan.wang@intel.com>
