### PR TITLE
[SYCLomatic] Remove empty statement in migration of cudaEventRecord.

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -7526,7 +7526,9 @@ void EventAPICallRule::handleEventRecordWithProfilingDisabled(
       std::string StrWithoutSubmitBarrier = Repl.str();
       auto ReplWithoutSB =
           ReplaceStmt(CE, StrWithoutSubmitBarrier).getReplacement(Context);
-      std::string ReplStr = ";";
+      std::string ReplStr;
+      if (!IsParmVarDecl)
+        ReplStr += ";";
       if (isInMacroDefinition(MD->getBeginLoc(), MD->getEndLoc())) {
         ReplStr += "\\";
       }
@@ -7538,13 +7540,15 @@ void EventAPICallRule::handleEventRecordWithProfilingDisabled(
         std::string Str = "*" + ArgName + " = {{NEEDREPLACEQ" +
                           std::to_string(Index) +
                           "}}.ext_oneapi_submit_barrier()";
-        ReplStr += getNL();
+        if (!IsParmVarDecl)
+          ReplStr += getNL();
         ReplStr += getIndent(IndentLoc, SM).str();
         ReplStr += Str;
       } else {
         std::string Str = "*" + ArgName + " = " + StreamName +
                           "->ext_oneapi_submit_barrier()";
-        ReplStr += getNL();
+        if (!IsParmVarDecl)
+          ReplStr += getNL();
         ReplStr += getIndent(IndentLoc, SM).str();
         ReplStr += Str;
       }

--- a/clang/test/dpct/query_api_mapping/Driver/test.cu
+++ b/clang/test/dpct/query_api_mapping/Driver/test.cu
@@ -449,7 +449,6 @@
 // CUEVENTRECORD-NEXT:   cuEventRecord(e /*CUevent*/, s /*CUstream*/);
 // CUEVENTRECORD-NEXT: Is migrated to:
 // CUEVENTRECORD-NEXT:   dpct::queue_ptr s;
-// CUEVENTRECORD-NEXT:   ;
 // CUEVENTRECORD-NEXT:   *e = s->ext_oneapi_submit_barrier();
 
 // RUN: dpct --cuda-include-path="%cuda-path/include" --query-api-mapping=cuEventSynchronize | FileCheck %s -check-prefix=CUEVENTSYNCHRONIZE

--- a/clang/test/dpct/query_api_mapping/Runtime/test.cu
+++ b/clang/test/dpct/query_api_mapping/Runtime/test.cu
@@ -247,7 +247,6 @@
 // CUDAEVENTRECORD-NEXT:   cudaEventRecord(e /*cudaEvent_t*/, s /*cudaStream_t*/);
 // CUDAEVENTRECORD-NEXT: Is migrated to:
 // CUDAEVENTRECORD-NEXT:   dpct::queue_ptr s;
-// CUDAEVENTRECORD-NEXT:   ;
 // CUDAEVENTRECORD-NEXT:   *e = s->ext_oneapi_submit_barrier();
 
 // RUN: dpct --cuda-include-path="%cuda-path/include" --query-api-mapping=cudaEventSynchronize | FileCheck %s -check-prefix=CUDAEVENTSYNCHRONIZE


### PR DESCRIPTION
Signed-off-by: Tang, Jiajun jiajun.tang@intel.com