### PR TITLE
[SYCLomatic] adding missing qualified name for dpct::transform_if

### DIFF
--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/algorithm.h
@@ -369,7 +369,7 @@ void scatter_if(Policy &&policy, InputIter1 first, InputIter1 last,
               typename std::iterator_traits<OutputIter>::iterator_category,
               std::random_access_iterator_tag>::value,
       "Iterators passed to algorithms must be random-access iterators.");
-  transform_if(
+  dpct::transform_if(
       ::std::forward<Policy>(policy), first, last, mask,
       oneapi::dpl::make_permutation_iterator(result, map),
       [=](auto &&v) { return v; }, [=](auto &&m) { return pred(m); });
@@ -405,7 +405,7 @@ OutputIter gather_if(Policy &&policy, InputIter1 map_first, InputIter1 map_last,
       oneapi::dpl::make_permutation_iterator(input_first, map_first);
   const int n = std::distance(map_first, map_last);
 
-  return transform_if(
+  return dpct::transform_if(
       ::std::forward<Policy>(policy), perm_begin, perm_begin + n, mask, result,
       [=](auto &&v) { return v; }, [=](auto &&m) { return pred(m); });
 }


### PR DESCRIPTION
Fully qualified name was missing from transform_if, which has caused an ambiguous function call with new API provided by oneDPL.  

We should update to use that oneDPL function, but for now, we should at least fix this ambiguity.