### PR TITLE
[SYCLomatic] cuda backend Impl for cuda shfl_sync* functions.

### DIFF
--- a/clang/runtime/dpct-rt/include/util.hpp
+++ b/clang/runtime/dpct-rt/include/util.hpp
@@ -358,6 +358,35 @@ unsigned int match_all_over_sub_group(sycl::sub_group g, unsigned member_mask,
 }
 
 namespace experimental {
+
+#define CUDA_SHFL_SYNC(RES, MASK, VAL, SHFL_PARAM, C, SHUFFLE_INSTR)           \
+if constexpr (std::is_same_v<T, double>) {                                     \
+  int x_a, x_b;                                                                \
+  asm("mov.b64 {%0,%1},%2;" : "=r"(x_a), "=r"(x_b) : "d"(VAL));                \
+  auto tmp_a = __nvvm_shfl_sync_##SHUFFLE_INSTR(MASK, x_a, SHFL_PARAM, C);     \
+  auto tmp_b = __nvvm_shfl_sync_##SHUFFLE_INSTR(MASK, x_b, SHFL_PARAM, C);     \
+  asm("mov.b64 %0,{%1,%2};" : "=d"(RES) : "r"(tmp_a), "r"(tmp_b));             \
+} else if constexpr (std::is_same_v<T, long> ||                                \
+                     std::is_same_v<T, unsigned long>) {                       \
+  int x_a, x_b;                                                                \
+  asm("mov.b64 {%0,%1},%2;" : "=r"(x_a), "=r"(x_b) : "l"(VAL));                \
+  auto tmp_a = __nvvm_shfl_sync_##SHUFFLE_INSTR(MASK, x_a, SHFL_PARAM, C);     \
+  auto tmp_b = __nvvm_shfl_sync_##SHUFFLE_INSTR(MASK, x_b, SHFL_PARAM, C);     \
+  asm("mov.b64 %0,{%1,%2};" : "=l"(RES) : "r"(tmp_a), "r"(tmp_b));             \
+} else if constexpr (std::is_same_v<T, half>) {                                \
+  short tmp_b16;                                                               \
+  asm("mov.b16 %0,%1;" : "=h"(tmp_b16) : "h"(VAL));                            \
+  auto tmp_b32 = __nvvm_shfl_sync_##SHUFFLE_INSTR(                             \
+      MASK, static_cast<int>(tmp_b16), SHFL_PARAM, C);                         \
+  asm("mov.b16 %0,%1;" : "=h"(RES) : "h"(static_cast<short>(tmp_b32)));        \
+} else if constexpr (std::is_same_v<T, float>) {                               \
+  auto tmp_b32 = __nvvm_shfl_sync_##SHUFFLE_INSTR(                             \
+      MASK, __nvvm_bitcast_f2i(VAL), SHFL_PARAM, C);                           \
+  RES = __nvvm_bitcast_i2f(tmp_b32);                                           \
+} else {                                                                       \
+  RES = __nvvm_shfl_sync_##SHUFFLE_INSTR(MASK, VAL, SHFL_PARAM, C);            \
+}
+
 /// Masked version of select_from_sub_group, which execute masked sub-group
 /// operation. The parameter member_mask indicating the work-items participating
 /// the call. Whether the n-th bit is set to 1 representing whether the
