### PR TITLE
[SYCLomatic] Support two overloading versions of thrust::scatter_if 

### DIFF
--- a/clang/lib/DPCT/APINamesThrust.inc
+++ b/clang/lib/DPCT/APINamesThrust.inc
@@ -1011,7 +1011,9 @@ CALL_FACTORY_ENTRY("thrust::make_counting_iterator", CALL(MapNames::getDpctNames
 // thrust::scatter_if
 thrustFactory("thrust::scatter_if",
               {{7,PolicyState::HasPolicy,5,MapNames::getDpctNamespace()+"scatter_if", HelperFeatureEnum::device_ext},
-               {6,PolicyState::NoPolicy, 5,MapNames::getDpctNamespace()+"scatter_if", HelperFeatureEnum::device_ext}}),
+               {6,PolicyState::NoPolicy, 5,MapNames::getDpctNamespace()+"scatter_if", HelperFeatureEnum::device_ext},
+               {6,PolicyState::HasPolicy,5,MapNames::getDpctNamespace()+"scatter_if", HelperFeatureEnum::device_ext},
+               {5,PolicyState::NoPolicy, 5,MapNames::getDpctNamespace()+"scatter_if", HelperFeatureEnum::device_ext}}),
 
 // thrust::uninitialized_copy(
 thrustFactory("thrust::uninitialized_copy",

--- a/clang/test/dpct/thrust-algo-raw-ptr-noneusm.cu
+++ b/clang/test/dpct/thrust-algo-raw-ptr-noneusm.cu
@@ -729,14 +729,16 @@ void scatter_if() {
   int D[N] = {0, 0, 0, 0, 0, 0, 0, 0};
   is_even_scatter_if pred;
 
-  // CHECK:  /*
-  // CHECK-NEXT:  DPCT1107:0: Migration for this overload of thrust::scatter_if is not supported.
-  // CHECK-NEXT:  */
-  // CHECK-NEXT:  thrust::scatter_if(oneapi::dpl::execution::seq, V, V + 8, M, S, D);
-  // CHECK-NEXT:  /*
-  // CHECK-NEXT:  DPCT1107:1: Migration for this overload of thrust::scatter_if is not supported.
-  // CHECK-NEXT:  */
-  // CHECK-NEXT:  thrust::scatter_if(V, V + 8, M, S, D);
+  // CHECK:  if (dpct::is_device_ptr(V)) {
+  // CHECK-NEXT:    dpct::scatter_if(oneapi::dpl::execution::make_device_policy(q_ct1), dpct::device_pointer<int>(V), dpct::device_pointer<int>(V + 8), dpct::device_pointer<int>(M), dpct::device_pointer<int>(S), dpct::device_pointer<int>(D));
+  // CHECK-NEXT:  } else {
+  // CHECK-NEXT:    dpct::scatter_if(oneapi::dpl::execution::seq, V, V + 8, M, S, D);
+  // CHECK-NEXT:  };
+  // CHECK-NEXT:  if (dpct::is_device_ptr(V)) {
+  // CHECK-NEXT:    dpct::scatter_if(oneapi::dpl::execution::make_device_policy(q_ct1), dpct::device_pointer<int>(V), dpct::device_pointer<int>(V + 8), dpct::device_pointer<int>(M), dpct::device_pointer<int>(S), dpct::device_pointer<int>(D));
+  // CHECK-NEXT:  } else {
+  // CHECK-NEXT:    dpct::scatter_if(oneapi::dpl::execution::seq, V, V + 8, M, S, D);
+  // CHECK-NEXT:  };
   // CHECK-NEXT:  if (dpct::is_device_ptr(V)) {
   // CHECK-NEXT:    dpct::scatter_if(oneapi::dpl::execution::make_device_policy(q_ct1), dpct::device_pointer<int>(V), dpct::device_pointer<int>(V + 8), dpct::device_pointer<int>(M), dpct::device_pointer<int>(S), dpct::device_pointer<int>(D), pred);
   // CHECK-NEXT:  } else {

--- a/clang/test/dpct/thrust-algo.cu
+++ b/clang/test/dpct/thrust-algo.cu
@@ -1118,34 +1118,16 @@ void scatter_if() {
   thrust::host_vector<int> h_S(S, S + N);
   thrust::host_vector<int> h_D(N);
 
-  // CHECK:  /*
-  // CHECK-NEXT:  DPCT1107:{{[0-9]+}}: Migration for this overload of thrust::scatter_if is not supported.
-  // CHECK-NEXT:  */
-  // CHECK-NEXT:  thrust::scatter_if(oneapi::dpl::execution::seq, V, V + 8, M, S, D);
-  // CHECK-NEXT:  /*
-  // CHECK-NEXT:  DPCT1107:{{[0-9]+}}: Migration for this overload of thrust::scatter_if is not supported.
-  // CHECK-NEXT:  */
-  // CHECK-NEXT:  thrust::scatter_if(V, V + 8, M, S, D);
+  // CHECK:  dpct::scatter_if(oneapi::dpl::execution::seq, V, V + 8, M, S, D);
+  // CHECK-NEXT:  dpct::scatter_if(oneapi::dpl::execution::seq, V, V + 8, M, S, D);
   // CHECK-NEXT:  dpct::scatter_if(oneapi::dpl::execution::seq, V, V + 8, M, S, D, pred);
   // CHECK-NEXT:  dpct::scatter_if(oneapi::dpl::execution::seq, V, V + 8, M, S, D, pred);
-  // CHECK-NEXT:  /*
-  // CHECK-NEXT:  DPCT1107:{{[0-9]+}}: Migration for this overload of thrust::scatter_if is not supported.
-  // CHECK-NEXT:  */
-  // CHECK-NEXT:  thrust::scatter_if(oneapi::dpl::execution::make_device_policy(q_ct1), d_V.begin(), d_V.end(), d_M.begin(), d_S.begin(), d_D.begin());
-  // CHECK-NEXT:  /*
-  // CHECK-NEXT:  DPCT1107:{{[0-9]+}}: Migration for this overload of thrust::scatter_if is not supported.
-  // CHECK-NEXT:  */
-  // CHECK-NEXT:  thrust::scatter_if(d_V.begin(), d_V.end(), d_M.begin(), d_S.begin(), d_D.begin());
+  // CHECK-NEXT:  dpct::scatter_if(oneapi::dpl::execution::make_device_policy(q_ct1), d_V.begin(), d_V.end(), d_M.begin(), d_S.begin(), d_D.begin());
+  // CHECK-NEXT:  dpct::scatter_if(oneapi::dpl::execution::make_device_policy(q_ct1), d_V.begin(), d_V.end(), d_M.begin(), d_S.begin(), d_D.begin());
   // CHECK-NEXT:  dpct::scatter_if(oneapi::dpl::execution::make_device_policy(q_ct1), d_V.begin(), d_V.end(), d_M.begin(), d_S.begin(), d_D.begin(), pred);
   // CHECK-NEXT:  dpct::scatter_if(oneapi::dpl::execution::make_device_policy(q_ct1), d_V.begin(), d_V.end(), d_M.begin(), d_S.begin(), d_D.begin(), pred);
-  // CHECK-NEXT:  /*
-  // CHECK-NEXT:  DPCT1107:{{[0-9]+}}: Migration for this overload of thrust::scatter_if is not supported.
-  // CHECK-NEXT:  */
-  // CHECK-NEXT:  thrust::scatter_if(oneapi::dpl::execution::seq, h_V.begin(), h_V.end(), h_M.begin(), h_S.begin(), h_D.begin());
-  // CHECK-NEXT:  /*
-  // CHECK-NEXT:  DPCT1107:{{[0-9]+}}: Migration for this overload of thrust::scatter_if is not supported.
-  // CHECK-NEXT:  */
-  // CHECK-NEXT:  thrust::scatter_if(h_V.begin(), h_V.end(), h_M.begin(), h_S.begin(),  h_D.begin());
+  // CHECK-NEXT:  dpct::scatter_if(oneapi::dpl::execution::seq, h_V.begin(), h_V.end(), h_M.begin(), h_S.begin(), h_D.begin());
+  // CHECK-NEXT:  dpct::scatter_if(oneapi::dpl::execution::seq, h_V.begin(), h_V.end(), h_M.begin(), h_S.begin(), h_D.begin());
   // CHECK-NEXT:  dpct::scatter_if(oneapi::dpl::execution::seq, h_V.begin(), h_V.end(), h_M.begin(), h_S.begin(), h_D.begin(), pred);
   // CHECK-NEXT:  dpct::scatter_if(oneapi::dpl::execution::seq, h_V.begin(), h_V.end(), h_M.begin(), h_S.begin(), h_D.begin(), pred);
   thrust::scatter_if(thrust::host, V, V + 8, M, S, D);


### PR DESCRIPTION
1. Support to migrate six args version with policy specified.
2. Support to migrate five args version without policy specified.