### PR TITLE
[SYCLomatic] Support option without '=' when using --query-api-mapping.

### DIFF
--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -263,6 +263,10 @@ bool hasOptConflictWithQuery(int argc, const char **argv) {
         !Opt.starts_with("--extra-arg")) {
       return true;
     }
+    if (Opt == "--query-api-mapping" || Opt == "--cuda-include-path" ||
+        Opt == "--extra-arg") {
+      ++I; // Skip option value when using option without '='.
+    }
   }
   return false;
 }

--- a/clang/test/dpct/query_api_mapping/test.cu
+++ b/clang/test/dpct/query_api_mapping/test.cu
@@ -11,6 +11,8 @@
 
 // RUN: dpct --cuda-include-path="%cuda-path/include" --query-api-mapping=" __HfMa " | FileCheck %s
 
+// RUN: dpct --cuda-include-path="%cuda-path/include" --query-api-mapping hfma | FileCheck %s
+
 // CHECK: CUDA API:
 // CHECK-NEXT:   __hfma(h1 /*__half*/, h2 /*__half*/, h3 /*__half*/);
 // CHECK-NEXT:   __hfma(b1 /*__nv_bfloat16*/, b2 /*__nv_bfloat16*/, b3 /*__nv_bfloat16*/);

--- a/clang/test/dpct/query_api_mapping/test_all.cu
+++ b/clang/test/dpct/query_api_mapping/test_all.cu
@@ -1,5 +1,7 @@
 // RUN: dpct --cuda-include-path="%cuda-path/include" --query-api-mapping=- | FileCheck %s
 
+// RUN: dpct --cuda-include-path="%cuda-path/include" --query-api-mapping - | FileCheck %s
+
 // CHECK: __activemask
 // CHECK-NEXT: __all
 // CHECK-NEXT: __all_sync


### PR DESCRIPTION
Signed-off-by: Tang, Jiajun jiajun.tang@intel.com