@@ -375,13 +404,18 @@ template <typename T>
 T select_from_sub_group(unsigned int member_mask,
                         sycl::sub_group g, T x, int remote_local_id,
                         int logical_sub_group_size = 32) {
+#if defined(__SYCL_DEVICE_ONLY__) && defined(__INTEL_LLVM_COMPILER)
+#if defined(__SPIR__)
   unsigned int start_index =
       g.get_local_linear_id() / logical_sub_group_size * logical_sub_group_size;
   unsigned logical_remote_id =
       start_index + remote_local_id % logical_sub_group_size;
-#if defined(__SYCL_DEVICE_ONLY__) && defined(__INTEL_LLVM_COMPILER)
-#if defined(__SPIR__)
   return __spirv_GroupNonUniformShuffle(__spv::Scope::Subgroup, x, logical_remote_id);
+#elif defined(__NVPTX__)
+  T result;
+  int cVal = ((32 - logical_sub_group_size) << 8) | 31;
+  CUDA_SHFL_SYNC(result, member_mask, x, remote_local_id, cVal, idx_i32)
+  return result;
 #else
   throw sycl::exception(sycl::errc::runtime, "Masked version of select_from_sub_group "
                         "only supports SPIR-V backends.");
@@ -414,15 +448,20 @@ template <typename T>
 T shift_sub_group_left(unsigned int member_mask,
                        sycl::sub_group g, T x, unsigned int delta,
                        int logical_sub_group_size = 32) {
+#if defined(__SYCL_DEVICE_ONLY__) && defined(__INTEL_LLVM_COMPILER)
+#if defined(__SPIR__)
   unsigned int id = g.get_local_linear_id();
   unsigned int end_index =
       (id / logical_sub_group_size + 1) * logical_sub_group_size;
-#if defined(__SYCL_DEVICE_ONLY__) && defined(__INTEL_LLVM_COMPILER)
-#if defined(__SPIR__)
   T result = __spirv_GroupNonUniformShuffleDown(__spv::Scope::Subgroup, x, delta);
   if ((id + delta) >= end_index) {
     result = x;
   }
+  return result;
+#elif defined(__NVPTX__)
+  T result;
+  int cVal = ((32 - logical_sub_group_size) << 8) | 31;
+  CUDA_SHFL_SYNC(result, member_mask, x, delta, cVal, down_i32)
   return result;
 #else
   throw sycl::exception(sycl::errc::runtime, "Masked version of shift_sub_group_left "
@@ -456,15 +495,20 @@ template <typename T>
 T shift_sub_group_right(unsigned int member_mask,
                         sycl::sub_group g, T x, unsigned int delta,
                         int logical_sub_group_size = 32) {
+#if defined(__SYCL_DEVICE_ONLY__) && defined(__INTEL_LLVM_COMPILER)
+#if defined(__SPIR__)
   unsigned int id = g.get_local_linear_id();
   unsigned int start_index =
       id / logical_sub_group_size * logical_sub_group_size;
-#if defined(__SYCL_DEVICE_ONLY__) && defined(__INTEL_LLVM_COMPILER)
-#if defined(__SPIR__)
   T result = __spirv_GroupNonUniformShuffleUp(__spv::Scope::Subgroup, x, delta);
   if ((id - start_index) < delta) {
     result = x;
   }
+  return result;
+#elif defined(__NVPTX__)
+  T result;
+  int cVal = ((32 - logical_sub_group_size) << 8);
+  CUDA_SHFL_SYNC(result, member_mask, x, delta, cVal, up_i32)
   return result;
 #else
   throw sycl::exception(sycl::errc::runtime, "Masked version of shift_sub_group_right "
@@ -498,14 +542,19 @@ template <typename T>
 T permute_sub_group_by_xor(unsigned int member_mask,
                            sycl::sub_group g, T x, unsigned int mask,
                            int logical_sub_group_size = 32) {
+#if defined(__SYCL_DEVICE_ONLY__) && defined(__INTEL_LLVM_COMPILER)
+#if defined(__SPIR__)
   unsigned int id = g.get_local_linear_id();
   unsigned int start_index =
       id / logical_sub_group_size * logical_sub_group_size;
   unsigned int target_offset = (id % logical_sub_group_size) ^ mask;
   unsigned logical_remote_id = (target_offset < logical_sub_group_size) ? start_index + target_offset : id;
-#if defined(__SYCL_DEVICE_ONLY__) && defined(__INTEL_LLVM_COMPILER)
-#if defined(__SPIR__)
   return __spirv_GroupNonUniformShuffle(__spv::Scope::Subgroup, x, logical_remote_id);
+#elif defined(__NVPTX__)
+  T result;
+  int cVal = ((32 - logical_sub_group_size) << 8) | 31;
+  CUDA_SHFL_SYNC(result, member_mask, x, mask, cVal, bfly_i32)
+  return result;
 #else
   throw sycl::exception(sycl::errc::runtime, "Masked version of permute_sub_group_by_xor "
                         "only supports SPIR-V backends.");
@@ -520,6 +569,7 @@ T permute_sub_group_by_xor(unsigned int member_mask,
                         "supported on host device and none intel compiler.");
 #endif // __SYCL_DEVICE_ONLY__ && __INTEL_LLVM_COMPILER
 }
+#undef CUDA_SHFL_SYNC
 } // namespace experimental
 
 /// Computes the multiplication of two complex numbers.


### PR DESCRIPTION
////////////////////////////
**PR Summary**
////////////////////////////

The mapping already exists to dpct functions, so this is just filling in the missing impl for __NVPTX__.

This impl uses a MACRO CUDA_SHFL_SYNC that uses the "T" template param in calling functions to select the correct implementation for type "T". The MACRO calls the correct cuda shfl_sync* clang builtin depending on the "SHUFFLE_INSTR" input.

////////////////////////////
**Testing problems**
////////////////////////////


Following contributing guidelines I have tried to build / run SYCLomatic-test on this PR. However if I do
```
python3 run_test.py --suite features --option option_cuda_backend
```

I get something following this pattern for every test:

```
----------------------------
error: unknown target triple 'unknown'
dpct exited with code: 1 (Migration not necessary; no CUDA code detected)

NOTE: Could not auto-detect compilation database for file 'math-bf16-conv.cu' in '/home/jakirk/SYCLomatic-test/test_workspace/features/option_cuda_backend/math-bf16-conv' or any parent directory.
Parsing: /home/jakirk/SYCLomatic-test/test_workspace/features/option_cuda_backend/math-bf16-conv/math-bf16-conv.cu

----------------------
```

I looked at the scripts and it looks like in the cuda option it is setup so the correct triple is passed with these options. The scripts are quite complex and I could not work out easily what the issue is, so any advise is appreciated.

I could not even build the non backend specific test in SYCLomatic (that should not be affected by this patch):

```
ninja check-clang-c2s
``` 

fails at the end with
```
[1587/1588] Running lit suite /home/jack/mySyclomatic/SYCLomatic/clang/test/dpct
llvm-lit: /home/jack/mySyclomatic/SYCLomatic/llvm/utils/lit/lit/llvm/config.py:487: note: using clang: /home/jack/mySyclomatic/SYCLomatic/build/bin/clang
llvm-lit: /home/jack/mySyclomatic/SYCLomatic/llvm/utils/lit/lit/llvm/config.py:337: fatal: Could not turn '' into Itanium ABI triple
FAILED: tools/clang/test/CMakeFiles/check-clang-c2s /home/jack/mySyclomatic/SYCLomatic/build/tools/clang/test/CMakeFiles/check-clang-c2s 
cd /home/jack/mySyclomatic/SYCLomatic/build/tools/clang/test && /home/jack/bin/python3 /home/jack/mySyclomatic/SYCLomatic/build/./bin/llvm-lit -vv -a --param USE_Z3_SOLVER=0 dpct
ninja: build stopped: subcommand failed.
```

As I understand it from the python scripts I should open a PR in where I simply remove the lines

```
<optlevelRule excludeOptlevelNameString="cuda_backend" />
```

from the config files corresponding to the tests that call `shfl_sync*` functions: I believe "[sync_warp_p1](https://github.com/oneapi-src/SYCLomatic-test/tree/SYCLomatic/features/feature_case/sync_warp_p1)" and "[sync_warp_p2](https://github.com/oneapi-src/SYCLomatic-test/tree/SYCLomatic/features/feature_case/sync_warp_p2)" tests already have full coverage.

But I'd like to be able to check everything is working fine.
