### PR TITLE
[SYCLomatic] Support two overloading versions of thrust::gather_if

### DIFF
--- a/clang/lib/DPCT/APINamesThrust.inc
+++ b/clang/lib/DPCT/APINamesThrust.inc
@@ -92,7 +92,9 @@ thrustFactory("thrust::mismatch",
 // thrust::gather_if
 thrustFactory("thrust::gather_if",
               {{7,PolicyState::HasPolicy,5,MapNames::getDpctNamespace()+"gather_if", HelperFeatureEnum::device_ext},
-               {6,PolicyState::NoPolicy ,5,MapNames::getDpctNamespace()+"gather_if", HelperFeatureEnum::device_ext}}),
+               {6,PolicyState::NoPolicy ,5,MapNames::getDpctNamespace()+"gather_if", HelperFeatureEnum::device_ext},
+               {6,PolicyState::HasPolicy,5,MapNames::getDpctNamespace()+"gather_if", HelperFeatureEnum::device_ext},
+               {5,PolicyState::NoPolicy ,5,MapNames::getDpctNamespace()+"gather_if", HelperFeatureEnum::device_ext}}),
 
 // thrust::merge_by_key
 thrustFactory("thrust::merge_by_key",

--- a/clang/test/dpct/thrust_gather.cu
+++ b/clang/test/dpct/thrust_gather.cu
@@ -78,18 +78,13 @@ int main(void) {
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// CHECK: /*
-// CHECK-NEXT: DPCT1107:{{[0-9]+}}: Migration for this overload of thrust::gather_if is not supported.
-// CHECK-NEXT: */
-// CHECK-NEXT: thrust::gather_if(AH.begin(), AH.end(), SH.begin(), BH.begin(), RH.begin());
-// CHECK-NEXT: /*
-// CHECK-NEXT: DPCT1107:{{[0-9]+}}: Migration for this overload of thrust::gather_if is not supported.
-// CHECK-NEXT: */
-// CHECK-NEXT: thrust::gather_if(AD.begin(), AD.end(), SD.begin(), BD.begin(), RD.begin());
-// CHECK-NEXT: /*
-// CHECK-NEXT: DPCT1107:{{[0-9]+}}: Migration for this overload of thrust::gather_if is not supported.
-// CHECK-NEXT: */
-// CHECK-NEXT: thrust::gather_if(h_ptr, h_ptr + 4, SH.begin(), BH.begin(), RH.begin());
+// CHECK:  dpct::gather_if(oneapi::dpl::execution::seq, AH.begin(), AH.end(), SH.begin(), BH.begin(), RH.begin());
+// CHECK-NEXT:  dpct::gather_if(oneapi::dpl::execution::make_device_policy(q_ct1), AD.begin(), AD.end(), SD.begin(), BD.begin(), RD.begin());
+// CHECK-NEXT:  if (dpct::is_device_ptr(h_ptr)) {
+// CHECK-NEXT:    dpct::gather_if(oneapi::dpl::execution::make_device_policy(q_ct1), dpct::device_pointer<int>(h_ptr), dpct::device_pointer<int>(h_ptr + 4), dpct::device_pointer<>(SH.begin()), dpct::device_pointer<>(BH.begin()), dpct::device_pointer<>(RH.begin()));
+// CHECK-NEXT:  } else {
+// CHECK-NEXT:    dpct::gather_if(oneapi::dpl::execution::seq, h_ptr, h_ptr + 4, SH.begin(), BH.begin(), RH.begin());
+// CHECK-NEXT:  };
   // VERSION                        first       last      stencil     input       result
   thrust::gather_if(                AH.begin(), AH.end(), SH.begin(), BH.begin(), RH.begin());
   thrust::gather_if(                AD.begin(), AD.end(), SD.begin(), BD.begin(), RD.begin());
@@ -99,22 +94,18 @@ int main(void) {
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// CHECK: /*
-// CHECK-NEXT: DPCT1107:{{[0-9]+}}: Migration for this overload of thrust::gather_if is not supported.
-// CHECK-NEXT: */
-// CHECK-NEXT: thrust::gather_if(oneapi::dpl::execution::seq, AH.begin(), AH.end(), SH.begin(), BH.begin(), RH.begin());
-// CHECK-NEXT: /*
-// CHECK-NEXT: DPCT1107:{{[0-9]+}}: Migration for this overload of thrust::gather_if is not supported.
-// CHECK-NEXT: */
-// CHECK-NEXT: thrust::gather_if(oneapi::dpl::execution::make_device_policy(q_ct1), AD.begin(), AD.end(), SD.begin(), BD.begin(), RD.begin());
-// CHECK-NEXT: /*
-// CHECK-NEXT: DPCT1107:{{[0-9]+}}: Migration for this overload of thrust::gather_if is not supported.
-// CHECK-NEXT: */
-// CHECK-NEXT: thrust::gather_if(oneapi::dpl::execution::seq, h_ptr, h_ptr + 4, SH.begin(), BH.begin(), RH.begin());
-// CHECK-NEXT: /*
-// CHECK-NEXT: DPCT1107:{{[0-9]+}}: Migration for this overload of thrust::gather_if is not supported.
-// CHECK-NEXT: */
-// CHECK-NEXT: thrust::gather_if(oneapi::dpl::execution::make_device_policy(q_ct1), d_ptr, d_ptr + 4, SD.begin(), BD.begin(), RD.begin());
+// CHECK:  dpct::gather_if(oneapi::dpl::execution::seq, AH.begin(), AH.end(), SH.begin(), BH.begin(), RH.begin());
+// CHECK-NEXT:  dpct::gather_if(oneapi::dpl::execution::make_device_policy(q_ct1), AD.begin(), AD.end(), SD.begin(), BD.begin(), RD.begin());
+// CHECK-NEXT:  if (dpct::is_device_ptr(h_ptr)) {
+// CHECK-NEXT:    dpct::gather_if(oneapi::dpl::execution::make_device_policy(q_ct1), dpct::device_pointer<int>(h_ptr), dpct::device_pointer<int>(h_ptr + 4), dpct::device_pointer<>(SH.begin()), dpct::device_pointer<>(BH.begin()), dpct::device_pointer<>(RH.begin()));
+// CHECK-NEXT:  } else {
+// CHECK-NEXT:    dpct::gather_if(oneapi::dpl::execution::seq, h_ptr, h_ptr + 4, SH.begin(), BH.begin(), RH.begin());
+// CHECK-NEXT:  };
+// CHECK-NEXT:  if (dpct::is_device_ptr(d_ptr)) {
+// CHECK-NEXT:    dpct::gather_if(oneapi::dpl::execution::make_device_policy(q_ct1), dpct::device_pointer<int>(d_ptr), dpct::device_pointer<int>(d_ptr + 4), dpct::device_pointer<>(SD.begin()), dpct::device_pointer<>(BD.begin()), dpct::device_pointer<>(RD.begin()));
+// CHECK-NEXT:  } else {
+// CHECK-NEXT:    dpct::gather_if(oneapi::dpl::execution::seq, d_ptr, d_ptr + 4, SD.begin(), BD.begin(), RD.begin());
+// CHECK-NEXT:  };
   // VERSION        exec            first       last      stencil     input       result
   thrust::gather_if(thrust::host,   AH.begin(), AH.end(), SH.begin(), BH.begin(), RH.begin());
   thrust::gather_if(thrust::device, AD.begin(), AD.end(), SD.begin(), BD.begin(), RD.begin());

--- a/clang/test/dpct/thrust_gather_usm.cu
+++ b/clang/test/dpct/thrust_gather_usm.cu
@@ -67,18 +67,10 @@ int main(void) {
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// CHECK: /*
-// CHECK-NEXT: DPCT1107:{{[0-9]+}}: Migration for this overload of thrust::gather_if is not supported.
-// CHECK-NEXT: */
-// CHECK-NEXT: thrust::gather_if(AH.begin(), AH.end(), SH.begin(), BH.begin(), RH.begin());
-// CHECK-NEXT: /*
-// CHECK-NEXT: DPCT1107:{{[0-9]+}}: Migration for this overload of thrust::gather_if is not supported.
-// CHECK-NEXT: */
-// CHECK-NEXT: thrust::gather_if(AD.begin(), AD.end(), SD.begin(), BD.begin(), RD.begin());
-// CHECK-NEXT: /*
-// CHECK-NEXT: DPCT1107:{{[0-9]+}}: Migration for this overload of thrust::gather_if is not supported.
-// CHECK-NEXT: */
-// CHECK-NEXT: thrust::gather_if(h_ptr, h_ptr + 4, SH.begin(), BH.begin(), RH.begin());
+
+// CHECK:  dpct::gather_if(oneapi::dpl::execution::seq, AH.begin(), AH.end(), SH.begin(), BH.begin(), RH.begin());
+// CHECK-NEXT:  dpct::gather_if(oneapi::dpl::execution::make_device_policy(q_ct1), AD.begin(), AD.end(), SD.begin(), BD.begin(), RD.begin());
+// CHECK-NEXT:  dpct::gather_if(oneapi::dpl::execution::seq, h_ptr, h_ptr + 4, SH.begin(), BH.begin(), RH.begin());
   // VERSION                        first       last      stencil     input       result
   thrust::gather_if(                AH.begin(), AH.end(), SH.begin(), BH.begin(), RH.begin());
   thrust::gather_if(                AD.begin(), AD.end(), SD.begin(), BD.begin(), RD.begin());
@@ -88,22 +80,10 @@ int main(void) {
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// CHECK: /*
-// CHECK-NEXT: DPCT1107:{{[0-9]+}}: Migration for this overload of thrust::gather_if is not supported.
-// CHECK-NEXT: */
-// CHECK-NEXT: thrust::gather_if(oneapi::dpl::execution::seq, AH.begin(), AH.end(), SH.begin(), BH.begin(), RH.begin());
-// CHECK-NEXT: /*
-// CHECK-NEXT: DPCT1107:{{[0-9]+}}: Migration for this overload of thrust::gather_if is not supported.
-// CHECK-NEXT: */
-// CHECK-NEXT: thrust::gather_if(oneapi::dpl::execution::make_device_policy(q_ct1), AD.begin(), AD.end(), SD.begin(), BD.begin(), RD.begin());
-// CHECK-NEXT: /*
-// CHECK-NEXT: DPCT1107:{{[0-9]+}}: Migration for this overload of thrust::gather_if is not supported.
-// CHECK-NEXT: */
-// CHECK-NEXT: thrust::gather_if(oneapi::dpl::execution::seq, h_ptr, h_ptr + 4, SH.begin(), BH.begin(), RH.begin());
-// CHECK-NEXT: /*
-// CHECK-NEXT: DPCT1107:{{[0-9]+}}: Migration for this overload of thrust::gather_if is not supported.
-// CHECK-NEXT: */
-// CHECK-NEXT: thrust::gather_if(oneapi::dpl::execution::make_device_policy(q_ct1), d_ptr, d_ptr + 4, SD.begin(), BD.begin(), RD.begin());
+// CHECK:  dpct::gather_if(oneapi::dpl::execution::seq, AH.begin(), AH.end(), SH.begin(), BH.begin(), RH.begin());
+// CHECK-NEXT:  dpct::gather_if(oneapi::dpl::execution::make_device_policy(q_ct1), AD.begin(), AD.end(), SD.begin(), BD.begin(), RD.begin());
+// CHECK-NEXT:  dpct::gather_if(oneapi::dpl::execution::seq, h_ptr, h_ptr + 4, SH.begin(), BH.begin(), RH.begin());
+// CHECK-NEXT:  dpct::gather_if(oneapi::dpl::execution::make_device_policy(q_ct1), d_ptr, d_ptr + 4, SD.begin(), BD.begin(), RD.begin());
   // VERSION        exec            first       last      stencil     input       result
   thrust::gather_if(thrust::host,   AH.begin(), AH.end(), SH.begin(), BH.begin(), RH.begin());
   thrust::gather_if(thrust::device, AD.begin(), AD.end(), SD.begin(), BD.begin(), RD.begin());


### PR DESCRIPTION
1. Support to migrate six args version with policy specified.
2. Support to migrate five args version without policy specified.