### PR TITLE
[SYCLomatic] Refine the free_image_mem call to fix build warning.

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -10578,7 +10578,9 @@ void MemoryMigrationRule::freeMigration(const MatchFinder::MatchResult &Result,
           new ReplaceStmt(C, MapNames::getClNamespace() +
                                  "ext::oneapi::experimental::free_image_mem(" +
                                  ExprAnalysis::ref(C->getArg(0)) +
-                                 "->get_handle(), {{NEEDREPLACEQ" +
+                                 "->get_handle(), "
+                                 "sycl::ext::oneapi::experimental::image_type::"
+                                 "standard, {{NEEDREPLACEQ" +
                                  std::to_string(Index) + "}})"));
     }
     ExprAnalysis EA(C->getArg(0));

--- a/clang/runtime/dpct-rt/include/dpct/bindless_images.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/bindless_images.hpp
@@ -268,7 +268,8 @@ static inline void destroy_bindless_image(
   auto &mem = detail::get_img_mem_map(handle);
   if (mem) {
     sycl::ext::oneapi::experimental::free_image_mem(
-        mem->get_handle(), q.get_device(), q.get_context());
+        mem->get_handle(),
+        sycl::ext::oneapi::experimental::image_type::standard, q);
     mem = 0;
   }
   sycl::ext::oneapi::experimental::destroy_image_handle(handle, q);

--- a/clang/test/dpct/texture/texture_object_bindless_image.cu
+++ b/clang/test/dpct/texture/texture_object_bindless_image.cu
@@ -137,9 +137,7 @@ int main() {
   kernel<<<1, 1>>>(tex);
   // CHECK: dpct::experimental::destroy_bindless_image(tex, q_ct1);
   cudaDestroyTextureObject(tex);
-#ifndef BUILD_TEST
-  // CHECK: sycl::ext::oneapi::experimental::free_image_mem(pArr->get_handle(), dpct::get_in_order_queue());
+  // CHECK: sycl::ext::oneapi::experimental::free_image_mem(pArr->get_handle(), sycl::ext::oneapi::experimental::image_type::standard, dpct::get_in_order_queue());
   cudaFreeArray(pArr);
-#endif
   return 0;
 }


### PR DESCRIPTION
Signed-off-by: Tang, Jiajun jiajun.tang@intel.com