### PR TITLE
[SYCLomatic] CUDA header files's path will be used during migration if CUDA SDK header files are detected in path specified by option '-I' in the compilation database

### DIFF
--- a/clang/lib/Tooling/CommonOptionsParser.cpp
+++ b/clang/lib/Tooling/CommonOptionsParser.cpp
@@ -388,6 +388,25 @@ OPT_TYPE OPT_VAR(OPTION_NAME, __VA_ARGS__);
       ExtraIncPathList.push_back(IncPath);
     }
   }
+
+  if (AdjustingCompilations) {
+    for (const auto &SourceFile : AdjustingCompilations->getAllFiles()) {
+      std::vector<CompileCommand> CompileCommandsForFile =
+          AdjustingCompilations->getCompileCommands(SourceFile);
+      for (CompileCommand &CompileCommand : CompileCommandsForFile) {
+        for (auto &I : CompileCommand.CommandLine) {
+          if (I.size() > 2 && I.substr(0, 2) == "-I") {
+            std::string IncPath = I.substr(2);
+            const auto StartPos = IncPath.find_first_not_of(" ");
+            if (StartPos != std::string::npos)
+              IncPath = IncPath.substr(StartPos);
+            ExtraIncPathList.push_back(IncPath);
+          }
+        }
+      }
+    }
+  }
+
   if (IsCudaFile) {
     Adjuster = combineAdjusters(
         std::move(Adjuster),


### PR DESCRIPTION
 Signed-off-by: chenwei.sun <chenwei.sun@intel.com>