### PR TITLE
[SYCLomatic]Add migration rules and enable lit tests for 4 cmake syntax migration

### DIFF
--- a/clang/lib/DPCT/MigrateCmakeScript.cpp
+++ b/clang/lib/DPCT/MigrateCmakeScript.cpp
@@ -688,29 +688,6 @@ void doCmakeScriptMigration(const clang::tooling::UnifiedPath &InRoot,
   unifyInputFileFormat();
   reserveImplicitMigrationRules();
   doCmakeScriptAnalysis();
-
-#if 1 // used to debug
-  printf("#### applyPatternRewriterToCmakeScriptFile ###\n");
-  for (const auto &Entry : CmakeBuildInRules) {
-    auto &PR = Entry.second;
-    printf("PR.RuleId: [%s]\n", PR.RuleId.c_str());
-    printf("PR.CmakeSyntax: [%s]\n", PR.CmakeSyntax.c_str());
-    printf("PR.MatchMode: [%d]\n", PR.MatchMode);
-    printf("PR.In: [%s]\n", PR.In.c_str());
-    printf("PR.Out: [%s]\n", PR.Out.c_str());
-
-    for (auto SubPR : PR.Subrules) {
-      printf("\tSubPR.first: [%s]\n", SubPR.first.c_str());
-      printf("\tSubPR.second.MatchMode: [%d]\n", SubPR.second.MatchMode);
-      printf("\tSubPR.second.In: [%s]\n", SubPR.second.In.c_str());
-      printf("\tSubPR.second.Out: [%s]\n", SubPR.second.Out.c_str());
-    }
-    printf("\n");
-  }
-  printf("#### applyPatternRewriterToCmakeScriptFile ###\n");
-#endif
-
-
   applyCmakeMigrationRules();
   storeBufferToFile();
 }

--- a/clang/lib/DPCT/MigrateCmakeScript.cpp
+++ b/clang/lib/DPCT/MigrateCmakeScript.cpp
@@ -688,6 +688,29 @@ void doCmakeScriptMigration(const clang::tooling::UnifiedPath &InRoot,
   unifyInputFileFormat();
   reserveImplicitMigrationRules();
   doCmakeScriptAnalysis();
+
+#if 1 // used to debug
+  printf("#### applyPatternRewriterToCmakeScriptFile ###\n");
+  for (const auto &Entry : CmakeBuildInRules) {
+    auto &PR = Entry.second;
+    printf("PR.RuleId: [%s]\n", PR.RuleId.c_str());
+    printf("PR.CmakeSyntax: [%s]\n", PR.CmakeSyntax.c_str());
+    printf("PR.MatchMode: [%d]\n", PR.MatchMode);
+    printf("PR.In: [%s]\n", PR.In.c_str());
+    printf("PR.Out: [%s]\n", PR.Out.c_str());
+
+    for (auto SubPR : PR.Subrules) {
+      printf("\tSubPR.first: [%s]\n", SubPR.first.c_str());
+      printf("\tSubPR.second.MatchMode: [%d]\n", SubPR.second.MatchMode);
+      printf("\tSubPR.second.In: [%s]\n", SubPR.second.In.c_str());
+      printf("\tSubPR.second.Out: [%s]\n", SubPR.second.Out.c_str());
+    }
+    printf("\n");
+  }
+  printf("#### applyPatternRewriterToCmakeScriptFile ###\n");
+#endif
+
+
   applyCmakeMigrationRules();
   storeBufferToFile();
 }

--- a/clang/lib/DPCT/PatternRewriter.cpp
+++ b/clang/lib/DPCT/PatternRewriter.cpp
@@ -419,7 +419,7 @@ static std::optional<MatchResult> findFullMatch(const MatchPattern &Pattern,
         return {};
       }
 
