### PR TITLE
[SYCLomatic] Resolve compilations errors and correctness issues in dpct::device_new and dpct::device_delete

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/memory.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/memory.h
@@ -269,52 +269,6 @@ public:
   } // required
 };
 
-template <typename T, sycl::access_mode Mode, typename Allocator>
-class device_pointer
-    : public device_pointer_base<T, Allocator,
-                                 device_pointer<T, Mode, Allocator>> {
-private:
-  using base_type = device_pointer_base<T, Allocator, device_pointer>;
-
-public:
-  using value_type = T;
-  using difference_type = std::make_signed<std::size_t>::type;
-  using pointer = T *;
-  using reference = T &;
-  using iterator_category = std::random_access_iterator_tag;
-  using is_hetero = std::true_type; // required
-  using is_passed_directly = std::false_type;
-  static constexpr sycl::access_mode mode = Mode; // required
-
-  device_pointer(sycl::buffer<T, 1> in, std::size_t i = 0) : base_type(in, i) {}
-#ifdef __USE_DPCT
-  template <typename OtherT> device_pointer(OtherT *ptr) : base_type(ptr) {}
-#endif
-  // needed for malloc_device, count is number of bytes to allocate
-  device_pointer(const std::size_t count) : base_type(count) {}
-  device_pointer() : base_type() {}
-  device_pointer(const device_pointer &in) : base_type(in) {}
-  device_pointer &operator+=(difference_type forward) {
-    this->idx += forward;
-    return *this;
-  }
-  device_pointer &operator-=(difference_type backward) {
-    this->idx -= backward;
-    return *this;
-  }
-  // include operators from base class
-  using base_type::operator++;
-  using base_type::operator--;
-  device_pointer &operator++() {
-    this->idx += 1;
-    return *this;
-  }
-  device_pointer &operator--() {
-    this->idx -= 1;
-    return *this;
-  }
-};
-
 template <sycl::access_mode Mode, typename Allocator>
 class device_pointer<void, Mode, Allocator>
     : public device_pointer_base<dpct::byte_t, Allocator,
@@ -349,6 +303,58 @@ public:
   device_pointer &operator-=(difference_type backward) {
     this->idx -= backward;
     return *this;
+  }
+  // include operators from base class
+  using base_type::operator++;
+  using base_type::operator--;
+  device_pointer &operator++() {
+    this->idx += 1;
+    return *this;
+  }
+  device_pointer &operator--() {
+    this->idx -= 1;
+    return *this;
+  }
+};
+
+template <typename T, sycl::access_mode Mode, typename Allocator>
+class device_pointer
+    : public device_pointer_base<T, Allocator,
+                                 device_pointer<T, Mode, Allocator>> {
+private:
+  using base_type = device_pointer_base<T, Allocator, device_pointer>;
+
+public:
+  using value_type = T;
+  using difference_type = std::make_signed<std::size_t>::type;
+  using pointer = T *;
+  using reference = T &;
+  using iterator_category = std::random_access_iterator_tag;
+  using is_hetero = std::true_type; // required
+  using is_passed_directly = std::false_type;
+  static constexpr sycl::access_mode mode = Mode; // required
+
+  device_pointer(sycl::buffer<T, 1> in, std::size_t i = 0) : base_type(in, i) {}
+#ifdef __USE_DPCT
+  template <typename OtherT> device_pointer(OtherT *ptr) : base_type(ptr) {}
+#endif
+  // needed for malloc_device, count is number of bytes to allocate
+  device_pointer(const std::size_t count) : base_type(count) {}
+  device_pointer() : base_type() {}
+  device_pointer(const device_pointer &in) : base_type(in) {}
+  device_pointer &operator+=(difference_type forward) {
+    this->idx += forward;
+    return *this;
+  }
+  device_pointer &operator-=(difference_type backward) {
+    this->idx -= backward;
+    return *this;
+  }
+  operator device_pointer<void>() {
+    auto converted_buf = (this->buffer)
+                             .template reinterpret<dpct::byte_t>(sycl::range<1>(
+                                 sizeof(value_type) * this->buffer.size()));
+    return device_pointer<void>(converted_buf, this->idx);
   }
   // include operators from base class
   using base_type::operator++;
@@ -406,51 +412,6 @@ public:
   difference_type operator-(const Derived &it) const { return ptr - it.ptr; }
 };
 
