### PR TITLE
[SYCLomatic] Fix issue that cuda include path is missed when space exists between option "-I" and the include path in compilation database

### DIFF
--- a/clang/lib/Tooling/CommonOptionsParser.cpp
+++ b/clang/lib/Tooling/CommonOptionsParser.cpp
@@ -401,7 +401,7 @@ OPT_TYPE OPT_VAR(OPTION_NAME, __VA_ARGS__);
       std::vector<CompileCommand> CompileCommandsForFile =
           AdjustingCompilations->getCompileCommands(SourceFile);
       for (CompileCommand &CompileCommand : CompileCommandsForFile) {
-        bool IsIncludeOpt = false;
+        bool IsIncludeSearchPathOpt = false;
         for (auto &I : CompileCommand.CommandLine) {
           if (I.size() > 2 && I.substr(0, 2) == "-I") {
             std::string IncPath = I.substr(2);
@@ -410,10 +410,10 @@ OPT_TYPE OPT_VAR(OPTION_NAME, __VA_ARGS__);
               IncPath = IncPath.substr(StartPos);
             ExtraIncPathList.push_back(IncPath);
           } else if (I == "-I") {
-            IsIncludeOpt = true;
-          } else if (IsIncludeOpt) {
+            IsIncludeSearchPathOpt = true;
+          } else if (IsIncludeSearchPathOpt) {
             ExtraIncPathList.push_back(I);
-            IsIncludeOpt = false;
+            IsIncludeSearchPathOpt = false;
           }
         }
       }

--- a/clang/lib/Tooling/CommonOptionsParser.cpp
+++ b/clang/lib/Tooling/CommonOptionsParser.cpp
@@ -401,6 +401,7 @@ OPT_TYPE OPT_VAR(OPTION_NAME, __VA_ARGS__);
       std::vector<CompileCommand> CompileCommandsForFile =
           AdjustingCompilations->getCompileCommands(SourceFile);
       for (CompileCommand &CompileCommand : CompileCommandsForFile) {
+        bool IsIncludeOpt = false;
         for (auto &I : CompileCommand.CommandLine) {
           if (I.size() > 2 && I.substr(0, 2) == "-I") {
             std::string IncPath = I.substr(2);
@@ -408,6 +409,11 @@ OPT_TYPE OPT_VAR(OPTION_NAME, __VA_ARGS__);
             if (StartPos != std::string::npos)
               IncPath = IncPath.substr(StartPos);
             ExtraIncPathList.push_back(IncPath);
+          } else if (I == "-I") {
+            IsIncludeOpt = true;
+          } else if (IsIncludeOpt) {
+            ExtraIncPathList.push_back(I);
+            IsIncludeOpt = false;
           }
         }
       }


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>