### PR TITLE
[SYCLomatic]Refine the migration of __funnelshift_*

### DIFF
--- a/clang/lib/DPCT/APINamesMath.inc
+++ b/clang/lib/DPCT/APINamesMath.inc
@@ -230,10 +230,10 @@ ENTRY_RENAMED("__brevll", MapNames::getDpctNamespace() + "reverse_bits<unsigned 
 ENTRY_RENAMED("__byte_perm", MapNames::getDpctNamespace() + "byte_level_permute")
 ENTRY_RENAMED("__ffs", MapNames::getDpctNamespace() + "ffs<int>")
 ENTRY_RENAMED("__ffsll", MapNames::getDpctNamespace() + "ffs<long long int>")
-ENTRY_EMULATED("__funnelshift_l", "((upsample(hi, lo) << (shift & 31)) >> 32)")
-ENTRY_EMULATED("__funnelshift_lc", "((upsample(hi, lo) << min(shift, 32)) >> 32)")
-ENTRY_EMULATED("__funnelshift_r", "((upsample(hi, lo) >> (shift & 31)) & 0xFFFFFFFF)")
-ENTRY_EMULATED("__funnelshift_rc", "((upsample(hi, lo) >> min(shift, 32)) & 0xFFFFFFFF)")
+ENTRY_REWRITE("__funnelshift_l")
+ENTRY_REWRITE("__funnelshift_lc")
+ENTRY_REWRITE("__funnelshift_r")
+ENTRY_REWRITE("__funnelshift_rc")
 // Used to add header file "<cmath>" into the file that calls "fabs".
 ENTRY_RENAMED("fabs", "::fabs")
 

--- a/clang/lib/DPCT/APINamesMathRewrite.inc
+++ b/clang/lib/DPCT/APINamesMathRewrite.inc
@@ -1606,6 +1606,66 @@ CALL_FACTORY_ENTRY("__double2half",
 ARRAYSUBSCRIPT_EXPR_FACTORY_ENTRY("__high2float", ARG(0), LITERAL("1"))
 
 MATH_API_REWRITER_DEVICE(
+    "__funnelshift_l",
+    MATH_API_DEVICE_NODES(
+        EMPTY_FACTORY_ENTRY("__funnelshift_l"),
+        EMPTY_FACTORY_ENTRY("__funnelshift_l"),
+        EMPTY_FACTORY_ENTRY("__funnelshift_l"),
+        WARNING_FACTORY_ENTRY(
+            "__funnelshift_l",
+            CALL_FACTORY_ENTRY("__funnelshift_l",
+                               CALL(MapNames::getDpctNamespace() +
+                                        "funnelshift_l",
+                                    ARG(0), ARG(1), ARG(2))),
+            Diagnostics::MATH_EMULATION, std::string("__funnelshift_l"),
+            MapNames::getDpctNamespace() + "funnelshift_l")))
+
+MATH_API_REWRITER_DEVICE(
+    "__funnelshift_lc",
+    MATH_API_DEVICE_NODES(
+        EMPTY_FACTORY_ENTRY("__funnelshift_lc"),
+        EMPTY_FACTORY_ENTRY("__funnelshift_lc"),
+        EMPTY_FACTORY_ENTRY("__funnelshift_lc"),
+        WARNING_FACTORY_ENTRY(
+            "__funnelshift_lc",
+            CALL_FACTORY_ENTRY("__funnelshift_lc",
+                               CALL(MapNames::getDpctNamespace() +
+                                        "funnelshift_lc",
+                                    ARG(0), ARG(1), ARG(2))),
+            Diagnostics::MATH_EMULATION, std::string("__funnelshift_lc"),
+            MapNames::getDpctNamespace() + "funnelshift_lc")))
+
+MATH_API_REWRITER_DEVICE(
+    "__funnelshift_r",
+    MATH_API_DEVICE_NODES(
+        EMPTY_FACTORY_ENTRY("__funnelshift_r"),
+        EMPTY_FACTORY_ENTRY("__funnelshift_r"),
+        EMPTY_FACTORY_ENTRY("__funnelshift_r"),
+        WARNING_FACTORY_ENTRY(
+            "__funnelshift_r",
+            CALL_FACTORY_ENTRY("__funnelshift_r",
+                               CALL(MapNames::getDpctNamespace() +
+                                        "funnelshift_r",
+                                    ARG(0), ARG(1), ARG(2))),
+            Diagnostics::MATH_EMULATION, std::string("__funnelshift_r"),
+            MapNames::getDpctNamespace() + "funnelshift_r")))
+
+MATH_API_REWRITER_DEVICE(
+    "__funnelshift_rc",
+    MATH_API_DEVICE_NODES(
+        EMPTY_FACTORY_ENTRY("__funnelshift_rc"),
+        EMPTY_FACTORY_ENTRY("__funnelshift_rc"),
+        EMPTY_FACTORY_ENTRY("__funnelshift_rc"),
+        WARNING_FACTORY_ENTRY(
+            "__funnelshift_rc",
+            CALL_FACTORY_ENTRY("__funnelshift_rc",
+                               CALL(MapNames::getDpctNamespace() +
+                                        "funnelshift_rc",
+                                    ARG(0), ARG(1), ARG(2))),
+            Diagnostics::MATH_EMULATION, std::string("__funnelshift_rc"),
+            MapNames::getDpctNamespace() + "funnelshift_rc")))
+
+MATH_API_REWRITER_DEVICE(
     "__ldca",
     MATH_API_DEVICE_NODES(
         EMPTY_FACTORY_ENTRY("__ldca"), EMPTY_FACTORY_ENTRY("__ldca"),

--- a/clang/lib/DPCT/CallExprRewriterMath.cpp
+++ b/clang/lib/DPCT/CallExprRewriterMath.cpp
@@ -826,25 +826,33 @@ std::optional<std::string> MathSimulatedRewriter::rewrite() {
     auto Low = getMigratedArg(0);
     auto High = getMigratedArg(1);
     auto Shift = getMigratedArg(2);
+    auto getTypeCastStrIfNeed = [&](const clang::Expr *E,
+                                    std::string TypeStr) -> std::string {
+      return E->IgnoreImplicit()->getType().getAsString(
+                 PrintingPolicy(LangOptions())) == TypeStr
+                 ? ""
+                 : "(" + TypeStr + ")";
+    };
     if (FuncName == "__funnelshift_l") {
       OS << "((" << Namespace << "upsample("
-         << "(unsigned int)" + High << ", "
-         << "(unsigned int)" + Low << ") << (" << Shift << " & 31)) >> 32)";
+         << getTypeCastStrIfNeed(Call->getArg(0), "unsigned int") + High << ", "
+         << getTypeCastStrIfNeed(Call->getArg(1), "unsigned int") + Low
+         << ") << (" << Shift << " & 31)) >> 32)";
     } else if (FuncName == "__funnelshift_lc") {
       OS << "((" << Namespace << "upsample("
-         << "(unsigned int)" + High << ", "
-         << "(unsigned int)" + Low << ") << " << Namespace << "min(" << Shift
-         << ", 32)) >> 32)";
+         << getTypeCastStrIfNeed(Call->getArg(0), "unsigned int") + High << ", "
+         << getTypeCastStrIfNeed(Call->getArg(1), "unsigned int") + Low
+         << ") << " << Namespace << "min(" << Shift << ", 32)) >> 32)";
     } else if (FuncName == "__funnelshift_r") {
       OS << "((" << Namespace << "upsample("
-         << "(unsigned int)" + High << ", "
-         << "(unsigned int)" + Low << ") >> (" << Shift
-         << " & 31)) & 0xFFFFFFFF)";
+         << getTypeCastStrIfNeed(Call->getArg(0), "unsigned int") + High << ", "
+         << getTypeCastStrIfNeed(Call->getArg(1), "unsigned int") + Low
+         << ") >> (" << Shift << " & 31)) & 0xFFFFFFFF)";
     } else if (FuncName == "__funnelshift_rc") {
       OS << "((" << Namespace << "upsample("
-         << "(unsigned int)" + High << ", "
-         << "(unsigned int)" + Low << ") >> " << Namespace << "min(" << Shift
-         << ", 32)) & 0xFFFFFFFF)";
+         << getTypeCastStrIfNeed(Call->getArg(0), "unsigned int") + High << ", "
+         << getTypeCastStrIfNeed(Call->getArg(1), "unsigned int") + Low
+         << ") >> " << Namespace << "min(" << Shift << ", 32)) & 0xFFFFFFFF)";
     }
   }
 

--- a/clang/lib/DPCT/CallExprRewriterMath.cpp
+++ b/clang/lib/DPCT/CallExprRewriterMath.cpp
@@ -827,18 +827,23 @@ std::optional<std::string> MathSimulatedRewriter::rewrite() {
     auto High = getMigratedArg(1);
     auto Shift = getMigratedArg(2);
     if (FuncName == "__funnelshift_l") {
-      OS << "((" << Namespace << "upsample<unsigned>(" << High
-         << ", " << Low << ") << (" << Shift << " & 31)) >> 32)";
+      OS << "((" << Namespace << "upsample("
+         << "(unsigned int)" + High << ", "
+         << "(unsigned int)" + Low << ") << (" << Shift << " & 31)) >> 32)";
     } else if (FuncName == "__funnelshift_lc") {
-      OS << "((" << Namespace << "upsample<unsigned>(" << High
-         << ", " << Low << ") << " << Namespace << "min(" << Shift
+      OS << "((" << Namespace << "upsample("
+         << "(unsigned int)" + High << ", "
+         << "(unsigned int)" + Low << ") << " << Namespace << "min(" << Shift
          << ", 32)) >> 32)";
     } else if (FuncName == "__funnelshift_r") {
-      OS << "((" << Namespace << "upsample<unsigned>(" << High
-         << ", " << Low << ") >> (" << Shift << " & 31)) & 0xFFFFFFFF)";
+      OS << "((" << Namespace << "upsample("
+         << "(unsigned int)" + High << ", "
+         << "(unsigned int)" + Low << ") >> (" << Shift
+         << " & 31)) & 0xFFFFFFFF)";
     } else if (FuncName == "__funnelshift_rc") {
-      OS << "((" << Namespace << "upsample<unsigned>(" << High
-         << ", " << Low << ") >> " << Namespace << "min(" << Shift
+      OS << "((" << Namespace << "upsample("
+         << "(unsigned int)" + High << ", "
+         << "(unsigned int)" + Low << ") >> " << Namespace << "min(" << Shift
          << ", 32)) & 0xFFFFFFFF)";
     }
   }

--- a/clang/lib/DPCT/CallExprRewriterMath.cpp
+++ b/clang/lib/DPCT/CallExprRewriterMath.cpp
@@ -519,10 +519,6 @@ std::optional<std::string> MathSimulatedRewriter::rewrite() {
   if (SourceCalleeName != "pow"                     && 
       SourceCalleeName != "powf"                    &&
       SourceCalleeName != "__powf"                  && 
-      SourceCalleeName != "__funnelshift_l"         &&
-      SourceCalleeName != "__funnelshift_lc"        &&
-      SourceCalleeName != "__funnelshift_r"         &&
-      SourceCalleeName != "__funnelshift_rc"        &&
       SourceCalleeName != "__drcp_rd"               &&
       SourceCalleeName != "__drcp_rn"               &&
       SourceCalleeName != "__drcp_ru"               &&
@@ -817,42 +813,6 @@ std::optional<std::string> MathSimulatedRewriter::rewrite() {
     } else {
       OS << TargetCalleeName;
       OS << "(" << MigratedArg0 << ")";
-    }
-  } else if (FuncName == "__funnelshift_l" || FuncName == "__funnelshift_lc" ||
-             FuncName == "__funnelshift_r" || FuncName == "__funnelshift_rc") {
-    report(Diagnostics::MATH_EMULATION_EXPRESSION, false,
-           MapNames::ITFName.at(SourceCalleeName.str()), TargetCalleeName);
-    auto Namespace = MapNames::getClNamespace();
-    auto Low = getMigratedArg(0);
-    auto High = getMigratedArg(1);
-    auto Shift = getMigratedArg(2);
-    auto getTypeCastStrIfNeed = [&](const clang::Expr *E,
-                                    std::string TypeStr) -> std::string {
-      return E->IgnoreImplicit()->getType().getAsString(
-                 PrintingPolicy(LangOptions())) == TypeStr
-                 ? ""
-                 : "(" + TypeStr + ")";
-    };
-    if (FuncName == "__funnelshift_l") {
-      OS << "((" << Namespace << "upsample("
-         << getTypeCastStrIfNeed(Call->getArg(0), "unsigned int") + High << ", "
-         << getTypeCastStrIfNeed(Call->getArg(1), "unsigned int") + Low
-         << ") << (" << Shift << " & 31)) >> 32)";
-    } else if (FuncName == "__funnelshift_lc") {
-      OS << "((" << Namespace << "upsample("
-         << getTypeCastStrIfNeed(Call->getArg(0), "unsigned int") + High << ", "
-         << getTypeCastStrIfNeed(Call->getArg(1), "unsigned int") + Low
-         << ") << " << Namespace << "min(" << Shift << ", 32)) >> 32)";
-    } else if (FuncName == "__funnelshift_r") {
-      OS << "((" << Namespace << "upsample("
-         << getTypeCastStrIfNeed(Call->getArg(0), "unsigned int") + High << ", "
-         << getTypeCastStrIfNeed(Call->getArg(1), "unsigned int") + Low
-         << ") >> (" << Shift << " & 31)) & 0xFFFFFFFF)";
-    } else if (FuncName == "__funnelshift_rc") {
-      OS << "((" << Namespace << "upsample("
-         << getTypeCastStrIfNeed(Call->getArg(0), "unsigned int") + High << ", "
-         << getTypeCastStrIfNeed(Call->getArg(1), "unsigned int") + Low
-         << ") >> " << Namespace << "min(" << Shift << ", 32)) & 0xFFFFFFFF)";
     }
   }
 

--- a/clang/runtime/dpct-rt/include/math.hpp
+++ b/clang/runtime/dpct-rt/include/math.hpp
@@ -234,6 +234,30 @@ inline std::enable_if_t<T::size() == 2, T> isnan(const T a) {
   return {detail::isnan(a[0]), detail::isnan(a[1])};
 }
 
+/// Emulated function for __funnelshift_l
+inline unsigned int funnelshift_l(unsigned int low, unsigned int high,
+                                  unsigned int shift) {
+  return (sycl::upsample(high, low) << (shift & 31U)) >> 32;
+}
+
+/// Emulated function for __funnelshift_lc
+inline unsigned int funnelshift_lc(unsigned int low, unsigned int high,
+                                   unsigned int shift) {
+  return (sycl::upsample(high, low) << sycl::min(shift, 32U)) >> 32;
+}
+
+/// Emulated function for __funnelshift_r
+inline unsigned int funnelshift_r(unsigned int low, unsigned int high,
+                                  unsigned int shift) {
+  return (sycl::upsample(high, low) >> (shift & 31U)) & 0xFFFFFFFF;
+}
+
+/// Emulated function for __funnelshift_rc
+inline unsigned int funnelshift_rc(unsigned int low, unsigned int high,
+                                   unsigned int shift) {
+  return (sycl::upsample(high, low) >> sycl::min(shift, 32U)) & 0xFFFFFFFF;
+}
+
 /// cbrt function wrapper.
 template <typename T> inline T cbrt(T val) { return sycl::cbrt((T)val); }
 

--- a/clang/test/dpct/math/cuda-math-intrinsics.cu
+++ b/clang/test/dpct/math/cuda-math-intrinsics.cu
@@ -2275,23 +2275,43 @@ __global__ void testUnsupported() {
   // CHECK: /*
   // CHECK-NEXT: DPCT1098:{{[0-9]+}}: The ((upsample(hi, lo) << (shift & 31)) >> 32) expression is used instead of the __funnelshift_l call. These two expressions do not provide the exact same functionality. Check the generated code for potential precision and/or performance issues.
   // CHECK-NEXT: */
-  // CHECK-NEXT: u = ((sycl::upsample((unsigned int)u, (unsigned int)u) << (u & 31)) >> 32);
+  // CHECK-NEXT: u = ((sycl::upsample(u, u) << (u & 31)) >> 32);
   u = __funnelshift_l(u, u, u);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1098:{{[0-9]+}}: The ((upsample(hi, lo) << (shift & 31)) >> 32) expression is used instead of the __funnelshift_l call. These two expressions do not provide the exact same functionality. Check the generated code for potential precision and/or performance issues.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: u = ((sycl::upsample((unsigned int)i, (unsigned int)i) << (u & 31)) >> 32);
+  u = __funnelshift_l(i, i, u);
   // CHECK: /*
   // CHECK-NEXT: DPCT1098:{{[0-9]+}}: The ((upsample(hi, lo) << min(shift, 32)) >> 32) expression is used instead of the __funnelshift_lc call. These two expressions do not provide the exact same functionality. Check the generated code for potential precision and/or performance issues.
   // CHECK-NEXT: */
-  // CHECK-NEXT: u = ((sycl::upsample((unsigned int)u, (unsigned int)u) << sycl::min(u, 32)) >> 32);
+  // CHECK-NEXT: u = ((sycl::upsample(u, u) << sycl::min(u, 32)) >> 32);
   u = __funnelshift_lc(u, u, u);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1098:{{[0-9]+}}: The ((upsample(hi, lo) << min(shift, 32)) >> 32) expression is used instead of the __funnelshift_lc call. These two expressions do not provide the exact same functionality. Check the generated code for potential precision and/or performance issues.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: u = ((sycl::upsample((unsigned int)i, (unsigned int)i) << sycl::min(u, 32)) >> 32);
+  u = __funnelshift_lc(i, i, u);
   // CHECK: /*
   // CHECK-NEXT: DPCT1098:{{[0-9]+}}: The ((upsample(hi, lo) >> (shift & 31)) & 0xFFFFFFFF) expression is used instead of the __funnelshift_r call. These two expressions do not provide the exact same functionality. Check the generated code for potential precision and/or performance issues.
   // CHECK-NEXT: */
-  // CHECK-NEXT: u = ((sycl::upsample((unsigned int)u, (unsigned int)u) >> (u & 31)) & 0xFFFFFFFF);
+  // CHECK-NEXT: u = ((sycl::upsample(u, u) >> (u & 31)) & 0xFFFFFFFF);
   u = __funnelshift_r(u, u, u);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1098:{{[0-9]+}}: The ((upsample(hi, lo) >> (shift & 31)) & 0xFFFFFFFF) expression is used instead of the __funnelshift_r call. These two expressions do not provide the exact same functionality. Check the generated code for potential precision and/or performance issues.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: u = ((sycl::upsample((unsigned int)i, (unsigned int)i) >> (u & 31)) & 0xFFFFFFFF);
+  u = __funnelshift_r(i, i, u);
   // CHECK: /*
   // CHECK-NEXT: DPCT1098:{{[0-9]+}}: The ((upsample(hi, lo) >> min(shift, 32)) & 0xFFFFFFFF) expression is used instead of the __funnelshift_rc call. These two expressions do not provide the exact same functionality. Check the generated code for potential precision and/or performance issues.
   // CHECK-NEXT: */
-  // CHECK-NEXT: u = ((sycl::upsample((unsigned int)u, (unsigned int)u) >> sycl::min(u, 32)) & 0xFFFFFFFF);
+  // CHECK-NEXT: u = ((sycl::upsample(u, u) >> sycl::min(u, 32)) & 0xFFFFFFFF);
   u = __funnelshift_rc(u, u, u);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1098:{{[0-9]+}}: The ((upsample(hi, lo) >> min(shift, 32)) & 0xFFFFFFFF) expression is used instead of the __funnelshift_rc call. These two expressions do not provide the exact same functionality. Check the generated code for potential precision and/or performance issues.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: u = ((sycl::upsample((unsigned int)i, (unsigned int)i) >> sycl::min(u, 32)) & 0xFFFFFFFF);
+  u = __funnelshift_rc(i, i, u);
   // CHECK: ll = sycl::mul_hi(ll, ll);
   ll = __mul64hi(ll, ll);
   // CHECK: i = sycl::rhadd(i, i);

--- a/clang/test/dpct/math/cuda-math-intrinsics.cu
+++ b/clang/test/dpct/math/cuda-math-intrinsics.cu
@@ -2275,22 +2275,22 @@ __global__ void testUnsupported() {
   // CHECK: /*
   // CHECK-NEXT: DPCT1098:{{[0-9]+}}: The ((upsample(hi, lo) << (shift & 31)) >> 32) expression is used instead of the __funnelshift_l call. These two expressions do not provide the exact same functionality. Check the generated code for potential precision and/or performance issues.
   // CHECK-NEXT: */
-  // CHECK-NEXT: u = ((sycl::upsample<unsigned>(u, u) << (u & 31)) >> 32);
+  // CHECK-NEXT: u = ((sycl::upsample((unsigned int)u, (unsigned int)u) << (u & 31)) >> 32);
   u = __funnelshift_l(u, u, u);
   // CHECK: /*
   // CHECK-NEXT: DPCT1098:{{[0-9]+}}: The ((upsample(hi, lo) << min(shift, 32)) >> 32) expression is used instead of the __funnelshift_lc call. These two expressions do not provide the exact same functionality. Check the generated code for potential precision and/or performance issues.
   // CHECK-NEXT: */
-  // CHECK-NEXT: u = ((sycl::upsample<unsigned>(u, u) << sycl::min(u, 32)) >> 32);
+  // CHECK-NEXT: u = ((sycl::upsample((unsigned int)u, (unsigned int)u) << sycl::min(u, 32)) >> 32);
   u = __funnelshift_lc(u, u, u);
   // CHECK: /*
   // CHECK-NEXT: DPCT1098:{{[0-9]+}}: The ((upsample(hi, lo) >> (shift & 31)) & 0xFFFFFFFF) expression is used instead of the __funnelshift_r call. These two expressions do not provide the exact same functionality. Check the generated code for potential precision and/or performance issues.
   // CHECK-NEXT: */
-  // CHECK-NEXT: u = ((sycl::upsample<unsigned>(u, u) >> (u & 31)) & 0xFFFFFFFF);
+  // CHECK-NEXT: u = ((sycl::upsample((unsigned int)u, (unsigned int)u) >> (u & 31)) & 0xFFFFFFFF);
   u = __funnelshift_r(u, u, u);
   // CHECK: /*
   // CHECK-NEXT: DPCT1098:{{[0-9]+}}: The ((upsample(hi, lo) >> min(shift, 32)) & 0xFFFFFFFF) expression is used instead of the __funnelshift_rc call. These two expressions do not provide the exact same functionality. Check the generated code for potential precision and/or performance issues.
   // CHECK-NEXT: */
-  // CHECK-NEXT: u = ((sycl::upsample<unsigned>(u, u) >> sycl::min(u, 32)) & 0xFFFFFFFF);
+  // CHECK-NEXT: u = ((sycl::upsample((unsigned int)u, (unsigned int)u) >> sycl::min(u, 32)) & 0xFFFFFFFF);
   u = __funnelshift_rc(u, u, u);
   // CHECK: ll = sycl::mul_hi(ll, ll);
   ll = __mul64hi(ll, ll);

--- a/clang/test/dpct/math/cuda-math-intrinsics.cu
+++ b/clang/test/dpct/math/cuda-math-intrinsics.cu
@@ -2273,45 +2273,25 @@ __global__ void testUnsupported() {
   // CHECK: i = dpct::ffs<long long int>(ll);
   i = __ffsll(ll);
   // CHECK: /*
-  // CHECK-NEXT: DPCT1098:{{[0-9]+}}: The ((upsample(hi, lo) << (shift & 31)) >> 32) expression is used instead of the __funnelshift_l call. These two expressions do not provide the exact same functionality. Check the generated code for potential precision and/or performance issues.
+  // CHECK-NEXT: DPCT1017:{{[0-9]+}}: The dpct::funnelshift_l call is used instead of the __funnelshift_l call. These two calls do not provide exactly the same functionality. Check the potential precision and/or performance issues for the generated code.
   // CHECK-NEXT: */
-  // CHECK-NEXT: u = ((sycl::upsample(u, u) << (u & 31)) >> 32);
+  // CHECK-NEXT: u = dpct::funnelshift_l(u, u, u);
   u = __funnelshift_l(u, u, u);
   // CHECK: /*
-  // CHECK-NEXT: DPCT1098:{{[0-9]+}}: The ((upsample(hi, lo) << (shift & 31)) >> 32) expression is used instead of the __funnelshift_l call. These two expressions do not provide the exact same functionality. Check the generated code for potential precision and/or performance issues.
+  // CHECK-NEXT: DPCT1017:{{[0-9]+}}: The dpct::funnelshift_lc call is used instead of the __funnelshift_lc call. These two calls do not provide exactly the same functionality. Check the potential precision and/or performance issues for the generated code.
   // CHECK-NEXT: */
-  // CHECK-NEXT: u = ((sycl::upsample((unsigned int)i, (unsigned int)i) << (u & 31)) >> 32);
-  u = __funnelshift_l(i, i, u);
-  // CHECK: /*
-  // CHECK-NEXT: DPCT1098:{{[0-9]+}}: The ((upsample(hi, lo) << min(shift, 32)) >> 32) expression is used instead of the __funnelshift_lc call. These two expressions do not provide the exact same functionality. Check the generated code for potential precision and/or performance issues.
-  // CHECK-NEXT: */
-  // CHECK-NEXT: u = ((sycl::upsample(u, u) << sycl::min(u, 32)) >> 32);
+  // CHECK-NEXT: u = dpct::funnelshift_lc(u, u, u);
   u = __funnelshift_lc(u, u, u);
   // CHECK: /*
-  // CHECK-NEXT: DPCT1098:{{[0-9]+}}: The ((upsample(hi, lo) << min(shift, 32)) >> 32) expression is used instead of the __funnelshift_lc call. These two expressions do not provide the exact same functionality. Check the generated code for potential precision and/or performance issues.
+  // CHECK-NEXT: DPCT1017:{{[0-9]+}}: The dpct::funnelshift_r call is used instead of the __funnelshift_r call. These two calls do not provide exactly the same functionality. Check the potential precision and/or performance issues for the generated code.
   // CHECK-NEXT: */
-  // CHECK-NEXT: u = ((sycl::upsample((unsigned int)i, (unsigned int)i) << sycl::min(u, 32)) >> 32);
-  u = __funnelshift_lc(i, i, u);
-  // CHECK: /*
-  // CHECK-NEXT: DPCT1098:{{[0-9]+}}: The ((upsample(hi, lo) >> (shift & 31)) & 0xFFFFFFFF) expression is used instead of the __funnelshift_r call. These two expressions do not provide the exact same functionality. Check the generated code for potential precision and/or performance issues.
-  // CHECK-NEXT: */
-  // CHECK-NEXT: u = ((sycl::upsample(u, u) >> (u & 31)) & 0xFFFFFFFF);
+  // CHECK-NEXT: u = dpct::funnelshift_r(u, u, u);
   u = __funnelshift_r(u, u, u);
   // CHECK: /*
-  // CHECK-NEXT: DPCT1098:{{[0-9]+}}: The ((upsample(hi, lo) >> (shift & 31)) & 0xFFFFFFFF) expression is used instead of the __funnelshift_r call. These two expressions do not provide the exact same functionality. Check the generated code for potential precision and/or performance issues.
+  // CHECK-NEXT: DPCT1017:{{[0-9]+}}: The dpct::funnelshift_rc call is used instead of the __funnelshift_rc call. These two calls do not provide exactly the same functionality. Check the potential precision and/or performance issues for the generated code.
   // CHECK-NEXT: */
-  // CHECK-NEXT: u = ((sycl::upsample((unsigned int)i, (unsigned int)i) >> (u & 31)) & 0xFFFFFFFF);
-  u = __funnelshift_r(i, i, u);
-  // CHECK: /*
-  // CHECK-NEXT: DPCT1098:{{[0-9]+}}: The ((upsample(hi, lo) >> min(shift, 32)) & 0xFFFFFFFF) expression is used instead of the __funnelshift_rc call. These two expressions do not provide the exact same functionality. Check the generated code for potential precision and/or performance issues.
-  // CHECK-NEXT: */
-  // CHECK-NEXT: u = ((sycl::upsample(u, u) >> sycl::min(u, 32)) & 0xFFFFFFFF);
+  // CHECK-NEXT: u = dpct::funnelshift_rc(u, u, u);
   u = __funnelshift_rc(u, u, u);
-  // CHECK: /*
-  // CHECK-NEXT: DPCT1098:{{[0-9]+}}: The ((upsample(hi, lo) >> min(shift, 32)) & 0xFFFFFFFF) expression is used instead of the __funnelshift_rc call. These two expressions do not provide the exact same functionality. Check the generated code for potential precision and/or performance issues.
-  // CHECK-NEXT: */
-  // CHECK-NEXT: u = ((sycl::upsample((unsigned int)i, (unsigned int)i) >> sycl::min(u, 32)) & 0xFFFFFFFF);
-  u = __funnelshift_rc(i, i, u);
   // CHECK: ll = sycl::mul_hi(ll, ll);
   ll = __mul64hi(ll, ll);
   // CHECK: i = sycl::rhadd(i, i);


### PR DESCRIPTION
Refine the migartion of `__funnelshift_l`,  `__funnelshift_lc`, `__funnelshift_r`, `__funnelshift_rc`
Signed-off-by: Ni, Wenhui <wenhui.ni@intel.com>