### PR TITLE
[SYCLomatic][part1] Implement cmake script migration framework

### DIFF
--- a/clang/include/clang/DPCT/DPCTOptions.inc
+++ b/clang/include/clang/DPCT/DPCTOptions.inc
@@ -389,10 +389,10 @@ DPCT_NON_ENUM_OPTION(DPCT_OPT_TYPE(llvm::cl::opt<std::string>), BuildScriptFile,
         llvm::cl::value_desc("file"), llvm::cl::cat(DPCTCat), llvm::cl::Optional)
 
 DPCT_NON_ENUM_OPTION(DPCT_OPT_TYPE(llvm::cl::opt<bool>), MigrateCmakeScript, "migrate-cmake-script",
-        llvm::cl::desc("migrate the cmakfile build script. Default: off."),
+        llvm::cl::desc("EXPERIMENTAL: Migrate the cmakfile build script. Default: off."),
         llvm::cl::cat(DPCTCat), llvm::cl::init(false))
 DPCT_NON_ENUM_OPTION(DPCT_OPT_TYPE(llvm::cl::opt<bool>), MigrateCmakeScriptOnly, "migrate-cmake-script-only",
-        llvm::cl::desc("Only migrate the cmakfile build script. Default: off."),
+        llvm::cl::desc("EXPERIMENTAL: Only migrate the cmakfile build script. Default: off."),
         llvm::cl::cat(DPCTCat), llvm::cl::init(false))
 
 DPCT_NON_ENUM_OPTION(DPCT_OPT_TYPE(static llvm::cl::list<std::string>), ExcludePathList, "in-root-exclude",

--- a/clang/include/clang/DPCT/DPCTOptions.inc
+++ b/clang/include/clang/DPCT/DPCTOptions.inc
@@ -388,6 +388,13 @@ DPCT_NON_ENUM_OPTION(DPCT_OPT_TYPE(llvm::cl::opt<std::string>), BuildScriptFile,
                     "Default name: Makefile.dpct."),
         llvm::cl::value_desc("file"), llvm::cl::cat(DPCTCat), llvm::cl::Optional)
 
+DPCT_NON_ENUM_OPTION(DPCT_OPT_TYPE(llvm::cl::opt<bool>), MigrateCmakeStript, "migrate-cmake-script",
+        llvm::cl::desc("migrate the cmakfile build script. Default: off."),
+        llvm::cl::cat(DPCTCat), llvm::cl::init(false))
+DPCT_NON_ENUM_OPTION(DPCT_OPT_TYPE(llvm::cl::opt<bool>), MigrateCmakeStriptOnly, "migrate-cmake-script-only",
+        llvm::cl::desc("Only migrate the cmakfile build script. Default: off."),
+        llvm::cl::cat(DPCTCat), llvm::cl::init(false))
+
 DPCT_NON_ENUM_OPTION(DPCT_OPT_TYPE(static llvm::cl::list<std::string>), ExcludePathList, "in-root-exclude",
         llvm::cl::desc("Excludes the specified directory or file from processing."),
         llvm::cl::value_desc("dir|file"), llvm::cl::cat(DPCTCat), llvm::cl::ZeroOrMore)

--- a/clang/include/clang/DPCT/DPCTOptions.inc
+++ b/clang/include/clang/DPCT/DPCTOptions.inc
@@ -388,10 +388,10 @@ DPCT_NON_ENUM_OPTION(DPCT_OPT_TYPE(llvm::cl::opt<std::string>), BuildScriptFile,
                     "Default name: Makefile.dpct."),
         llvm::cl::value_desc("file"), llvm::cl::cat(DPCTCat), llvm::cl::Optional)
 
-DPCT_NON_ENUM_OPTION(DPCT_OPT_TYPE(llvm::cl::opt<bool>), MigrateCmakeStript, "migrate-cmake-script",
+DPCT_NON_ENUM_OPTION(DPCT_OPT_TYPE(llvm::cl::opt<bool>), MigrateCmakeScript, "migrate-cmake-script",
         llvm::cl::desc("migrate the cmakfile build script. Default: off."),
         llvm::cl::cat(DPCTCat), llvm::cl::init(false))
-DPCT_NON_ENUM_OPTION(DPCT_OPT_TYPE(llvm::cl::opt<bool>), MigrateCmakeStriptOnly, "migrate-cmake-script-only",
+DPCT_NON_ENUM_OPTION(DPCT_OPT_TYPE(llvm::cl::opt<bool>), MigrateCmakeScriptOnly, "migrate-cmake-script-only",
         llvm::cl::desc("Only migrate the cmakfile build script. Default: off."),
         llvm::cl::cat(DPCTCat), llvm::cl::init(false))
 

--- a/clang/include/clang/Tooling/CommonOptionsParser.h
+++ b/clang/include/clang/Tooling/CommonOptionsParser.h
@@ -164,7 +164,6 @@ using FunPtrParserType = void (*)(std::string &, std::string &);
 void SetParserHandle(FunPtrParserType FPParser);
 void DoParserHandle(std::string &BuildDir, std::string &FilePath);
 #endif
-void SetMigrateCmakeScriptOnlyEnabled(bool Enable = true);
 #endif // SYCLomatic_CUSTOMIZATION
 
 }  // namespace tooling

--- a/clang/include/clang/Tooling/CommonOptionsParser.h
+++ b/clang/include/clang/Tooling/CommonOptionsParser.h
@@ -164,6 +164,7 @@ using FunPtrParserType = void (*)(std::string &, std::string &);
 void SetParserHandle(FunPtrParserType FPParser);
 void DoParserHandle(std::string &BuildDir, std::string &FilePath);
 #endif
+void SetMigrateCmakeScriptOnlyEnabled(bool Enable = true);
 #endif // SYCLomatic_CUSTOMIZATION
 
 }  // namespace tooling

--- a/clang/lib/DPCT/AnalysisInfo.cpp
+++ b/clang/lib/DPCT/AnalysisInfo.cpp
@@ -62,6 +62,8 @@ DPCTFormatStyle DpctGlobalInfo::FmtST = DPCTFormatStyle::FS_LLVM;
 std::set<ExplicitNamespace> DpctGlobalInfo::ExplicitNamespaceSet;
 bool DpctGlobalInfo::EnableCtad = false;
 bool DpctGlobalInfo::GenBuildScript = false;
+bool DpctGlobalInfo::MigrateCmakeScript = false;
+bool DpctGlobalInfo::MigrateCmakeScriptOnly = false;
 bool DpctGlobalInfo::EnableComments = false;
 bool DpctGlobalInfo::TempEnableDPCTNamespace = false;
 bool DpctGlobalInfo::IsMLKHeaderUsed = false;

--- a/clang/lib/DPCT/AnalysisInfo.h
+++ b/clang/lib/DPCT/AnalysisInfo.h
@@ -1112,6 +1112,18 @@ public:
   inline static void setGenBuildScriptEnabled(bool Enable = true) {
     GenBuildScript = Enable;
   }
