### PR TITLE
[SYCLomatic] Fix two bug issues in pattern-rewriter for cmake scripts migration

### DIFF
--- a/clang/lib/DPCT/MigrateCmakeScript.cpp
+++ b/clang/lib/DPCT/MigrateCmakeScript.cpp
@@ -686,6 +686,29 @@ void doCmakeScriptMigration(const clang::tooling::UnifiedPath &InRoot,
                             const clang::tooling::UnifiedPath &OutRoot) {
   loadBufferFromFile(InRoot, OutRoot);
   unifyInputFileFormat();
+
+#if 1
+  printf("#### doCmakeScriptMigration ###\n");
+  for (const auto &Entry : CmakeBuildInRules) {
+    auto PR = Entry.second;
+    printf("PR.MatchMode: [%d]\n", PR.MatchMode);
+    printf("PR.CmakeSyntax: [%s]\n", PR.CmakeSyntax.c_str());
+    printf("PR.RuleId: [%s]\n", PR.RuleId.c_str());
+    printf("PR.In: [%s]\n", PR.In.c_str());
+    printf("PR.Out: [%s]\n", PR.Out.c_str());
+
+    for (auto SubPR : PR.Subrules) {
+      printf("\tSubPR.first: [%s]\n", SubPR.first.c_str());
+      printf("\tSubPR.second.MatchMode: [%d]\n", SubPR.second.MatchMode);
+      printf("\tSubPR.second.In: [%s]\n", SubPR.second.In.c_str());
+      printf("\tSubPR.second.Out: [%s]\n", SubPR.second.Out.c_str());
+    }
+    printf("\n");
+  }
+  printf("#### doCmakeScriptMigration ###\n");
+#endif
+
+
   reserveImplicitMigrationRules();
   doCmakeScriptAnalysis();
   applyCmakeMigrationRules();

--- a/clang/lib/DPCT/MigrateCmakeScript.cpp
+++ b/clang/lib/DPCT/MigrateCmakeScript.cpp
@@ -686,29 +686,6 @@ void doCmakeScriptMigration(const clang::tooling::UnifiedPath &InRoot,
                             const clang::tooling::UnifiedPath &OutRoot) {
   loadBufferFromFile(InRoot, OutRoot);
   unifyInputFileFormat();
-
-#if 1
-  printf("#### doCmakeScriptMigration ###\n");
-  for (const auto &Entry : CmakeBuildInRules) {
-    auto PR = Entry.second;
-    printf("PR.MatchMode: [%d]\n", PR.MatchMode);
-    printf("PR.CmakeSyntax: [%s]\n", PR.CmakeSyntax.c_str());
-    printf("PR.RuleId: [%s]\n", PR.RuleId.c_str());
-    printf("PR.In: [%s]\n", PR.In.c_str());
-    printf("PR.Out: [%s]\n", PR.Out.c_str());
-
-    for (auto SubPR : PR.Subrules) {
-      printf("\tSubPR.first: [%s]\n", SubPR.first.c_str());
-      printf("\tSubPR.second.MatchMode: [%d]\n", SubPR.second.MatchMode);
-      printf("\tSubPR.second.In: [%s]\n", SubPR.second.In.c_str());
-      printf("\tSubPR.second.Out: [%s]\n", SubPR.second.Out.c_str());
-    }
-    printf("\n");
-  }
-  printf("#### doCmakeScriptMigration ###\n");
-#endif
-
-
   reserveImplicitMigrationRules();
   doCmakeScriptAnalysis();
   applyCmakeMigrationRules();

--- a/clang/lib/DPCT/PatternRewriter.cpp
+++ b/clang/lib/DPCT/PatternRewriter.cpp
@@ -458,14 +458,26 @@ static std::optional<MatchResult> findMatch(const MatchPattern &Pattern,
       if (Next == -1) {
         return {};
       }
+      printf("###input#####\n[%s]\n#########\n\n", Input.c_str());
+      printf("#### Index[%d]\n", Index);
       const int Indentation = detectIndentation(Input, Index);
+      printf("#### Indentation[%d]\n\n", Indentation);
+
+      if(Input[Index] == '\n') {
+        Index ++;
+      }
+
+
       std::string ElementContents =
           dedent(Input.substr(Index, Next - Index), Indentation);
+      
+      printf("ElementContents [%s]\n", ElementContents.c_str());
       if (Result.Bindings.count(Code.Name)) {
         if (Result.Bindings[Code.Name] != ElementContents) {
           return {};
         }
       } else {
+        printf("\t[%s]-->[%s]\n", Code.Name.c_str(), ElementContents.c_str());
         Result.Bindings[Code.Name] = std::move(ElementContents);
       }
       Index = Next;
@@ -531,6 +543,7 @@ static void instantiateTemplate(
             detectIndentation(Template, BindingStart) + Indentation;
         const std::string Contents =
             indent(BindingIterator->second, BindingIndentation);
+        printf("#######00##### [%s]\n", Contents.c_str());
         OutputStream << Contents;
       }
       continue;
@@ -584,6 +597,29 @@ std::string applyPatternRewriter(const MetaRuleObject::PatternRewriter &PP,
 
   const auto Pattern = parseMatchPattern(PP.In);
 
+#if 1 // use for debug print
+  int Count = 0;
+  printf("Pattern start:\n");
+  for(auto Element: Pattern) {
+    if (std::holds_alternative<CodeElement>(Element)) {
+      auto &Code = std::get<CodeElement>(Element);
+      printf("\t[%d]->[%s]:[%d]\n", Count, Code.Name.c_str(), Code.SuffixLength);
+    }
+    if (std::holds_alternative<LiteralElement>(Element)) {
+      const auto &Literal = std::get<LiteralElement>(Element);
+      printf("\t[%d]->[%c]\n", Count, Literal.Value);
+    }
+    if (std::holds_alternative<SpacingElement>(Element)) {
+      printf("\t[%d]->[%s]\n", Count, "space");
+    }
+    Count++;
+  }
+  printf("Pattern end.\n\n");
+  #endif
+
+
+
+
   const int Size = Input.size();
   int Index = 0;
   while (Index < Size) {
@@ -602,6 +638,7 @@ std::string applyPatternRewriter(const MetaRuleObject::PatternRewriter &PP,
     if (Result.has_value()) {
       auto &Match = Result.value();
       for (const auto &[Name, Value] : Match.Bindings) {
+        printf("\t[%s]->[%s]\n", Name.c_str(), Value.c_str());
         const auto &SubruleIterator = PP.Subrules.find(Name);
         if (SubruleIterator != PP.Subrules.end()) {
           Match.Bindings[Name] =
@@ -610,7 +647,15 @@ std::string applyPatternRewriter(const MetaRuleObject::PatternRewriter &PP,
       }
       const int Indentation = detectIndentation(Input, Index);
       instantiateTemplate(PP.Out, Match.Bindings, Indentation, OutputStream);
+      printf("###########################[%s]\n", OutputStream.str().c_str());
       Index = Match.End;
+      printf("#####Found Match Index [%d]\n", Index);
+      printf("#####Found Match Value [%c]\n", Input[Index]);
+      printf("\n\n");
+      while (Input[Index] == '\n') {
+        OutputStream << Input[Index];
+        Index++;
+      }
       continue;
     }
 

--- a/clang/lib/DPCT/PatternRewriter.cpp
+++ b/clang/lib/DPCT/PatternRewriter.cpp
@@ -419,8 +419,8 @@ static std::optional<MatchResult> findFullMatch(const MatchPattern &Pattern,
         return {};
       }
 
-      // To make sure first character behind the matched word is a not
-      // indentified character or sufix match '('.
+      // To make sure first character after the matched word isn't an
+      // identified character or suffix match '('.
       if (Index < Size - 1 && isIdentifiedChar(Input[Index + 1]) &&
           PatternIndex + 1 == PatternSize && Literal.Value != '(') {
         return {};

--- a/clang/test/dpct/cmake_migation/case_001/expected.txt
+++ b/clang/test/dpct/cmake_migation/case_001/expected.txt
@@ -13,7 +13,8 @@ set (CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 find_package(IntelSYCL REQUIRED)
 set(SOURCES
-    ${CMAKE_SOURCE_DIR}/foo/main.dp.cpp ${CMAKE_SOURCE_DIR}/foo/bar/util.dp.cpp)
+    ${CMAKE_SOURCE_DIR}/foo/main.dp.cpp
+ ${CMAKE_SOURCE_DIR}/foo/bar/util.dp.cpp)
 include_directories(
     ${CMAKE_SOURCE_DIR}/foo/bar
     ${CUDA_INCLUDE_DIRS}

--- a/clang/test/dpct/cmake_migation/case_001/expected.txt
+++ b/clang/test/dpct/cmake_migation/case_001/expected.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 ###CMake_minimum_required(VERSION 3.10)
 #CMake_minimum_required(VERSION 3.10)
-project(foo-bar LANGUAGES CXX)
+project(foo-bar LANGUAGES CXX )
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsycl")
 find_program(dpct_bin_path NAMES dpct PATHS)
 get_filename_component(bin_path_of_dpct ${dpct_bin_path} DIRECTORY)
@@ -14,7 +14,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 find_package(IntelSYCL REQUIRED)
 set(SOURCES
     ${CMAKE_SOURCE_DIR}/foo/main.dp.cpp
- ${CMAKE_SOURCE_DIR}/foo/bar/util.dp.cpp)
+    ${CMAKE_SOURCE_DIR}/foo/bar/util.dp.cpp
+)
 include_directories(
     ${CMAKE_SOURCE_DIR}/foo/bar
     ${CUDA_INCLUDE_DIRS}

--- a/clang/test/dpct/cmake_migation/case_001/expected.txt
+++ b/clang/test/dpct/cmake_migation/case_001/expected.txt
@@ -35,3 +35,5 @@ set(dpct_cmake_file_path "${bin_path_of_dpct}/../cmake/dpct.cmake")
 include(${dpct_cmake_file_path})
 
 target_link_libraries(foo3 PUBLIC  ${TCNN_LIBRARIES} fmt)
+
+set(SOURCES a.dp.cpp b.cuh)

--- a/clang/test/dpct/cmake_migation/case_001/input.cmake
+++ b/clang/test/dpct/cmake_migation/case_001/input.cmake
@@ -21,3 +21,5 @@ project(foo CUDA)
 project(foo2 CUDA CXX)
 
 target_link_libraries(foo3 PUBLIC ${CUDA_LIBRARIES} ${TCNN_LIBRARIES} fmt)
+
+set(SOURCES a.cu b.cuh)

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -71,3 +71,17 @@
       MatchMode: Full
       In: ${arg}.cu
       Out: ${arg}.dp.cpp
+
+- Rule: rule_user_defined_function
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: cuda_files_in_user_defined_function
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: ${arg}.cu
+      Out: ${arg}.dp.cpp
+

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -42,6 +42,7 @@
   Out: set(${value})
   Subrules:
     value:
+      MatchMode: Full
       In: ${arg}.cu
       Out: ${arg}.dp.cpp
 
@@ -67,5 +68,6 @@
   Out: dpct_compile_sycl_code(${device} ${value})
   Subrules:
     value:
+      MatchMode: Full
       In: ${arg}.cu
       Out: ${arg}.dp.cpp


### PR DESCRIPTION
1. Fix bug that miss newline character in some scenario.
2. Fix bug that *.cuh is matched for match expr ${arg}.cu when "MatchMode: Full" is specified in Yaml based rule


Signed-off-by: chenwei.sun <chenwei.sun@intel.com>