### PR TITLE
[SYCLomatic] Fix bug issue that thrust::device_ptr is not migrated if space exists between type name and left angle

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -1796,7 +1796,12 @@ bool TypeInDeclRule::replaceTemplateSpecialization(
   if (TyLen <= 0)
     return false;
 
-  const std::string RealTypeNameStr(Start, TyLen);
+  std::string RealTypeNameStr(Start, TyLen);
+  const auto StartPos = RealTypeNameStr.find_last_not_of(" ");
+  // Remove spaces between type name and left angle, like "thrust::device_ptr[Spaces]
+  // <int> tmp".
+  if (StartPos != std::string::npos)
+    RealTypeNameStr = RealTypeNameStr.substr(0, StartPos + 1);
 
   if (DpctGlobalInfo::getUsmLevel() == UsmLevel::UL_None &&
       RealTypeNameStr.find("device_malloc_allocator") != std::string::npos) {

--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -1798,8 +1798,8 @@ bool TypeInDeclRule::replaceTemplateSpecialization(
 
   std::string RealTypeNameStr(Start, TyLen);
   const auto StartPos = RealTypeNameStr.find_last_not_of(" ");
-  // Remove spaces between type name and left angle, like "thrust::device_ptr[Spaces]
-  // <int> tmp".
+  // Remove spaces between type name and template arg, like
+  // "thrust::device_ptr[Spaces]<int> tmp".
   if (StartPos != std::string::npos)
     RealTypeNameStr = RealTypeNameStr.substr(0, StartPos + 1);
 

--- a/clang/test/dpct/types002.cu
+++ b/clang/test/dpct/types002.cu
@@ -27,6 +27,9 @@ int main(int argc, char **argv) {
   a = sizeof(device_p);
   a = sizeof device_p;
 
+  //CHECK: dpct::device_pointer<unsigned int> ttt;
+  thrust::device_ptr <unsigned int> ttt;
+
   //CHECK:dpct::device_reference<int> device_ref = device_vec[0];
   //CHECK-NEXT:a = sizeof(dpct::device_reference<int>);
   //CHECK-NEXT:a = sizeof(device_ref);


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>