### PR TITLE
Enabled migration for link_libraires CMake macro

### DIFF
--- a/clang/test/dpct/cmake_migration/case_032/case_032_link_libraries.cpp
+++ b/clang/test/dpct/cmake_migration/case_032/case_032_link_libraries.cpp
@@ -1,0 +1,10 @@
+// RUN: rm -rf %T && mkdir -p %T
+// RUN: cd %T
+// RUN: cp %S/input.cmake ./input.cmake
+// RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-cmake-script-only
+// RUN: echo "begin" > %T/diff.txt
+// RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
+// RUN: echo "end" >> %T/diff.txt
+
+// CHECK: begin
+// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_032/expected.txt
+++ b/clang/test/dpct/cmake_migration/case_032/expected.txt
@@ -1,0 +1,21 @@
+link_libraries(main PRIVATE cxxopts fmt::fmt -qmkl)
+
+link_libraries(foo3 PUBLIC  ${TCNN_LIBRARIES} fmt)
+
+link_libraries(transformer_engine PUBLIC 
+   -qmkl
+   
+   
+   
+   
+   ${DNN_LIB})
+                     
+link_libraries(${target} PRIVATE
+         -static-libgcc
+         
+         )
+                     
+link_libraries(${PROJECT_NAME}
+   
+   
+)

--- a/clang/test/dpct/cmake_migration/case_032/expected.txt
+++ b/clang/test/dpct/cmake_migration/case_032/expected.txt
@@ -1,4 +1,4 @@
-link_libraries(main PRIVATE cxxopts fmt::fmt -qmkl)
+link_libraries(main PRIVATE cxxopts fmt::fmt -qmkl MKL::MKL_SYCL)
 
 link_libraries(foo3 PUBLIC  ${TCNN_LIBRARIES} fmt)
 

--- a/clang/test/dpct/cmake_migration/case_032/input.cmake
+++ b/clang/test/dpct/cmake_migration/case_032/input.cmake
@@ -1,0 +1,21 @@
+link_libraries(main PRIVATE cxxopts fmt::fmt -lcublas)
+
+link_libraries(foo3 PUBLIC ${CUDA_LIBRARIES} ${TCNN_LIBRARIES} fmt)
+
+link_libraries(transformer_engine PUBLIC 
+   CUDA::cublas
+   CUDA::cuda_driver
+   CUDA::cudart
+   CUDA::nvrtc
+   CUDA::nvToolsExt
+   cudnn)
+                     
+link_libraries(${target} PRIVATE
+         -static-libgcc
+         -static-libstdc++
+         )
+                     
+link_libraries(${PROJECT_NAME}
+   libnvinfer.so
+   libnvonnxparser.so
+)

--- a/clang/test/dpct/cmake_migration/case_032/input.cmake
+++ b/clang/test/dpct/cmake_migration/case_032/input.cmake
@@ -1,4 +1,4 @@
-link_libraries(main PRIVATE cxxopts fmt::fmt -lcublas)
+link_libraries(main PRIVATE cxxopts fmt::fmt -lcublas cublas)
 
 link_libraries(foo3 PUBLIC ${CUDA_LIBRARIES} ${TCNN_LIBRARIES} fmt)
 

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -444,8 +444,8 @@
   Kind: CMakeRule
   Priority: Fallback
   CmakeSyntax: CUDA_LIBRARIES_target_link_libraries
-  In: target_link_libraries(${CULibraries})
-  Out: target_link_libraries(${CULibraries})
+  In: ${prefix}link_libraries(${CULibraries})
+  Out: ${prefix}link_libraries(${CULibraries})
   Subrules:
     CULibraries:
       In: |
@@ -458,8 +458,8 @@
   Kind: CMakeRule
   Priority: Fallback
   CmakeSyntax: -lcublas_target_link_libraries
-  In: target_link_libraries(${CUDALibraries})
-  Out: target_link_libraries(${CUDALibraries})
+  In: ${prefix}link_libraries(${CUDALibraries})
+  Out: ${prefix}link_libraries(${CUDALibraries})
   Subrules:
     CUDALibraries:
       In: -lcublas
@@ -471,8 +471,8 @@
   Kind: CMakeRule
   Priority: Fallback
   CmakeSyntax: CUDA_cublas_target_link_libraries
-  In: target_link_libraries(${CUDALibraries})
-  Out: target_link_libraries(${CUDALibraries})
+  In: ${prefix}link_libraries(${CUDALibraries})
+  Out: ${prefix}link_libraries(${CUDALibraries})
   Subrules:
     CUDALibraries:
       In: "CUDA::cublas"
@@ -485,8 +485,8 @@
   Kind: CMakeRule
   Priority: Fallback
   CmakeSyntax: cuda_driver_target_link_libraries
