### PR TITLE
[SYCLomatic] Cleanup dpct::tagged_pointer and dpct::release_temporary_allocation

### DIFF
--- a/clang/runtime/dpct-rt/include/dpl_extras/memory.h
+++ b/clang/runtime/dpct-rt/include/dpl_extras/memory.h
@@ -706,8 +706,7 @@ template <typename T, typename Tag> class tagged_pointer {
                 "tagged_pointer is not supported with DPCT_USM_LEVEL_NONE");
 };
 template <typename PolicyOrTag, typename Pointer>
-void release_temporary_allocation(PolicyOrTag &&policy_or_tag, Pointer ptr,
-                                  ::std::ptrdiff_t) {
+void release_temporary_allocation(PolicyOrTag &&policy_or_tag, Pointer ptr) {
   static_assert(
       false,
       "release_temporary_allocation is not supported with DPCT_USM_LEVEL_NONE");
@@ -925,8 +924,7 @@ auto get_temporary_allocation(PolicyOrTag &&policy_or_tag,
 }
 
 template <typename PolicyOrTag, typename Pointer>
-void release_temporary_allocation(PolicyOrTag &&policy_or_tag, Pointer ptr,
-                                  ::std::ptrdiff_t) {
+void release_temporary_allocation(PolicyOrTag &&policy_or_tag, Pointer ptr) {
   dpct::free(::std::forward<PolicyOrTag>(policy_or_tag), ptr);
 }
 #endif


### PR DESCRIPTION
This PR cleans up the function signatures of dpct::tagged_pointer and dpct::release_temporary_allocation to enable easier migration to these APIs by the SYCLomatic team.

Please note that these changes will cause SYCLomatic tests to fail until the corresponding test PR changes ([SYCLomatic-test #497](https://github.com/oneapi-src/SYCLomatic-test/pull/497)) are merged.