### PR TITLE
[SYCLomatic] Use rewriter to migrate cublas[Create|Destroy], cublas[Set|Get]Stream and cudaGetDeviceProperties[_v2]

### DIFF
--- a/clang/lib/DPCT/APINamesCUBLAS.inc
+++ b/clang/lib/DPCT/APINamesCUBLAS.inc
@@ -18,6 +18,14 @@ ASSIGNABLE_FACTORY(FEATURE_REQUEST_FACTORY(
                        CALL(MapNames::getDpctNamespace() + "mkl_get_version",
                             ARG(MapNames::getDpctNamespace() + "version_field::major"), ARG(0)))))
 
+ASSIGNABLE_FACTORY(FEATURE_REQUEST_FACTORY(
+    HelperFeatureEnum::device_ext,
+    ASSIGN_FACTORY_ENTRY("cublasCreate_v2", DEREF(0), QUEUEPTRSTR)))
+ASSIGNABLE_FACTORY(ASSIGN_FACTORY_ENTRY("cublasDestroy_v2", ARG(0),
+                                        ARG("nullptr")))
+ASSIGNABLE_FACTORY(ASSIGN_FACTORY_ENTRY("cublasSetStream_v2", ARG(0), ARG(1)))
+ASSIGNABLE_FACTORY(ASSIGN_FACTORY_ENTRY("cublasGetStream_v2", DEREF(1), ARG(0)))
+
 ASSIGNABLE_FACTORY(CALL_FACTORY_ENTRY(
     "cublasSgemm_v2",
     CALL("oneapi::mkl::blas::column_major::gemm", DEREF(0),

--- a/clang/lib/DPCT/APINamesMisc.inc
+++ b/clang/lib/DPCT/APINamesMisc.inc
@@ -87,3 +87,37 @@ CONDITIONAL_FACTORY_ENTRY(
                       Diagnostics::API_NOT_MIGRATED))
 CALL_FACTORY_ENTRY("__assertfail", CALL("assert", LITERAL("0")))
 CALL_FACTORY_ENTRY("__assert_fail", CALL("assert", LITERAL("0")))
+
+CONDITIONAL_FACTORY_ENTRY(
+    checkIsUseNoQueueDevice(),
+    ASSIGNABLE_FACTORY(FEATURE_REQUEST_FACTORY(
+        HelperFeatureEnum::device_ext,
+        CALL_FACTORY_ENTRY(
+            "cudaGetDeviceProperties",
+            CALL(MapNames::getDpctNamespace() + "get_device_info", DEREF(0),
+                 ARG(DpctGlobalInfo::getGlobalDeviceName()))))),
+    ASSIGNABLE_FACTORY(FEATURE_REQUEST_FACTORY(
+        HelperFeatureEnum::device_ext,
+        CALL_FACTORY_ENTRY(
+            "cudaGetDeviceProperties",
+            CALL(MapNames::getDpctNamespace() + "get_device_info", DEREF(0),
+                 CALL(MapNames::getDpctNamespace() +
+                          "dev_mgr::instance().get_device",
+                      ARG(1)))))))
+
+CONDITIONAL_FACTORY_ENTRY(
+    checkIsUseNoQueueDevice(),
+    ASSIGNABLE_FACTORY(FEATURE_REQUEST_FACTORY(
+        HelperFeatureEnum::device_ext,
+        CALL_FACTORY_ENTRY(
+            "cudaGetDeviceProperties_v2",
+            CALL(MapNames::getDpctNamespace() + "get_device_info", DEREF(0),
+                 ARG(DpctGlobalInfo::getGlobalDeviceName()))))),
+    ASSIGNABLE_FACTORY(FEATURE_REQUEST_FACTORY(
+        HelperFeatureEnum::device_ext,
+        CALL_FACTORY_ENTRY(
+            "cudaGetDeviceProperties_v2",
+            CALL(MapNames::getDpctNamespace() + "get_device_info", DEREF(0),
+                 CALL(MapNames::getDpctNamespace() +
+                          "dev_mgr::instance().get_device",
+                      ARG(1)))))))

--- a/clang/lib/DPCT/MapNames.cpp
+++ b/clang/lib/DPCT/MapNames.cpp
@@ -1712,6 +1712,10 @@ void MapNames::setExplicitNamespaceMap() {
   };
 
   BLASAPIWithRewriter = {
+      {"cublasCreate_v2", "handle = queue_p"},
+      {"cublasDestroy_v2", "handle = nullptr"},
+      {"cublasSetStream_v2", "handle = s"},
+      {"cublasGetStream_v2", "s = handle"},
       {"cublasSgemm_v2", "oneapi::mkl::blas::column_major::gemm"},
       {"cublasDgemm_v2", "oneapi::mkl::blas::column_major::gemm"},
       {"cublasCgemm_v2", "oneapi::mkl::blas::column_major::gemm"},

--- a/clang/test/dpct/cublas-create-Sgemm-destroy.cu
+++ b/clang/test/dpct/cublas-create-Sgemm-destroy.cu
@@ -210,3 +210,19 @@ void foo() {
   const cublasHandle_t h_c = nullptr;
   cublasHandle_t h = h_c;
 }
+
+#define CHECK_INTERNAL(err)                                                    \
+  { auto err_ = (err); }
+
+#define CHECK(err) CHECK_INTERNAL(err)
+
+void foo2(cublasHandle_t *handles, int i, cudaStream_t s) {
+  // CHECK: CHECK(DPCT_CHECK_ERROR(handles[i] = &dpct::get_out_of_order_queue()));
+  // CHECK-NEXT: CHECK(DPCT_CHECK_ERROR(handles[i] = nullptr));
+  // CHECK-NEXT: CHECK(DPCT_CHECK_ERROR(handles[i] = s));
+  // CHECK-NEXT: CHECK(DPCT_CHECK_ERROR(s = handles[i]));
+  CHECK(cublasCreate(&handles[i]));
+  CHECK(cublasDestroy(handles[i]));
+  CHECK(cublasSetStream(handles[i], s));
+  CHECK(cublasGetStream(handles[i], &s));
+}

--- a/clang/test/dpct/device004.cu
+++ b/clang/test/dpct/device004.cu
@@ -31,3 +31,15 @@ int main() {
   // CHECK-NEXT: properties.uuid = uuid;
   properties.uuid = uuid;
 }
+
+#define CHECK_INTERNAL(err)                                                    \
+  { auto err_ = (err); }
+
+#define CHECK(err) CHECK_INTERNAL(err)
+
+void foo() {
+  int dev = 1;
+  cudaDeviceProp p;
+  // CHECK: CHECK(DPCT_CHECK_ERROR(dpct::get_device_info(p, dpct::dev_mgr::instance().get_device(dev))));
+  CHECK(cudaGetDeviceProperties(&p, dev));
+}

--- a/clang/test/dpct/query_api_mapping/Runtime/test.cu
+++ b/clang/test/dpct/query_api_mapping/Runtime/test.cu
@@ -65,7 +65,7 @@
 // CUDAGETDEVICEPROPERTIES-NEXT:   cudaGetDeviceProperties(pd, i /*int*/);
 // CUDAGETDEVICEPROPERTIES-NEXT: Is migrated to:
 // CUDAGETDEVICEPROPERTIES-NEXT:   dpct::device_info *pd;
-// CUDAGETDEVICEPROPERTIES-NEXT:   dpct::get_device_info(*pd, dpct::dev_mgr::instance().get_device(i) /*int*/);
+// CUDAGETDEVICEPROPERTIES-NEXT:   dpct::get_device_info(*pd, dpct::dev_mgr::instance().get_device(i));
 
 // RUN: dpct --cuda-include-path="%cuda-path/include" --query-api-mapping=cudaSetDevice | FileCheck %s -check-prefix=CUDASETDEVICE
 // CUDASETDEVICE: CUDA API:


### PR DESCRIPTION
Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>