### PR TITLE
[SYCLomatic] Move device memory init() call out of command group of queue.submit() to avoid nested call to submit()

### DIFF
--- a/clang/lib/DPCT/AnalysisInfo.cpp
+++ b/clang/lib/DPCT/AnalysisInfo.cpp
@@ -1454,7 +1454,7 @@ void KernelCallExpr::addDevCapCheckStmt() {
       OS << ", " << AspectList[i];
     }
     OS << "});";
-    OuterStmts.emplace_back(OS.str());
+    OuterStmts.OthersList.emplace_back(OS.str());
   }
 }
 
@@ -1496,7 +1496,7 @@ void KernelCallExpr::addAccessorDecl(std::shared_ptr<MemVarInfo> VI) {
   }
   if (!VI->isShared()) {
     requestFeature(HelperFeatureEnum::device_ext);
-    SubmitStmtsList.InitList.emplace_back(VI->getInitStmt(getQueueStr()));
+    OuterStmts.InitList.emplace_back(VI->getInitStmt(getQueueStr()));
     if (VI->isLocal()) {
       SubmitStmtsList.MemoryList.emplace_back(
           VI->getMemoryDecl(ExecutionConfig.ExternMemSize));
@@ -1622,8 +1622,7 @@ void KernelCallExpr::print(KernelPrinter &Printer) {
       Block = std::move(Printer.block(true));
     else
       Block = std::move(Printer.block(false));
-    for (auto &S : OuterStmts)
-      Printer.line(S.StmtStr);
+    OuterStmts.print(Printer);
   }
   if (NeedLambda) {
     Block = std::move(Printer.block(true));

--- a/clang/lib/DPCT/AnalysisInfo.h
+++ b/clang/lib/DPCT/AnalysisInfo.h
@@ -4294,35 +4294,35 @@ private:
           buildString(MapNames::getDpctNamespace(), "get_",
                       DpctGlobalInfo::getDeviceQueueName(), "()");
       if (DpctGlobalInfo::getUsmLevel() == UsmLevel::UL_None) {
-        OuterStmts.emplace_back(
+        OuterStmts.OthersList.emplace_back(
             buildString(MapNames::getDpctNamespace(), "global_memory<",
                         MapNames::getDpctNamespace(), "byte_t, 1> d_",
                         DpctGlobalInfo::getSyncName(), "(4);"));
 
-        OuterStmts.emplace_back(buildString("d_", DpctGlobalInfo::getSyncName(),
-                                            ".init(", DefaultQueue, ");"));
+        OuterStmts.OthersList.emplace_back(buildString(
+            "d_", DpctGlobalInfo::getSyncName(), ".init(", DefaultQueue, ");"));
 
         SubmitStmtsList.SyncList.emplace_back(
             buildString("auto ", DpctGlobalInfo::getSyncName(), " = ",
                         MapNames::getDpctNamespace(), "get_access(d_",
                         DpctGlobalInfo::getSyncName(), ".get_ptr(), cgh);"));
 
-        OuterStmts.emplace_back(buildString(
+        OuterStmts.OthersList.emplace_back(buildString(
             MapNames::getDpctNamespace(), "dpct_memset(d_",
             DpctGlobalInfo::getSyncName(), ".get_ptr(), 0, sizeof(int));\n"));
 
         requestFeature(HelperFeatureEnum::device_ext);
       } else {
-        OuterStmts.emplace_back(buildString(
+        OuterStmts.OthersList.emplace_back(buildString(
             MapNames::getDpctNamespace(), "global_memory<unsigned int, 0> d_",
             DpctGlobalInfo::getSyncName(), "(0);"));
-        OuterStmts.emplace_back(buildString(
+        OuterStmts.OthersList.emplace_back(buildString(
             "unsigned *", DpctGlobalInfo::getSyncName(), " = d_",
             DpctGlobalInfo::getSyncName(), ".get_ptr(", DefaultQueue, ");"));
 
-        OuterStmts.emplace_back(buildString(DefaultQueue, ".memset(",
-                                            DpctGlobalInfo::getSyncName(),
-                                            ", 0, sizeof(int)).wait();"));
+        OuterStmts.OthersList.emplace_back(
+            buildString(DefaultQueue, ".memset(", DpctGlobalInfo::getSyncName(),
+                        ", 0, sizeof(int)).wait();"));
 
         requestFeature(HelperFeatureEnum::device_ext);
       }
@@ -4364,7 +4364,6 @@ private:
     StmtList SyncList;
     StmtList RangeList;
     StmtList MemoryList;
-    StmtList InitList;
     StmtList ExternList;
     StmtList PtrList;
     StmtList AccessorList;
@@ -4378,7 +4377,6 @@ private:
       printList(Printer, SyncList);
       printList(Printer, ExternList);
       printList(Printer, MemoryList);
-      printList(Printer, InitList, "init global memory");
       printList(Printer, RangeList,
                 "ranges used for accessors to device memory");
       printList(Printer, PtrList, "pointers to device memory");
@@ -4393,7 +4391,7 @@ private:
 
     bool empty() const noexcept {
       return CommandGroupList.empty() && NdRangeList.empty() &&
-             AccessorList.empty() && PtrList.empty() && InitList.empty() &&
+             AccessorList.empty() && PtrList.empty() &&
              ExternList.empty() && MemoryList.empty() && RangeList.empty() &&
              TextureList.empty() && SamplerList.empty() && StreamList.empty() &&
              SyncList.empty();
@@ -4411,7 +4409,32 @@ private:
     }
   } SubmitStmtsList;
 
-  StmtList OuterStmts;
+  class {
+  public:
+    StmtList InitList;
+    StmtList OthersList;
+
+    inline KernelPrinter &print(KernelPrinter &Printer) {
+      printList(Printer, InitList, "init global memory");
+      printList(Printer, OthersList);
+      return Printer;
+    }
+
+    bool empty() const noexcept {
+      return InitList.empty() && OthersList.empty();
+    }
+
+  private:
+    KernelPrinter &printList(KernelPrinter &Printer, const StmtList &List,
+                             StringRef Comments = "") {
+      if (List.empty())
+        return Printer;
+      if (!Comments.empty() && DpctGlobalInfo::isCommentsEnabled())
+        Printer.line("// ", Comments);
+      Printer << List;
+      return Printer.newLine();
+    }
+  } OuterStmts;
   StmtList KernelStmts;
   std::string KernelArgs;
   int TotalArgsSize = 0;

--- a/clang/lib/DPCT/AnalysisInfo.h
+++ b/clang/lib/DPCT/AnalysisInfo.h
@@ -4309,7 +4309,7 @@ private:
 
         OuterStmts.OthersList.emplace_back(buildString(
             MapNames::getDpctNamespace(), "dpct_memset(d_",
-            DpctGlobalInfo::getSyncName(), ".get_ptr(), 0, sizeof(int));\n"));
+            DpctGlobalInfo::getSyncName(), ".get_ptr(), 0, sizeof(int));"));
 
         requestFeature(HelperFeatureEnum::device_ext);
       } else {

--- a/clang/test/dpct/comments.cu
+++ b/clang/test/dpct/comments.cu
@@ -32,36 +32,38 @@ int main() {
     dim3 griddim(1, 2, 3);
     dim3 threaddim(1, 2, 3);
 
-// CHECK:    dpct::get_in_order_queue().submit(
-// CHECK-NEXT:        [&](sycl::handler &cgh) {
-// CHECK-NEXT:          sycl::stream stream_ct1(64 * 1024, 80, cgh);
+//      CHECK:    {
+// CHECK-NEXT:      // init global memory
+// CHECK-NEXT:      a.init();
+// CHECK-NEXT:      b.init();
+// CHECK-NEXT:      al.init();
 // CHECK-EMPTY:
-// CHECK-NEXT:          // init global memory
-// CHECK-NEXT:          a.init();
-// CHECK-NEXT:          b.init();
-// CHECK-NEXT:          al.init();
+// CHECK-NEXT:      dpct::get_in_order_queue().submit(
+// CHECK-NEXT:          [&](sycl::handler &cgh) {
+// CHECK-NEXT:            sycl::stream stream_ct1(64 * 1024, 80, cgh);
 // CHECK-EMPTY:  
-// CHECK-NEXT:          // pointers to device memory
-// CHECK-NEXT:          auto a_ptr_ct1 = a.get_ptr();
-// CHECK-NEXT:          auto al_ptr_ct1 = al.get_ptr();
+// CHECK-NEXT:            // pointers to device memory
+// CHECK-NEXT:            auto a_ptr_ct1 = a.get_ptr();
+// CHECK-NEXT:            auto al_ptr_ct1 = al.get_ptr();
 // CHECK-EMPTY:  
-// CHECK-NEXT:          // accessors to device memory
-// CHECK-NEXT:          sycl::local_accessor<int, 1> cl_acc_ct1(sycl::range<1>(36), cgh);
-// CHECK-NEXT:          sycl::local_accessor<int, 2> bl_acc_ct1(sycl::range<2>(12, 12), cgh);
-// CHECK-NEXT:          auto b_acc_ct1 = b.get_access(cgh);
+// CHECK-NEXT:            // accessors to device memory
+// CHECK-NEXT:            sycl::local_accessor<int, 1> cl_acc_ct1(sycl::range<1>(36), cgh);
+// CHECK-NEXT:            sycl::local_accessor<int, 2> bl_acc_ct1(sycl::range<2>(12, 12), cgh);
+// CHECK-NEXT:            auto b_acc_ct1 = b.get_access(cgh);
 // CHECK-EMPTY:  
-// CHECK-NEXT:          // accessors to image objects
-// CHECK-NEXT:          auto tex21_acc = tex21.get_access(cgh);
+// CHECK-NEXT:            // accessors to image objects
+// CHECK-NEXT:            auto tex21_acc = tex21.get_access(cgh);
 // CHECK-EMPTY:  
-// CHECK-NEXT:          // sampler of image objects
-// CHECK-NEXT:          auto tex21_smpl = tex21.get_sampler();
+// CHECK-NEXT:            // sampler of image objects
+// CHECK-NEXT:            auto tex21_smpl = tex21.get_sampler();
 // CHECK-EMPTY:  
-// CHECK-NEXT:          cgh.parallel_for(
-// CHECK-NEXT:            sycl::nd_range<3>(griddim * threaddim, threaddim),
-// CHECK-NEXT:            [=](sycl::nd_item<3> item_ct1) {
-// CHECK-NEXT:              kernel(stream_ct1, *a_ptr_ct1, b_acc_ct1, al_ptr_ct1, cl_acc_ct1.get_pointer(), bl_acc_ct1, dpct::image_accessor_ext<sycl::uint2, 1>(tex21_smpl, tex21_acc));
-// CHECK-NEXT:            });
-// CHECK-NEXT:        });
+// CHECK-NEXT:            cgh.parallel_for(
+// CHECK-NEXT:              sycl::nd_range<3>(griddim * threaddim, threaddim),
+// CHECK-NEXT:              [=](sycl::nd_item<3> item_ct1) {
+// CHECK-NEXT:                kernel(stream_ct1, *a_ptr_ct1, b_acc_ct1, al_ptr_ct1, cl_acc_ct1.get_pointer(), bl_acc_ct1, dpct::image_accessor_ext<sycl::uint2, 1>(tex21_smpl, tex21_acc));
+// CHECK-NEXT:              });
+// CHECK-NEXT:          });
+// CHECK-NEXT:    }
     kernel<<<griddim, threaddim>>>();
 }
 

--- a/clang/test/dpct/constant_variable_optimization.cu
+++ b/clang/test/dpct/constant_variable_optimization.cu
@@ -41,32 +41,38 @@ __global__ void kernel2(int *ptr){
 int main(){
   int *dp;
   cudaMallocManaged(&dp, sizeof(int));
-// CHECK:   q_ct1.submit(
-// CHECK:     [&](sycl::handler &cgh) {
-// CHECK:       dev_c.init();
-// CHECK:       auto dev_c_ptr_ct1 = dev_c.get_ptr();
-// CHECK:       cgh.parallel_for(
-// CHECK:         sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
-// CHECK:         [=](sycl::nd_item<3> item_ct1) {
-// CHECK:           kernel1(dp, *dev_c_ptr_ct1);
-// CHECK:         });
-// CHECK:     });
+// CHECK:   {
+// CHECK:     dev_c.init();
+// CHECK-EMPTY:
+// CHECK:     q_ct1.submit(
+// CHECK:       [&](sycl::handler &cgh) {
+// CHECK:         auto dev_c_ptr_ct1 = dev_c.get_ptr();
+// CHECK:         cgh.parallel_for(
+// CHECK:           sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
+// CHECK:           [=](sycl::nd_item<3> item_ct1) {
+// CHECK:             kernel1(dp, *dev_c_ptr_ct1);
+// CHECK:           });
+// CHECK:       });
+// CHECK:   }
   kernel1<<<1, 1>>>(dp);
   cudaDeviceSynchronize();
   std::cout << *dp << std::endl;
 
   int *dp2;
   cudaMallocManaged(&dp2, 32 * sizeof(int));
-// CHECK:   q_ct1.submit(
-// CHECK:     [&](sycl::handler &cgh) {
-// CHECK:       dev_d.init();
-// CHECK:       auto dev_d_ptr_ct1 = dev_d.get_ptr();
-// CHECK:       cgh.parallel_for(
-// CHECK:         sycl::nd_range<3>(sycl::range<3>(1, 1, 32), sycl::range<3>(1, 1, 32)),
-// CHECK:         [=](sycl::nd_item<3> item_ct1) {
-// CHECK:           kernel2(dp2, item_ct1, dev_d_ptr_ct1);
-// CHECK:         });
-// CHECK:     });
+// CHECK:   {
+// CHECK:     dev_d.init();
+// CHECK-EMPTY:
+// CHECK:     q_ct1.submit(
+// CHECK:       [&](sycl::handler &cgh) {
+// CHECK:         auto dev_d_ptr_ct1 = dev_d.get_ptr();
+// CHECK:         cgh.parallel_for(
+// CHECK:           sycl::nd_range<3>(sycl::range<3>(1, 1, 32), sycl::range<3>(1, 1, 32)),
+// CHECK:           [=](sycl::nd_item<3> item_ct1) {
+// CHECK:             kernel2(dp2, item_ct1, dev_d_ptr_ct1);
+// CHECK:           });
+// CHECK:       });
+// CHECK:   }
   kernel2<<<1, 32>>>(dp2);
   cudaDeviceSynchronize();
   for(int i = 0; i < 32; i++) {

--- a/clang/test/dpct/cuda_const.cu
+++ b/clang/test/dpct/cuda_const.cu
@@ -130,34 +130,38 @@ int main(int argc, char **argv) {
   // CHECK:  dpct::dpct_memcpy(&h_array[0], const_angle.get_ptr() + 3+NUM, sizeof(float) * 354);
   cudaMemcpyFromSymbol(&h_array[0], &const_angle[3+NUM], sizeof(float) * 354);
 
-  // CHECK:   q_ct1.submit(
+  //      CHECK:   {
+  // CHECK-NEXT:     t1.init();
+  // CHECK-EMPTY:
+  // CHECK-NEXT:     q_ct1.submit(
+  // CHECK-NEXT:       [&](sycl::handler &cgh) {
+  // CHECK-NEXT:         auto t1_acc_ct1 = t1.get_access(cgh);
+  // CHECK-EMPTY:
+  // CHECK-NEXT:         cgh.parallel_for<dpct_kernel_name<class member_acc_{{[a-f0-9]+}}>>(
+  // CHECK-NEXT:           sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
+  // CHECK-NEXT:           [=](sycl::nd_item<3> item_ct1) {
+  // CHECK-NEXT:             member_acc(t1_acc_ct1);
+  // CHECK-NEXT:           });
+  // CHECK-NEXT:       });
+  // CHECK-NEXT:   }
+  member_acc<<<1, 1>>>();
+  //      CHECK: {
+  // CHECK-NEXT:   const_angle.init();
+  // CHECK-NEXT:   const_ptr.init();
+  // CHECK-EMPTY:
+  // CHECK-NEXT:   q_ct1.submit(
   // CHECK-NEXT:     [&](sycl::handler &cgh) {
-  // CHECK-NEXT:       t1.init();
+  // CHECK-NEXT:       auto const_angle_acc_ct1 = const_angle.get_access(cgh);
+  // CHECK-NEXT:       auto const_ptr_acc_ct1 = const_ptr.get_access(cgh);
+  // CHECK-NEXT:       auto d_array_acc_ct0 = dpct::get_access(d_array, cgh);
   // CHECK-EMPTY:
-  // CHECK-NEXT:       auto t1_acc_ct1 = t1.get_access(cgh);
-  // CHECK-EMPTY:
-  // CHECK-NEXT:       cgh.parallel_for<dpct_kernel_name<class member_acc_{{[a-f0-9]+}}>>(
-  // CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
+  // CHECK-NEXT:       cgh.parallel_for<dpct_kernel_name<class simple_kernel_{{[a-f0-9]+}}>>(
+  // CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, size / 64) * sycl::range<3>(1, 1, 64), sycl::range<3>(1, 1, 64)),
   // CHECK-NEXT:         [=](sycl::nd_item<3> item_ct1) {
-  // CHECK-NEXT:           member_acc(t1_acc_ct1);
+  // CHECK-NEXT:           simple_kernel((float *)(&d_array_acc_ct0[0]), item_ct1, const_angle_acc_ct1.get_pointer(), const_ptr_acc_ct1.get_pointer());
   // CHECK-NEXT:         });
   // CHECK-NEXT:     });
-  member_acc<<<1, 1>>>();
-  // CHECK: q_ct1.submit(
-  // CHECK-NEXT:   [&](sycl::handler &cgh) {
-  // CHECK-NEXT:     const_angle.init();
-  // CHECK-NEXT:     const_ptr.init();
-  // CHECK-EMPTY:
-  // CHECK-NEXT:     auto const_angle_acc_ct1 = const_angle.get_access(cgh);
-  // CHECK-NEXT:     auto const_ptr_acc_ct1 = const_ptr.get_access(cgh);
-  // CHECK-NEXT:     auto d_array_acc_ct0 = dpct::get_access(d_array, cgh);
-  // CHECK-EMPTY:
-  // CHECK-NEXT:     cgh.parallel_for<dpct_kernel_name<class simple_kernel_{{[a-f0-9]+}}>>(
-  // CHECK-NEXT:       sycl::nd_range<3>(sycl::range<3>(1, 1, size / 64) * sycl::range<3>(1, 1, 64), sycl::range<3>(1, 1, 64)),
-  // CHECK-NEXT:       [=](sycl::nd_item<3> item_ct1) {
-  // CHECK-NEXT:         simple_kernel((float *)(&d_array_acc_ct0[0]), item_ct1, const_angle_acc_ct1.get_pointer(), const_ptr_acc_ct1.get_pointer());
-  // CHECK-NEXT:       });
-  // CHECK-NEXT:   });
+  // CHECK-NEXT: }
   simple_kernel<<<size / 64, 64>>>(d_array);
 
   float hangle_h[360];
@@ -174,21 +178,23 @@ int main(int argc, char **argv) {
   cudaMemcpyToSymbol(&const_one, &h_array[0], sizeof(float) * 1);
 
   cudaStream_t stream;
-  // CHECK:  stream->submit(
-  // CHECK-NEXT:   [&](sycl::handler &cgh) {
-  // CHECK-NEXT:     const_float.init(*stream);
-  // CHECK-NEXT:     const_one.init(*stream);
+  //      CHECK:  {
+  // CHECK-NEXT:    const_float.init(*stream);
+  // CHECK-NEXT:    const_one.init(*stream);
   // CHECK-EMPTY:
-  // CHECK-NEXT:     auto const_float_acc_ct1 = const_float.get_access(cgh);
-  // CHECK-NEXT:     auto const_one_acc_ct1 = const_one.get_access(cgh);
-  // CHECK-NEXT:     auto d_array_acc_ct0 = dpct::get_access(d_array, cgh);
+  // CHECK-NEXT:    stream->submit(
+  // CHECK-NEXT:     [&](sycl::handler &cgh) {
+  // CHECK-NEXT:       auto const_float_acc_ct1 = const_float.get_access(cgh);
+  // CHECK-NEXT:       auto const_one_acc_ct1 = const_one.get_access(cgh);
+  // CHECK-NEXT:       auto d_array_acc_ct0 = dpct::get_access(d_array, cgh);
   // CHECK-EMPTY:
-  // CHECK-NEXT:     cgh.parallel_for<dpct_kernel_name<class simple_kernel_one_{{[a-f0-9]+}}>>(
-  // CHECK-NEXT:       sycl::nd_range<3>(sycl::range<3>(1, 1, size / 64) * sycl::range<3>(1, 1, 64), sycl::range<3>(1, 1, 64)),
-  // CHECK-NEXT:       [=](sycl::nd_item<3> item_ct1) {
-  // CHECK-NEXT:         simple_kernel_one((float *)(&d_array_acc_ct0[0]), item_ct1, const_float_acc_ct1, const_one_acc_ct1);
-  // CHECK-NEXT:        });
-  // CHECK-NEXT:   });
+  // CHECK-NEXT:       cgh.parallel_for<dpct_kernel_name<class simple_kernel_one_{{[a-f0-9]+}}>>(
+  // CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, size / 64) * sycl::range<3>(1, 1, 64), sycl::range<3>(1, 1, 64)),
+  // CHECK-NEXT:         [=](sycl::nd_item<3> item_ct1) {
+  // CHECK-NEXT:           simple_kernel_one((float *)(&d_array_acc_ct0[0]), item_ct1, const_float_acc_ct1, const_one_acc_ct1);
+  // CHECK-NEXT:          });
+  // CHECK-NEXT:     });
+  // CHECK-NEXT:  }
   simple_kernel_one<<<size / 64, 64, 0, stream>>>(d_array);
 
   // CHECK:  dpct::dpct_memcpy(hangle_h, d_array, 360 * sizeof(float), dpct::device_to_host);
@@ -247,10 +253,10 @@ __device__ void foo() {
 //CHECK-NEXT:  float *a = const_cast<float *>(aaa + 5);
 //CHECK-NEXT:}
 //CHECK-NEXT:void foo1() {
+//CHECK-NEXT:  aaa.init();
+//CHECK-EMPTY:
 //CHECK-NEXT:  dpct::get_out_of_order_queue().submit(
 //CHECK-NEXT:    [&](sycl::handler &cgh) {
-//CHECK-NEXT:      aaa.init();
-//CHECK-EMPTY:
 //CHECK-NEXT:      auto aaa_acc_ct1 = aaa.get_access(cgh);
 //CHECK-EMPTY:
 //CHECK-NEXT:      cgh.parallel_for<dpct_kernel_name<class kernel1_{{[a-f0-9]+}}>>(

--- a/clang/test/dpct/cuda_const_usm.cu
+++ b/clang/test/dpct/cuda_const_usm.cu
@@ -126,33 +126,37 @@ int main(int argc, char **argv) {
   // CHECK:  q_ct1.memcpy(&h_array[0], const_angle.get_ptr() + 3+NUM, sizeof(float) * 354);
   cudaMemcpyFromSymbol(&h_array[0], &const_angle[3+NUM], sizeof(float) * 354);
 
-  // CHECK:   q_ct1.submit(
-  // CHECK-NEXT:     [&](sycl::handler &cgh) {
-  // CHECK-NEXT:       t1.init();
+  //      CHECK:   {
+  // CHECK-NEXT:     t1.init();
   // CHECK-EMPTY:
-  // CHECK-NEXT:       auto t1_ptr_ct1 = t1.get_ptr();
+  // CHECK-NEXT:     q_ct1.submit(
+  // CHECK-NEXT:       [&](sycl::handler &cgh) {
+  // CHECK-NEXT:         auto t1_ptr_ct1 = t1.get_ptr();
   // CHECK-EMPTY:
-  // CHECK-NEXT:       cgh.parallel_for<dpct_kernel_name<class member_acc_{{[a-f0-9]+}}>>(
-  // CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
-  // CHECK-NEXT:         [=](sycl::nd_item<3> item_ct1) {
-  // CHECK-NEXT:           member_acc(*t1_ptr_ct1);
-  // CHECK-NEXT:         });
-  // CHECK-NEXT:     });
+  // CHECK-NEXT:         cgh.parallel_for<dpct_kernel_name<class member_acc_{{[a-f0-9]+}}>>(
+  // CHECK-NEXT:           sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
+  // CHECK-NEXT:           [=](sycl::nd_item<3> item_ct1) {
+  // CHECK-NEXT:             member_acc(*t1_ptr_ct1);
+  // CHECK-NEXT:           });
+  // CHECK-NEXT:       });
+  // CHECK-NEXT:   }
   member_acc<<<1, 1>>>();
-  // CHECK:   q_ct1.submit(
-  // CHECK-NEXT:     [&](sycl::handler &cgh) {
-  // CHECK-NEXT:       const_angle.init();
-  // CHECK-NEXT:       const_ptr.init();
+  //      CHECK:   {
+  // CHECK-NEXT:     const_angle.init();
+  // CHECK-NEXT:     const_ptr.init();
   // CHECK-EMPTY:
-  // CHECK-NEXT:       auto const_angle_ptr_ct1 = const_angle.get_ptr();
-  // CHECK-NEXT:       auto const_ptr_ptr_ct1 = const_ptr.get_ptr();
+  // CHECK-NEXT:     q_ct1.submit(
+  // CHECK-NEXT:       [&](sycl::handler &cgh) {
+  // CHECK-NEXT:         auto const_angle_ptr_ct1 = const_angle.get_ptr();
+  // CHECK-NEXT:         auto const_ptr_ptr_ct1 = const_ptr.get_ptr();
   // CHECK-EMPTY:
-  // CHECK-NEXT:       cgh.parallel_for<dpct_kernel_name<class simple_kernel_{{[a-f0-9]+}}>>(
-  // CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, size / 64) * sycl::range<3>(1, 1, 64), sycl::range<3>(1, 1, 64)),
-  // CHECK-NEXT:         [=](sycl::nd_item<3> item_ct1) {
-  // CHECK-NEXT:           simple_kernel(d_array, item_ct1, const_angle_ptr_ct1, *const_ptr_ptr_ct1);
-  // CHECK-NEXT:         });
-  // CHECK-NEXT:     });
+  // CHECK-NEXT:         cgh.parallel_for<dpct_kernel_name<class simple_kernel_{{[a-f0-9]+}}>>(
+  // CHECK-NEXT:           sycl::nd_range<3>(sycl::range<3>(1, 1, size / 64) * sycl::range<3>(1, 1, 64), sycl::range<3>(1, 1, 64)),
+  // CHECK-NEXT:           [=](sycl::nd_item<3> item_ct1) {
+  // CHECK-NEXT:             simple_kernel(d_array, item_ct1, const_angle_ptr_ct1, *const_ptr_ptr_ct1);
+  // CHECK-NEXT:           });
+  // CHECK-NEXT:       });
+  // CHECK-NEXT:   }
   simple_kernel<<<size / 64, 64>>>(d_array);
 
   float hangle_h[360];
@@ -169,21 +173,23 @@ int main(int argc, char **argv) {
   cudaMemcpyToSymbol(&const_one, &h_array[0], sizeof(float) * 1);
 
   cudaStream_t stream;
-  // CHECK:   stream->submit(
-  // CHECK-NEXT:     [&](sycl::handler &cgh) {
-  // CHECK-NEXT:       const_float.init(*stream);
-  // CHECK-NEXT:       const_one.init(*stream);
+  //      CHECK:   {
+  // CHECK-NEXT:     const_float.init(*stream);
+  // CHECK-NEXT:     const_one.init(*stream);
   // CHECK-EMPTY:
-  // CHECK-NEXT:       auto const_one_ptr_ct1 = const_one.get_ptr();
+  // CHECK-NEXT:     stream->submit(
+  // CHECK-NEXT:       [&](sycl::handler &cgh) {
+  // CHECK-NEXT:         auto const_one_ptr_ct1 = const_one.get_ptr();
   // CHECK-EMPTY:
-  // CHECK-NEXT:       auto const_float_acc_ct1 = const_float.get_access(cgh);
+  // CHECK-NEXT:         auto const_float_acc_ct1 = const_float.get_access(cgh);
   // CHECK-EMPTY:
-  // CHECK-NEXT:       cgh.parallel_for<dpct_kernel_name<class simple_kernel_one_{{[a-f0-9]+}}>>(
-  // CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, size / 64) * sycl::range<3>(1, 1, 64), sycl::range<3>(1, 1, 64)),
-  // CHECK-NEXT:         [=](sycl::nd_item<3> item_ct1) {
-  // CHECK-NEXT:           simple_kernel_one(d_array, item_ct1, const_float_acc_ct1, *const_one_ptr_ct1);
-  // CHECK-NEXT:         });
-  // CHECK-NEXT:     });
+  // CHECK-NEXT:         cgh.parallel_for<dpct_kernel_name<class simple_kernel_one_{{[a-f0-9]+}}>>(
+  // CHECK-NEXT:           sycl::nd_range<3>(sycl::range<3>(1, 1, size / 64) * sycl::range<3>(1, 1, 64), sycl::range<3>(1, 1, 64)),
+  // CHECK-NEXT:           [=](sycl::nd_item<3> item_ct1) {
+  // CHECK-NEXT:             simple_kernel_one(d_array, item_ct1, const_float_acc_ct1, *const_one_ptr_ct1);
+  // CHECK-NEXT:           });
+  // CHECK-NEXT:       });
+  // CHECK-NEXT:   }
   simple_kernel_one<<<size / 64, 64, 0, stream>>>(d_array);
 
   // CHECK:  q_ct1.memcpy(hangle_h, d_array, 360 * sizeof(float)).wait();
@@ -206,10 +212,10 @@ int main(int argc, char **argv) {
 //CHECK-NEXT:  float *a = const_cast<float *>(aaa + 5);
 //CHECK-NEXT:}
 //CHECK-NEXT:void foo1() {
+//CHECK-NEXT:  aaa.init();
+//CHECK-EMPTY:
 //CHECK-NEXT:  dpct::get_in_order_queue().submit(
 //CHECK-NEXT:    [&](sycl::handler &cgh) {
-//CHECK-NEXT:      aaa.init();
-//CHECK-EMPTY:
 //CHECK-NEXT:      auto aaa_ptr_ct1 = aaa.get_ptr();
 //CHECK-EMPTY:
 //CHECK-NEXT:      cgh.parallel_for<dpct_kernel_name<class kernel1_{{[a-f0-9]+}}>>(

--- a/clang/test/dpct/devicemem.cu
+++ b/clang/test/dpct/devicemem.cu
@@ -82,23 +82,26 @@ int main() {
   cudaMalloc((void **)&d_out, array_size);
 
   const int threads_per_block = NUM_ELEMENTS;
-  // CHECK:   q_ct1.submit(
-  // CHECK-NEXT:     [&](sycl::handler &cgh) {
-  // CHECK-NEXT:       t1.init();
+  //      CHECK:   {
+  // CHECK-NEXT:     t1.init();
   // CHECK-EMPTY:
-  // CHECK-NEXT:       auto t1_acc_ct1 = t1.get_access(cgh);
+  // CHECK-NEXT:     q_ct1.submit(
+  // CHECK-NEXT:       [&](sycl::handler &cgh) {
+  // CHECK-NEXT:         auto t1_acc_ct1 = t1.get_access(cgh);
   // CHECK-EMPTY:
-  // CHECK-NEXT:       cgh.parallel_for<dpct_kernel_name<class member_acc_{{[a-f0-9]+}}>>(
-  // CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, threads_per_block), sycl::range<3>(1, 1, threads_per_block)),
-  // CHECK-NEXT:         [=](sycl::nd_item<3> item_ct1) {
-  // CHECK-NEXT:           member_acc(t1_acc_ct1);
-  // CHECK-NEXT:         });
-  // CHECK-NEXT:     });
+  // CHECK-NEXT:         cgh.parallel_for<dpct_kernel_name<class member_acc_{{[a-f0-9]+}}>>(
+  // CHECK-NEXT:           sycl::nd_range<3>(sycl::range<3>(1, 1, threads_per_block), sycl::range<3>(1, 1, threads_per_block)),
+  // CHECK-NEXT:           [=](sycl::nd_item<3> item_ct1) {
+  // CHECK-NEXT:             member_acc(t1_acc_ct1);
+  // CHECK-NEXT:           });
+  // CHECK-NEXT:       });
+  // CHECK-NEXT:   }
   member_acc<<<1, threads_per_block>>>();
-  // CHECK: q_ct1.submit(
-  // CHECK-NEXT:   [&](sycl::handler &cgh) {
-  // CHECK-NEXT:     in.init();
+  //      CHECK: {
+  // CHECK-NEXT: in.init();
   // CHECK-EMPTY:
+  // CHECK-NEXT: q_ct1.submit(
+  // CHECK-NEXT:   [&](sycl::handler &cgh) {
   // CHECK-NEXT:     auto in_acc_ct1 = in.get_access(cgh);
   // CHECK-NEXT:     auto d_out_acc_ct0 = dpct::get_access(d_out, cgh);
   // CHECK-EMPTY:
@@ -108,27 +111,30 @@ int main() {
   // CHECK-NEXT:         kernel1((float *)(&d_out_acc_ct0[0]), item_ct1, in_acc_ct1.get_pointer());
   // CHECK-NEXT:       });
   // CHECK-NEXT:   });
+  // CHECK-NEXT: }
   kernel1<<<1, threads_per_block>>>(d_out);
 
-  // CHECK: q_ct1.submit(
-  // CHECK-NEXT:   [&](sycl::handler &cgh) {
-  // CHECK-NEXT:     al.init();
-  // CHECK-NEXT:     fx.init();
-  // CHECK-NEXT:     fy.init();
-  // CHECK-NEXT:     tmp.init();
+  //      CHECK: {
+  // CHECK-NEXT:   al.init();
+  // CHECK-NEXT:   fx.init();
+  // CHECK-NEXT:   fy.init();
+  // CHECK-NEXT:   tmp.init();
   // CHECK-EMPTY:
-  // CHECK-NEXT:     auto al_acc_ct1 = al.get_access(cgh);
-  // CHECK-NEXT:     auto fx_acc_ct1 = fx.get_access(cgh);
-  // CHECK-NEXT:     auto fy_acc_ct1 = fy.get_access(cgh);
-  // CHECK-NEXT:     auto tmp_acc_ct1 = tmp.get_access(cgh);
-  // CHECK-NEXT:     auto d_out_acc_ct0 = dpct::get_access(d_out, cgh);
+  // CHECK-NEXT:   q_ct1.submit(
+  // CHECK-NEXT:     [&](sycl::handler &cgh) {
+  // CHECK-NEXT:       auto al_acc_ct1 = al.get_access(cgh);
+  // CHECK-NEXT:       auto fx_acc_ct1 = fx.get_access(cgh);
+  // CHECK-NEXT:       auto fy_acc_ct1 = fy.get_access(cgh);
+  // CHECK-NEXT:       auto tmp_acc_ct1 = tmp.get_access(cgh);
+  // CHECK-NEXT:       auto d_out_acc_ct0 = dpct::get_access(d_out, cgh);
   // CHECK-EMPTY:
-  // CHECK-NEXT:     cgh.parallel_for<dpct_kernel_name<class kernel2_{{[a-f0-9]+}}>>(
-  // CHECK-NEXT:       sycl::nd_range<3>(sycl::range<3>(1, 1, threads_per_block), sycl::range<3>(1, 1, threads_per_block)),
-  // CHECK-NEXT:       [=](sycl::nd_item<3> item_ct1) {
-  // CHECK-NEXT:         kernel2((float *)(&d_out_acc_ct0[0]), item_ct1, al_acc_ct1, fx_acc_ct1.get_pointer(), fy_acc_ct1, tmp_acc_ct1.get_pointer());
-  // CHECK-NEXT:       });
-  // CHECK-NEXT:   });
+  // CHECK-NEXT:       cgh.parallel_for<dpct_kernel_name<class kernel2_{{[a-f0-9]+}}>>(
+  // CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, threads_per_block), sycl::range<3>(1, 1, threads_per_block)),
+  // CHECK-NEXT:         [=](sycl::nd_item<3> item_ct1) {
+  // CHECK-NEXT:           kernel2((float *)(&d_out_acc_ct0[0]), item_ct1, al_acc_ct1, fx_acc_ct1.get_pointer(), fy_acc_ct1, tmp_acc_ct1.get_pointer());
+  // CHECK-NEXT:         });
+  // CHECK-NEXT:     });
+  // CHECK-NEXT: }
   kernel2<<<1, threads_per_block>>>(d_out);
 
   cudaMemcpy(h_out, d_out, array_size, cudaMemcpyDeviceToHost);

--- a/clang/test/dpct/devicemem_usm.cu
+++ b/clang/test/dpct/devicemem_usm.cu
@@ -82,51 +82,58 @@ int main() {
   cudaMalloc((void **)&d_out, array_size);
 
   const int threads_per_block = NUM_ELEMENTS;
-  // CHECK:     [&](sycl::handler &cgh) {
-  // CHECK-NEXT:       t1.init();
+  //      CHECK:   {
+  // CHECK-NEXT:     t1.init();
   // CHECK-EMPTY:
-  // CHECK-NEXT:       auto t1_ptr_ct1 = t1.get_ptr();
+  // CHECK-NEXT:     q_ct1.submit(
+  // CHECK-NEXT:       [&](sycl::handler &cgh) {
+  // CHECK-NEXT:         auto t1_ptr_ct1 = t1.get_ptr();
   // CHECK-EMPTY:
-  // CHECK-NEXT:       cgh.parallel_for<dpct_kernel_name<class member_acc_{{[a-f0-9]+}}>>(
-  // CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, threads_per_block), sycl::range<3>(1, 1, threads_per_block)),
-  // CHECK-NEXT:         [=](sycl::nd_item<3> item_ct1) {
-  // CHECK-NEXT:           member_acc(*t1_ptr_ct1);
-  // CHECK-NEXT:         });
-  // CHECK-NEXT:     });
+  // CHECK-NEXT:         cgh.parallel_for<dpct_kernel_name<class member_acc_{{[a-f0-9]+}}>>(
+  // CHECK-NEXT:           sycl::nd_range<3>(sycl::range<3>(1, 1, threads_per_block), sycl::range<3>(1, 1, threads_per_block)),
+  // CHECK-NEXT:           [=](sycl::nd_item<3> item_ct1) {
+  // CHECK-NEXT:             member_acc(*t1_ptr_ct1);
+  // CHECK-NEXT:           });
+  // CHECK-NEXT:       });
+  // CHECK-NEXT:   }
   member_acc<<<1, threads_per_block>>>();
-  // CHECK:   q_ct1.submit(
-  // CHECK-NEXT:     [&](sycl::handler &cgh) {
-  // CHECK-NEXT:       in.init();
+  //      CHECK:   {
+  // CHECK-NEXT:     in.init();
   // CHECK-EMPTY:
-  // CHECK-NEXT:       auto in_ptr_ct1 = in.get_ptr();
+  // CHECK-NEXT:     q_ct1.submit(
+  // CHECK-NEXT:       [&](sycl::handler &cgh) {
+  // CHECK-NEXT:         auto in_ptr_ct1 = in.get_ptr();
   // CHECK-EMPTY:
-  // CHECK-NEXT:       cgh.parallel_for<dpct_kernel_name<class kernel1_{{[a-f0-9]+}}>>(
-  // CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, threads_per_block), sycl::range<3>(1, 1, threads_per_block)),
-  // CHECK-NEXT:         [=](sycl::nd_item<3> item_ct1) {
-  // CHECK-NEXT:           kernel1(d_out, item_ct1, in_ptr_ct1);
-  // CHECK-NEXT:         });
-  // CHECK-NEXT:     });
+  // CHECK-NEXT:         cgh.parallel_for<dpct_kernel_name<class kernel1_{{[a-f0-9]+}}>>(
+  // CHECK-NEXT:           sycl::nd_range<3>(sycl::range<3>(1, 1, threads_per_block), sycl::range<3>(1, 1, threads_per_block)),
+  // CHECK-NEXT:           [=](sycl::nd_item<3> item_ct1) {
+  // CHECK-NEXT:             kernel1(d_out, item_ct1, in_ptr_ct1);
+  // CHECK-NEXT:           });
+  // CHECK-NEXT:       });
+  // CHECK-NEXT:   }
   kernel1<<<1, threads_per_block>>>(d_out);
 
-  // CHECK:   q_ct1.submit(
-  // CHECK-NEXT:     [&](sycl::handler &cgh) {
-  // CHECK-NEXT:       al.init();
-  // CHECK-NEXT:       fx.init();
-  // CHECK-NEXT:       fy.init();
-  // CHECK-NEXT:       tmp.init();
+  //      CHECK:   {
+  // CHECK-NEXT:     al.init();
+  // CHECK-NEXT:     fx.init();
+  // CHECK-NEXT:     fy.init();
+  // CHECK-NEXT:     tmp.init();
   // CHECK-EMPTY:
-  // CHECK-NEXT:       auto al_ptr_ct1 = al.get_ptr();
-  // CHECK-NEXT:       auto fx_ptr_ct1 = fx.get_ptr();
-  // CHECK-NEXT:       auto tmp_ptr_ct1 = tmp.get_ptr();
+  // CHECK-NEXT:     q_ct1.submit(
+  // CHECK-NEXT:       [&](sycl::handler &cgh) {
+  // CHECK-NEXT:         auto al_ptr_ct1 = al.get_ptr();
+  // CHECK-NEXT:         auto fx_ptr_ct1 = fx.get_ptr();
+  // CHECK-NEXT:         auto tmp_ptr_ct1 = tmp.get_ptr();
   // CHECK-EMPTY:
-  // CHECK-NEXT:       auto fy_acc_ct1 = fy.get_access(cgh);
+  // CHECK-NEXT:         auto fy_acc_ct1 = fy.get_access(cgh);
   // CHECK-EMPTY:
-  // CHECK-NEXT:       cgh.parallel_for<dpct_kernel_name<class kernel2_{{[a-f0-9]+}}>>(
-  // CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, threads_per_block), sycl::range<3>(1, 1, threads_per_block)),
-  // CHECK-NEXT:         [=](sycl::nd_item<3> item_ct1) {
-  // CHECK-NEXT:           kernel2(d_out, item_ct1, *al_ptr_ct1, fx_ptr_ct1, fy_acc_ct1, tmp_ptr_ct1);
-  // CHECK-NEXT:         });
-  // CHECK-NEXT:     });
+  // CHECK-NEXT:         cgh.parallel_for<dpct_kernel_name<class kernel2_{{[a-f0-9]+}}>>(
+  // CHECK-NEXT:           sycl::nd_range<3>(sycl::range<3>(1, 1, threads_per_block), sycl::range<3>(1, 1, threads_per_block)),
+  // CHECK-NEXT:           [=](sycl::nd_item<3> item_ct1) {
+  // CHECK-NEXT:             kernel2(d_out, item_ct1, *al_ptr_ct1, fx_ptr_ct1, fy_acc_ct1, tmp_ptr_ct1);
+  // CHECK-NEXT:           });
+  // CHECK-NEXT:       });
+  // CHECK-NEXT:   }
   kernel2<<<1, threads_per_block>>>(d_out);
 
   cudaMemcpy(h_out, d_out, array_size, cudaMemcpyDeviceToHost);

--- a/clang/test/dpct/global_var_main.cu
+++ b/clang/test/dpct/global_var_main.cu
@@ -12,18 +12,20 @@ __global__ void kernel(){
 }
 
 //CHECK:extern "C" int foo(){
-//CHECK-NEXT:  dpct::get_in_order_queue().submit(
-//CHECK-NEXT:    [&](sycl::handler &cgh) {
-//CHECK-NEXT:      c_clusters.init();
+//CHECK-NEXT:  {
+//CHECK-NEXT:    c_clusters.init();
 //CHECK-EMPTY:
-//CHECK-NEXT:      auto c_clusters_ptr_ct1 = c_clusters.get_ptr();
+//CHECK-NEXT:    dpct::get_in_order_queue().submit(
+//CHECK-NEXT:      [&](sycl::handler &cgh) {
+//CHECK-NEXT:        auto c_clusters_ptr_ct1 = c_clusters.get_ptr();
 //CHECK-EMPTY:
-//CHECK-NEXT:      cgh.parallel_for(
-//CHECK-NEXT:        sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
-//CHECK-NEXT:        [=](sycl::nd_item<3> item_ct1) {
-//CHECK-NEXT:          kernel(c_clusters_ptr_ct1);
-//CHECK-NEXT:        });
-//CHECK-NEXT:    });
+//CHECK-NEXT:        cgh.parallel_for(
+//CHECK-NEXT:          sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
+//CHECK-NEXT:          [=](sycl::nd_item<3> item_ct1) {
+//CHECK-NEXT:            kernel(c_clusters_ptr_ct1);
+//CHECK-NEXT:          });
+//CHECK-NEXT:      });
+//CHECK-NEXT:  }
 //CHECK-NEXT:  return 0;
 //CHECK-NEXT:}
 extern "C" int foo(){

--- a/clang/test/dpct/macro_test.cu
+++ b/clang/test/dpct/macro_test.cu
@@ -1105,6 +1105,7 @@ template<class T1, class T2, int N> __global__ void foo31();
 
 //CHECK: {
 //CHECK-NEXT:   dpct::has_capability_or_fail(q_ct1.get_device(), {sycl::aspect::fp64});
+//CHECK-EMPTY:
 //CHECK-NEXT:   q_ct1.submit([&](sycl::handler &cgh) {
 //CHECK-NEXT:     /*
 //CHECK-NEXT:     DPCT1101:{{[0-9]+}}: 'BLOCK_PAIR / SIMD_SIZE' expression was replaced with a
@@ -1273,7 +1274,6 @@ void foo35() {
 template<class T>
 class TemplateClass{};
 
-__global__
 template<class a>
 __global__ void templatefoo3(){}
 
@@ -1290,7 +1290,7 @@ __global__ void templatefoo3(){}
 
 #define CALLTEMPLATEFOO templatefoo3<TemplateClass<TemplateClass<int>>><<<1,1,0>>>()
 #define CALLTEMPLATEFOO2 templatefoo3<TemplateClass<int>><<<1,1,0>>>()
-void foo35() {
+void foo36() {
   CALLTEMPLATEFOO;
   CALLTEMPLATEFOO2;
 }

--- a/clang/test/dpct/mf-kernel.cu
+++ b/clang/test/dpct/mf-kernel.cu
@@ -32,7 +32,7 @@ __global__ void local_foo_2() { }
 
 __device__ void device_fp() {
   double a = 0;
-  half b = 0;
+  half b = __float2half(0);
 }
 __global__ void test_fp() { device_fp(); }
 
@@ -69,19 +69,21 @@ __global__ void constAdd(float *C) {
 
 // CHECK: void call_constAdd(float *h_C, int size) {
 // CHECK-NEXT:  float *d_C = NULL;
-// CHECK-NEXT:  dpct::get_out_of_order_queue().submit(
-// CHECK-NEXT:    [&](sycl::handler &cgh) {
-// CHECK-NEXT:      A_ct.init();
+// CHECK-NEXT:  {
+// CHECK-NEXT:    A_ct.init();
 // CHECK-EMPTY:
-// CHECK-NEXT:      auto A_acc_ct1 = A_ct.get_access(cgh);
-// CHECK-NEXT:      dpct::access_wrapper<float *> d_C_acc_ct0(d_C, cgh);
+// CHECK-NEXT:    dpct::get_out_of_order_queue().submit(
+// CHECK-NEXT:      [&](sycl::handler &cgh) {
+// CHECK-NEXT:        auto A_acc_ct1 = A_ct.get_access(cgh);
+// CHECK-NEXT:        dpct::access_wrapper<float *> d_C_acc_ct0(d_C, cgh);
 // CHECK-EMPTY:
-// CHECK-NEXT:      cgh.parallel_for<dpct_kernel_name<class constAdd_{{[a-f0-9]+}}>>(
-// CHECK-NEXT:        sycl::nd_range<3>(sycl::range<3>(1, 1, 3) * sycl::range<3>(1, 1, 3), sycl::range<3>(1, 1, 3)),
-// CHECK-NEXT:        [=](sycl::nd_item<3> item_ct1) {
-// CHECK-NEXT:          constAdd(d_C_acc_ct0.get_raw_pointer(), item_ct1, A_acc_ct1.get_pointer());
-// CHECK-NEXT:        });
-// CHECK-NEXT:    });
+// CHECK-NEXT:        cgh.parallel_for<dpct_kernel_name<class constAdd_{{[a-f0-9]+}}>>(
+// CHECK-NEXT:          sycl::nd_range<3>(sycl::range<3>(1, 1, 3) * sycl::range<3>(1, 1, 3), sycl::range<3>(1, 1, 3)),
+// CHECK-NEXT:          [=](sycl::nd_item<3> item_ct1) {
+// CHECK-NEXT:            constAdd(d_C_acc_ct0.get_raw_pointer(), item_ct1, A_acc_ct1.get_pointer());
+// CHECK-NEXT:          });
+// CHECK-NEXT:      });
+// CHECK-NEXT:  }
 // CHECK-NEXT:}
 void call_constAdd(float *h_C, int size) {
   float *d_C = NULL;

--- a/clang/test/dpct/mf-test.cu
+++ b/clang/test/dpct/mf-test.cu
@@ -26,20 +26,22 @@ void test() {
   // CHECK: dpct::device_ext &dev_ct1 = dpct::get_current_device();
   // CHECK-NEXT: sycl::queue &q_ct1 = dev_ct1.out_of_order_queue();
 
-  // CHECK:     q_ct1.submit(
-  // CHECK-NEXT:       [&](sycl::handler &cgh) {
-  // CHECK-NEXT:         extern dpct::global_memory<volatile int, 0> g_mutex;
+  //      CHECK:     {
+  // CHECK-NEXT:       g_mutex.init();
   // CHECK-EMPTY:
-  // CHECK-NEXT:         g_mutex.init();
+  // CHECK-NEXT:       q_ct1.submit(
+  // CHECK-NEXT:         [&](sycl::handler &cgh) {
+  // CHECK-NEXT:           extern dpct::global_memory<volatile int, 0> g_mutex;
   // CHECK-EMPTY:
-  // CHECK-NEXT:         auto g_mutex_acc_ct1 = g_mutex.get_access(cgh);
+  // CHECK-NEXT:           auto g_mutex_acc_ct1 = g_mutex.get_access(cgh);
   // CHECK-EMPTY:
-  // CHECK-NEXT:         cgh.parallel_for<dpct_kernel_name<class Reset_kernel_parameters_{{[a-f0-9]+}}>>(
-  // CHECK-NEXT:           sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
-  // CHECK-NEXT:           [=](sycl::nd_item<3> item_ct1) {
-  // CHECK-NEXT:             Reset_kernel_parameters(g_mutex_acc_ct1);
-  // CHECK-NEXT:           });
-  // CHECK-NEXT:       });
+  // CHECK-NEXT:           cgh.parallel_for<dpct_kernel_name<class Reset_kernel_parameters_{{[a-f0-9]+}}>>(
+  // CHECK-NEXT:             sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
+  // CHECK-NEXT:             [=](sycl::nd_item<3> item_ct1) {
+  // CHECK-NEXT:               Reset_kernel_parameters(g_mutex_acc_ct1);
+  // CHECK-NEXT:             });
+  // CHECK-NEXT:         });
+  // CHECK-NEXT:     }
   Reset_kernel_parameters<<<1,1>>>();
   // CHECK: q_ct1.parallel_for<dpct_kernel_name<class cuda_hello_{{[a-f0-9]+}}>>(
   // CHECK-NEXT:      sycl::nd_range<3>(sycl::range<3>(1, 1, 2) * sycl::range<3>(1, 1, 2), sycl::range<3>(1, 1, 2)),
@@ -60,12 +62,15 @@ void test() {
   // CHECK-NEXT:       });
   kernel_extern<<<1,1>>>();
 
-  // CHECK:   dpct::has_capability_or_fail(q_ct1.get_device(), {sycl::aspect::fp64, sycl::aspect::fp16});
-  // CHECK-NEXT:   q_ct1.parallel_for<dpct_kernel_name<class test_fp_{{[a-f0-9]+}}>>(
-  // CHECK-NEXT:     sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)), 
-  // CHECK-NEXT:     [=](sycl::nd_item<3> item_ct1) {
-  // CHECK-NEXT:       test_fp();
-  // CHECK-NEXT:     });
+  //      CHECK:   {
+  // CHECK-NEXT:     dpct::has_capability_or_fail(q_ct1.get_device(), {sycl::aspect::fp64, sycl::aspect::fp16});
+  // CHECK-EMPTY:
+  // CHECK-NEXT:     q_ct1.parallel_for<dpct_kernel_name<class test_fp_{{[a-f0-9]+}}>>(
+  // CHECK-NEXT:       sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)), 
+  // CHECK-NEXT:       [=](sycl::nd_item<3> item_ct1) {
+  // CHECK-NEXT:         test_fp();
+  // CHECK-NEXT:       });
+  // CHECK-NEXT:   }
   test_fp<<<1, 1>>>();
 }
 

--- a/clang/test/dpct/module_kernel.cu
+++ b/clang/test/dpct/module_kernel.cu
@@ -29,9 +29,10 @@ __constant__ unsigned int const_data[3] = {1, 2, 3};
 // CHECK-NEXT:     dpct::args_selector<2, 0, decltype(foo)> selector(kernelParams, extra);
 // CHECK-NEXT:     auto& k = selector.get<0>();
 // CHECK-NEXT:     auto& y = selector.get<1>();
+// CHECK-NEXT:     const_data.init(queue);
+// CHECK-EMPTY:
 // CHECK-NEXT:     queue.submit(
 // CHECK-NEXT:       [&](sycl::handler &cgh) {
-// CHECK-NEXT:         const_data.init(queue);
 // CHECK:              auto const_data_ptr_ct1 = const_data.get_ptr();
 // CHECK:              sycl::local_accessor<uint8_t, 1> dpct_local_acc_ct1(sycl::range<1>(localMemSize), cgh);
 // CHECK:              cgh.parallel_for(
@@ -72,17 +73,20 @@ extern "C" __global__ void foo2(float* k, float* y, int2 x=make_int2(1, 2)) {
 
 //CHECK: void goo(){
 //CHECK-NEXT:     float *a, *b;
-//CHECK-NEXT:     dpct::get_in_order_queue().submit(
-//CHECK-NEXT:       [&](sycl::handler &cgh) {
-//CHECK-NEXT:         const_data.init();
-//CHECK:         auto const_data_ptr_ct1 = const_data.get_ptr();
-//CHECK:         sycl::local_accessor<uint8_t, 1> dpct_local_acc_ct1(sycl::range<1>(0), cgh);
-//CHECK:         cgh.parallel_for(
-//CHECK-NEXT:           sycl::nd_range<3>(sycl::range<3>(1, 1, 2), sycl::range<3>(1, 1, 2)),
-//CHECK-NEXT:           [=](sycl::nd_item<3> item_ct1) {
-//CHECK-NEXT:             foo(a, b, item_ct1, dpct_local_acc_ct1.get_pointer(), const_data_ptr_ct1);
-//CHECK-NEXT:           });
-//CHECK-NEXT:       });
+//CHECK-NEXT:     {
+//CHECK-NEXT:       const_data.init();
+//CHECK-EMPTY:
+//CHECK-NEXT:       dpct::get_in_order_queue().submit(
+//CHECK-NEXT:         [&](sycl::handler &cgh) {
+//CHECK:                 auto const_data_ptr_ct1 = const_data.get_ptr();
+//CHECK:                 sycl::local_accessor<uint8_t, 1> dpct_local_acc_ct1(sycl::range<1>(0), cgh);
+//CHECK:                 cgh.parallel_for(
+//CHECK-NEXT:              sycl::nd_range<3>(sycl::range<3>(1, 1, 2), sycl::range<3>(1, 1, 2)),
+//CHECK-NEXT:              [=](sycl::nd_item<3> item_ct1) {
+//CHECK-NEXT:                foo(a, b, item_ct1, dpct_local_acc_ct1.get_pointer(), const_data_ptr_ct1);
+//CHECK-NEXT:              });
+//CHECK-NEXT:          });
+//CHECK-NEXT:     }
 //CHECK-NEXT: }
 void goo(){
     float *a, *b;

--- a/clang/test/dpct/sync_api.cu
+++ b/clang/test/dpct/sync_api.cu
@@ -107,6 +107,7 @@ int main() {
 // CHECK-NEXT:    dpct::global_memory<unsigned int, 0> d_sync_ct1(0);
 // CHECK-NEXT:    unsigned *sync_ct1 = d_sync_ct1.get_ptr(dpct::get_in_order_queue());
 // CHECK-NEXT:    dpct::get_in_order_queue().memset(sync_ct1, 0, sizeof(int)).wait();
+// CHECK-EMPTY:
 // CHECK-NEXT:    dpct::get_in_order_queue().parallel_for(
 // CHECK-NEXT:      sycl::nd_range<3>(sycl::range<3>(1, 1, 2) * sycl::range<3>(1, 1, 2), sycl::range<3>(1, 1, 2)),
 // CHECK-NEXT:      [=](sycl::nd_item<3> item_ct1)  {

--- a/clang/test/dpct/template-kernel-call.cu
+++ b/clang/test/dpct/template-kernel-call.cu
@@ -251,6 +251,7 @@ __global__ void convert_kernel(T b){
 // CHECK-NEXT:  T b;
 // CHECK-NEXT:  {
 // CHECK-NEXT:  dpct::has_capability_or_fail(dpct::get_out_of_order_queue().get_device(), {sycl::aspect::fp64});
+// CHECK-EMPTY:
 // CHECK-NEXT:  dpct::get_out_of_order_queue().submit(
 // CHECK-NEXT:    [&](sycl::handler &cgh) {
 // CHECK-NEXT:      sycl::local_accessor<int, 1> aaa_acc_ct1(sycl::range<1>(0), cgh);

--- a/clang/test/dpct/tm-complex-profiling.cu
+++ b/clang/test/dpct/tm-complex-profiling.cu
@@ -353,6 +353,7 @@ void foo_test_4() {
   // CHECK-NEXT:  */
   // CHECK-NEXT:  {
   // CHECK-NEXT:    dpct::has_capability_or_fail(dpct::get_in_order_queue().get_device(), {sycl::aspect::fp64});
+  // CHECK-EMPTY:
   // CHECK-NEXT:    dpct::get_in_order_queue().parallel_for<dpct_kernel_name<class set_array_{{[a-z0-9]+}}>>(
   // CHECK-NEXT:                sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
   // CHECK-NEXT:                [=](sycl::nd_item<3> item_ct1) {
@@ -373,6 +374,7 @@ void foo_test_4() {
     // CHECK-NEXT:    */
     // CHECK-NEXT:    {
     // CHECK-NEXT:        dpct::has_capability_or_fail(dpct::get_in_order_queue().get_device(), {sycl::aspect::fp64});
+    // CHECK-EMPTY:
     // CHECK-NEXT:        dpct::get_in_order_queue().parallel_for<dpct_kernel_name<class STREAM_Copy_{{[a-z0-9]+}}>>(
     // CHECK-NEXT:                    sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
     // CHECK-NEXT:                    [=](sycl::nd_item<3> item_ct1) {
@@ -394,6 +396,7 @@ void foo_test_4() {
     // CHECK-NEXT:    */
     // CHECK-NEXT:    {
     // CHECK-NEXT:        dpct::has_capability_or_fail(dpct::get_in_order_queue().get_device(), {sycl::aspect::fp64});
+    // CHECK-EMPTY:
     // CHECK-NEXT:        dpct::get_in_order_queue().parallel_for<dpct_kernel_name<class STREAM_Copy_Optimized_{{[a-z0-9]+}}>>(
     // CHECK-NEXT:                    sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
     // CHECK-NEXT:                    [=](sycl::nd_item<3> item_ct1) {

--- a/clang/test/dpct/tm-complex.cu
+++ b/clang/test/dpct/tm-complex.cu
@@ -222,6 +222,7 @@ void foo_test_1() {
   CHECK_FOO(cudaEventRecord(start));
   // CHECK:  {
   // CHECK-NEXT:    dpct::has_capability_or_fail(dpct::get_in_order_queue().get_device(), {sycl::aspect::fp64});
+  // CHECK-EMPTY:
   // CHECK-NEXT:    *stop = dpct::get_in_order_queue().parallel_for<dpct_kernel_name<class kernel_1_{{[a-z0-9]+}}>>(
   // CHECK-NEXT:                sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
   // CHECK-NEXT:                [=](sycl::nd_item<3> item_ct1) {
@@ -488,6 +489,7 @@ void foo_test_4() {
   // CHECK-NEXT:  */
   // CHECK-NEXT:  {
   // CHECK-NEXT:    dpct::has_capability_or_fail(dpct::get_in_order_queue().get_device(), {sycl::aspect::fp64});
+  // CHECK-EMPTY:
   // CHECK-NEXT:    dpct::get_in_order_queue().parallel_for<dpct_kernel_name<class set_array_{{[a-z0-9]+}}>>(
   // CHECK-NEXT:                sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
   // CHECK-NEXT:                [=](sycl::nd_item<3> item_ct1) {
@@ -514,6 +516,7 @@ void foo_test_4() {
     // CHECK-NEXT:    */
     // CHECK-NEXT:    {
     // CHECK-NEXT:        dpct::has_capability_or_fail(dpct::get_in_order_queue().get_device(), {sycl::aspect::fp64});
+    // CHECK-EMPTY:
     // CHECK-NEXT:        dpct::get_in_order_queue().parallel_for<dpct_kernel_name<class STREAM_Copy_{{[a-z0-9]+}}>>(
     // CHECK-NEXT:                    sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
     // CHECK-NEXT:                    [=](sycl::nd_item<3> item_ct1) {
@@ -543,6 +546,7 @@ void foo_test_4() {
     // CHECK-NEXT:    */
     // CHECK-NEXT:    {
     // CHECK-NEXT:        dpct::has_capability_or_fail(dpct::get_in_order_queue().get_device(), {sycl::aspect::fp64});
+    // CHECK-EMPTY:
     // CHECK-NEXT:        dpct::get_in_order_queue().parallel_for<dpct_kernel_name<class STREAM_Copy_Optimized_{{[a-z0-9]+}}>>(
     // CHECK-NEXT:                    sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
     // CHECK-NEXT:                    [=](sycl::nd_item<3> item_ct1) {


### PR DESCRIPTION
Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>