### PR TITLE
[SYCLomatic] Support conversion of dpct::device_reference to raw reference type

### DIFF
--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/memory.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/memory.h
@@ -79,7 +79,6 @@ template <typename T> struct device_reference {
     return *this;
   };
   pointer operator&() const { return pointer(&value); };
-  operator value_type() const { return T(value); }
   device_reference &operator++() {
     ++value;
     return *this;

--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/memory.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/memory.h
@@ -143,6 +143,8 @@ template <typename T> struct device_reference {
     *this = (input);
     input = (tmp);
   }
+  operator T &() { return value; }
+  operator const T &() const { return value; }
   T &value;
 };
 

--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/memory.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/memory.h
@@ -137,13 +137,13 @@ template <typename T> struct device_reference {
     value >>= input;
     return *this;
   };
+  operator T &() { return value; }
+  operator const T &() const { return value; }
   void swap(device_reference &input) {
     T tmp = (*this);
     *this = (input);
     input = (tmp);
   }
-  operator T &() { return value; }
-  operator const T &() const { return value; }
   T &value;
 };
 


### PR DESCRIPTION
The reference type of `device_vector` is `device_reference`, a wrapper class around a raw reference that provides additional functionality. The iterator type of `device_vector` is `device_iterator` which has a reference type around a raw reference. There is no conversion operator from a `device_reference` to a raw reference which means that code such as the following:
```
// where v is a device_vector<int>
typename std::iterator_traits<dpct::device_vector<int>::iterator>::reference ref = v[0];
```
does not compile as `operator[]` of `device_vector` returns a `device_reference` whereas the reference type from the `device_iterator` is still a raw reference. The reference type of `device_iterator` cannot be changed to `device_reference` as dereferencing / indexing `device_iterator` would return a temporary object which would cause compilation issues with operators / predicates that accept non-const lvalue reference such as the [following](https://github.com/oneapi-src/oneDPL/blob/fcf5dff087ff8c9e7f3e31835d54c34307d7d8d3/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h#L306) in oneDPL. 

Instead, we can add a conversion operator from a `device_reference` to a raw reference to enable code such as the example above to compile and function as expected.