### PR TITLE
[SYCLomatic] Fix the migration of mov instruction

### DIFF
--- a/clang/lib/DPCT/Asm/AsmParser.cpp
+++ b/clang/lib/DPCT/Asm/AsmParser.cpp
@@ -453,6 +453,7 @@ InlineAsmExprResult InlineAsmParser::ParseCastExpression() {
   }
   case asmtok::underscore:
     Res = ActOnDiscardExpr();
+    ConsumeToken();
     break;
   case asmtok::numeric_constant:
     Res = ActOnNumericConstant(Tok);
@@ -663,6 +664,8 @@ InlineAsmParser::ActOnVectorExpr(ArrayRef<InlineAsmExpr *> Vec) {
   InlineAsmBuiltinType *ElementType = nullptr;
   // The type of each element must have the same non-predicate builtin type.
   for (auto *E : Vec) {
+    if (isa<InlineAsmDiscardExpr>(E))
+        continue;
     if (auto *T = dyn_cast<InlineAsmBuiltinType>(E->getType())) {
       if (T->getKind() == InlineAsmBuiltinType::TK_pred)
         return AsmExprError();

--- a/clang/lib/DPCT/Asm/AsmParser.h
+++ b/clang/lib/DPCT/Asm/AsmParser.h
@@ -109,6 +109,7 @@ public:
   bool isUnsignedInt() const;
   bool isFloating() const;
   bool isBitSize() const;
+  unsigned getWidth() const;
 
   static bool classof(const InlineAsmType *T) {
     return T->getTypeClass() == BuiltinClass;

--- a/clang/lib/DPCT/AsmMigration.cpp
+++ b/clang/lib/DPCT/AsmMigration.cpp
@@ -545,15 +545,103 @@ public:
   bool handleStatement(const InlineAsmStmt *S) { return emitStmt(S); }
 
 protected:
+  unsigned getBitSizeTypeWidth(const InlineAsmBuiltinType *T) const {
+    switch (T->getKind()) {
+    case InlineAsmBuiltinType::TK_b8:
+      return 8;
+    case InlineAsmBuiltinType::TK_b16:
+      return 16;
+    case InlineAsmBuiltinType::TK_b32:
+      return 32;
+    case InlineAsmBuiltinType::TK_b64:
+      return 64;
+    default:
+      return 0;
+    }
+  }
+
+  const char *unpackBitSizeType(const InlineAsmBuiltinType *T,
+                                unsigned N) const {
+    assert(T->isBitSize());
+    unsigned OriginTypeWidth = getBitSizeTypeWidth(T);
+    unsigned UnpackTypeWidth = OriginTypeWidth / N;
+    switch (UnpackTypeWidth) {
+    case 8:
+      return "uint8_t";
+    case 16:
+      return "uint16_t";
+    case 32:
+      return "uint32_t";
+    default:
+      return nullptr;
+    }
+  }
+
   bool handle_mov(const InlineAsmInstruction *I) override {
     if (I->getNumInputOperands() != 1)
       return SYCLGenError();
-    if (emitStmt(I->getOutputOperand()))
-      return SYCLGenError();
-    OS() << " = ";
-    if (emitStmt(I->getInputOperand(0)))
-      return SYCLGenError();
-    endstmt();
+    // Handle data unpack mov.
+    // mov.b32 {%0, %1}, %2;
+    // %0 = sycl::vec<uint32_t, 1>(%2).template as<sycl::vec<uint16_t, 2>>()[0];
+    // %1 = sycl::vec<uint32_t, 1>(%2).template as<sycl::vec<uint16_t, 2>>()[1];
+    if (const auto *VE = dyn_cast<InlineAsmVectorExpr>(I->getOutputOperand())) {
+      const auto *Type =
+          llvm::dyn_cast_or_null<InlineAsmBuiltinType>(I->getType(0));
+      if (!Type || !Type->isBitSize())
+        return SYCLGenError();
+      std::string OriginType, InputOp;
+      std::string UnpackType = unpackBitSizeType(Type, VE->getNumElements());
+      if (tryEmitType(OriginType, Type) ||
+          tryEmitStmt(InputOp, I->getInputOperand(0)))
+        return SYCLGenError();
+      std::string SYCLVec;
+      {
+        llvm::raw_string_ostream TmpOS(SYCLVec);
+        TmpOS << MapNames::getClNamespace() << "vec<" << OriginType << ", 1>("
+              << InputOp << ").template as<" << MapNames::getClNamespace()
+              << "vec<" << UnpackType << ", " << VE->getNumElements() << ">>()";
+      }
+      for (unsigned I = 0, E = VE->getNumElements(); I != E; ++I) {
+        if (isa<InlineAsmDiscardExpr>(VE->getElement(I)))
+          continue;
+        if (I > 0)
+          indent();
+        if (emitStmt(VE->getElement(I)))
+          return SYCLGenError();
+        OS() << " = " << SYCLVec << '[' << I << ']';
+        endstmt();
+      }
+    } else if (const auto *VE =
+                   dyn_cast<InlineAsmVectorExpr>(I->getInputOperand(0))) {
+      // Handle data pack ov.
+      // mov.b32 %0, {%1, %2};
+      // %0 = sycl::vec<uint16_t, 2>{%1, %2}.template as<sycl::vec<uint32_t,
+      // 1>>()[0];
+      const auto *Type =
+          llvm::dyn_cast_or_null<InlineAsmBuiltinType>(I->getType(0));
+      if (!Type || !Type->isBitSize())
+        return SYCLGenError();
+      std::string PackType, OutputOp;
+      std::string OriginType = unpackBitSizeType(Type, VE->getNumElements());
+      if (tryEmitType(PackType, Type))
+        return SYCLGenError();
+      if (emitStmt(I->getOutputOperand()))
+        return SYCLGenError();
+      OS() << " = " << MapNames::getClNamespace() << "vec<" << OriginType
+           << ", " << VE->getNumElements() << ">(";
+      if (emitStmt(VE))
+        return SYCLGenError();
+      OS() << ").template as<" << MapNames::getClNamespace() << "vec<"
+           << PackType << ", 1>>()[0]";
+      endstmt();
+    } else {
+      if (emitStmt(I->getOutputOperand()))
+        return SYCLGenError();
+      OS() << " = ";
+      if (emitStmt(I->getInputOperand(0)))
+        return SYCLGenError();
+      endstmt();
+    }
     return SYCLGenSuccess();
   }
 

--- a/clang/test/dpct/asm/mov.cu
+++ b/clang/test/dpct/asm/mov.cu
@@ -30,4 +30,83 @@ __global__ void mov() {
   return;
 }
 
+inline __device__ float half_to_float(uint16_t h) {
+  float f = 0;
+  return f;
+}
+
+inline __device__ float2 half2_to_float2(uint32_t v) {
+  uint16_t lo, hi;
+  // CHECK: lo = sycl::vec<uint32_t, 1>(v).template as<sycl::vec<uint16_t, 2>>()[0];
+  // CHECK: hi = sycl::vec<uint32_t, 1>(v).template as<sycl::vec<uint16_t, 2>>()[1];
+  asm volatile("mov.b32 {%0, %1}, %2;\n" : "=h"(lo), "=h"(hi) : "r"(v));
+  return make_float2(half_to_float(lo), half_to_float(hi));
+}
+
+__global__ void test() {
+  {
+    uint32_t v;
+    uint16_t lo, hi;
+    // CHECK: lo = sycl::vec<uint32_t, 1>(v).template as<sycl::vec<uint16_t, 2>>()[0];
+    // CHECK: hi = sycl::vec<uint32_t, 1>(v).template as<sycl::vec<uint16_t, 2>>()[1];
+    asm volatile("mov.b32 {%0, %1}, %2;\n" : "=h"(lo), "=h"(hi) : "h"(v));
+  }
+  {
+    uint64_t v;
+    uint32_t lo, hi;
+    // CHECK: lo = sycl::vec<uint64_t, 1>(v).template as<sycl::vec<uint32_t, 2>>()[0];
+    // CHECK: hi = sycl::vec<uint64_t, 1>(v).template as<sycl::vec<uint32_t, 2>>()[1];
+    asm volatile("mov.b64 {%0, %1}, %2;\n" : "=r"(lo), "=r"(hi) : "l"(v));
+  }
+  {
+    uint64_t v;
+    uint16_t a, b, c, d;
+    // CHECK: a = sycl::vec<uint64_t, 1>(v).template as<sycl::vec<uint16_t, 4>>()[0];
+    // CHECK: b = sycl::vec<uint64_t, 1>(v).template as<sycl::vec<uint16_t, 4>>()[1];
+    // CHECK: c = sycl::vec<uint64_t, 1>(v).template as<sycl::vec<uint16_t, 4>>()[2];
+    // CHECK: d = sycl::vec<uint64_t, 1>(v).template as<sycl::vec<uint16_t, 4>>()[3];
+    asm volatile("mov.b64 {%0, %1, %2, %3}, %4;\n" : "=h"(a), "=h"(b), "=h"(c), "=h"(d) : "l"(v));
+  }
+  {
+    uint32_t v;
+    uint16_t lo, hi;
+    // CHECK: v = sycl::vec<uint16_t, 2>({lo, hi}).template as<sycl::vec<uint32_t, 1>>()[0];
+    asm volatile("mov.b32 %0, {%1, %2};\n" : "=r"(v) : "h"(lo), "h"(hi));
+  }
+  {
+    uint64_t v;
+    uint32_t lo, hi;
+    // CHECK: v = sycl::vec<uint32_t, 2>({lo, hi}).template as<sycl::vec<uint64_t, 1>>()[0];
+    asm volatile("mov.b64 %0, {%1, %2};\n" : "=l"(v) : "r"(lo), "r"(hi));
+  }
+  {
+    uint64_t v;
+    uint16_t a, b, c, d;
+    // CHECK: v = sycl::vec<uint16_t, 4>({a, b, c, d}).template as<sycl::vec<uint64_t, 1>>()[0];
+    asm volatile("mov.b64 %0, {%1, %2, %3, %4};\n" : "=l"(v) : "h"(a), "h"(b), "h"(c), "h"(d));
+  }
+  
+  {
+    uint32_t v;
+    uint16_t lo;
+    // CHECK: lo = sycl::vec<uint32_t, 1>(v).template as<sycl::vec<uint16_t, 2>>()[0];
+    asm volatile("mov.b32 {%0, _}, %1;\n" : "=h"(lo) : "h"(v));
+  }
+  {
+    uint64_t v;
+    uint32_t hi;
+    // CHECK: hi = sycl::vec<uint64_t, 1>(v).template as<sycl::vec<uint32_t, 2>>()[1];
+    asm volatile("mov.b64 {_, %0}, %1;\n" : "=r"(hi) : "l"(v));
+  }
+  {
+    uint64_t v;
+    uint16_t a, b, d;
+    // CHECK: a = sycl::vec<uint64_t, 1>(v).template as<sycl::vec<uint16_t, 4>>()[0];
+    // CHECK: b = sycl::vec<uint64_t, 1>(v).template as<sycl::vec<uint16_t, 4>>()[1];
+    // CHECK: d = sycl::vec<uint64_t, 1>(v).template as<sycl::vec<uint16_t, 4>>()[3];
+    asm volatile("mov.b64 {%0, %1, _, %2}, %3;\n" : "=h"(a), "=h"(b), "=h"(d) : "l"(v));
+  }
+}
+
+
 // clang-format on


### PR DESCRIPTION
Fix the migration of mov instruction when one of the input/output is a vector expression
```
{
    uint32_t v;
    uint16_t lo, hi;
    asm volatile("mov.b32 {%0, %1}, %2;\n" : "=h"(lo), "=h"(hi) : "h"(v));
}
```