### PR TITLE
[SYCLomatic] Enable cmake migration framework to auto load cmake build-in migration rule file and remove dependency of cuda header files if --migrate-cmake-script-only is specified

### DIFF
--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -36,6 +36,7 @@
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendActions.h"
 #include "clang/Tooling/CommonOptionsParser.h"
+#include "clang/Tooling/Core/UnifiedPath.h"
 #include "clang/Tooling/Refactoring.h"
 #include "clang/Tooling/Tooling.h"
 #include "llvm/ADT/SmallString.h"
@@ -1022,6 +1023,23 @@ int runDPCT(int argc, const char **argv) {
   TypeLocRewriterFactoryBase::initTypeLocRewriterMap();
   MemberExprRewriterFactoryBase::initMemberExprRewriterMap();
   clang::dpct::initHeaderSpellings();
+
+  if (MigrateCmakeScriptOnly || MigrateCmakeScriptOnly) {
+    printf("#### DpctInstallPath: [%s]\n",
+           DpctInstallPath.getCanonicalPath().str().c_str());
+    SmallString<128> CmakeRuleFilePath(DpctInstallPath.getCanonicalPath());
+    llvm::sys::path::append(CmakeRuleFilePath,
+                            Twine("extensions/opt_rules/cmake_rules/"
+                                  "cmake_script_migration_rule.yaml"));
+    printf("#### CmakeRuleFilePath: [%s]\n",
+           CmakeRuleFilePath.str().str().c_str());
+    if (llvm::sys::fs::exists(CmakeRuleFilePath)) {
+      std::vector<clang::tooling::UnifiedPath> CmakeRuleFiles{CmakeRuleFilePath};
+      printf("Read file from %s\n", CmakeRuleFilePath.str().str().c_str());
+      importRules(CmakeRuleFiles);
+    }
+  }
+
   if (!RuleFile.empty()) {
     importRules(RuleFile);
   }

--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -272,19 +272,24 @@ UnifiedPath getInstallPath(const char *invokeCommand) {
 
 // To validate the root path of the project to be migrated.
 void ValidateInputDirectory(UnifiedPath InRoot) {
-  if (!MigrateCmakeScriptOnly && isChildOrSamePath(CudaPath, InRoot)) {
+  if (isChildOrSamePath(InRoot, DpctInstallPath)) {
+    ShowStatus(MigrationErrorInputDirContainCTTool);
+    dpctExit(MigrationErrorInputDirContainCTTool);
+  }
+
+  // To skip to check the following cuda path when option
+  // "--migrate-cmake-script-only" is specified to migrate cmake script
+  if (MigrateCmakeScriptOnly)
+    return;
+
+  if (isChildOrSamePath(CudaPath, InRoot)) {
     ShowStatus(MigrationErrorRunFromSDKFolder);
     dpctExit(MigrationErrorRunFromSDKFolder);
   }
 
-  if (!MigrateCmakeScriptOnly && isChildOrSamePath(InRoot, CudaPath)) {
+  if (isChildOrSamePath(InRoot, CudaPath)) {
     ShowStatus(MigrationErrorInputDirContainSDKFolder);
     dpctExit(MigrationErrorInputDirContainSDKFolder);
-  }
-
-  if (isChildOrSamePath(InRoot, DpctInstallPath)) {
-    ShowStatus(MigrationErrorInputDirContainCTTool);
-    dpctExit(MigrationErrorInputDirContainCTTool);
   }
 }
 
@@ -1027,7 +1032,7 @@ int runDPCT(int argc, const char **argv) {
   MemberExprRewriterFactoryBase::initMemberExprRewriterMap();
   clang::dpct::initHeaderSpellings();
 
-  if (MigrateCmakeScriptOnly || MigrateCmakeScriptOnly) {
+  if (MigrateCmakeScriptOnly || MigrateCmakeScript) {
     SmallString<128> CmakeRuleFilePath(DpctInstallPath.getCanonicalPath());
     llvm::sys::path::append(CmakeRuleFilePath,
                             Twine("extensions/opt_rules/cmake_rules/"

--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -272,12 +272,12 @@ UnifiedPath getInstallPath(const char *invokeCommand) {
 
 // To validate the root path of the project to be migrated.
 void ValidateInputDirectory(UnifiedPath InRoot) {
-  if (isChildOrSamePath(CudaPath, InRoot)) {
+  if (!MigrateCmakeScriptOnly && isChildOrSamePath(CudaPath, InRoot)) {
     ShowStatus(MigrationErrorRunFromSDKFolder);
     dpctExit(MigrationErrorRunFromSDKFolder);
   }
 
-  if (isChildOrSamePath(InRoot, CudaPath)) {
+  if (!MigrateCmakeScriptOnly && isChildOrSamePath(InRoot, CudaPath)) {
     ShowStatus(MigrationErrorInputDirContainSDKFolder);
     dpctExit(MigrationErrorInputDirContainSDKFolder);
   }
@@ -806,9 +806,12 @@ int runDPCT(int argc, const char **argv) {
 
   ExtraIncPaths = OptParser->getExtraIncPathList();
 
-  // TODO: implement one of this for each source language.
-  CudaPath = getCudaInstallPath(OriginalArgc, argv);
-  DpctDiags() << "Cuda Include Path found: " << CudaPath.getCanonicalPath() << "\n";
+  if (!MigrateCmakeScriptOnly) {
+    // TODO: implement one of this for each source language.
+    CudaPath = getCudaInstallPath(OriginalArgc, argv);
+    DpctDiags() << "Cuda Include Path found: " << CudaPath.getCanonicalPath()
+                << "\n";
+  }
 
   std::vector<std::string> SourcePathList;
   if (QueryAPIMapping.getNumOccurrences()) {

--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -1025,17 +1025,13 @@ int runDPCT(int argc, const char **argv) {
   clang::dpct::initHeaderSpellings();
 
   if (MigrateCmakeScriptOnly || MigrateCmakeScriptOnly) {
-    printf("#### DpctInstallPath: [%s]\n",
-           DpctInstallPath.getCanonicalPath().str().c_str());
     SmallString<128> CmakeRuleFilePath(DpctInstallPath.getCanonicalPath());
     llvm::sys::path::append(CmakeRuleFilePath,
                             Twine("extensions/opt_rules/cmake_rules/"
                                   "cmake_script_migration_rule.yaml"));
-    printf("#### CmakeRuleFilePath: [%s]\n",
-           CmakeRuleFilePath.str().str().c_str());
     if (llvm::sys::fs::exists(CmakeRuleFilePath)) {
-      std::vector<clang::tooling::UnifiedPath> CmakeRuleFiles{CmakeRuleFilePath};
-      printf("Read file from %s\n", CmakeRuleFilePath.str().str().c_str());
+      std::vector<clang::tooling::UnifiedPath> CmakeRuleFiles{
+          CmakeRuleFilePath};
       importRules(CmakeRuleFiles);
     }
   }

--- a/clang/lib/DPCT/MigrateCmakeScript.cpp
+++ b/clang/lib/DPCT/MigrateCmakeScript.cpp
@@ -684,6 +684,28 @@ static void reserveImplicitMigrationRules() {
 
 void doCmakeScriptMigration(const clang::tooling::UnifiedPath &InRoot,
                             const clang::tooling::UnifiedPath &OutRoot) {
+
+#if 1 // used to debug
+  printf("#### applyPatternRewriterToCmakeScriptFile ###\n");
+  for (const auto &Entry : CmakeBuildInRules) {
+    auto &PR = Entry.second;
+    printf("PR.RuleId: [%s]\n", PR.RuleId.c_str());
+    printf("PR.CmakeSyntax: [%s]\n", PR.CmakeSyntax.c_str());
+    printf("PR.MatchMode: [%d]\n", PR.MatchMode);
+    printf("PR.In: [%s]\n", PR.In.c_str());
+    printf("PR.Out: [%s]\n", PR.Out.c_str());
+
+    for (auto SubPR : PR.Subrules) {
+      printf("\tSubPR.first: [%s]\n", SubPR.first.c_str());
+      printf("\tSubPR.second.MatchMode: [%d]\n", SubPR.second.MatchMode);
+      printf("\tSubPR.second.In: [%s]\n", SubPR.second.In.c_str());
+      printf("\tSubPR.second.Out: [%s]\n", SubPR.second.Out.c_str());
+    }
+    printf("\n");
+  }
+  printf("#### applyPatternRewriterToCmakeScriptFile ###\n");
+#endif
+
   loadBufferFromFile(InRoot, OutRoot);
   unifyInputFileFormat();
   reserveImplicitMigrationRules();
@@ -693,6 +715,7 @@ void doCmakeScriptMigration(const clang::tooling::UnifiedPath &InRoot,
 }
 
 void registerCmakeMigrationRule(MetaRuleObject &R) {
+  printf("Enter registerCmakeMigrationRule...\n");
   auto PR =
       MetaRuleObject::PatternRewriter(R.In, R.Out, R.Subrules, R.MatchMode,
                                       R.RuleId, R.CmakeSyntax, R.Priority);

--- a/clang/lib/DPCT/MigrateCmakeScript.cpp
+++ b/clang/lib/DPCT/MigrateCmakeScript.cpp
@@ -684,28 +684,6 @@ static void reserveImplicitMigrationRules() {
 
 void doCmakeScriptMigration(const clang::tooling::UnifiedPath &InRoot,
                             const clang::tooling::UnifiedPath &OutRoot) {
-
-#if 1 // used to debug
-  printf("#### applyPatternRewriterToCmakeScriptFile ###\n");
-  for (const auto &Entry : CmakeBuildInRules) {
-    auto &PR = Entry.second;
-    printf("PR.RuleId: [%s]\n", PR.RuleId.c_str());
-    printf("PR.CmakeSyntax: [%s]\n", PR.CmakeSyntax.c_str());
-    printf("PR.MatchMode: [%d]\n", PR.MatchMode);
-    printf("PR.In: [%s]\n", PR.In.c_str());
-    printf("PR.Out: [%s]\n", PR.Out.c_str());
-
-    for (auto SubPR : PR.Subrules) {
-      printf("\tSubPR.first: [%s]\n", SubPR.first.c_str());
-      printf("\tSubPR.second.MatchMode: [%d]\n", SubPR.second.MatchMode);
-      printf("\tSubPR.second.In: [%s]\n", SubPR.second.In.c_str());
-      printf("\tSubPR.second.Out: [%s]\n", SubPR.second.Out.c_str());
-    }
-    printf("\n");
-  }
-  printf("#### applyPatternRewriterToCmakeScriptFile ###\n");
-#endif
-
   loadBufferFromFile(InRoot, OutRoot);
   unifyInputFileFormat();
   reserveImplicitMigrationRules();
@@ -715,7 +693,6 @@ void doCmakeScriptMigration(const clang::tooling::UnifiedPath &InRoot,
 }
 
 void registerCmakeMigrationRule(MetaRuleObject &R) {
-  printf("Enter registerCmakeMigrationRule...\n");
   auto PR =
       MetaRuleObject::PatternRewriter(R.In, R.Out, R.Subrules, R.MatchMode,
                                       R.RuleId, R.CmakeSyntax, R.Priority);

--- a/clang/test/dpct/cmake_migation/case_001/case_001_framework.cpp
+++ b/clang/test/dpct/cmake_migation/case_001/case_001_framework.cpp
@@ -1,7 +1,7 @@
 // RUN: rm -rf %T && mkdir -p %T
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
-// RUN: dpct -in-root ./ -out-root out  ./input.cmake --rule-file=%S/../../../../tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml --migrate-cmake-script-only --cuda-include-path="%cuda-path/include"
+// RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-cmake-script-only
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt

--- a/clang/test/dpct/cmake_migation/case_009/case_009_cmake_minimum_required.cpp
+++ b/clang/test/dpct/cmake_migation/case_009/case_009_cmake_minimum_required.cpp
@@ -2,7 +2,7 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: cp %S/vars_def.cmake ./vars_def.cmake
-// RUN: dpct -in-root ./ -out-root out  ./input.cmake ./vars_def.cmake --rule-file=%S/../../../../tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml --migrate-cmake-script-only --cuda-include-path="%cuda-path/include"
+// RUN: dpct -in-root ./ -out-root out  ./input.cmake ./vars_def.cmake --migrate-cmake-script-only
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt

--- a/clang/test/dpct/cmake_migation/case_014/case_014_cmake_cxx_standard.cpp
+++ b/clang/test/dpct/cmake_migation/case_014/case_014_cmake_cxx_standard.cpp
@@ -1,7 +1,7 @@
 // RUN: rm -rf %T && mkdir -p %T
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
-// RUN: dpct -in-root ./ -out-root out  ./input.cmake --rule-file=%S/../../../../tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml --migrate-cmake-script-only --cuda-include-path="%cuda-path/include"
+// RUN: dpct -in-root ./ -out-root out  ./input.cmake  --migrate-cmake-script-only
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt

--- a/clang/test/dpct/cmake_migation/case_015/case_015_set_target_properties.cpp
+++ b/clang/test/dpct/cmake_migation/case_015/case_015_set_target_properties.cpp
@@ -1,7 +1,7 @@
 // RUN: rm -rf %T && mkdir -p %T
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
-// RUN: dpct -in-root ./ -out-root out  ./input.cmake --rule-file=%S/../../../../tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml --migrate-cmake-script-only --cuda-include-path="%cuda-path/include"
+// RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-cmake-script-only
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt

--- a/clang/test/dpct/cmake_migation/case_017/case_017_cmake_cxx_compiler.cpp
+++ b/clang/test/dpct/cmake_migation/case_017/case_017_cmake_cxx_compiler.cpp
@@ -1,7 +1,7 @@
 // RUN: rm -rf %T && mkdir -p %T
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
-// RUN: dpct -in-root ./ -out-root out  ./input.cmake --rule-file=%S/../../../../tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml --migrate-cmake-script-only --cuda-include-path="%cuda-path/include"
+// RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-cmake-script-only
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt

--- a/clang/test/dpct/cmake_migation/case_023/case_023_cuda_compile_ptx.cpp
+++ b/clang/test/dpct/cmake_migation/case_023/case_023_cuda_compile_ptx.cpp
@@ -1,7 +1,7 @@
 // RUN: rm -rf %T && mkdir -p %T
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
-// RUN: dpct -in-root ./ -out-root out  ./input.cmake --rule-file=%S/../../../../tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml --migrate-cmake-script-only --cuda-include-path="%cuda-path/include"
+// RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-cmake-script-only
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt

--- a/clang/tools/dpct/DpctOptRules/CMakeLists.txt
+++ b/clang/tools/dpct/DpctOptRules/CMakeLists.txt
@@ -19,6 +19,12 @@ install(
   PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   DESTINATION ./extensions/opt_rules/cmake_rules)
 
+install(
+  FILES ${dpct_cmake_rule_files}
+  COMPONENT dpct-cmake-rules
+  PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+  DESTINATION ${CMAKE_BINARY_DIR}/extensions/opt_rules/cmake_rules)
+
 if (NOT CMAKE_CONFIGURATION_TYPES) # don't add this for IDE's.
   add_llvm_install_targets(install-dpct-opt-rules
                            COMPONENT dpct-opt-rules)


### PR DESCRIPTION
 Signed-off-by: chenwei.sun <chenwei.sun@intel.com>
