### PR TITLE
[SYCLomatic][NFC] Add lit test to cover the scenario that thrust::cuda::par(thrust_allocator) is passed as the first argument for thrust::reduce.

### DIFF
--- a/clang/test/dpct/thrust-reduce.cu
+++ b/clang/test/dpct/thrust-reduce.cu
@@ -71,11 +71,19 @@ public:
   }
 };
 
+class MyAlloctor {
+public:
+  typedef char value_type;
+  char *allocate(std::ptrdiff_t size) { return nullptr; }
+  void deallocate(char *p, size_t size) {}
+};
+
 void thrust_test() {
   int data[6] = {1, 0, 2, 2, 1, 3};
   thrust::device_vector<int> d_data(data, data + 6);
   thrust::host_vector<int> h_data(data, data + 6);
   int result;
+  MyAlloctor thrust_allocator;
 
   // CHECK:  result = std::reduce(oneapi::dpl::execution::seq, data, data + 6);
   // CHECK-NEXT:  result = std::reduce(oneapi::dpl::execution::seq, data, data + 6);
@@ -95,6 +103,7 @@ void thrust_test() {
   // CHECK-NEXT:  result = std::reduce(oneapi::dpl::execution::seq, h_data.begin(), h_data.begin() + 6, 1);
   // CHECK-NEXT:  result = std::reduce(oneapi::dpl::execution::seq, h_data.begin(), h_data.begin() + 6, -1, oneapi::dpl::maximum<int>());
   // CHECK-NEXT:  result = std::reduce(oneapi::dpl::execution::seq, h_data.begin(), h_data.begin() + 6, -1, oneapi::dpl::maximum<int>());
+  // CHECK-NEXT:  result = std::reduce(oneapi::dpl::execution::make_device_policy(q_ct1), d_data.begin(), d_data.begin() + 6, -1, oneapi::dpl::maximum<int>());
   result = thrust::reduce(thrust::host, data, data + 6);
   result = thrust::reduce(data, data + 6);
   result = thrust::reduce(thrust::host, data, data + 6, 1);
@@ -113,4 +122,5 @@ void thrust_test() {
   result = thrust::reduce(h_data.begin(), h_data.begin() + 6, 1);
   result = thrust::reduce(thrust::host, h_data.begin(), h_data.begin() + 6, -1, thrust::maximum<int>());
   result = thrust::reduce(h_data.begin(), h_data.begin() + 6, -1, thrust::maximum<int>());
+  result = thrust::reduce(thrust::cuda::par(thrust_allocator), d_data.begin(), d_data.begin() + 6, -1, thrust::maximum<int>());
 }


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>