### PR TITLE
Clarify CUDA headers requirement and add links for use with non-intel devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ expected to be similar to the daily releases.
   * Windows: `Visual Studio` 2019 or 2022 (In the following description, assume that the version used is 2019) -
     [Download](https://visualstudio.microsoft.com/downloads/)
 
+Note: SYCLomatic can be built from source without any CUDA dependencies. However, before migration of CUDA codebases to SYCL, ensure that CUDA header files are accessible to the tool. These header files are necessary for SYCLomatic to properly understand and process CUDA code during the migration process.
+
 ### Create SYCLomatic workspace
 
 Throughout this document `SYCLOMATIC_HOME` denotes the path to the local directory
@@ -179,6 +181,11 @@ Follow instructions from the link below to build and run tests:
 * SYCL\* 2020 specification:
 [https://www.khronos.org/registry/SYCL/](https://www.khronos.org/registry/SYCL/)
 * More information on oneAPI and DPC++ is available at [https://www.oneapi.com/](https://www.oneapi.com/)
+* Check the following documentation for guidance on using the migrated SYCL code with non-Intel devices using the DPC++ Compatibility Tool:
+
+  Targeting nVIDIA GPUs - https://developer.codeplay.com/products/oneapi/nvidia/2023.2.1/guides/get-started-guide-nvidia#use-dpc-to-target-nvidia-gpus
+
+  Targeting AMD GPUs - https://developer.codeplay.com/products/oneapi/amd/2023.2.1/guides/get-started-guide-amd#use-dpc-to-target-amd-gpus
 
 ## License
 

--- a/clang/include/clang/DPCT/DPCTOptions.inc
+++ b/clang/include/clang/DPCT/DPCTOptions.inc
@@ -427,7 +427,7 @@ DPCT_NON_ENUM_OPTION(
 
 #ifndef _WIN32
 DPCT_NON_ENUM_OPTION(
-    DPCT_OPT_TYPE(static llvm::cl::opt<std::string>), InterceptBuildCommand,
+    DPCT_OPT_TYPE(static llvm::cl::list<std::string>), InterceptBuildCommand,
     "intercept-build",
     llvm::cl::desc("Intercept build tool to generate a compilation database"),
     llvm::cl::value_desc("build command"), llvm::cl::cat(DPCTCat))

--- a/clang/include/clang/DPCT/DPCTOptions.inc
+++ b/clang/include/clang/DPCT/DPCTOptions.inc
@@ -425,6 +425,14 @@ DPCT_NON_ENUM_OPTION(
         "Print the installation directory for helper function header files."),
     llvm::cl::cat(DPCTCat), llvm::cl::init(false))
 
+#ifndef _WIN32
+DPCT_NON_ENUM_OPTION(
+    DPCT_OPT_TYPE(static llvm::cl::opt<std::string>), InterceptBuildCommand,
+    "intercept-build",
+    llvm::cl::desc("Intercept build tool to generate a compilation database"),
+    llvm::cl::value_desc("build command"), llvm::cl::cat(DPCTCat))
+#endif
+
 DPCT_NON_ENUM_OPTION(
     DPCT_OPT_TYPE(static llvm::cl::opt<std::string>), QueryAPIMapping,
     "query-api-mapping",

--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -615,6 +615,7 @@ int runDPCT(int argc, const char **argv) {
     dpctExit(MigrationSucceeded);
   }
 
+#ifndef _WIN32
   if (!InterceptBuildCommand.empty()) {
     SmallString<512> pathToInterceptBuildBinary(DpctInstallPath);
     llvm::sys::path::append(pathToInterceptBuildBinary, "bin",
@@ -637,6 +638,7 @@ int runDPCT(int argc, const char **argv) {
     ShowStatus(MigrationSucceeded);
     dpctExit(MigrationSucceeded);
   }
+#endif
 
   if (InRoot.size() >= MAX_PATH_LEN - 1) {
     DpctLog() << "Error: --in-root '" << InRoot << "' is too long\n";

--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -36,6 +36,7 @@
 #include "clang/Tooling/CommonOptionsParser.h"
 #include "clang/Tooling/Refactoring.h"
 #include "clang/Tooling/Tooling.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/InitLLVM.h"
@@ -610,6 +611,29 @@ int runDPCT(int argc, const char **argv) {
       dpctExit(MigrationErrorInvalidInstallPath);
     }
     std::cout << pathToHelperFunction.c_str() << "\n";
+    ShowStatus(MigrationSucceeded);
+    dpctExit(MigrationSucceeded);
+  }
+
+  if (!InterceptBuildCommand.empty()) {
+    SmallString<512> pathToInterceptBuildBinary(DpctInstallPath);
+    llvm::sys::path::append(pathToInterceptBuildBinary, "bin",
+                            "intercept-build");
+    if (!llvm::sys::fs::exists(pathToInterceptBuildBinary)) {
+      DpctLog() << "Error: intercept-build tool not found"
+                << "\n";
+      ShowStatus(MigrationErrorInvalidInstallPath);
+      dpctExit(MigrationErrorInvalidInstallPath);
+    }
+    std::string interceptBuildSystemCall =
+        (pathToInterceptBuildBinary + " " + InterceptBuildCommand).str();
+    int processExitCode = system(interceptBuildSystemCall.c_str());
+    if (processExitCode) {
+      DpctLog() << "Error: intercept-build process call not successful"
+                << "\n";
+      ShowStatus(MigrationError);
+      dpctExit(MigrationError);
+    }
     ShowStatus(MigrationSucceeded);
     dpctExit(MigrationSucceeded);
   }

--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -616,7 +616,7 @@ int runDPCT(int argc, const char **argv) {
   }
 
 #ifndef _WIN32
-  if (!InterceptBuildCommand.empty()) {
+  if (InterceptBuildCommand.getNumOccurrences()) {
     SmallString<512> pathToInterceptBuildBinary(DpctInstallPath);
     llvm::sys::path::append(pathToInterceptBuildBinary, "bin",
                             "intercept-build");
@@ -626,8 +626,11 @@ int runDPCT(int argc, const char **argv) {
       ShowStatus(MigrationErrorInvalidInstallPath);
       dpctExit(MigrationErrorInvalidInstallPath);
     }
-    std::string interceptBuildSystemCall =
-        (pathToInterceptBuildBinary + " " + InterceptBuildCommand).str();
+    std::string interceptBuildSystemCall(pathToInterceptBuildBinary.str());
+    for (int argumentIndex = 2; argumentIndex < argc; argumentIndex++) {
+      interceptBuildSystemCall.append(" ");
+      interceptBuildSystemCall.append(std::string(argv[argumentIndex]));
+    }
     int processExitCode = system(interceptBuildSystemCall.c_str());
     if (processExitCode) {
       DpctLog() << "Error: intercept-build process call not successful"

--- a/clang/test/dpct/autocomplete.c
+++ b/clang/test/dpct/autocomplete.c
@@ -28,6 +28,7 @@
 // DASH-NEXT: --helper-function-preference=
 // DASH-NEXT: --in-root
 // DASH-NEXT: --in-root-exclude
+// DASH-NEXT: --intercept-build
 // DASH-NEXT: --keep-original-code
 // DASH-NEXT: --no-cl-namespace-inline
 // DASH-NEXT: --no-dpcpp-extensions=


### PR DESCRIPTION
Adds note to prerequisite to clarify need of CUDA headers while migration and not while building from source.

Adds links that guide users on how to use migrated SYCL code with non-Intel devices.