### PR TITLE
[SYCLomatic] iterator_adaptor implementation

### DIFF
--- a/clang/lib/DPCT/CMakeLists.txt
+++ b/clang/lib/DPCT/CMakeLists.txt
@@ -25,6 +25,7 @@ set(RUNTIME_HEADERS
   ${CMAKE_SOURCE_DIR}/../clang/runtime/dpct-rt/include/dpct/dpl_extras/algorithm.h
   ${CMAKE_SOURCE_DIR}/../clang/runtime/dpct-rt/include/dpct/dpl_extras/functional.h
   ${CMAKE_SOURCE_DIR}/../clang/runtime/dpct-rt/include/dpct/dpl_extras/iterators.h
+  ${CMAKE_SOURCE_DIR}/../clang/runtime/dpct-rt/include/dpct/dpl_extras/iterator_adaptor.h
   ${CMAKE_SOURCE_DIR}/../clang/runtime/dpct-rt/include/dpct/dpl_extras/memory.h
   ${CMAKE_SOURCE_DIR}/../clang/runtime/dpct-rt/include/dpct/dpl_extras/numeric.h
   ${CMAKE_SOURCE_DIR}/../clang/runtime/dpct-rt/include/dpct/dpl_extras/vector.h

--- a/clang/lib/DPCT/GenHelperFunction.cpp
+++ b/clang/lib/DPCT/GenHelperFunction.cpp
@@ -169,10 +169,10 @@ void genHelperFunction(const clang::tooling::UnifiedPath &OutRoot) {
   GENERATE_ALL_FILE_CONTENT(DplExtrasVector, "dpl_extras", vector.h)
   GENERATE_ALL_FILE_CONTENT(DplExtrasDpcppExtensions, "dpl_extras",
                             dpcpp_extensions.h)
-  GENERATE_ALL_FILE_CONTENT(DplExtrasIteratorAdaptor, "dpl_extras", iterator_adaptor.h)
+  GENERATE_ALL_FILE_CONTENT(DplExtrasIteratorAdaptor, "dpl_extras",
+                            iterator_adaptor.h)
 #undef GENERATE_ALL_FILE_CONTENT
 }
 
 } // namespace dpct
 } // namespace clang
-

--- a/clang/lib/DPCT/GenHelperFunction.cpp
+++ b/clang/lib/DPCT/GenHelperFunction.cpp
@@ -94,6 +94,9 @@ const std::string DplExtrasVectorAllContentStr =
 const std::string DplExtrasDpcppExtensionsAllContentStr =
 #include "clang/DPCT/dpl_extras/dpcpp_extensions.h.inc"
     ;
+const std::string DplExtrasIteratorAdaptorAllContentStr =
+#include "clang/DPCT/dpl_extras/iterator_adaptor.h.inc"
+    ;
 
 const std::string CodePinAllContentStr =
 #include "clang/DPCT/codepin/codepin.hpp.inc"
@@ -166,8 +169,10 @@ void genHelperFunction(const clang::tooling::UnifiedPath &OutRoot) {
   GENERATE_ALL_FILE_CONTENT(DplExtrasVector, "dpl_extras", vector.h)
   GENERATE_ALL_FILE_CONTENT(DplExtrasDpcppExtensions, "dpl_extras",
                             dpcpp_extensions.h)
+  GENERATE_ALL_FILE_CONTENT(DplExtrasIteratorAdaptor, "dpl_extras", iterator_adaptor.h)
 #undef GENERATE_ALL_FILE_CONTENT
 }
 
 } // namespace dpct
 } // namespace clang
+