-template <typename T>
-class device_pointer : public device_pointer_base<T, device_pointer<T>> {
-private:
-  using base_type = device_pointer_base<T, device_pointer<T>>;
-
-public:
-  using value_type = T;
-  using difference_type = std::make_signed<std::size_t>::type;
-  using pointer = T *;
-  using reference = T &;
-  using const_reference = const T &;
-  using iterator_category = std::random_access_iterator_tag;
-  using is_hetero = std::false_type;         // required
-  using is_passed_directly = std::true_type; // required
-
-  device_pointer(T *p) : base_type(p) {}
-  // needed for malloc_device, count is number of bytes to allocate
-  device_pointer(const std::size_t count) : base_type(count) {}
-  device_pointer() : base_type() {}
-  device_pointer &operator=(const device_iterator<T> &in) {
-    this->ptr = static_cast<device_pointer<T>>(in).ptr;
-    return *this;
-  }
-
-  // include operators from base class
-  using base_type::operator++;
-  using base_type::operator--;
-  device_pointer &operator++() {
-    ++(this->ptr);
-    return *this;
-  }
-  device_pointer &operator--() {
-    --(this->ptr);
-    return *this;
-  }
-  device_pointer &operator+=(difference_type forward) {
-    this->ptr = this->ptr + forward;
-    return *this;
-  }
-  device_pointer &operator-=(difference_type backward) {
-    this->ptr = this->ptr - backward;
-    return *this;
-  }
-};
-
 template <>
 class device_pointer<void>
     : public device_pointer_base<dpct::byte_t, device_pointer<void>> {
@@ -475,6 +436,53 @@ public:
   operator void *() { return this->ptr; }
   operator void *() const { return this->ptr; }
 
+  // include operators from base class
+  using base_type::operator++;
+  using base_type::operator--;
+  device_pointer &operator++() {
+    ++(this->ptr);
+    return *this;
+  }
+  device_pointer &operator--() {
+    --(this->ptr);
+    return *this;
+  }
+  device_pointer &operator+=(difference_type forward) {
+    this->ptr = this->ptr + forward;
+    return *this;
+  }
+  device_pointer &operator-=(difference_type backward) {
+    this->ptr = this->ptr - backward;
+    return *this;
+  }
+};
+
+template <typename T>
+class device_pointer : public device_pointer_base<T, device_pointer<T>> {
+private:
+  using base_type = device_pointer_base<T, device_pointer<T>>;
+
+public:
+  using value_type = T;
+  using difference_type = std::make_signed<std::size_t>::type;
+  using pointer = T *;
+  using reference = T &;
+  using const_reference = const T &;
+  using iterator_category = std::random_access_iterator_tag;
+  using is_hetero = std::false_type;         // required
+  using is_passed_directly = std::true_type; // required
+
+  device_pointer(T *p) : base_type(p) {}
+  // needed for malloc_device, count is number of bytes to allocate
+  device_pointer(const std::size_t count) : base_type(count) {}
+  device_pointer() : base_type() {}
+  device_pointer &operator=(const device_iterator<T> &in) {
+    this->ptr = static_cast<device_pointer<T>>(in).ptr;
+    return *this;
+  }
+  operator device_pointer<void>() {
+    return device_pointer<void>(static_cast<void *>(this->ptr));
+  }
   // include operators from base class
   using base_type::operator++;
   using base_type::operator--;
@@ -928,20 +936,16 @@ device_pointer<T> malloc_device(const std::size_t num_elements) {
 static inline device_pointer<void> malloc_device(const std::size_t num_bytes) {
   return device_pointer<void>(num_bytes);
 }
-template <typename T>
-device_pointer<T> device_new(device_pointer<::std::decay_t<T>> p,
-                             const T &value, const std::size_t count) {
-  ::std::uninitialized_fill(
-      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()), p,
-      p + count, value);
-  return p;
-}
 #ifdef DPCT_USM_LEVEL_NONE
 template <typename T>
 device_pointer<T> device_new(device_pointer<void> p, const T &value,
                              const std::size_t count) {
   auto converted_buf = p.buffer.template reinterpret<T>(sycl::range<1>(count));
-  return device_new(device_pointer<T>(converted_buf, p.idx), value, count);
+  ::std::uninitialized_fill(
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      oneapi::dpl::begin(converted_buf),
+      oneapi::dpl::end(converted_buf), value);
+  return device_pointer<T>(converted_buf, p.idx);
 }
 // buffer manages lifetime
 template <typename T> void free_device(device_pointer<T> ptr) {}
@@ -950,17 +954,15 @@ template <typename T>
 device_pointer<T> device_new(device_pointer<void> p, const T &value,
                              const std::size_t count = 1) {
   dpct::device_pointer<T> converted_p(static_cast<T *>(p.get()));
-  return device_new(converted_p, value, count);
+  ::std::uninitialized_fill(
+      oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+      converted_p, converted_p + count, value);
+  return converted_p;
 }
 template <typename T> void free_device(device_pointer<T> ptr) {
   sycl::free(ptr.get(), dpct::get_default_queue());
 }
 #endif
-template <typename T>
-device_pointer<T> device_new(device_pointer<::std::decay_t<T>> p,
-                             const std::size_t count = 1) {
-  return device_new(p, T{}, count);
-}
 template <typename T>
 device_pointer<T> device_new(device_pointer<void> p,
                              const std::size_t count = 1) {
@@ -968,7 +970,7 @@ device_pointer<T> device_new(device_pointer<void> p,
 }
 template <typename T>
 device_pointer<T> device_new(const std::size_t count = 1) {
-  return device_new(device_pointer<T>(sizeof(T) * count), T{}, count);
+  return device_new(device_pointer<void>(sizeof(T) * count), T{}, count);
 }
 
 template <typename T>


### PR DESCRIPTION
## Summary
This PR resolves identified compilation and correctness issues within `dpct::device_new` and `dpct::device_delete`. Furthermore, `dpct::device_free` is corrected to properly work in USM mode. A corresponding test PR is provided in [SYCLomatic-test #477](https://github.com/oneapi-src/SYCLomatic-test/pull/477)

## Details
The following bugs have been identified and resolved:

- A correct implementation for USM enabled mode is provided for `dpct::device_new`.
- The placement new `dpct::device_new` implementation now accepts an allocation passed as `dpct::device_pointer<void>`.
- For non-USM mode, `dpct::device_new` is made a friend function of `dpct::device_pointer` in order to access its protected members.
- `dpct::device_new` now constructs objects in allocated memory.
- `dpct::device_new` allocates the correct number of elements requested.
- `dpct::device_delete` now frees device memory in USM mode.
- `dpct::device_free` now frees device memory in USM mode.