### PR TITLE
[SYCLomatic] Add dpct::unique_count API

### DIFF
--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/algorithm.h
@@ -2542,7 +2542,7 @@ unique_count(ExecutionPolicy &&policy, InputIterator begin, InputIterator end,
   auto zip_beg = dpl::make_zip_iterator(begin, begin + 1);
   auto zip_end = zip_beg + n - 1;
   return 1 + dpl::count_if(::std::forward<ExecutionPolicy>(policy), zip_beg,
-                           zip_end, [binary_pred](auto e) {
+                           zip_end, [binary_pred](const auto &e) {
                              using ::std::get;
                              return !binary_pred(get<0>(e), get<1>(e));
                            });

--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/algorithm.h
@@ -2539,13 +2539,14 @@ unique_count(ExecutionPolicy &&policy, InputIterator begin, InputIterator end,
     return 0;
   if (n == 1)
     return 1;
-  auto zip_beg = dpl::make_zip_iterator(begin, begin + 1);
+  auto zip_beg = oneapi::dpl::make_zip_iterator(begin, begin + 1);
   auto zip_end = zip_beg + n - 1;
-  return 1 + dpl::count_if(::std::forward<ExecutionPolicy>(policy), zip_beg,
-                           zip_end, [binary_pred](const auto &e) {
-                             using ::std::get;
-                             return !binary_pred(get<0>(e), get<1>(e));
-                           });
+  return 1 + oneapi::dpl::count_if(::std::forward<ExecutionPolicy>(policy),
+                                   zip_beg, zip_end,
+                                   [binary_pred](const auto &e) {
+                                     using ::std::get;
+                                     return !binary_pred(get<0>(e), get<1>(e));
+                                   });
 }
 
 template <typename ExecutionPolicy, typename InputIterator>

--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/algorithm.h
@@ -2530,6 +2530,32 @@ void partition_flagged(ExecutionPolicy &&policy, InputIterator input,
             num_true_items);
 }
 
+template <typename ExecutionPolicy, typename InputIterator, typename BinaryPred>
+typename ::std::iterator_traits<InputIterator>::difference_type
+unique_count(ExecutionPolicy &&policy, InputIterator begin, InputIterator end,
+             BinaryPred binary_pred) {
+  auto n = ::std::distance(begin, end);
+  if (n == 0)
+    return 0;
+  if (n == 1)
+    return 1;
+  auto zip_beg = dpl::make_zip_iterator(begin, begin + 1);
+  auto zip_end = zip_beg + n - 1;
+  return 1 + dpl::count_if(::std::forward<ExecutionPolicy>(policy), zip_beg,
+                           zip_end, [binary_pred](auto e) {
+                             using ::std::get;
+                             return !binary_pred(get<0>(e), get<1>(e));
+                           });
+}
+
+template <typename ExecutionPolicy, typename InputIterator>
+typename ::std::iterator_traits<InputIterator>::difference_type
+unique_count(ExecutionPolicy &&policy, InputIterator begin, InputIterator end) {
+  using T = typename ::std::iterator_traits<InputIterator>::value_type;
+  return dpct::unique_count(::std::forward<ExecutionPolicy>(policy), begin, end,
+                            ::std::equal_to<T>());
+}
+
 } // end namespace dpct
 
 #endif


### PR DESCRIPTION
This PR adds the `dpct::unique_count` API which counts the number of unique runs in an input buffer.

As an example, the unique count of `[1, 1, 3, 4, 4, 4, 5, 6]` is `5` as there are five unique runs: `[1, 1]`, `[3]`, `[4, 4, 4]`, `[5]`, and `[6]`. Two APIs are added: the first uses `std::equal_to<>` as the default predicate, and the second accepts a user-provided binary predicate.

The corresponding test PR for this API is [SYCLomatic-test #602](https://github.com/oneapi-src/SYCLomatic-test/pull/602)