--- a/clang/runtime/dpct-rt/CMakeLists.txt
+++ b/clang/runtime/dpct-rt/CMakeLists.txt
@@ -22,6 +22,7 @@ set(dpct_rt_files
 set(dpct_rt_dpstd_files
   include/dpct/dpl_extras/functional.h
   include/dpct/dpl_extras/memory.h
+  include/dpct/dpl_extras/iterator_adaptor.h
   include/dpct/dpl_extras/iterators.h
   include/dpct/dpl_extras/algorithm.h
   include/dpct/dpl_extras/numeric.h

--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/iterator_adaptor.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/iterator_adaptor.h
@@ -33,7 +33,6 @@ protected:
   //       is kept for potential future extension by specialization based on
   //       this part of the type definition.
 
-
 public:
   // It is the user's responsibility to ensure extra data is available on the
   // device if they want to use this iterator with device execution policies

--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/iterator_adaptor.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/iterator_adaptor.h
@@ -1,0 +1,59 @@
+//==---- iterator_adaptor.h -----------------------*- C++ -*----------------==//
+//
+// Copyright (C) Intel Corporation
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __DPCT_ITERATOR_ADAPTOR_H__
+#define __DPCT_ITERATOR_ADAPTOR_H__
+
+#include <boost/iterator_adaptors.hpp>
+
+namespace dpct {
+
+typedef boost::use_default use_default;
+
+typedef boost::iterator_core_access iterator_core_access;
+
+template <class Derived,
+          class Base, 
+          class Value = use_default,
+          class Traversal = use_default,
+          class System = use_default,
+          class Reference = use_default,
+          class Difference = use_default>
+class iterator_adaptor
+    : public boost::iterator_adaptor<Derived, Base, Value, Traversal, Reference,
+                                     Difference> {
+protected:
+  typedef boost::iterator_adaptor<Derived, Base, Value, Traversal, Reference,
+                                  Difference>
+      base_t;
+
+  //Note: System tag is not used to dispatch to any specific backend, this is
+  //      controlled explicitly by the user with execution policies. System tag
+  //      is kept for potential future extension by specialization based on this
+  //      part of the type definition.
+
+
+public:
+  //It is the user's responsibility to ensure extra data may be passed directly,
+  // if they want to use the use this iterator with device execution policies
+  using is_passed_directly = ::std::true_type;
+  using iterator_category = ::std::random_access_iterator_tag;
+
+  iterator_adaptor() {}
+
+  explicit iterator_adaptor(Base const &iter) : base_t(iter) {}
+
+  typename base_t::reference
+  operator[](typename base_t::difference_type n) const {
+    return *(this->derived() + n);
+  }
+};
+
+} // end namespace dpct
+
+#endif

--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/iterator_adaptor.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/iterator_adaptor.h
@@ -17,13 +17,9 @@ typedef boost::use_default use_default;
 
 typedef boost::iterator_core_access iterator_core_access;
 
-template <class Derived,
-          class Base, 
-          class Value = use_default,
-          class Traversal = use_default,
-          class System = use_default,
-          class Reference = use_default,
-          class Difference = use_default>
+template <class Derived, class Base, class Value = use_default,
+          class Traversal = use_default, class System = use_default,
+          class Reference = use_default, class Difference = use_default>
 class iterator_adaptor
     : public boost::iterator_adaptor<Derived, Base, Value, Traversal, Reference,
                                      Difference> {
@@ -32,15 +28,15 @@ protected:
                                   Difference>
       base_t;
 
-  //Note: System tag is not used to dispatch to any specific backend, this is
-  //      controlled explicitly by the user with execution policies. System tag
-  //      is kept for potential future extension by specialization based on this
-  //      part of the type definition.
+  // Note: System tag is not used to dispatch to any specific backend, this is
+  //       controlled explicitly by the user with execution policies. System tag
+  //       is kept for potential future extension by specialization based on
+  //       this part of the type definition.
 
 
 public:
-  //It is the user's responsibility to ensure extra data may be passed directly,
-  // if they want to use the use this iterator with device execution policies
+  // It is the user's responsibility to ensure extra data is available on the
+  // device if they want to use this iterator with device execution policies
   using is_passed_directly = ::std::true_type;
   using iterator_category = ::std::random_access_iterator_tag;
 

--- a/clang/runtime/dpct-rt/include/dpct/dpl_utils.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_utils.hpp
@@ -20,8 +20,12 @@
 #include "dpl_extras/algorithm.h"
 #include "dpl_extras/numeric.h"
 #include "dpl_extras/iterators.h"
-#include "dpl_extras/iterator_adaptor.h"
 #include "dpl_extras/vector.h"
 #include "dpl_extras/dpcpp_extensions.h"
+
+// Only include iterator adaptor (and therefore boost) if necessary
+#ifdef ITERATOR_ADAPTOR_REQUIRED
+#include "dpl_extras/iterator_adaptor.h"
+#endif //ITERATOR_ADAPTOR_REQUIRED
 
 #endif // __DPCT_DPL_UTILS_HPP__

--- a/clang/runtime/dpct-rt/include/dpct/dpl_utils.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_utils.hpp
@@ -20,6 +20,7 @@
 #include "dpl_extras/algorithm.h"
 #include "dpl_extras/numeric.h"
 #include "dpl_extras/iterators.h"
+#include "dpl_extras/iterator_adaptor.h"
 #include "dpl_extras/vector.h"
 #include "dpl_extras/dpcpp_extensions.h"
 

--- a/clang/runtime/dpct-rt/include/dpct/dpl_utils.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_utils.hpp
@@ -26,6 +26,6 @@
 // Only include iterator adaptor (and therefore boost) if necessary
 #ifdef ITERATOR_ADAPTOR_REQUIRED
 #include "dpl_extras/iterator_adaptor.h"
-#endif //ITERATOR_ADAPTOR_REQUIRED
+#endif // ITERATOR_ADAPTOR_REQUIRED
 
 #endif // __DPCT_DPL_UTILS_HPP__

--- a/clang/test/dpct/check_header_files.cpp
+++ b/clang/test/dpct/check_header_files.cpp
@@ -97,6 +97,11 @@
 // RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
 // RUN: echo "begin" > %T/check_header_files/diff_res.txt
+// RUN: diff %T/check_header_files/out/include/dpct/dpl_extras/iterator_adaptor.h  %S/../../runtime/dpct-rt/include/dpct/dpl_extras/iterator_adaptor.h >> %T/check_header_files/diff_res.txt
+// RUN: echo "end" >> %T/check_header_files/diff_res.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
+
+// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/dpl_extras/memory.h  %S/../../runtime/dpct-rt/include/dpct/dpl_extras/memory.h >> %T/check_header_files/diff_res.txt
 // RUN: echo "end" >> %T/check_header_files/diff_res.txt
 // RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt

--- a/clang/test/dpct/check_header_files.cpp
+++ b/clang/test/dpct/check_header_files.cpp
@@ -121,6 +121,11 @@
 // RUN: echo "end" >> %T/check_header_files/diff_res.txt
 // RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
+// RUN: echo "begin" > %T/check_header_files/diff_res.txt
+// RUN: diff %T/check_header_files/out/include/dpct/dpl_extras/iterator_adaptor.h  %S/../../runtime/dpct-rt/include/dpct/dpl_extras/iterator_adaptor.h >> %T/check_header_files/diff_res.txt
+// RUN: echo "end" >> %T/check_header_files/diff_res.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
+
 // RUN: rm -rf %T/check_header_files
 
 // CHECK: begin


### PR DESCRIPTION
Implements a `dpct::iterator_adaptor` which adapts boost's iterator adaptor minimally to achieve what we require for use in oneDPL algorithms.

I've put the implementation in a new header to better isolate the inclusion of boost.  I think that I've added the necessary changes to support that new header, but please take a look at that.  With the elimination of the .inc files, I'm not sure how to only include this if it is used (is this done automatically)?

I have a SYCLomatic-test PR which corresponds and tests this functionality with a simple example.  (https://github.com/oneapi-src/SYCLomatic-test/pull/587)