### PR TITLE
[SYCLomatic] Add ostream overload for device_reference

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/memory.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/memory.h
@@ -155,6 +155,12 @@ template <typename T> void swap(T &x, T &y) {
   y = tmp;
 }
 
+template <typename T>
+::std::ostream &operator<<(::std::ostream &out,
+                           const device_reference<T> &ref) {
+  return out << T(ref);
+}
+
 namespace internal {
 // struct for checking if iterator is heterogeneous or not
 template <typename Iter,


### PR DESCRIPTION
Adding ostream overload for device_reference.  This should allow it to handle things like `device_reference<::std::complex<float>>`.