-  In: target_link_libraries(${CUDALibraries})
-  Out: target_link_libraries(${CUDALibraries})
+  In: ${prefix}link_libraries(${CUDALibraries})
+  Out: ${prefix}link_libraries(${CUDALibraries})
   Subrules:
     CUDALibraries:
       In: "CUDA::cuda_driver"
@@ -499,8 +499,8 @@
   Kind: CMakeRule
   Priority: Fallback
   CmakeSyntax: cudart_target_link_libraries
-  In: target_link_libraries(${CUDALibraries})
-  Out: target_link_libraries(${CUDALibraries})
+  In: ${prefix}link_libraries(${CUDALibraries})
+  Out: ${prefix}link_libraries(${CUDALibraries})
   Subrules:
     CUDALibraries:
       In: "CUDA::cudart"
@@ -512,8 +512,8 @@
   Kind: CMakeRule
   Priority: Fallback
   CmakeSyntax: cudnn_target_link_libraries
-  In: target_link_libraries(${CUDALibraries})
-  Out: target_link_libraries(${CUDALibraries})
+  In: ${prefix}link_libraries(${CUDALibraries})
+  Out: ${prefix}link_libraries(${CUDALibraries})
   Subrules:
     CUDALibraries:
       In: "cudnn"
@@ -527,8 +527,8 @@
   Kind: CMakeRule
   Priority: Fallback
   CmakeSyntax: nvrtc_target_link_libraries
-  In: target_link_libraries(${CUDALibraries})
-  Out: target_link_libraries(${CUDALibraries})
+  In: ${prefix}link_libraries(${CUDALibraries})
+  Out: ${prefix}link_libraries(${CUDALibraries})
   Subrules:
     CUDALibraries:
       In: "CUDA::nvrtc"
@@ -541,8 +541,8 @@
   Kind: CMakeRule
   Priority: Fallback
   CmakeSyntax: nvToolsExt_target_link_libraries
-  In: target_link_libraries(${CUDALibraries})
-  Out: target_link_libraries(${CUDALibraries})
+  In: ${prefix}link_libraries(${CUDALibraries})
+  Out: ${prefix}link_libraries(${CUDALibraries})
   Subrules:
     CUDALibraries:
       In: "CUDA::nvToolsExt"
@@ -555,8 +555,8 @@
   Kind: CMakeRule
   Priority: Fallback
   CmakeSyntax: libnvinfer_target_link_libraries
-  In: target_link_libraries(${CUDALibraries})
-  Out: target_link_libraries(${CUDALibraries})
+  In: ${prefix}link_libraries(${CUDALibraries})
+  Out: ${prefix}link_libraries(${CUDALibraries})
   Subrules:
     CUDALibraries:
       In: libnvinfer.so
@@ -569,8 +569,8 @@
   Kind: CMakeRule
   Priority: Fallback
   CmakeSyntax: libnvonnxparser_target_link_libraries
-  In: target_link_libraries(${CUDALibraries})
-  Out: target_link_libraries(${CUDALibraries})
+  In: ${prefix}link_libraries(${CUDALibraries})
+  Out: ${prefix}link_libraries(${CUDALibraries})
   Subrules:
     CUDALibraries:
       In: libnvonnxparser.so
@@ -583,8 +583,8 @@
   Kind: CMakeRule
   Priority: Fallback
   CmakeSyntax: libstdc++_target_link_libraries
-  In: target_link_libraries(${StaticLibraries})
-  Out: target_link_libraries(${StaticLibraries})
+  In: ${prefix}link_libraries(${StaticLibraries})
+  Out: ${prefix}link_libraries(${StaticLibraries})
   Subrules:
     StaticLibraries:
       In: -static-libstdc++

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -454,6 +454,19 @@
       MatchMode: Full
       RuleId: "remove_cuda_reserved_variable_CUDA_LIBRARIES"
 
+- Rule: rule_target_link_libraries_cublas
+  Kind: CMakeRule
+  Priority: Fallback
+  CmakeSyntax: cublas_target_link_libraries
+  In: ${prefix}link_libraries(${CUDALibraries})
+  Out: ${prefix}link_libraries(${CUDALibraries})
+  Subrules:
+    CUDALibraries:
+      In: cublas
+      Out: MKL::MKL_SYCL
+      MatchMode: Full
+      RuleId: "replace_cublas_with_MKL_target"
+
 - Rule: rule_target_link_libraries_-lcublas
   Kind: CMakeRule
   Priority: Fallback


### PR DESCRIPTION
Enabled migration for link_libraires CMake macro
- Modified **target_link_libraires** to **${prefix}link_libraires** in CMake migration rule