### PR TITLE
[SYCLomatic] Use FD->getDeclName().getAsString() to avoid assert checking in FD->getName()

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -8673,7 +8673,8 @@ void DeviceFunctionDeclRule::runRule(
     // For Xe-LP architecture, if the sub-group size is 32, then each work-item
     // can use 128 * 32 Byte / 32 = 128 Byte registers.
     if(LocalVariableSize > 128) {
-      report(SM.getExpansionLoc(FD->getBeginLoc()), Warnings::REGISTER_USAGE, false, FD->getName());
+      report(SM.getExpansionLoc(FD->getBeginLoc()), Warnings::REGISTER_USAGE,
+             false, FD->getDeclName().getAsString());
     }
   }
   if (isLambda(FD) && !FuncInfo->isLambda()) {


### PR DESCRIPTION
Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>