### PR TITLE
[SYCLomatic] Fix two bug issues related to auto-generated build script

### DIFF
--- a/clang/test/dpct/ar_target/Makefile.dpct.ref
+++ b/clang/test/dpct/ar_target/Makefile.dpct.ref
@@ -24,8 +24,8 @@
 // CHECK:TARGET_1_SRC_2 = ./three.cpp
 // CHECK:TARGET_1_OBJ_2 = ./three.o
 // CHECK:TARGET_1_FLAG_2 = ${FLAGS}
-// CHECK:TARGET_0 := foo
-// CHECK:TARGET_1 := full.a
+// CHECK:TARGET_0 := ./foo
+// CHECK:TARGET_1 := ./full.a
 // CHECK:TARGET :=  ${TARGET_0} ${TARGET_1}
 // CHECK:.PHONY:all clean
 // CHECK:OBJS_0 :=  ${TARGET_0_OBJ_0} ${TARGET_0_OBJ_1}

--- a/clang/test/dpct/gen_build_script/Makefile.dpct.ref
+++ b/clang/test/dpct/gen_build_script/Makefile.dpct.ref
@@ -11,11 +11,11 @@
 // CHECK:INCLUDE_CL   := $(ROOT_DIR)/../include/sycl
 // CHECK:TARGET_0_SRC_0 = ./source/foo.dp.cpp
 // CHECK:TARGET_0_OBJ_0 = ./source/foo.dp.o
-// CHECK:TARGET_0_FLAG_0 = -std=c++20 ${FLAGS}
+// CHECK:TARGET_0_FLAG_0 = -std=c++20 -I. ${FLAGS}
 // CHECK:TARGET_0_SRC_1 = ./source/bar.cpp.dp.cpp
 // CHECK:TARGET_0_OBJ_1 = ./source/bar.cpp.dp.o
 // CHECK:TARGET_0_FLAG_1 = -std=c++17 -I $(INCLUDE_SYCL) -I $(INCLUDE_CL) ${FLAGS}
-// CHECK:TARGET_0 := app
+// CHECK:TARGET_0 := ./build/app
 // CHECK:TARGET :=  ${TARGET_0}
 // CHECK:.PHONY:all clean
 // CHECK:OBJS_0 :=  ${TARGET_0_OBJ_0} ${TARGET_0_OBJ_1}

--- a/clang/test/dpct/gen_build_script/foo.cu
+++ b/clang/test/dpct/gen_build_script/foo.cu
@@ -7,18 +7,18 @@
 // RUN: cd %T/build
 // RUN: echo "[" > compile_commands.json
 // RUN: echo "    {" >> compile_commands.json
-// RUN: echo "        \"command\": \"nvcc -c -std=c++20 -o /%T/build/objs/foo.cu.o /%T/source/foo.cu\"," >> compile_commands.json
+// RUN: echo "        \"command\": \"nvcc -c -std=c++20 -I %T -o %T/build/objs/foo.cu.o %T/source/foo.cu\"," >> compile_commands.json
 // RUN: echo "        \"directory\": \"/%T\"," >> compile_commands.json
-// RUN: echo "        \"file\": \"/%T/source/foo.cu\"" >> compile_commands.json
+// RUN: echo "        \"file\": \"%T/source/foo.cu\"" >> compile_commands.json
 // RUN: echo "    }," >> compile_commands.json
 // RUN: echo "    {" >> compile_commands.json
-// RUN: echo "        \"command\": \"g++ -c -std=c++11 -o /%T/build/objs/bar.cpp.dp.o /%T/source/bar.cpp\"," >> compile_commands.json
+// RUN: echo "        \"command\": \"g++ -c -std=c++11 -o %T/build/objs/bar.cpp.dp.o %T/source/bar.cpp\"," >> compile_commands.json
 // RUN: echo "        \"directory\": \"/%T\"," >> compile_commands.json
 // RUN: echo "        \"file\": \"/%T/source/bar.cpp\"" >> compile_commands.json
 // RUN: echo "    }," >> compile_commands.json
 // RUN: echo "    {" >> compile_commands.json
 // RUN: echo "        \"command\": \"ld objs/foo.cu.o objs/bar.cpp.dp.o -o app\"," >> compile_commands.json
-// RUN: echo "        \"directory\": \"/%T/build\"" >> compile_commands.json
+// RUN: echo "        \"directory\": \"%T/build\"" >> compile_commands.json
 // RUN: echo "    }" >> compile_commands.json
 // RUN: echo "]" >> compile_commands.json
 // RUN: cd %T


### PR DESCRIPTION
1. Fix issue of missing adding including path with "-I" option when working directory of including path is in-root directory
2. Fix issue that target binary is generated outside of out-root directory

Signed-off-by: chenwei.sun <chenwei.sun@intel.com>
