### PR TITLE
[SYCLomatic] Fix two bugs in the --intercept-build option implementation

### DIFF
--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -1540,10 +1540,11 @@ bool CommandLineParser::ParseCommandLineOptions(int argc,
 
 #ifdef SYCLomatic_CUSTOMIZATION
 #ifndef _WIN32
-  if (std::string(argv[FirstArg]) == "--intercept-build" ||
-      std::string(argv[FirstArg]) == "-intercept-build" ||
-      std::string(argv[FirstArg]) == "intercept-build") {
-    StringRef ArgName = "intercept-build";
+  if (argc >= 2 && (std::string(argv[FirstArg]) == "--intercept-build" ||
+                    std::string(argv[FirstArg]) == "-intercept-build" ||
+                    std::string(argv[FirstArg]) == "intercept-build")) {
+    const static std::string InterceptBuildCommand = "intercept-build";
+    StringRef ArgName(InterceptBuildCommand);
     StringRef Value;
     Option *Handler = LookupLongOption(*ChosenSubCommand, ArgName, Value,
                                        LongOptionsUseDoubleDash, false);

--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -1540,9 +1540,10 @@ bool CommandLineParser::ParseCommandLineOptions(int argc,
 
 #ifdef SYCLomatic_CUSTOMIZATION
 #ifndef _WIN32
-  if (argc >= 2 && (std::string(argv[FirstArg]) == "--intercept-build" ||
-                    std::string(argv[FirstArg]) == "-intercept-build" ||
-                    std::string(argv[FirstArg]) == "intercept-build")) {
+  if ((argc >= FirstArg + 1) &&
+      (std::string(argv[FirstArg]) == "--intercept-build" ||
+       std::string(argv[FirstArg]) == "-intercept-build" ||
+       std::string(argv[FirstArg]) == "intercept-build")) {
     const static std::string InterceptBuildCommand = "intercept-build";
     StringRef ArgName(InterceptBuildCommand);
     StringRef Value;


### PR DESCRIPTION
1. Check argc before accessing argv
2. Fix the dangling reference

Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>