### PR TITLE
Aligning migrate-cmake-script-only behavior to DPCT migration

### DIFF
--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -730,6 +730,14 @@ int runDPCT(int argc, const char **argv) {
     dpctExit(MigrationErrorNoExplicitInRoot);
   }
 
+  if (MigrateCmakeScriptOnly) {
+    if (InRoot.getPath().empty() &&
+        !cmakeScriptFileSpecified(OptParser->getSourcePathList())) {
+      ShowStatus(MigrationErrorNoExplicitInRootAndCMakeScript);
+      dpctExit(MigrationErrorNoExplicitInRootAndCMakeScript);
+    }
+  }
+
   if (!makeInRootCanonicalOrSetDefaults(InRoot,
                                         OptParser->getSourcePathList())) {
     ShowStatus(MigrationErrorInvalidInRootOrOutRoot);

--- a/clang/lib/DPCT/Error.cpp
+++ b/clang/lib/DPCT/Error.cpp
@@ -203,7 +203,7 @@ void ShowStatus(int Status, std::string Message) {
   case MigrationErrorNoExplicitInRootAndCMakeScript:
     StatusString =
         "Error: The option -migrate-cmake-script-only requires that either "
-        "the option '--in-root' or the CMake files be specified explicitly.";
+        "the option '--in-root' or the CMake file(s) be specified explicitly.";
     break;
   default:
     DpctLog() << "Unknown error\n";

--- a/clang/lib/DPCT/Error.cpp
+++ b/clang/lib/DPCT/Error.cpp
@@ -200,6 +200,11 @@ void ShowStatus(int Status, std::string Message) {
     StatusString = "Error: option '-migrate-cmake-script' and "
                    "'-migrate-cmake-script-only' cannot be used together.\n";
     break;
+  case MigrationErrorNoExplicitInRootAndCMakeScript:
+    StatusString =
+        "Error: The option -migrate-cmake-script-only requires that either "
+        "the option '--in-root' or the CMake files be specified explicitly.";
+    break;
   default:
     DpctLog() << "Unknown error\n";
     dpctExit(-1);

--- a/clang/lib/DPCT/Error.h
+++ b/clang/lib/DPCT/Error.h
@@ -62,7 +62,8 @@ enum ProcessStatus {
   MigrationErrorCMakeScriptPathInvalid = -48,
   MigrateCmakeScriptOnlyNotSpecifed = -49,
   MigarteCmakeScriptIncorrectUse = -50,
-  MigarteCmakeScriptAndMigarteCmakeScriptOnlyBothUse= -51,
+  MigarteCmakeScriptAndMigarteCmakeScriptOnlyBothUse = -51,
+  MigrationErrorNoExplicitInRootAndCMakeScript = -52,
 };
 
 namespace clang {


### PR DESCRIPTION
'-migrate-cmake-script-only' option now follows the same behavior as DPCT src code migration: 

```
$  dpct  --migrate-cmake-script-only
dpct exited with code: -52 (Error: The option -migrate-cmake-script-only requires that either the option '--in-root' or the CMake files be specified explicitly.)

$  dpct  --migrate-cmake-script-only -in-root=./
The directory "dpct_output" is used as "out-root"
Processing: <path-to-cmake-file>/<name>.cmake
Processing: <path-to-cmake-file>/CMakeLists.txt
...

$  dpct  --migrate-cmake-script-only CMakelist.txt
The directory "dpct_output" is used as "out-root"
Processing: <path-to-cmake-file>/CMakeLists.txt

$  dpct  --migrate-cmake-script-only <name>.cmake
The directory "dpct_output" is used as "out-root"
Processing: <path-to-cmake-file>/<name>.cmake
```