+  inline static bool IsMigrateCmakeScriptEnabled() {
+    return MigrateCmakeScript;
+  }
+  inline static void setMigrateCmakeScriptEnabled(bool Enable = true) {
+    MigrateCmakeScript = Enable;
+  }
+  inline static bool IsMigrateCmakeScriptOnlyEnabled() {
+    return MigrateCmakeScriptOnly;
+  }
+  inline static void setMigrateCmakeScriptOnlyEnabled(bool Enable = true) {
+    MigrateCmakeScriptOnly = Enable;
+  }
   inline static bool isCommentsEnabled() { return EnableComments; }
   inline static void setCommentsEnabled(bool Enable = true) {
     EnableComments = Enable;
@@ -2041,6 +2053,8 @@ private:
   static bool EnableCtad;
   static bool IsMLKHeaderUsed;
   static bool GenBuildScript;
+  static bool MigrateCmakeScript;
+  static bool MigrateCmakeScriptOnly;
   static bool EnableComments;
   static std::string ClNamespace;
   static std::set<ExplicitNamespace> ExplicitNamespaceSet;

--- a/clang/lib/DPCT/CMakeLists.txt
+++ b/clang/lib/DPCT/CMakeLists.txt
@@ -156,6 +156,7 @@ add_clang_library(DPCT
   IncrementalMigrationUtility.cpp
   Rules.cpp
   PatternRewriter.cpp
+  MigrateCmakeScript.cpp
   Homoglyph.cpp
   MisleadingBidirectional.cpp
   BarrierFenceSpaceAnalyzer.cpp

--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -1248,7 +1248,8 @@ int runDPCT(int argc, const char **argv) {
                      DpctGlobalInfo::getAnalysisScope(),
                      AnalysisScope.getNumOccurrences());
 
-    if (clang::dpct::DpctGlobalInfo::isIncMigration()) {
+    if (!MigrateCmakeScriptOnly &&
+        clang::dpct::DpctGlobalInfo::isIncMigration()) {
       std::string Msg;
       if (!canContinueMigration(Msg)) {
         ShowStatus(MigrationErrorDifferentOptSet, Msg);

--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -72,7 +72,6 @@ using namespace clang::dpct;
 using namespace clang::tooling;
 
 using namespace llvm::cl;
-using namespace llvm;
 namespace path = llvm::sys::path;
 namespace fs = llvm::sys::fs;
 
@@ -584,8 +583,6 @@ static std::string getCmakeBuildPathFromInRoot(StringRef InRoot,
       if (fs::exists(OutDirectory + "/CMakeFiles") &&
           fs::exists(OutDirectory + "/CMakeCache.txt")) {
         CmakeBuildDirectory = OutDirectory.str().str();
-        printf("#### Found Cmake Build Directory [%s]\n",
-               CmakeBuildDirectory.c_str());
         break;
       }
     }
@@ -721,7 +718,6 @@ int runDPCT(int argc, const char **argv) {
   // Set function handle for libclangTooling to parse vcxproj file.
   clang::tooling::SetParserHandle(vcxprojParser);
 #endif
-
   llvm::cl::SetVersionPrinter(
       [](llvm::raw_ostream &OS) { OS << printCTVersion() << "\n"; });
   auto OptParser =
@@ -1278,9 +1274,6 @@ int runDPCT(int argc, const char **argv) {
   }
 
   if (MigrateCmakeScriptOnly) {
-    // for (auto Entry : RuleFile) {
-    //   printf("Entry [%s]\n", Entry.c_str());
-    // }
     auto CmakeScriptLists = OptParser->getSourcePathList();
     if (!CmakeScriptLists.empty()) {
       for (auto FilePath : CmakeScriptLists) {
@@ -1442,9 +1435,6 @@ int runDPCT(int argc, const char **argv) {
   ShowStatus(Status);
 
   if (MigrateCmakeScript) {
-    // check the input files should not be specified.
-    printf("Process cmake script migration for option --migrate-cmake-script "
-           "option\n");
     std::vector<std::string> CmakeScriptFiles;
     collectCmakeScripts(InRoot, OutRoot, CmakeScriptFiles);
     for (const auto &ScriptFile : CmakeScriptFiles) {

--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -72,6 +72,9 @@ using namespace clang::dpct;
 using namespace clang::tooling;
 
 using namespace llvm::cl;
+using namespace llvm;
+namespace path = llvm::sys::path;
+namespace fs = llvm::sys::fs;
 
 namespace clang {
 namespace tooling {
@@ -235,7 +238,6 @@ std::string getCudaInstallPath(int argc, const char **argv) {
   } else if (!CudaIncludeDetector.isVersionSupported()) {
     ShowStatus(MigrationErrorDetectedCudaVersionUnsupported);
     dpctExit(MigrationErrorDetectedCudaVersionUnsupported);
-
   }
 
   makeCanonical(Path);
@@ -542,6 +544,159 @@ void parseFormatStyle() {
   DpctGlobalInfo::setCodeFormatStyle(Style);
 }
 
+static std::string getCmakeBuildPathFromInRoot(StringRef InRoot,
+                                               StringRef OutRoot) {
+  std::error_code EC;
+
+  std::string CmakeBuildDirectory;
+  for (fs::recursive_directory_iterator Iter(Twine(InRoot), EC), End;
+       Iter != End; Iter.increment(EC)) {
+    if ((bool)EC) {
+      std::string ErrMsg = "[ERROR] Access : " + std::string(InRoot.str()) +
+                           " fail: " + EC.message() + "\n";
+      PrintMsg(ErrMsg);
+    }
+
+    auto FilePath = Iter->path();
+
+    // Skip output directory if it is in the in-root directory.
+    if (isChildOrSamePath(OutRoot.str(), FilePath))
+      continue;
+
+    bool IsHidden = false;
+    for (path::const_iterator PI = path::begin(FilePath),
+                              PE = path::end(FilePath);
+         PI != PE; ++PI) {
+      StringRef Comp = *PI;
+      if (Comp.startswith(".")) {
+        IsHidden = true;
+        break;
+      }
+    }
+    // Skip hidden folder or file whose name begins with ".".
+    if (IsHidden) {
+      continue;
+    }
+
+    if (Iter->type() == fs::file_type::directory_file) {
+      const auto Path = Iter->path();
+      SmallString<512> OutDirectory = llvm::StringRef(Path);
+      if (fs::exists(OutDirectory + "/CMakeFiles") &&
+          fs::exists(OutDirectory + "/CMakeCache.txt")) {
+        CmakeBuildDirectory = OutDirectory.str().str();
+        printf("#### Found Cmake Build Directory [%s]\n",
+               CmakeBuildDirectory.c_str());
+        break;
+      }
+    }
+  }
+  return CmakeBuildDirectory;
+}
+
+static void collectCmakeScripts(StringRef InRoot, StringRef OutRoot,
+                                std::vector<std::string> &CmakeScriptFiles) {
+  std::error_code EC;
+
+  std::string CmakeBuildDirectory =
+      getCmakeBuildPathFromInRoot(InRoot, OutRoot);
+  for (fs::recursive_directory_iterator Iter(Twine(InRoot), EC), End;
+       Iter != End; Iter.increment(EC)) {
+    if ((bool)EC) {
+      std::string ErrMsg = "[ERROR] Access : " + std::string(InRoot.str()) +
+                           " fail: " + EC.message() + "\n";
+      PrintMsg(ErrMsg);
+    }
+
+    auto FilePath = Iter->path();
+
+    // Skip output directory if it is in the in-root directory.
+    if (isChildOrSamePath(OutRoot.str(), FilePath))
+      continue;
+
+    // Skip cmake build directory if it is in the in-root directory.
+    if (!CmakeBuildDirectory.empty() &&
+        isChildOrSamePath(CmakeBuildDirectory, FilePath))
+      continue;
+
+    bool IsHidden = false;
+    for (path::const_iterator PI = path::begin(FilePath),
+                              PE = path::end(FilePath);
+         PI != PE; ++PI) {
+      StringRef Comp = *PI;
+      if (Comp.startswith(".")) {
+        IsHidden = true;
+        break;
+      }
+    }
+    // Skip hidden folder or file whose name begins with ".".
+    if (IsHidden) {
+      continue;
+    }
+
+    if (Iter->type() == fs::file_type::regular_file) {
+      SmallString<512> OutputFile = llvm::StringRef(FilePath);
+
+      llvm::StringRef Name = llvm::sys::path::filename(FilePath);
+      if (Name == "CMakeLists.txt" || Name.ends_with(".cmake")) {
+        CmakeScriptFiles.push_back(OutputFile.str().str());
+      }
+    }
+  }
+}
+
+static std::string readFile(const std::string &Name) {
+  std::ifstream Stream(Name, std::ios::in | std::ios::binary);
+  std::string Contents((std::istreambuf_iterator<char>(Stream)),
+                       (std::istreambuf_iterator<char>()));
+  return Contents;
+}
+
+static bool migrateCmakeScriptFile(StringRef InRoot, StringRef OutRoot,
+                                   std::string InFileName) {
+  makeCanonical(InFileName);
+  SmallString<512> OutFileName = llvm::StringRef(InFileName);
+  if (!rewriteDir(OutFileName, InRoot, OutRoot)) {
+    return false;
+  }
+  auto Parent = path::parent_path(OutFileName);
+  std::error_code EC;
+  EC = fs::create_directories(Parent);
+  if ((bool)EC) {
+    std::string ErrMsg =
+        "[ERROR] Create Directory : " + std::string(Parent.str()) +
+        " fail: " + EC.message() + "\n";
+    PrintMsg(ErrMsg);
+  }
+  printf("### OutputFile: [%s]\n", OutFileName.c_str());
+  std::ofstream Out(OutFileName.c_str(), std::ios::binary);
+  if (Out.fail()) {
+    std::string ErrMsg =
+        "[ERROR] Create file : " + std::string(OutFileName.c_str()) +
+        " failure!\n";
+    PrintMsg(ErrMsg);
+  }
+
+  llvm::raw_os_ostream Stream(Out);
+  applyPatternRewriterToCmakeScriptFile(readFile(InFileName), Stream);
+
+  Stream.flush();
+  Out.close();
+  return true;
+}
+
+static bool
+cmakeScriptFileSpecified(const std::vector<std::string> &SourceFiles) {
+  bool IsCmakeScript = false;
+  for (const auto &FilePath : SourceFiles) {
+    if (!llvm::sys::path::has_extension(FilePath) ||
+        llvm::sys::path::filename(FilePath).ends_with(".cmake") ||
+        llvm::sys::path::filename(FilePath).ends_with(".txt"))
+      IsCmakeScript = true;
+    break;
+  }
+  return IsCmakeScript;
+}
+
 int runDPCT(int argc, const char **argv) {
 
   if (argc < 2) {
@@ -567,6 +722,7 @@ int runDPCT(int argc, const char **argv) {
   // Set function handle for libclangTooling to parse vcxproj file.
   clang::tooling::SetParserHandle(vcxprojParser);
 #endif
+
   llvm::cl::SetVersionPrinter(
       [](llvm::raw_ostream &OS) { OS << printCTVersion() << "\n"; });
   auto OptParser =
@@ -655,7 +811,8 @@ int runDPCT(int argc, const char **argv) {
     dpctExit(MigrationErrorPathTooLong);
   }
   if (AnalysisScope.size() >= MAX_PATH_LEN - 1) {
-    DpctLog() << "Error: --analysis-scope-path '" << AnalysisScope << "' is too long\n";
+    DpctLog() << "Error: --analysis-scope-path '" << AnalysisScope
+              << "' is too long\n";
     ShowStatus(MigrationErrorPathTooLong);
     dpctExit(MigrationErrorPathTooLong);
   }
@@ -708,13 +865,41 @@ int runDPCT(int argc, const char **argv) {
     dpctExit(MigrationErrorInvalidInRootOrOutRoot);
   }
 
-  int ValidPath = validatePaths(InRoot, OptParser->getSourcePathList());
-  if (ValidPath == -1) {
-    ShowStatus(MigrationErrorInvalidInRootPath);
-    dpctExit(MigrationErrorInvalidInRootPath);
-  } else if (ValidPath == -2) {
-    ShowStatus(MigrationErrorNoFileTypeAvail);
-    dpctExit(MigrationErrorNoFileTypeAvail);
+  if (!MigrateCmakeScriptOnly) {
+    int ValidPath = validatePaths(InRoot, OptParser->getSourcePathList());
+    if (ValidPath == -1) {
+      ShowStatus(MigrationErrorInvalidInRootPath);
+      dpctExit(MigrationErrorInvalidInRootPath);
+    } else if (ValidPath == -2) {
+      ShowStatus(MigrationErrorNoFileTypeAvail);
+      dpctExit(MigrationErrorNoFileTypeAvail);
+    }
+
+    if (cmakeScriptFileSpecified(OptParser->getSourcePathList())) {
+      ShowStatus(MigrateCmakeScriptOnlyNotSpecifed);
+      dpctExit(MigrateCmakeScriptOnlyNotSpecifed);
+    }
+
+  } else {
+    // To validate the path of cmake file script or directory
+    int ValidPath =
+        validateCmakeScriptPaths(InRoot, OptParser->getSourcePathList());
+    if (ValidPath == -1) {
+      ShowStatus(MigrationErrorInvalidInRootPath);
+      dpctExit(MigrationErrorInvalidInRootPath);
+    } else if (ValidPath < -1) {
+      ShowStatus(MigrationErrorCMakeScriptPathInvalid);
+      dpctExit(MigrationErrorCMakeScriptPathInvalid);
+    }
+  }
+
+  if (MigrateCmakeScript && !OptParser->getSourcePathList().empty()) {
+    ShowStatus(MigarteCmakeScriptIncorrectUse);
+    dpctExit(MigarteCmakeScriptIncorrectUse);
+  }
+  if (MigrateCmakeScript && MigrateCmakeScriptOnly) {
+    ShowStatus(MigarteCmakeScriptAndMigarteCmakeScriptOnlyBothUse);
+    dpctExit(MigarteCmakeScriptAndMigarteCmakeScriptOnlyBothUse);
   }
 
   int SDKIncPathRes =
@@ -945,8 +1130,8 @@ int runDPCT(int argc, const char **argv) {
   DpctGlobalInfo::setFormatStyle(FormatST);
   DpctGlobalInfo::setCtadEnabled(EnableCTAD);
   DpctGlobalInfo::setGenBuildScriptEnabled(GenBuildScript);
-  DpctGlobalInfo::setMigrateCmakeScriptEnabled(MigrateCmakeStript);
-  DpctGlobalInfo::setMigrateCmakeScriptOnlyEnabled(MigrateCmakeStriptOnly);
+  DpctGlobalInfo::setMigrateCmakeScriptEnabled(MigrateCmakeScript);
+  DpctGlobalInfo::setMigrateCmakeScriptOnlyEnabled(MigrateCmakeScriptOnly);
   DpctGlobalInfo::setCommentsEnabled(EnableComments);
   DpctGlobalInfo::setHelperFuncPreferenceFlag(Preferences.getBits());
   DpctGlobalInfo::setUsingDRYPattern(!NoDRYPatternFlag);
@@ -1056,8 +1241,8 @@ int runDPCT(int argc, const char **argv) {
     setValueToOptMap(clang::dpct::OPTION_OptimizeMigration,
                      OptimizeMigration.getValue(),
                      OptimizeMigration.getNumOccurrences());
-    setValueToOptMap(clang::dpct::OPTION_EnablepProfiling,
-                     EnablepProfilingFlag, EnablepProfilingFlag);
+    setValueToOptMap(clang::dpct::OPTION_EnablepProfiling, EnablepProfilingFlag,
+                     EnablepProfilingFlag);
     setValueToOptMap(clang::dpct::OPTION_RuleFile, MetaRuleObject::RuleFiles,
                      RuleFile.getNumOccurrences());
     setValueToOptMap(clang::dpct::OPTION_AnalysisScopePath,
@@ -1090,6 +1275,36 @@ int runDPCT(int argc, const char **argv) {
 
   if (DpctGlobalInfo::getFormatRange() != clang::format::FormatRange::none) {
     parseFormatStyle();
+  }
+
+  if (MigrateCmakeScriptOnly) {
+    for (auto Entry : RuleFile) {
+      printf("Entry [%s]\n", Entry.c_str());
+    }
+    auto CmakeScriptLists = OptParser->getSourcePathList();
+    if (!CmakeScriptLists.empty()) {
+      for (auto FilePath : CmakeScriptLists) {
+        if (fs::is_directory(FilePath)) {
+          std::vector<std::string> CmakeScriptFiles;
+          collectCmakeScripts(FilePath, OutRoot, CmakeScriptFiles);
+          for (const auto &ScriptFile : CmakeScriptFiles) {
+            if (!migrateCmakeScriptFile(InRoot, OutRoot, ScriptFile))
+              continue;
+          }
+        } else {
+          if (!migrateCmakeScriptFile(InRoot, OutRoot, FilePath))
+            continue;
+        }
+      }
+    } else {
+      std::vector<std::string> CmakeScriptFiles;
+      collectCmakeScripts(InRoot, OutRoot, CmakeScriptFiles);
+      for (const auto &ScriptFile : CmakeScriptFiles) {
+        if (!migrateCmakeScriptFile(InRoot, OutRoot, ScriptFile))
+          continue;
+      }
+    }
+    return MigrationSucceeded;
   }
 
   volatile int RunCount = 0;
@@ -1225,6 +1440,18 @@ int runDPCT(int argc, const char **argv) {
   // if run was successful
   int Status = saveNewFiles(Tool, InRoot, OutRoot);
   ShowStatus(Status);
+
+  if (MigrateCmakeScript) {
+    // check the input files should not be specified.
+    printf("Process cmake script migration for option --migrate-cmake-script "
+           "option\n");
+    std::vector<std::string> CmakeScriptFiles;
+    collectCmakeScripts(InRoot, OutRoot, CmakeScriptFiles);
+    for (const auto &ScriptFile : CmakeScriptFiles) {
+      if (!migrateCmakeScriptFile(InRoot, OutRoot, ScriptFile))
+        continue;
+    }
+  }
 
   DumpOutputFile();
   return Status;

--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -667,7 +667,6 @@ static bool migrateCmakeScriptFile(StringRef InRoot, StringRef OutRoot,
         " fail: " + EC.message() + "\n";
     PrintMsg(ErrMsg);
   }
-  printf("### OutputFile: [%s]\n", OutFileName.c_str());
   std::ofstream Out(OutFileName.c_str(), std::ios::binary);
   if (Out.fail()) {
     std::string ErrMsg =
@@ -1278,9 +1277,9 @@ int runDPCT(int argc, const char **argv) {
   }
 
   if (MigrateCmakeScriptOnly) {
-    for (auto Entry : RuleFile) {
-      printf("Entry [%s]\n", Entry.c_str());
-    }
+    // for (auto Entry : RuleFile) {
+    //   printf("Entry [%s]\n", Entry.c_str());
+    // }
     auto CmakeScriptLists = OptParser->getSourcePathList();
     if (!CmakeScriptLists.empty()) {
       for (auto FilePath : CmakeScriptLists) {

--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -945,6 +945,8 @@ int runDPCT(int argc, const char **argv) {
   DpctGlobalInfo::setFormatStyle(FormatST);
   DpctGlobalInfo::setCtadEnabled(EnableCTAD);
   DpctGlobalInfo::setGenBuildScriptEnabled(GenBuildScript);
+  DpctGlobalInfo::setMigrateCmakeScriptEnabled(MigrateCmakeStript);
+  DpctGlobalInfo::setMigrateCmakeScriptOnlyEnabled(MigrateCmakeStriptOnly);
   DpctGlobalInfo::setCommentsEnabled(EnableComments);
   DpctGlobalInfo::setHelperFuncPreferenceFlag(Preferences.getBits());
   DpctGlobalInfo::setUsingDRYPattern(!NoDRYPatternFlag);

--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -29,6 +29,7 @@
 #include "Utility.h"
 #include "ValidateArguments.h"
 #include "VcxprojParser.h"
+#include "MigrateCmakeScript.h"
 #include "clang/AST/ASTConsumer.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/Format/Format.h"
@@ -72,8 +73,6 @@ using namespace clang::dpct;
 using namespace clang::tooling;
 
 using namespace llvm::cl;
-namespace path = llvm::sys::path;
-namespace fs = llvm::sys::fs;
 
 namespace clang {
 namespace tooling {
@@ -543,156 +542,6 @@ void parseFormatStyle() {
   DpctGlobalInfo::setCodeFormatStyle(Style);
 }
 
-static std::string getCmakeBuildPathFromInRoot(StringRef InRoot,
-                                               StringRef OutRoot) {
-  std::error_code EC;
-
-  std::string CmakeBuildDirectory;
-  for (fs::recursive_directory_iterator Iter(Twine(InRoot), EC), End;
-       Iter != End; Iter.increment(EC)) {
-    if ((bool)EC) {
-      std::string ErrMsg = "[ERROR] Access : " + std::string(InRoot.str()) +
-                           " fail: " + EC.message() + "\n";
-      PrintMsg(ErrMsg);
-    }
-
-    auto FilePath = Iter->path();
-
-    // Skip output directory if it is in the in-root directory.
-    if (isChildOrSamePath(OutRoot.str(), FilePath))
-      continue;
-
-    bool IsHidden = false;
-    for (path::const_iterator PI = path::begin(FilePath),
-                              PE = path::end(FilePath);
-         PI != PE; ++PI) {
-      StringRef Comp = *PI;
-      if (Comp.startswith(".")) {
-        IsHidden = true;
-        break;
-      }
-    }
-    // Skip hidden folder or file whose name begins with ".".
-    if (IsHidden) {
-      continue;
-    }
-
-    if (Iter->type() == fs::file_type::directory_file) {
-      const auto Path = Iter->path();
-      SmallString<512> OutDirectory = llvm::StringRef(Path);
-      if (fs::exists(OutDirectory + "/CMakeFiles") &&
-          fs::exists(OutDirectory + "/CMakeCache.txt")) {
-        CmakeBuildDirectory = OutDirectory.str().str();
-        break;
-      }
-    }
-  }
-  return CmakeBuildDirectory;
-}
-
-static void collectCmakeScripts(StringRef InRoot, StringRef OutRoot,
-                                std::vector<std::string> &CmakeScriptFiles) {
-  std::error_code EC;
-
-  std::string CmakeBuildDirectory =
-      getCmakeBuildPathFromInRoot(InRoot, OutRoot);
-  for (fs::recursive_directory_iterator Iter(Twine(InRoot), EC), End;
-       Iter != End; Iter.increment(EC)) {
-    if ((bool)EC) {
-      std::string ErrMsg = "[ERROR] Access : " + std::string(InRoot.str()) +
-                           " fail: " + EC.message() + "\n";
-      PrintMsg(ErrMsg);
-    }
-
-    auto FilePath = Iter->path();
-
-    // Skip output directory if it is in the in-root directory.
-    if (isChildOrSamePath(OutRoot.str(), FilePath))
-      continue;
-
-    // Skip cmake build directory if it is in the in-root directory.
-    if (!CmakeBuildDirectory.empty() &&
-        isChildOrSamePath(CmakeBuildDirectory, FilePath))
-      continue;
-
-    bool IsHidden = false;
-    for (path::const_iterator PI = path::begin(FilePath),
-                              PE = path::end(FilePath);
-         PI != PE; ++PI) {
-      StringRef Comp = *PI;
-      if (Comp.startswith(".")) {
-        IsHidden = true;
-        break;
-      }
-    }
-    // Skip hidden folder or file whose name begins with ".".
-    if (IsHidden) {
-      continue;
-    }
-
-    if (Iter->type() == fs::file_type::regular_file) {
-      SmallString<512> OutputFile = llvm::StringRef(FilePath);
-
-      llvm::StringRef Name = llvm::sys::path::filename(FilePath);
-      if (Name == "CMakeLists.txt" || Name.ends_with(".cmake")) {
-        CmakeScriptFiles.push_back(OutputFile.str().str());
-      }
-    }
-  }
-}
-
-static std::string readFile(const std::string &Name) {
-  std::ifstream Stream(Name, std::ios::in | std::ios::binary);
-  std::string Contents((std::istreambuf_iterator<char>(Stream)),
-                       (std::istreambuf_iterator<char>()));
-  return Contents;
-}
-
-static bool migrateCmakeScriptFile(StringRef InRoot, StringRef OutRoot,
-                                   std::string InFileName) {
-  makeCanonical(InFileName);
-  SmallString<512> OutFileName = llvm::StringRef(InFileName);
-  if (!rewriteDir(OutFileName, InRoot, OutRoot)) {
-    return false;
-  }
-  auto Parent = path::parent_path(OutFileName);
-  std::error_code EC;
-  EC = fs::create_directories(Parent);
-  if ((bool)EC) {
-    std::string ErrMsg =
-        "[ERROR] Create Directory : " + std::string(Parent.str()) +
-        " fail: " + EC.message() + "\n";
-    PrintMsg(ErrMsg);
-  }
-  std::ofstream Out(OutFileName.c_str(), std::ios::binary);
-  if (Out.fail()) {
-    std::string ErrMsg =
-        "[ERROR] Create file : " + std::string(OutFileName.c_str()) +
-        " failure!\n";
-    PrintMsg(ErrMsg);
-  }
-
-  llvm::raw_os_ostream Stream(Out);
-  applyPatternRewriterToCmakeScriptFile(readFile(InFileName), Stream);
-
-  Stream.flush();
-  Out.close();
-  return true;
-}
-
-static bool
-cmakeScriptFileSpecified(const std::vector<std::string> &SourceFiles) {
-  bool IsCmakeScript = false;
-  for (const auto &FilePath : SourceFiles) {
-    if (!llvm::sys::path::has_extension(FilePath) ||
-        llvm::sys::path::filename(FilePath).ends_with(".cmake") ||
-        llvm::sys::path::filename(FilePath).ends_with(".txt"))
-      IsCmakeScript = true;
-    break;
-  }
-  return IsCmakeScript;
-}
-
 int runDPCT(int argc, const char **argv) {
 
   if (argc < 2) {
@@ -806,8 +655,7 @@ int runDPCT(int argc, const char **argv) {
     dpctExit(MigrationErrorPathTooLong);
   }
   if (AnalysisScope.size() >= MAX_PATH_LEN - 1) {
-    DpctLog() << "Error: --analysis-scope-path '" << AnalysisScope
-              << "' is too long\n";
+    DpctLog() << "Error: --analysis-scope-path '" << AnalysisScope << "' is too long\n";
     ShowStatus(MigrationErrorPathTooLong);
     dpctExit(MigrationErrorPathTooLong);
   }
@@ -1274,29 +1122,7 @@ int runDPCT(int argc, const char **argv) {
   }
 
   if (MigrateCmakeScriptOnly) {
-    auto CmakeScriptLists = OptParser->getSourcePathList();
-    if (!CmakeScriptLists.empty()) {
-      for (auto FilePath : CmakeScriptLists) {
-        if (fs::is_directory(FilePath)) {
-          std::vector<std::string> CmakeScriptFiles;
-          collectCmakeScripts(FilePath, OutRoot, CmakeScriptFiles);
-          for (const auto &ScriptFile : CmakeScriptFiles) {
-            if (!migrateCmakeScriptFile(InRoot, OutRoot, ScriptFile))
-              continue;
-          }
-        } else {
-          if (!migrateCmakeScriptFile(InRoot, OutRoot, FilePath))
-            continue;
-        }
-      }
-    } else {
-      std::vector<std::string> CmakeScriptFiles;
-      collectCmakeScripts(InRoot, OutRoot, CmakeScriptFiles);
-      for (const auto &ScriptFile : CmakeScriptFiles) {
-        if (!migrateCmakeScriptFile(InRoot, OutRoot, ScriptFile))
-          continue;
-      }
-    }
+    migrateCmakeScriptOnly(OptParser, InRoot, OutRoot);
     return MigrationSucceeded;
   }
 

--- a/clang/lib/DPCT/Error.cpp
+++ b/clang/lib/DPCT/Error.cpp
@@ -183,6 +183,21 @@ void ShowStatus(int Status, std::string Message) {
   case InterceptBuildError:
     StatusString = "Error: Call to intercept-build failed";
     break;
+  case MigrationErrorCMakeScriptPathInvalid:
+    StatusString = "Error: Cmake Script Path invalid.\n";
+    break;
+  case MigrateCmakeScriptOnlyNotSpecifed:
+    StatusString = "Error: option '-migrate-cmake-script-only' is not specified "
+                   "for cmake script migartion.\n";
+    break;
+  case MigarteCmakeScriptIncorrectUse:
+    StatusString = "Error: option '-migrate-cmake-script' is only used for "
+                   "whole project code migration.\n";
+    break;
+  case MigarteCmakeScriptAndMigarteCmakeScriptOnlyBothUse:
+    StatusString = "Error: option '-migrate-cmake-script' and "
+                   "'-migrate-cmake-script-only' cannot be used together.\n";
+    break;
   default:
     DpctLog() << "Unknown error\n";
     dpctExit(-1);

--- a/clang/lib/DPCT/Error.cpp
+++ b/clang/lib/DPCT/Error.cpp
@@ -184,7 +184,7 @@ void ShowStatus(int Status, std::string Message) {
     StatusString = "Error: Call to intercept-build failed";
     break;
   case MigrationErrorCMakeScriptPathInvalid:
-    StatusString = "Error: Cmake Script Path invalid.\n";
+    StatusString = "Error: Path of Cmake Script is invalid.\n";
     break;
   case MigrateCmakeScriptOnlyNotSpecifed:
     StatusString = "Error: option '-migrate-cmake-script-only' is not specified "

--- a/clang/lib/DPCT/Error.h
+++ b/clang/lib/DPCT/Error.h
@@ -58,6 +58,10 @@ enum ProcessStatus {
   MigrationErrorAPIMappingNoCUDAHeader = -45,
   MigrationErrorCannotDetectCudaPath = -46,
   InterceptBuildError = -47,
+  MigrationErrorCMakeScriptPathInvalid = -48,
+  MigrateCmakeScriptOnlyNotSpecifed = -49,
+  MigarteCmakeScriptIncorrectUse = -50,
+  MigarteCmakeScriptAndMigarteCmakeScriptOnlyBothUse= -51,
 };
 
 namespace clang {

--- a/clang/lib/DPCT/MigrateCmakeScript.cpp
+++ b/clang/lib/DPCT/MigrateCmakeScript.cpp
@@ -1,0 +1,202 @@
+//===--------------- MigrateCmakeScript.cpp--------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#include "MigrateCmakeScript.h"
+#include "SaveNewFiles.h"
+#include "Statics.h"
+#include "Utility.h"
+
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
+
+#include <algorithm>
+#include <cstring>
+#include <fstream>
+#include <string>
+
+using namespace clang::dpct;
+using namespace llvm::cl;
+
+namespace path = llvm::sys::path;
+namespace fs = llvm::sys::fs;
+
+static std::string readFile(const std::string &Name) {
+  std::ifstream Stream(Name, std::ios::in | std::ios::binary);
+  std::string Contents((std::istreambuf_iterator<char>(Stream)),
+                       (std::istreambuf_iterator<char>()));
+  return Contents;
+}
+
+std::string getCmakeBuildPathFromInRoot(StringRef InRoot, StringRef OutRoot) {
+  std::error_code EC;
+
+  std::string CmakeBuildDirectory;
+  for (fs::recursive_directory_iterator Iter(Twine(InRoot), EC), End;
+       Iter != End; Iter.increment(EC)) {
+    if ((bool)EC) {
+      std::string ErrMsg = "[ERROR] Access : " + std::string(InRoot.str()) +
+                           " fail: " + EC.message() + "\n";
+      PrintMsg(ErrMsg);
+    }
+
+    auto FilePath = Iter->path();
+
+    // Skip output directory if it is in the in-root directory.
+    if (isChildOrSamePath(OutRoot.str(), FilePath))
+      continue;
+
+    bool IsHidden = false;
+    for (path::const_iterator PI = path::begin(FilePath),
+                              PE = path::end(FilePath);
+         PI != PE; ++PI) {
+      StringRef Comp = *PI;
+      if (Comp.startswith(".")) {
+        IsHidden = true;
+        break;
+      }
+    }
+    // Skip hidden folder or file whose name begins with ".".
+    if (IsHidden) {
+      continue;
+    }
+
+    if (Iter->type() == fs::file_type::directory_file) {
+      const auto Path = Iter->path();
+      SmallString<512> OutDirectory = llvm::StringRef(Path);
+      if (fs::exists(OutDirectory + "/CMakeFiles") &&
+          fs::exists(OutDirectory + "/CMakeCache.txt")) {
+        CmakeBuildDirectory = OutDirectory.str().str();
+        break;
+      }
+    }
+  }
+  return CmakeBuildDirectory;
+}
+
+void collectCmakeScripts(StringRef InRoot, StringRef OutRoot,
+                         std::vector<std::string> &CmakeScriptFiles) {
+  std::error_code EC;
+
+  std::string CmakeBuildDirectory =
+      getCmakeBuildPathFromInRoot(InRoot, OutRoot);
+  for (fs::recursive_directory_iterator Iter(Twine(InRoot), EC), End;
+       Iter != End; Iter.increment(EC)) {
+    if ((bool)EC) {
+      std::string ErrMsg = "[ERROR] Access : " + std::string(InRoot.str()) +
+                           " fail: " + EC.message() + "\n";
+      PrintMsg(ErrMsg);
+    }
+
+    auto FilePath = Iter->path();
+
+    // Skip output directory if it is in the in-root directory.
+    if (isChildOrSamePath(OutRoot.str(), FilePath))
+      continue;
+
+    // Skip cmake build directory if it is in the in-root directory.
+    if (!CmakeBuildDirectory.empty() &&
+        isChildOrSamePath(CmakeBuildDirectory, FilePath))
+      continue;
+
+    bool IsHidden = false;
+    for (path::const_iterator PI = path::begin(FilePath),
+                              PE = path::end(FilePath);
+         PI != PE; ++PI) {
+      StringRef Comp = *PI;
+      if (Comp.startswith(".")) {
+        IsHidden = true;
+        break;
+      }
+    }
+    // Skip hidden folder or file whose name begins with ".".
+    if (IsHidden) {
+      continue;
+    }
+
+    if (Iter->type() == fs::file_type::regular_file) {
+      SmallString<512> OutputFile = llvm::StringRef(FilePath);
+
+      llvm::StringRef Name = llvm::sys::path::filename(FilePath);
+      if (Name == "CMakeLists.txt" || Name.ends_with(".cmake")) {
+        CmakeScriptFiles.push_back(OutputFile.str().str());
+      }
+    }
+  }
+}
+
+bool migrateCmakeScriptFile(StringRef InRoot, StringRef OutRoot,
+                            std::string InFileName) {
+  makeCanonical(InFileName);
+  SmallString<512> OutFileName = llvm::StringRef(InFileName);
+  if (!rewriteDir(OutFileName, InRoot, OutRoot)) {
+    return false;
+  }
+  auto Parent = path::parent_path(OutFileName);
+  std::error_code EC;
+  EC = fs::create_directories(Parent);
+  if ((bool)EC) {
+    std::string ErrMsg =
+        "[ERROR] Create Directory : " + std::string(Parent.str()) +
+        " fail: " + EC.message() + "\n";
+    PrintMsg(ErrMsg);
+  }
+  std::ofstream Out(OutFileName.c_str(), std::ios::binary);
+  if (Out.fail()) {
+    std::string ErrMsg =
+        "[ERROR] Create file : " + std::string(OutFileName.c_str()) +
+        " failure!\n";
+    PrintMsg(ErrMsg);
+  }
+
+  llvm::raw_os_ostream Stream(Out);
+  applyPatternRewriterToCmakeScriptFile(readFile(InFileName), Stream);
+
+  Stream.flush();
+  Out.close();
+  return true;
+}
+
+bool cmakeScriptFileSpecified(const std::vector<std::string> &SourceFiles) {
+  bool IsCmakeScript = false;
+  for (const auto &FilePath : SourceFiles) {
+    if (!llvm::sys::path::has_extension(FilePath) ||
+        llvm::sys::path::filename(FilePath).ends_with(".cmake") ||
+        llvm::sys::path::filename(FilePath).ends_with(".txt"))
+      IsCmakeScript = true;
+    break;
+  }
+  return IsCmakeScript;
+}
+
+void migrateCmakeScriptOnly(
+    const llvm::Expected<clang::tooling::CommonOptionsParser> &OptParser,
+    StringRef InRoot, StringRef OutRoot) {
+
+  auto CmakeScriptLists = OptParser->getSourcePathList();
+  if (!CmakeScriptLists.empty()) {
+    for (auto FilePath : CmakeScriptLists) {
+      if (fs::is_directory(FilePath)) {
+        std::vector<std::string> CmakeScriptFiles;
+        collectCmakeScripts(FilePath, OutRoot, CmakeScriptFiles);
+        for (const auto &ScriptFile : CmakeScriptFiles) {
+          if (!migrateCmakeScriptFile(InRoot, OutRoot, ScriptFile))
+            continue;
+        }
+      } else {
+        if (!migrateCmakeScriptFile(InRoot, OutRoot, FilePath))
+          continue;
+      }
+    }
+  } else {
+    std::vector<std::string> CmakeScriptFiles;
+    collectCmakeScripts(InRoot, OutRoot, CmakeScriptFiles);
+    for (const auto &ScriptFile : CmakeScriptFiles) {
+      if (!migrateCmakeScriptFile(InRoot, OutRoot, ScriptFile))
+        continue;
+    }
+  }
+}

--- a/clang/lib/DPCT/MigrateCmakeScript.h
+++ b/clang/lib/DPCT/MigrateCmakeScript.h
@@ -1,0 +1,27 @@
+//===--------------- MigrateCmakeScript.h ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef DPCT_MIGRATE_CMAKE_SCRIPT_H
+#define DPCT_MIGRATE_CMAKE_SCRIPT_H
+
+#include "clang/Tooling/CommonOptionsParser.h"
+#include "llvm/ADT/StringRef.h"
+
+
+std::string getCmakeBuildPathFromInRoot(llvm::StringRef InRoot,
+                                        llvm::StringRef OutRoot);
+void collectCmakeScripts(llvm::StringRef InRoot, llvm::StringRef OutRoot,
+                         std::vector<std::string> &CmakeScriptFiles);
+bool migrateCmakeScriptFile(llvm::StringRef InRoot, llvm::StringRef OutRoot,
+                            std::string InFileName);
+bool cmakeScriptFileSpecified(const std::vector<std::string> &SourceFiles);
+
+void migrateCmakeScriptOnly(
+    const llvm::Expected<clang::tooling::CommonOptionsParser> &OptParser,
+    llvm::StringRef InRoot, llvm::StringRef OutRoot);
+#endif

--- a/clang/lib/DPCT/PatternRewriter.cpp
+++ b/clang/lib/DPCT/PatternRewriter.cpp
@@ -605,25 +605,6 @@ std::string applyPatternRewriter(const MetaRuleObject::PatternRewriter &PP,
                                  const std::string &Input) {
   std::stringstream OutputStream;
   const auto Pattern = parseMatchPattern(PP.In);
-#if 1 // use for debug print
-  int Count = 0;
-  printf("Pattern start:\n");
-  for(auto Element: Pattern) {
-    if (std::holds_alternative<CodeElement>(Element)) {
-      auto &Code = std::get<CodeElement>(Element);
-      printf("\t[%d]->[%s]:[%d]\n", Count, Code.Name.c_str(), Code.SuffixLength);
-    }
-    if (std::holds_alternative<LiteralElement>(Element)) {
-      const auto &Literal = std::get<LiteralElement>(Element);
-      printf("\t[%d]->[%c]\n", Count, Literal.Value);
-    }
-    if (std::holds_alternative<SpacingElement>(Element)) {
-      printf("\t[%d]->[%s]\n", Count, "space");
-    }
-    Count++;
-  }
-  printf("Pattern end.\n\n");
-#endif
   const int Size = Input.size();
   int Index = 0;
   while (Index < Size) {
@@ -640,8 +621,7 @@ std::string applyPatternRewriter(const MetaRuleObject::PatternRewriter &PP,
       }
 
       const int Indentation = detectIndentation(Input, Index);
-      instantiateTemplate(PP.Out, Match.Bindings, Indentation,
-                                            OutputStream);
+      instantiateTemplate(PP.Out, Match.Bindings, Indentation, OutputStream);
       Index = Match.End;
       continue;
     }

--- a/clang/lib/DPCT/PatternRewriter.cpp
+++ b/clang/lib/DPCT/PatternRewriter.cpp
@@ -97,7 +97,11 @@ static std::string indent(const std::string &Input, int Indentation) {
     const bool ContainsNonWhitespace = (trim(Line).size() > 0);
     Output.push_back(ContainsNonWhitespace ? (Indent + Line) : "");
   }
-  return trim(join(Output, "\n"));
+  std::string Str = trim(join(Output, "\n"));
+  if (isWhitespace(Input[0])) {
+    Str = " " + Str;
+  }
+  return Str;
 }
 
 static std::string dedent(const std::string &Input, int Indentation) {
@@ -478,6 +482,25 @@ std::string applyPatternRewriter(const MetaRuleObject::PatternRewriter &PP,
                                  const std::string &Input) {
   std::stringstream OutputStream;
   const auto Pattern = parseMatchPattern(PP.In);
+#if 0 // use for debug print
+  int Count = 0;
+  printf("Pattern start:");
+  for(auto Element: Pattern) {
+    if (std::holds_alternative<CodeElement>(Element)) {
+      auto &Code = std::get<CodeElement>(Element);
+      printf("[%d]->[%s]\n", Count, Code.Name.c_str());
+    }
+    if (std::holds_alternative<LiteralElement>(Element)) {
+      const auto &Literal = std::get<LiteralElement>(Element);
+      printf("[%d]->[%c]\n", Count, Literal.Value);
+    }
+    if (std::holds_alternative<SpacingElement>(Element)) {
+      printf("[%d]->[%s]\n", Count, "space");
+    }
+    Count++;
+  }
+  printf("Pattern end.");
+#endif
   const int Size = Input.size();
   int Index = 0;
   while (Index < Size) {
@@ -503,6 +526,5 @@ std::string applyPatternRewriter(const MetaRuleObject::PatternRewriter &PP,
     OutputStream << Input[Index];
     Index++;
   }
-
   return OutputStream.str();
 }

--- a/clang/lib/DPCT/PatternRewriter.h
+++ b/clang/lib/DPCT/PatternRewriter.h
@@ -19,4 +19,6 @@ std::string applyPatternRewriter(const MetaRuleObject::PatternRewriter &PP,
 
 bool fixLineEndings(const std::string &Input, std::string &Output);
 
+std::string convertCmakeCommandsToLower(const std::string &InputString);
+
 #endif // DPCT_PATTERN_REWRITER_H

--- a/clang/lib/DPCT/Rules.cpp
+++ b/clang/lib/DPCT/Rules.cpp
@@ -226,7 +226,7 @@ void deregisterAPIRule(MetaRuleObject &R) {
 
 void registerPatternRewriterRule(MetaRuleObject &R) {
   MapNames::PatternRewriters.emplace_back(
-      MetaRuleObject::PatternRewriter(R.In, R.Out, R.Subrules));
+      MetaRuleObject::PatternRewriter(R.In, R.Out, R.Subrules, R.MatchMode));
 }
 
 void importRules(llvm::cl::list<std::string> &RuleFiles) {
@@ -249,12 +249,13 @@ void importRules(llvm::cl::list<std::string> &RuleFiles) {
 #if 1 // for debug
     printf("Read rule start:\n");
     for(auto Entry: CurrentRules) {
-      printf("Entry ->RuleFile [%s]\n", Entry->RuleFile.c_str());
-      printf("Entry ->RuleId [%s]\n", Entry->RuleId.c_str());
-      printf("Entry ->In [%s]\n",  Entry->In.c_str());
-      printf("Entry ->Out [%s]\n", Entry->Out.c_str());
-      printf("Entry ->Priority [%d]\n", Entry->Priority);
-      printf("Entry ->Kind [%d]\n", Entry->Kind);
+      printf("\tEntry ->RuleFile [%s]\n", Entry->RuleFile.c_str());
+      printf("\tEntry ->RuleId [%s]\n", Entry->RuleId.c_str());
+      printf("\tEntry ->In [%s]\n",  Entry->In.c_str());
+      printf("\tEntry ->Out [%s]\n", Entry->Out.c_str());
+      printf("\tEntry ->Priority [%d]\n", Entry->Priority);
+      printf("\tEntry ->Kind [%d]\n", Entry->Kind);
+      printf("\tEntry ->MatchMode [%d]\n\n", Entry->MatchMode);
     }
     printf("Read rule end.\n\n");
 #endif

--- a/clang/lib/DPCT/Rules.cpp
+++ b/clang/lib/DPCT/Rules.cpp
@@ -246,17 +246,17 @@ void importRules(llvm::cl::list<std::string> &RuleFiles) {
     std::vector<std::shared_ptr<MetaRuleObject>> CurrentRules;
     llvm::yaml::Input YAMLIn(Buffer.get()->getBuffer());
     YAMLIn >> CurrentRules;
-#if 0 // for debug
-    printf("###############################\n");
+#if 1 // for debug
+    printf("Read rule start:\n");
     for(auto Entry: CurrentRules) {
       printf("Entry ->RuleFile [%s]\n", Entry->RuleFile.c_str());
       printf("Entry ->RuleId [%s]\n", Entry->RuleId.c_str());
       printf("Entry ->In [%s]\n",  Entry->In.c_str());
       printf("Entry ->Out [%s]\n", Entry->Out.c_str());
       printf("Entry ->Priority [%d]\n", Entry->Priority);
-      printf("Entry ->Kind [%d]\n\n", Entry->Kind);
+      printf("Entry ->Kind [%d]\n", Entry->Kind);
     }
-    printf("###############################\n");
+    printf("Read rule end.\n\n");
 #endif
     // store the rules, also prevent MetaRuleObjects from being destructed
     MetaRules.insert(MetaRules.end(), CurrentRules.begin(), CurrentRules.end());

--- a/clang/lib/DPCT/Rules.cpp
+++ b/clang/lib/DPCT/Rules.cpp
@@ -246,6 +246,18 @@ void importRules(llvm::cl::list<std::string> &RuleFiles) {
     std::vector<std::shared_ptr<MetaRuleObject>> CurrentRules;
     llvm::yaml::Input YAMLIn(Buffer.get()->getBuffer());
     YAMLIn >> CurrentRules;
+#if 0 // for debug
+    printf("###############################\n");
+    for(auto Entry: CurrentRules) {
+      printf("Entry ->RuleFile [%s]\n", Entry->RuleFile.c_str());
+      printf("Entry ->RuleId [%s]\n", Entry->RuleId.c_str());
+      printf("Entry ->In [%s]\n",  Entry->In.c_str());
+      printf("Entry ->Out [%s]\n", Entry->Out.c_str());
+      printf("Entry ->Priority [%d]\n", Entry->Priority);
+      printf("Entry ->Kind [%d]\n\n", Entry->Kind);
+    }
+    printf("###############################\n");
+#endif
     // store the rules, also prevent MetaRuleObjects from being destructed
     MetaRules.insert(MetaRules.end(), CurrentRules.begin(), CurrentRules.end());
 

--- a/clang/lib/DPCT/Rules.cpp
+++ b/clang/lib/DPCT/Rules.cpp
@@ -246,19 +246,6 @@ void importRules(llvm::cl::list<std::string> &RuleFiles) {
     std::vector<std::shared_ptr<MetaRuleObject>> CurrentRules;
     llvm::yaml::Input YAMLIn(Buffer.get()->getBuffer());
     YAMLIn >> CurrentRules;
-#if 1 // for debug
-    printf("Read rule start:\n");
-    for(auto Entry: CurrentRules) {
-      printf("\tEntry ->RuleFile [%s]\n", Entry->RuleFile.c_str());
-      printf("\tEntry ->RuleId [%s]\n", Entry->RuleId.c_str());
-      printf("\tEntry ->In [%s]\n",  Entry->In.c_str());
-      printf("\tEntry ->Out [%s]\n", Entry->Out.c_str());
-      printf("\tEntry ->Priority [%d]\n", Entry->Priority);
-      printf("\tEntry ->Kind [%d]\n", Entry->Kind);
-      printf("\tEntry ->MatchMode [%d]\n\n", Entry->MatchMode);
-    }
-    printf("Read rule end.\n\n");
-#endif
     // store the rules, also prevent MetaRuleObjects from being destructed
     MetaRules.insert(MetaRules.end(), CurrentRules.begin(), CurrentRules.end());
 

--- a/clang/lib/DPCT/Rules.h
+++ b/clang/lib/DPCT/Rules.h
@@ -175,7 +175,7 @@ template <> struct llvm::yaml::MappingTraits<std::shared_ptr<MetaRuleObject>> {
     Io.mapRequired("Priority", Doc->Priority);
     Io.mapRequired("In", Doc->In);
     Io.mapRequired("Out", Doc->Out);
-    Io.mapRequired("Includes", Doc->Includes);
+    Io.mapOptional("Includes", Doc->Includes);
     Io.mapOptional("Fields", Doc->Fields);
     Io.mapOptional("Methods", Doc->Methods);
     Io.mapOptional("EnumName", Doc->EnumName);

--- a/clang/lib/DPCT/Rules.h
+++ b/clang/lib/DPCT/Rules.h
@@ -18,19 +18,23 @@
 enum RuleKind { API, DataType, Macro, Header, TypeRule, Class, Enum, DisableAPIMigration, PatternRewriter };
 
 enum RulePriority { Takeover, Default, Fallback };
+enum RuleMatchMode { Partial , Full };
 
 struct TypeNameRule {
   std::string NewName;
   clang::dpct::HelperFeatureEnum RequestFeature;
   RulePriority Priority;
+  RuleMatchMode MatchMode;
   std::vector<std::string> Includes;
   TypeNameRule(std::string Name)
       : NewName(Name),
         RequestFeature(clang::dpct::HelperFeatureEnum::none),
-        Priority(RulePriority::Fallback) {}
+        Priority(RulePriority::Fallback),
+        MatchMode(RuleMatchMode::Partial) {}
   TypeNameRule(std::string Name, clang::dpct::HelperFeatureEnum Feature,
-               RulePriority Priority = RulePriority::Fallback)
-      : NewName(Name), RequestFeature(Feature), Priority(Priority) {}
+               RulePriority Priority = RulePriority::Fallback,
+               RuleMatchMode MatchMode = RuleMatchMode::Partial)
+      : NewName(Name), RequestFeature(Feature), Priority(Priority), MatchMode(MatchMode) {}
 };
 
 struct ClassFieldRule : public TypeNameRule {
@@ -38,11 +42,13 @@ struct ClassFieldRule : public TypeNameRule {
   std::string GetterName;
   ClassFieldRule(std::string Name) : TypeNameRule(Name) {}
   ClassFieldRule(std::string Name, clang::dpct::HelperFeatureEnum Feature,
-                 RulePriority Priority = RulePriority::Fallback)
+                 RulePriority Priority = RulePriority::Fallback,
+                 RuleMatchMode MatchMode = RuleMatchMode::Partial)
       : TypeNameRule(Name, Feature) {}
   ClassFieldRule(std::string SetterName, std::string GetterName,
                  clang::dpct::HelperFeatureEnum Feature,
-                 RulePriority Priority = RulePriority::Fallback)
+                 RulePriority Priority = RulePriority::Fallback,
+                 RuleMatchMode MatchMode = RuleMatchMode::Partial)
       : TypeNameRule(SetterName, Feature), SetterName(SetterName),
         GetterName(GetterName) {}
 };
@@ -50,7 +56,8 @@ struct ClassFieldRule : public TypeNameRule {
 struct EnumNameRule : public TypeNameRule {
   EnumNameRule(std::string Name) : TypeNameRule(Name) {}
   EnumNameRule(std::string Name, clang::dpct::HelperFeatureEnum Feature,
-                 RulePriority Priority = RulePriority::Fallback)
+                 RulePriority Priority = RulePriority::Fallback,
+                 RuleMatchMode MatchMode = RuleMatchMode::Partial)
       : TypeNameRule(Name, Feature) {}
 };
 
@@ -77,12 +84,15 @@ public:
   struct PatternRewriter {
     std::string In;
     std::string Out;
+    RuleMatchMode MatchMode;
     std::map<std::string, PatternRewriter> Subrules;
     PatternRewriter(){};
+
     PatternRewriter(
         const std::string &I, const std::string &O,
-        const std::map<std::string, PatternRewriter> &S)
-        : In(I), Out(O) {
+        const std::map<std::string, PatternRewriter> &S,
+        RuleMatchMode MatchMode)
+        : In(I), Out(O), MatchMode(MatchMode) {
       Subrules = std::move(S);
     }
   };
@@ -91,6 +101,7 @@ public:
   std::string RuleFile;
   std::string RuleId;
   RulePriority Priority;
+  RuleMatchMode MatchMode;
   RuleKind Kind;
   std::string In;
   std::string Out;
@@ -103,9 +114,9 @@ public:
   std::vector<std::shared_ptr<ClassMethod>> Methods;
   std::map<std::string, PatternRewriter> Subrules;
   MetaRuleObject()
-      : Priority(RulePriority::Default), Kind(RuleKind::API) {}
-  MetaRuleObject(std::string id, RulePriority priority, RuleKind kind)
-      : RuleId(id), Priority(priority), Kind(kind) {}
+      : Priority(RulePriority::Default), MatchMode(RuleMatchMode::Partial), Kind(RuleKind::API) {}
+  MetaRuleObject(std::string id, RulePriority priority, RuleKind kind, RuleMatchMode MatchMode)
+      : RuleId(id), Priority(priority), MatchMode(MatchMode), Kind(kind) {}
   static void setRuleFiles(std::string File) { RuleFiles.push_back(File); }
 };
 
@@ -152,6 +163,14 @@ template <> struct llvm::yaml::ScalarEnumerationTraits<RulePriority> {
   }
 };
 
+template <> struct llvm::yaml::ScalarEnumerationTraits<RuleMatchMode> {
+  static void enumeration(llvm::yaml::IO &Io, RuleMatchMode &Value) {
+    Io.enumCase(Value, "Partial", RuleMatchMode::Partial);
+    Io.enumCase(Value, "Full", RuleMatchMode::Full);
+
+  }
+};
+
 template <> struct llvm::yaml::ScalarEnumerationTraits<RuleKind> {
   static void enumeration(llvm::yaml::IO &Io, RuleKind &Value) {
     Io.enumCase(Value, "API", RuleKind::API);
@@ -183,6 +202,7 @@ template <> struct llvm::yaml::MappingTraits<std::shared_ptr<MetaRuleObject>> {
     Io.mapOptional("Postfix", Doc->Postfix);
     Io.mapOptional("Attributes", Doc->RuleAttributes);
     Io.mapOptional("Subrules", Doc->Subrules);
+    Io.mapOptional("MatchMode", Doc->MatchMode);
   }
 };
 
@@ -230,6 +250,7 @@ class RuleBase {
 public:
   std::string Id;
   RulePriority Priority;
+  RuleMatchMode MatchMode;
   RuleKind Kind;
   std::string In;
   std::string Out;

--- a/clang/lib/DPCT/SaveNewFiles.cpp
+++ b/clang/lib/DPCT/SaveNewFiles.cpp
@@ -387,7 +387,6 @@ void applyPatternRewriter(const std::string &InputString,
   }
 }
 
-
 void applyPatternRewriterToCmakeScriptFile(const std::string &InputString,
                                            llvm::raw_os_ostream &Stream) {
   std::string LineEndingString;
@@ -396,23 +395,6 @@ void applyPatternRewriterToCmakeScriptFile(const std::string &InputString,
 
   // Convert cmake command to lower case in cmake script files
   LineEndingString = convertCmakeCommandsToLower(LineEndingString);
-#if 0 // used to debug
-  printf("#### applyPatternRewriterToCmakeScriptFile ###\n");
-  for (const auto &PR : MapNames::PatternRewriters) {
-    printf("PR.MatchMode: [%d]\n", PR.MatchMode);
-    printf("PR.In: [%s]\n", PR.In.c_str());
-    printf("PR.Out: [%s]\n", PR.Out.c_str());
-
-    for (auto SubPR : PR.Subrules) {
-      printf("\tSubPR.first: [%s]\n", SubPR.first.c_str());
-      printf("\tSubPR.second.MatchMode: [%d]\n", SubPR.second.MatchMode);
-      printf("\tSubPR.second.In: [%s]\n", SubPR.second.In.c_str());
-      printf("\tSubPR.second.Out: [%s]\n", SubPR.second.Out.c_str());
-    }
-    printf("\n");
-  }
-  printf("#### applyPatternRewriterToCmakeScriptFile ###\n");
-#endif
   for (const auto &PR : MapNames::PatternRewriters) {
     LineEndingString = applyPatternRewriter(PR, LineEndingString);
   }

--- a/clang/lib/DPCT/SaveNewFiles.cpp
+++ b/clang/lib/DPCT/SaveNewFiles.cpp
@@ -396,7 +396,23 @@ void applyPatternRewriterToCmakeScriptFile(const std::string &InputString,
 
   // Convert cmake command to lower case in cmake script files
   LineEndingString = convertCmakeCommandsToLower(LineEndingString);
+#if 0 // used to debug
+  printf("#### applyPatternRewriterToCmakeScriptFile ###\n");
+  for (const auto &PR : MapNames::PatternRewriters) {
+    printf("PR.MatchMode: [%d]\n", PR.MatchMode);
+    printf("PR.In: [%s]\n", PR.In.c_str());
+    printf("PR.Out: [%s]\n", PR.Out.c_str());
 
+    for (auto SubPR : PR.Subrules) {
+      printf("\tSubPR.first: [%s]\n", SubPR.first.c_str());
+      printf("\tSubPR.second.MatchMode: [%d]\n", SubPR.second.MatchMode);
+      printf("\tSubPR.second.In: [%s]\n", SubPR.second.In.c_str());
+      printf("\tSubPR.second.Out: [%s]\n", SubPR.second.Out.c_str());
+    }
+    printf("\n");
+  }
+  printf("#### applyPatternRewriterToCmakeScriptFile ###\n");
+#endif
   for (const auto &PR : MapNames::PatternRewriters) {
     LineEndingString = applyPatternRewriter(PR, LineEndingString);
   }

--- a/clang/lib/DPCT/SaveNewFiles.cpp
+++ b/clang/lib/DPCT/SaveNewFiles.cpp
@@ -370,6 +370,34 @@ void applyPatternRewriter(const std::string &InputString,
   std::string LineEndingString;
   // pattern_rewriter require the input file to be LF
   bool IsCRLF = fixLineEndings(InputString, LineEndingString);
+
+  for (const auto &PR : MapNames::PatternRewriters) {
+    LineEndingString = applyPatternRewriter(PR, LineEndingString);
+  }
+  // Restore line ending for the formator
+  if (IsCRLF) {
+    std::stringstream ResultStream;
+    std::vector<std::string> SplitedStr = split(LineEndingString, '\n');
+    for (auto &SS : SplitedStr) {
+      ResultStream << SS << "\r\n";
+    }
+    Stream << llvm::StringRef(ResultStream.str().c_str());
+  } else {
+    Stream << llvm::StringRef(LineEndingString.c_str());
+  }
+}
+
+void applyPatternRewriterToCmakeScriptFile(const std::string &InputString,
+                                           llvm::raw_os_ostream &Stream) {
+  printf("applyPatternRewriter InputString: [%s]\n", InputString.c_str());
+  std::string LineEndingString;
+  // pattern_rewriter require the input file to be LF
+  bool IsCRLF = fixLineEndings(InputString, LineEndingString);
+
+  // TODO: convert cmake command to lower case in cmake script files
+
+
+
   for (const auto &PR : MapNames::PatternRewriters) {
     LineEndingString = applyPatternRewriter(PR, LineEndingString);
   }

--- a/clang/lib/DPCT/SaveNewFiles.cpp
+++ b/clang/lib/DPCT/SaveNewFiles.cpp
@@ -387,16 +387,15 @@ void applyPatternRewriter(const std::string &InputString,
   }
 }
 
+
 void applyPatternRewriterToCmakeScriptFile(const std::string &InputString,
                                            llvm::raw_os_ostream &Stream) {
-  printf("applyPatternRewriter InputString: [%s]\n", InputString.c_str());
   std::string LineEndingString;
   // pattern_rewriter require the input file to be LF
   bool IsCRLF = fixLineEndings(InputString, LineEndingString);
 
-  // TODO: convert cmake command to lower case in cmake script files
-
-
+  // Convert cmake command to lower case in cmake script files
+  LineEndingString = convertCmakeCommandsToLower(LineEndingString);
 
   for (const auto &PR : MapNames::PatternRewriters) {
     LineEndingString = applyPatternRewriter(PR, LineEndingString);

--- a/clang/lib/DPCT/SaveNewFiles.h
+++ b/clang/lib/DPCT/SaveNewFiles.h
@@ -12,6 +12,7 @@
 #include "ValidateArguments.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/raw_os_ostream.h"
 #include <map>
 
 #define DiagRef                                                                \
@@ -68,4 +69,8 @@ void rewriteFileName(llvm::SmallString<512> &FileName);
 // whether the file is in database.
 void rewriteFileName(llvm::SmallString<512> &FileName,
                      llvm::StringRef FullPathName);
+
+// apply patter rewrite rules to migrate cmake script file
+void applyPatternRewriterToCmakeScriptFile(const std::string &InputString,
+                                           llvm::raw_os_ostream &Stream);
 #endif // DPCT_SAVE_NEW_FILES_H

--- a/clang/lib/DPCT/ValidateArguments.h
+++ b/clang/lib/DPCT/ValidateArguments.h
@@ -97,6 +97,18 @@ bool makeAnalysisScopeCanonicalOrSetDefaults(std::string &AnalysisScope,
 /// -2: fail for there is file in SourceFiles without extension
 int validatePaths(const std::string &InRoot,
                   const std::vector<std::string> &SourceFiles);
+
+/// Make sure cmake script path is valide file path or directory path.
+/// return value:
+/// 0: success (InRoot and CmakeScriptPaths are valid)
+/// -1: fail for InRoot not valid
+/// -2: fail for there is file or directory not existing in CmakeScriptPaths
+/// -3: fail for there is directory not in InRoot directory in CmakeScriptPaths
+/// -4: fail for there is file not in InRoot directory in CmakeScriptPaths
+/// -5: fail for there is file that is is not a cmake script file in CmakeScriptPaths
+int validateCmakeScriptPaths(const std::string &InRoot,
+                             const std::vector<std::string> &CmakeScriptPaths);
+
 bool checkReportArgs(ReportTypeEnum &RType, ReportFormatEnum &RFormat,
                      std::string &RFile, bool &ROnly, bool &GenReport,
                      std::string &DVerbose);

--- a/clang/lib/Tooling/CommonOptionsParser.cpp
+++ b/clang/lib/Tooling/CommonOptionsParser.cpp
@@ -26,6 +26,7 @@
 #include "clang/Tooling/CommonOptionsParser.h"
 #include "clang/Tooling/Tooling.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Path.h"
 
 using namespace clang::tooling;
 using namespace llvm;
@@ -178,6 +179,21 @@ OPT_TYPE OPT_VAR(OPTION_NAME, __VA_ARGS__);
 
   SourcePathList = SourcePaths;
 #ifdef SYCLomatic_CUSTOMIZATION
+  bool IsMigrateCmakeScriptOnlySpecified = false;
+  for (auto i = 0; i < argc; i++) {
+    int Res1 = strcmp(argv[i], "--migrate-cmake-script-only");
+    int Res2 = strcmp(argv[i], "-migrate-cmake-script-only");
+    if (Res1 == 0 || Res2 == 0) {
+      IsMigrateCmakeScriptOnlySpecified = true;
+      break;
+    }
+  }
+  if (IsMigrateCmakeScriptOnlySpecified) {
+    Compilations.reset(
+        new FixedCompilationDatabase(".", std::vector<std::string>()));
+    return llvm::Error::success();
+  }
+
 #ifndef _WIN32
   if (std::string(argv[1]) == "--intercept-build" ||
       std::string(argv[1]) == "-intercept-build" ||

--- a/clang/test/dpct/autocomplete.c
+++ b/clang/test/dpct/autocomplete.c
@@ -30,6 +30,8 @@
 // DASH-NEXT: --in-root-exclude
 // DASH-NEXT: --intercept-build
 // DASH-NEXT: --keep-original-code
+// DASH-NEXT: --migrate-cmake-script
+// DASH-NEXT: --migrate-cmake-script-only
 // DASH-NEXT: --no-cl-namespace-inline
 // DASH-NEXT: --no-dpcpp-extensions=
 // DASH-NEXT: --no-dry-pattern

--- a/clang/test/dpct/cmake_migation/case_001/case_001.cpp
+++ b/clang/test/dpct/cmake_migation/case_001/case_001.cpp
@@ -1,7 +1,7 @@
 // RUN: rm -rf %T && mkdir -p %T
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
-// RUN: dpct -in-root ./ -out-root out  ./input.cmake  --rule-file %S/rules.yaml --migrate-cmake-script-only
+// RUN: dpct -in-root ./ -out-root out  ./input.cmake  --rule-file %S/rules.yaml --migrate-cmake-script-only --cuda-include-path="%cuda-path/include"
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt

--- a/clang/test/dpct/cmake_migation/case_001/case_001.cpp
+++ b/clang/test/dpct/cmake_migation/case_001/case_001.cpp
@@ -1,0 +1,10 @@
+// RUN: rm -rf %T && mkdir -p %T
+// RUN: cd %T
+// RUN: cp %S/input.cmake ./input.cmake
+// RUN: dpct -in-root ./ -out-root out  ./input.cmake  --rule-file %S/rules.yaml --migrate-cmake-script-only
+// RUN: echo "begin" > %T/diff.txt
+// RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
+// RUN: echo "end" >> %T/diff.txt
+
+// CHECK: begin
+// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migation/case_001/case_001.cpp
+++ b/clang/test/dpct/cmake_migation/case_001/case_001.cpp
@@ -1,3 +1,4 @@
+// UNSUPPORTED: system-windows
 // RUN: rm -rf %T && mkdir -p %T
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake

--- a/clang/test/dpct/cmake_migation/case_001/expected.txt
+++ b/clang/test/dpct/cmake_migation/case_001/expected.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.24)
+project(foo-bar LANGUAGES CXX)
+   set(CMAKE_CXX_FLAGS "-fsycl")
+set (CMAKE_CXX_STANDARD 17)
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+find_package(IntelSYCL REQUIRED)
+set(SOURCES
+    ${CMAKE_SOURCE_DIR}/foo/main.dp.cpp ${CMAKE_SOURCE_DIR}/foo/bar/util.dp.cpp)
+include_directories(
+    ${CMAKE_SOURCE_DIR}/foo/bar
+    ${CUDA_INCLUDE_DIRS}
+)
+add_executable(foo-bar ${SOURCES})
+

--- a/clang/test/dpct/cmake_migation/case_001/expected.txt
+++ b/clang/test/dpct/cmake_migation/case_001/expected.txt
@@ -1,4 +1,6 @@
 cmake_minimum_required(VERSION 3.24)
+###CMake_minimum_required(VERSION 3.10)
+#CMake_minimum_required(VERSION 3.10)
 project(foo-bar LANGUAGES CXX)
    set(CMAKE_CXX_FLAGS "-fsycl")
 set (CMAKE_CXX_STANDARD 17)

--- a/clang/test/dpct/cmake_migation/case_001/input.cmake
+++ b/clang/test/dpct/cmake_migation/case_001/input.cmake
@@ -1,0 +1,16 @@
+CMake_minimum_required(VERSION 3.10)
+Project(foo-bar LANGUAGES CXX CUDA)
+set (CMAKE_CXX_STANDARD 17)
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+Find_Package(CUDA REQUIRED)
+set(SOURCES
+    ${CMAKE_SOURCE_DIR}/foo/main.cu
+    ${CMAKE_SOURCE_DIR}/foo/bar/util.cu
+)
+include_directorieS(
+    ${CMAKE_SOURCE_DIR}/foo/bar
+    ${CUDA_INCLUDE_DIRS}
+)
+add_executable(foo-bar ${SOURCES})
+

--- a/clang/test/dpct/cmake_migation/case_001/input.cmake
+++ b/clang/test/dpct/cmake_migation/case_001/input.cmake
@@ -1,4 +1,6 @@
 CMake_minimum_required(VERSION 3.10)
+###CMake_minimum_required(VERSION 3.10)
+#CMake_minimum_required(VERSION 3.10)
 Project(foo-bar LANGUAGES CXX CUDA)
 set (CMAKE_CXX_STANDARD 17)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/clang/test/dpct/cmake_migation/case_001/rules.yaml
+++ b/clang/test/dpct/cmake_migation/case_001/rules.yaml
@@ -1,0 +1,35 @@
+- Rule: rule_cmake_minimum_required
+  Kind: PatternRewriter
+  MatchMode: Partial
+  Priority: Takeover
+  In: cmake_minimum_required(${name})
+  Out: cmake_minimum_required(VERSION 3.24)
+
+- Rule: rule_project
+  Kind: PatternRewriter
+  MatchMode: Full
+  Priority: Takeover
+  In: project(${arg0} ${value})
+  Out: project(${arg0} ${value})
+   set(CMAKE_CXX_FLAGS "-fsycl")
+  Subrules:
+    value:
+      In: CUDA
+      Out: ""
+
+- Rule: rule_find_package
+  Kind: PatternRewriter
+  Priority: Takeover
+  In: find_package(${arg0} REQUIRED)
+  Out: find_package(IntelSYCL REQUIRED)
+
+- Rule: rule_set
+  Kind: PatternRewriter
+  Priority: Takeover
+  In: set(${value})
+  Out: set(${value})
+  Subrules:
+    value:
+      In: ${arg}.cu
+      Out: ${arg}.dp.cpp
+


### PR DESCRIPTION
1. Add two options:
  --migrate-cmake-script         - migrate the cmakfile build script. Default: off.
  --migrate-cmake-script-only - Only migrate the cmakfile build script. Default: off.
  
2. Implement cmake migration framework to do cmake syntax migration