### PR TITLE
[SYCLomatic] Add one yaml based migration rule to remove "${CUDA_LIBRARIES}" in SYCL side

### DIFF
--- a/clang/test/dpct/cmake_migration/case_020/expected.txt
+++ b/clang/test/dpct/cmake_migration/case_020/expected.txt
@@ -1,2 +1,3 @@
 set(SOURCES foo.dp.cpp ${CMAKE_SOURCE_DIR}/foo/bar.dp.cpp)
 list(APPEND SOURCES foo.dp.cpp)
+list(append my_libs )

--- a/clang/test/dpct/cmake_migration/case_020/input.cmake
+++ b/clang/test/dpct/cmake_migration/case_020/input.cmake
@@ -1,2 +1,3 @@
 set(SOURCES foo.cu ${CMAKE_SOURCE_DIR}/foo/bar.cu)
 list(APPEND SOURCES foo.dp.cpp)
+list(append my_libs ${CUDA_LIBRARIES})

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -208,11 +208,11 @@
 
 # ${CUDA_LIBRARIES} is cmake reserved variable for static version of the CUDA runtime library.
 # In SYCL side, SYCL runtime is default auto-loaded when option "-fsycl" is specified, so we remove it in SYCL side.
-- Rule: rule_user_defined_function_cuda_libraries
+- Rule: CUDA_LIBRARIES_removed
   Kind: CMakeRule
   Priority: Fallback
   MatchMode: Partial
-  CmakeSyntax: cuda_files_in_user_defined_function_cuda_libraries
+  CmakeSyntax: CUDA_LIBRARIES
   In: ${func_name}(${value})
   Out: ${func_name}(${value})
   Subrules:
@@ -467,21 +467,6 @@
       Out: ""
       MatchMode: Full
       RuleId: "remove_cuda_reserved_variable_CUDA_cudadevrt_LIBRARY"
-
-# CUDA_LIBRARIES is cmake cuda reverved list variable, should be removed in SYCL
-- Rule: rule_target_link_libraries_CUDA_LIBRARIES
-  Kind: CMakeRule
-  Priority: Fallback
-  CmakeSyntax: CUDA_LIBRARIES_target_link_libraries
-  In: ${prefix}link_libraries(${CULibraries})
-  Out: ${prefix}link_libraries(${CULibraries})
-  Subrules:
-    CULibraries:
-      In: |
-        \${CUDA_LIBRARIES}
-      Out: ""
-      MatchMode: Full
-      RuleId: "remove_cuda_reserved_variable_CUDA_LIBRARIES"
 
 - Rule: rule_target_link_libraries_cuda
   Kind: CMakeRule

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -206,6 +206,20 @@
       In: ${arg}.cu
       Out: ${arg}.${rewrite_extention_name}
 
+# ${CUDA_LIBRARIES} is cmake reserved variable for static version of the CUDA runtime library.
+# In SYCL side, SYCL runtime is default auto-loaded when option "-fsycl" is specified, so we remove it in SYCL side.
+- Rule: rule_user_defined_function_cuda_libraries
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: cuda_files_in_user_defined_function_cuda_libraries
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: \${CUDA_LIBRARIES}
+      Out: ""
 
 - Rule: rule_cuda_compile_with_opts
   Kind: CMakeRule


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>