### PR TITLE
[SYCLomatic] Adding asserts for unsupported functionality with DPCT_USM_LEVEL_NONE

### DIFF
--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/memory.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/memory.h
@@ -997,13 +997,13 @@ device_pointer<T> get_device_pointer(const device_pointer<T> &ptr) {
 }
 
 template <typename T> T *get_raw_pointer(const device_pointer<T> &ptr) {
-  #ifdef DPCT_USM_LEVEL_NONE
+#ifdef DPCT_USM_LEVEL_NONE
   assert(false && "Invalid to get raw pointer of a device_pointer"
                   "with DPCT_USM_LEVEL_NONE, data is stored in a "
                   "sycl::buffer, and raw pointers to that data are "
                   "inaccessible.");
   return ::std::nullptr;
-else // DPCT_USM_LEVEL_NONE
+#else // DPCT_USM_LEVEL_NONE
   return ptr.get();
 #endif // DPCT_USM_LEVEL_NONE
 }

--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/memory.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/memory.h
@@ -220,23 +220,24 @@ public:
   device_pointer_base(const device_pointer_base &in)
       : buffer(in.buffer), idx(in.idx) {}
   pointer get() const {
-    auto res =
-        (const_cast<device_pointer_base *>(this)
-             ->buffer.template get_access<sycl::access_mode::read_write>())
-            .get_pointer();
-    return res + idx;
+    assert(false && "Invalid to use device_pointer::get() with "
+                    "DPCT_USM_LEVEL_NONE, data is stored in a sycl::buffer, "
+                    "and raw pointers to that data are inaccessible.");
+    return ::std::nullptr;
   }
   operator ValueType *() {
-    auto res = (buffer.template get_access<sycl::access_mode::read_write>())
-                   .get_pointer();
-    return res + idx;
+    assert(false && "Invalid to use device_pointer to raw pointer conversion "
+                    "with DPCT_USM_LEVEL_NONE, data is stored in a "
+                    "sycl::buffer, and raw pointers to that data are "
+                    "inaccessible.");
+    return ::std::nullptr;
   }
   operator ValueType *() const {
-    auto res =
-        (const_cast<device_pointer_base *>(this)
-             ->buffer.template get_access<sycl::access_mode::read_write>())
-            .get_pointer();
-    return res + idx;
+    assert(false && "Invalid to use device_pointer to raw pointer conversion "
+                    "with DPCT_USM_LEVEL_NONE, data is stored in a "
+                    "sycl::buffer, and raw pointers to that data are "
+                    "inaccessible.");
+    return ::std::nullptr;
   }
   Derived operator+(difference_type forward) const {
     return Derived{buffer, idx + forward};
@@ -996,7 +997,15 @@ device_pointer<T> get_device_pointer(const device_pointer<T> &ptr) {
 }
 
 template <typename T> T *get_raw_pointer(const device_pointer<T> &ptr) {
+  #ifdef DPCT_USM_LEVEL_NONE
+  assert(false && "Invalid to get raw pointer of a device_pointer"
+                  "with DPCT_USM_LEVEL_NONE, data is stored in a "
+                  "sycl::buffer, and raw pointers to that data are "
+                  "inaccessible.");
+  return ::std::nullptr;
+else // DPCT_USM_LEVEL_NONE
   return ptr.get();
+#endif // DPCT_USM_LEVEL_NONE
 }
 
 template <typename Pointer> Pointer get_raw_pointer(const Pointer &ptr) {
@@ -1004,10 +1013,22 @@ template <typename Pointer> Pointer get_raw_pointer(const Pointer &ptr) {
 }
 
 template <typename T> const T &get_raw_reference(const device_reference<T> &ref) {
+#ifdef DPCT_USM_LEVEL_NONE
+  assert(false && "Invalid to get raw reference of a device_reference"
+                  "with DPCT_USM_LEVEL_NONE, data is stored in a "
+                  "sycl::buffer, and raw references to that data are "
+                  "inaccessible.");
+#endif // DPCT_USM_LEVEL_NONE
   return ref.value;
 }
 
 template <typename T> T &get_raw_reference(device_reference<T> &ref) {
+#ifdef DPCT_USM_LEVEL_NONE
+  assert(false && "Invalid to get raw reference of a device_reference"
+                  "with DPCT_USM_LEVEL_NONE, data is stored in a "
+                  "sycl::buffer, and raw pointers to that data are "
+                  "inaccessible.");
+#endif // DPCT_USM_LEVEL_NONE
   return ref.value;
 }
 

--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/memory.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/memory.h
@@ -1003,7 +1003,7 @@ template <typename T> T *get_raw_pointer(const device_pointer<T> &ptr) {
                   "sycl::buffer, and raw pointers to that data are "
                   "inaccessible.");
   return ::std::nullptr;
-#else // DPCT_USM_LEVEL_NONE
+#else  // DPCT_USM_LEVEL_NONE
   return ptr.get();
 #endif // DPCT_USM_LEVEL_NONE
 }

--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/memory.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/memory.h
@@ -223,21 +223,21 @@ public:
     assert(false && "Invalid to use device_pointer::get() with "
                     "DPCT_USM_LEVEL_NONE, data is stored in a sycl::buffer, "
                     "and raw pointers to that data are inaccessible.");
-    return ::std::nullptr;
+    return nullptr;
   }
   operator ValueType *() {
     assert(false && "Invalid to use device_pointer to raw pointer conversion "
                     "with DPCT_USM_LEVEL_NONE, data is stored in a "
                     "sycl::buffer, and raw pointers to that data are "
                     "inaccessible.");
-    return ::std::nullptr;
+    return nullptr;
   }
   operator ValueType *() const {
     assert(false && "Invalid to use device_pointer to raw pointer conversion "
                     "with DPCT_USM_LEVEL_NONE, data is stored in a "
                     "sycl::buffer, and raw pointers to that data are "
                     "inaccessible.");
-    return ::std::nullptr;
+    return nullptr;
   }
   Derived operator+(difference_type forward) const {
     return Derived{buffer, idx + forward};
@@ -1002,7 +1002,7 @@ template <typename T> T *get_raw_pointer(const device_pointer<T> &ptr) {
                   "with DPCT_USM_LEVEL_NONE, data is stored in a "
                   "sycl::buffer, and raw pointers to that data are "
                   "inaccessible.");
-  return ::std::nullptr;
+  return nullptr;
 #else  // DPCT_USM_LEVEL_NONE
   return ptr.get();
 #endif // DPCT_USM_LEVEL_NONE

--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/vector.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/vector.h
@@ -563,13 +563,13 @@ public:
     assert(false && "Invalid to use device_vector::real_begin() with "
                     "DPCT_USM_LEVEL_NONE, data is stored in a sycl::buffer, "
                     "and raw pointers to that data are inaccessible.");
-    return ::std::nullptr;
+    return nullptr;
   }
   const T *real_begin() const {
     assert(false && "Invalid to use device_vector::real_begin() with "
                     "DPCT_USM_LEVEL_NONE, data is stored in a sycl::buffer, "
                     "and raw pointers to that data are inaccessible.");
-    return ::std::nullptr;
+    return nullptr;
   }
   void swap(device_vector &v) {
     void *temp = v._storage;

--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/vector.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/vector.h
@@ -560,17 +560,16 @@ public:
   const_iterator end() const { return device_iterator<T>(get_buffer(), _size); }
   const_iterator cend() const { return end(); }
   T *real_begin() {
-    return (detail::mem_mgr::instance()
-                .translate_ptr(_storage)
-                .buffer.template get_access<sycl::access_mode::read_write>())
-        .get_pointer();
+    assert(false && "Invalid to use device_vector::real_begin() with "
+                    "DPCT_USM_LEVEL_NONE, data is stored in a sycl::buffer, "
+                    "and raw pointers to that data are inaccessible.");
+    return ::std::nullptr;
   }
   const T *real_begin() const {
-    return const_cast<device_vector *>(this)
-        ->detail::mem_mgr::instance()
-        .translate_ptr(_storage)
-        .buffer.template get_access<sycl::access_mode::read_write>()
-        .get_pointer();
+    assert(false && "Invalid to use device_vector::real_begin() with "
+                    "DPCT_USM_LEVEL_NONE, data is stored in a sycl::buffer, "
+                    "and raw pointers to that data are inaccessible.");
+    return ::std::nullptr;
   }
   void swap(device_vector &v) {
     void *temp = v._storage;


### PR DESCRIPTION
Adding asserts for unsupported functionality when `DPCT_USM_LEVEL_NONE` is true.
