### PR TITLE
[SYCLomatic] Bugfix for initialization of device_vector from different type pointer

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/vector.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/vector.h
@@ -138,7 +138,9 @@ public:
             oneapi::dpl::execution::make_device_policy(get_default_queue()),
             first, last, begin());
       } else {
-        sycl::buffer<T, 1> buf(first, last);
+        sycl::buffer<typename ::std::iterator_traits<InputIterator>::value_type,
+                     1>
+            buf(first, last);
         auto buf_first = oneapi::dpl::begin(buf);
         auto buf_last = oneapi::dpl::end(buf);
         ::std::copy(


### PR DESCRIPTION
This resolves a bug when initializing a `dpct::device_vector<T>` from a pointer of a different type than `T`.