### PR TITLE
[SYCLomatic] When the first parameter of pow is float, then migrate all the pow to sycl::pow(float,float) API.

### DIFF
--- a/clang/runtime/dpct-rt/include/math.hpp
+++ b/clang/runtime/dpct-rt/include/math.hpp
@@ -11,6 +11,7 @@
 
 #include <limits>
 #include <sycl/sycl.hpp>
+#include <type_traits>
 
 namespace dpct {
 namespace detail {
@@ -369,7 +370,14 @@ inline float pow(const float a, const int b) { return sycl::pown(a, b); }
 inline double pow(const double a, const int b) { return sycl::pown(a, b); }
 inline float pow(const float a, const float b) { return sycl::pow(a, b); }
 inline double pow(const double a, const double b) { return sycl::pow(a, b); }
-template <typename T, typename U> inline double pow(const T a, const U b) {
+template <typename T, typename U>
+inline typename std::enable_if_t<std::is_floating_point_v<T>, float>
+pow(const T a, const U b) {
+  return sycl::pow(static_cast<float>(a), static_cast<float>(b));
+}
+template <typename T, typename U>
+inline typename std::enable_if_t<!std::is_floating_point_v<T>, double>
+pow(const T a, const U b) {
   return sycl::pow(static_cast<double>(a), static_cast<double>(b));
 }
 

--- a/clang/runtime/dpct-rt/include/math.hpp
+++ b/clang/runtime/dpct-rt/include/math.hpp
@@ -370,9 +370,9 @@ inline double pow(const double a, const int b) { return sycl::pown(a, b); }
 inline float pow(const float a, const float b) { return sycl::pow(a, b); }
 inline double pow(const double a, const double b) { return sycl::pow(a, b); }
 template <typename T, typename U>
-inline typename std::enable_if_t<std::is_floating_point_v<T>, float>
+inline typename std::enable_if_t<std::is_floating_point_v<T>, T>
 pow(const T a, const U b) {
-  return sycl::pow(static_cast<float>(a), static_cast<float>(b));
+  return sycl::pow(a, static_cast<T>(b));
 }
 template <typename T, typename U>
 inline typename std::enable_if_t<!std::is_floating_point_v<T>, double>

--- a/clang/runtime/dpct-rt/include/math.hpp
+++ b/clang/runtime/dpct-rt/include/math.hpp
@@ -11,7 +11,6 @@
 
 #include <limits>
 #include <sycl/sycl.hpp>
-#include <type_traits>
 
 namespace dpct {
 namespace detail {


### PR DESCRIPTION
Signed-off-by: Chen, Sheng S <sheng.s.chen@intel.com>
