### PR TITLE
[SYCLomatic] Fix the migration of thread_block.group_index/thread_index to sycl::group.get_group_id/get_local_id

### DIFF
--- a/clang/lib/DPCT/APINamesCooperativeGroups.inc
+++ b/clang/lib/DPCT/APINamesCooperativeGroups.inc
@@ -650,8 +650,8 @@ MEMBER_CALL_FACTORY_ENTRY("cooperative_groups::__v1::thread_group.num_threads",
                           MemberExprBase(), false, "get_local_linear_range")
 MEMBER_CALL_FACTORY_ENTRY("cooperative_groups::__v1::thread_group.get_type",
                           MemberExprBase(), false, "get_type")
-MEMBER_CALL_FACTORY_ENTRY("cooperative_groups::__v1::thread_block.group_index", NDITEM,
-                          false, "get_global_id")
-MEMBER_CALL_FACTORY_ENTRY("cooperative_groups::__v1::thread_block.thread_index", NDITEM,
+MEMBER_CALL_FACTORY_ENTRY("cooperative_groups::__v1::thread_block.group_index", MemberExprBase(),
+                          false, "get_group_id")
+MEMBER_CALL_FACTORY_ENTRY("cooperative_groups::__v1::thread_block.thread_index", MemberExprBase(),
                           false, "get_local_id")
 #endif

--- a/clang/test/dpct/cooperative_groups2.cu
+++ b/clang/test/dpct/cooperative_groups2.cu
@@ -16,8 +16,8 @@ __device__ void foo() {
   // CHECK: auto block = item_ct1.get_group();
   auto block = cg::this_thread_block();
 
-  // CHECK: auto group_x = item_ct1.get_global_id()[2];
-  // CHECK-NEXT: auto thread_x = item_ct1.get_local_id()[2];
+  // CHECK: auto group_x = block.get_group_id()[2];
+  // CHECK-NEXT: auto thread_x = block.get_local_id()[2];
   auto group_x = block.group_index().x;
   auto thread_x = block.thread_index().x;
 

--- a/clang/test/dpct/cooperative_groups_thread_group.cu
+++ b/clang/test/dpct/cooperative_groups_thread_group.cu
@@ -22,13 +22,13 @@ __device__ void testThreadGroup(cg::thread_group g) {
   g.size();
 
   auto block = cg::this_thread_block();
-  // CHECK: item_ct1.get_local_id();
+  // CHECK: block.get_local_id();
   block.thread_index();
 }
 
 __global__ void kernelFunc() {
   auto block = cg::this_thread_block();
-  // CHECK: item_ct1.get_local_id();
+  // CHECK: block.get_local_id();
   block.thread_index();
   // CHECK:  auto threadBlockGroup = sycl::ext::oneapi::experimental::this_group<3>();
   auto threadBlockGroup = cg::this_thread_block();

--- a/clang/test/dpct/cooperative_groups_thread_group_no_free_query.cu
+++ b/clang/test/dpct/cooperative_groups_thread_group_no_free_query.cu
@@ -24,13 +24,13 @@ __device__ void testThreadGroup(cg::thread_group g) {
   g.size();
 
   auto block = cg::this_thread_block();
-  // CHECK: item_ct1.get_local_id();
+  // CHECK: block.get_local_id();
   block.thread_index();
 }
 
 __global__ void kernelFunc() {
   auto block = cg::this_thread_block();
-  // CHECK: item_ct1.get_local_id();
+  // CHECK: block.get_local_id();
   block.thread_index();
   // CHECK:  auto threadBlockGroup = item_ct1.get_group();
   auto threadBlockGroup = cg::this_thread_block();


### PR DESCRIPTION
Signed-off-by: Bao, Di di.bao@intel.com 