### PR TITLE
 [SYCLomatic] Change cmake migration rule file from 'extensions/opt_rules/cmake_rules)' to 'extensions/cmake_rules'

### DIFF
--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -1061,7 +1061,7 @@ int runDPCT(int argc, const char **argv) {
   if (MigrateCmakeScriptOnly || MigrateCmakeScript) {
     SmallString<128> CmakeRuleFilePath(DpctInstallPath.getCanonicalPath());
     llvm::sys::path::append(CmakeRuleFilePath,
-                            Twine("extensions/opt_rules/cmake_rules/"
+                            Twine("extensions/cmake_rules/"
                                   "cmake_script_migration_rule.yaml"));
     if (llvm::sys::fs::exists(CmakeRuleFilePath)) {
       std::vector<clang::tooling::UnifiedPath> CmakeRuleFiles{

--- a/clang/tools/dpct/DpctOptRules/CMakeLists.txt
+++ b/clang/tools/dpct/DpctOptRules/CMakeLists.txt
@@ -17,13 +17,13 @@ install(
   FILES ${dpct_cmake_rule_files}
   COMPONENT dpct-cmake-rules
   PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
-  DESTINATION ./extensions/opt_rules/cmake_rules)
+  DESTINATION ./extensions/cmake_rules)
 
 install(
   FILES ${dpct_cmake_rule_files}
   COMPONENT dpct-cmake-rules
   PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
-  DESTINATION ${CMAKE_BINARY_DIR}/extensions/opt_rules/cmake_rules)
+  DESTINATION ${CMAKE_BINARY_DIR}/extensions/cmake_rules)
 
 if (NOT CMAKE_CONFIGURATION_TYPES) # don't add this for IDE's.
   add_llvm_install_targets(install-dpct-opt-rules


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>