-      // If input value has been matched to the end but match pattren still has
+      // If input value has been matched to the end but match pattern still has
       // value, it is considered not matched case.
       if (Index == Size - 1 && PatternIndex < PatternSize - 1) {
         return {};

--- a/clang/lib/DPCT/PatternRewriter.cpp
+++ b/clang/lib/DPCT/PatternRewriter.cpp
@@ -419,6 +419,12 @@ static std::optional<MatchResult> findFullMatch(const MatchPattern &Pattern,
         return {};
       }
 
+      // If input value has been matched to the end but match pattren still has
+      // value, it is considered not matched case.
+      if (Index == Size - 1 && PatternIndex < PatternSize - 1) {
+        return {};
+      }
+
       // To make sure first character after the matched word isn't an
       // identified character or suffix match '('.
       if (Index < Size - 1 && isIdentifiedChar(Input[Index + 1]) &&

--- a/clang/test/dpct/cmake_migation/case_020/case_020_user_defined_variables.cpp
+++ b/clang/test/dpct/cmake_migation/case_020/case_020_user_defined_variables.cpp
@@ -1,0 +1,10 @@
+// RUN: rm -rf %T && mkdir -p %T
+// RUN: cd %T
+// RUN: cp %S/input.cmake ./input.cmake
+// RUN: dpct -in-root ./ -out-root out  ./input.cmake --rule-file=%S/../../../../tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml --migrate-cmake-script-only --cuda-include-path="%cuda-path/include"
+// RUN: echo "begin" > %T/diff.txt
+// RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
+// RUN: echo "end" >> %T/diff.txt
+
+// CHECK: begin
+// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migation/case_020/expected.txt
+++ b/clang/test/dpct/cmake_migation/case_020/expected.txt
@@ -1,0 +1,2 @@
+set(SOURCES foo.dp.cpp ${CMAKE_SOURCE_DIR}/foo/bar.dp.cpp)
+list(APPEND SOURCES foo.dp.cpp)

--- a/clang/test/dpct/cmake_migation/case_020/input.cmake
+++ b/clang/test/dpct/cmake_migation/case_020/input.cmake
@@ -1,0 +1,2 @@
+set(SOURCES foo.cu ${CMAKE_SOURCE_DIR}/foo/bar.cu)
+list(APPEND SOURCES foo.dp.cpp)

--- a/clang/test/dpct/cmake_migation/case_021/case_021_add_compile_options.cpp
+++ b/clang/test/dpct/cmake_migation/case_021/case_021_add_compile_options.cpp
@@ -1,0 +1,10 @@
+// RUN: rm -rf %T && mkdir -p %T
+// RUN: cd %T
+// RUN: cp %S/input.cmake ./input.cmake
+// RUN: dpct -in-root ./ -out-root out  ./input.cmake --rule-file=%S/../../../../tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml --migrate-cmake-script-only --cuda-include-path="%cuda-path/include"
+// RUN: echo "begin" > %T/diff.txt
+// RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
+// RUN: echo "end" >> %T/diff.txt
+
+// CHECK: begin
+// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migation/case_021/expected.txt
+++ b/clang/test/dpct/cmake_migation/case_021/expected.txt
@@ -1,6 +1,7 @@
 add_compile_options(-std=c++17)
 add_compile_options(-std=c++17)
 add_compile_options(-std=c++17)
+
 #Currently we use Yaml based migartion rule to migarte -std=c++22 down to -std=c++17.
 #We will implement an implicit migration rule to fix this issue in future.
-add_compile_options(-std=c++17)
+#add_compile_options(-std=c++22)

--- a/clang/test/dpct/cmake_migation/case_021/expected.txt
+++ b/clang/test/dpct/cmake_migation/case_021/expected.txt
@@ -1,0 +1,6 @@
+add_compile_options(-std=c++17)
+add_compile_options(-std=c++17)
+add_compile_options(-std=c++17)
+#Currently we use Yaml based migartion rule to migarte -std=c++22 down to -std=c++17.
+#We will implement an implicit migration rule to fix this issue in future.
+add_compile_options(-std=c++17)

--- a/clang/test/dpct/cmake_migation/case_021/input.cmake
+++ b/clang/test/dpct/cmake_migation/case_021/input.cmake
@@ -1,0 +1,6 @@
+add_compile_options(-std=c++11)
+add_compile_options(-std=c++14)
+add_compile_options(-std=c++17)
+#Currently we use Yaml based migartion rule to migarte -std=c++22 down to -std=c++17.
+#We will implement an implicit migration rule to fix this issue in future.
+add_compile_options(-std=c++22)

--- a/clang/test/dpct/cmake_migation/case_021/input.cmake
+++ b/clang/test/dpct/cmake_migation/case_021/input.cmake
@@ -1,6 +1,7 @@
 add_compile_options(-std=c++11)
 add_compile_options(-std=c++14)
 add_compile_options(-std=c++17)
+
 #Currently we use Yaml based migartion rule to migarte -std=c++22 down to -std=c++17.
 #We will implement an implicit migration rule to fix this issue in future.
-add_compile_options(-std=c++22)
+#add_compile_options(-std=c++22)

--- a/clang/test/dpct/cmake_migation/case_022/case_022_target_compile_options.cpp
+++ b/clang/test/dpct/cmake_migation/case_022/case_022_target_compile_options.cpp
@@ -1,0 +1,10 @@
+// RUN: rm -rf %T && mkdir -p %T
+// RUN: cd %T
+// RUN: cp %S/input.cmake ./input.cmake
+// RUN: dpct -in-root ./ -out-root out  ./input.cmake --rule-file=%S/../../../../tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml --migrate-cmake-script-only --cuda-include-path="%cuda-path/include"
+// RUN: echo "begin" > %T/diff.txt
+// RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
+// RUN: echo "end" >> %T/diff.txt
+
+// CHECK: begin
+// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migation/case_022/expected.txt
+++ b/clang/test/dpct/cmake_migation/case_022/expected.txt
@@ -1,0 +1,1 @@
+target_compile_options(tiny-cuda-nn PUBLIC )

--- a/clang/test/dpct/cmake_migation/case_022/input.cmake
+++ b/clang/test/dpct/cmake_migation/case_022/input.cmake
@@ -1,0 +1,1 @@
+target_compile_options(tiny-cuda-nn PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:${CUDA_NVCC_FLAGS}>)

--- a/clang/test/dpct/cmake_migation/case_024/case_024_CUDA_HAS_FP16.cpp
+++ b/clang/test/dpct/cmake_migation/case_024/case_024_CUDA_HAS_FP16.cpp
@@ -1,0 +1,10 @@
+// RUN: rm -rf %T && mkdir -p %T
+// RUN: cd %T
+// RUN: cp %S/input.cmake ./input.cmake
+// RUN: dpct -in-root ./ -out-root out  ./input.cmake --rule-file=%S/../../../../tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml --migrate-cmake-script-only --cuda-include-path="%cuda-path/include"
+// RUN: echo "begin" > %T/diff.txt
+// RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
+// RUN: echo "end" >> %T/diff.txt
+
+// CHECK: begin
+// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migation/case_024/expected.txt
+++ b/clang/test/dpct/cmake_migation/case_024/expected.txt
@@ -1,0 +1,1 @@
+set(SYCL_HAS_FP16 TRUE)

--- a/clang/test/dpct/cmake_migation/case_024/input.cmake
+++ b/clang/test/dpct/cmake_migation/case_024/input.cmake
@@ -1,0 +1,1 @@
+set(CUDA_HAS_FP16 TRUE)

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -161,3 +161,16 @@
       In: $<$<COMPILE_LANGUAGE:CUDA>:\${CUDA_NVCC_FLAGS}>
       Out: ""
       RuleId: "target_compile_options_cuda_arg"
+
+- Rule: rule_CUDA_HAS_FP16
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_HAS_FP16
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA_HAS_FP16
+      Out: SYCL_HAS_FP16

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -138,3 +138,14 @@
       In: ${arg}.cu
       Out: ${arg}.dp.cpp
 
+- Rule: rule_add_compile_options
+  Kind: CMakeRule
+  Priority: Fallback
+  CmakeSyntax: add_compile_options
+  In: add_compile_options(${arg})
+  Out: add_compile_options(${arg})
+  Subrules:
+    arg:
+      In: -std=${cxx_standard}
+      Out: -std=c++17
+      RuleId: "add_compile_options_cxx_standard"

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -149,3 +149,15 @@
       In: -std=${cxx_standard}
       Out: -std=c++17
       RuleId: "add_compile_options_cxx_standard"
+
+- Rule: rule_target_compile_options
+  Kind: CMakeRule
+  Priority: Fallback
+  CmakeSyntax: target_compile_options
+  In: target_compile_options(${arg})
+  Out: target_compile_options(${arg})
+  Subrules:
+    arg:
+      In: $<$<COMPILE_LANGUAGE:CUDA>:\${CUDA_NVCC_FLAGS}>
+      Out: ""
+      RuleId: "target_compile_options_cuda_arg"

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -158,7 +158,7 @@
   Out: target_compile_options(${arg})
   Subrules:
     arg:
-      In: $<$<COMPILE_LANGUAGE:CUDA>:\${CUDA_NVCC_FLAGS}>
+      In: $<$<COMPILE_LANGUAGE:CUDA>:${flags}>
       Out: ""
       RuleId: "target_compile_options_cuda_arg"
 

--- a/clang/tools/dpct/cmake/dpct.cmake
+++ b/clang/tools/dpct/cmake/dpct.cmake
@@ -74,3 +74,6 @@ endmacro()
 macro(DPCT_COMPILE_SYCL_CODE generated_files)
   DPCT_COMPILE_SYCL_CODE_IMP(sycl_device ${generated_files} ${ARGN})
 endmacro()
+
+# Always set SYCL_HAS_FP16 to true to assume SYCL device to support float16
+set(SYCL_HAS_FP16 TRUE)

--- a/clang/tools/dpct/cmake/dpct.cmake
+++ b/clang/tools/dpct/cmake/dpct.cmake
@@ -76,4 +76,5 @@ macro(DPCT_COMPILE_SYCL_CODE generated_files)
 endmacro()
 
 # Always set SYCL_HAS_FP16 to true to assume SYCL device to support float16
+message("dpct.cmake: SYCL_HAS_FP16 is set true by default.")
 set(SYCL_HAS_FP16 TRUE)


### PR DESCRIPTION
This PR coveres 4 cmake syntaxes as below:
1.user defined CUDA specific variables migration
2.target_compile_options
3.add_compile_options
4.CUDA_HAS_FP16

 Signed-off-by: chenwei.sun <chenwei.sun@intel.com>
