### PR TITLE
[SYCLomatic] Enable CMake migration of CUDA_STANDARD

### DIFF
--- a/clang/test/dpct/cmake_migration/case_015/expected.txt
+++ b/clang/test/dpct/cmake_migration/case_015/expected.txt
@@ -17,9 +17,7 @@ set_target_properties(target_one PROPERTIES CXX_STANDARD 17)
 set_target_properties(target_one PROPERTIES CXX_STANDARD 17)
 
 # No change unless property matches exactly
-set_target_properties(target_one
-                      PROPERTIES
-                      CXX_Standard 14)
+set_target_properties(target_one PROPERTIES CXX_Standard 14)
 
 # Ideally there should be no change unless
 # value is one of 99, 11, 14. But due to the
@@ -30,30 +28,23 @@ set_target_properties(target_one PROPERTIES CXX_STANDARD 17)
 
 # Test CUDA_SEPARABLE_COMPILATION
 #[[
-set_target_properties(target_one
-                      PROPERTIES CUDA_SEPARABLE_COMPILATION Off)]]
+set_target_properties(target_one PROPERTIES CUDA_SEPARABLE_COMPILATION Off)]]
 
 # No change unless property matches exactly
-set_target_properties(target_one
-                      PROPERTIES
-                      Cuda_SEPARABLE_COMPILATION Off)
+set_target_properties(target_one PROPERTIES Cuda_SEPARABLE_COMPILATION Off)
 
 # Test CUDA_ARCHITECHTURES
 #[[
-set_target_properties(target_one
-                      PROPERTIES CUDA_ARCHITECHTURES Auto)]]
+set_target_properties(target_one PROPERTIES CUDA_ARCHITECHTURES Auto)]]
 
 # No change unless property matches exactly
-set_target_properties(target_one
-                      PROPERTIES
-                      cuda_architechtures All)
+set_target_properties(target_one PROPERTIES cuda_architechtures All)
 
 add_library(target_two MODULE nosrc2.dp.cpp)
 
 # Test two target specs
 #[[
-set_target_properties(target_one target_two
-                      PROPERTIES CUDA_ARCHITECHTURES Kepler+Tesla)]]
+set_target_properties(target_one target_two PROPERTIES CUDA_ARCHITECHTURES Kepler+Tesla)]]
 
 # Make sure other properties are intact
 set_target_properties(target_one PROPERTIES OTHER_PROPERTY 1)

--- a/clang/test/dpct/cmake_migration/case_034/case_034_cuda_std.cpp
+++ b/clang/test/dpct/cmake_migration/case_034/case_034_cuda_std.cpp
@@ -1,0 +1,10 @@
+// RUN: rm -rf %T && mkdir -p %T
+// RUN: cd %T
+// RUN: cp %S/input.cmake ./input.cmake
+// RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
+// RUN: echo "begin" > %T/diff.txt
+// RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
+// RUN: echo "end" >> %T/diff.txt
+
+// CHECK: begin
+// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_034/expected.txt
+++ b/clang/test/dpct/cmake_migration/case_034/expected.txt
@@ -1,0 +1,23 @@
+target_compile_features(foo PUBLIC cxx_std_17)
+
+target_compile_features(foo PUBLIC cxx_std_17)
+
+target_compile_features(foo PUBLIC cxx_std_17)
+
+set_property(TARGET cuda_project PROPERTY CXX_STANDARD 17)
+
+set_property(TARGET cuda_project PROPERTY CXX_STANDARD 17)
+
+set_property(TARGET cuda_project PROPERTY CXX_STANDARD 17)
+
+set_target_properties(${TARGETS} PROPERTIES CXX_STANDARD 17)
+
+set_target_properties(${TARGETS} PROPERTIES CXX_STANDARD 17 INCLUDE_DIRECTORIES ${INC_DIR})
+
+set_target_properties(${TARGETS} PROPERTIES INCLUDE_DIRECTORIES ${INC_DIR} CXX_STANDARD 17)
+
+set_target_properties(${TARGETS} PROPERTIES INCLUDE_DIRECTORIES ${INC_DIR} CXX_STANDARD 17 COMPILE_FLAGS ${TARGET_COMPILE_FLAGS})
+
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CMAKE_CXX_STANDARD_REQUIRED OFF)

--- a/clang/test/dpct/cmake_migration/case_034/expected.txt
+++ b/clang/test/dpct/cmake_migration/case_034/expected.txt
@@ -1,15 +1,24 @@
+# In the following cases no change is expected but due to limitations of
+# pattern-rewriter the C++ standard is updated to C++17. This will be fixed in
+# future.
 target_compile_features(foo PUBLIC cxx_std_17)
 
 target_compile_features(foo PUBLIC cxx_std_17)
 
 target_compile_features(foo PUBLIC cxx_std_17)
 
+# In the following cases no change is expected but due to limitations of
+# pattern-rewriter the C++ standard is updated to C++17. This will be fixed in
+# future.
 set_property(TARGET cuda_project PROPERTY CXX_STANDARD 17)
 
 set_property(TARGET cuda_project PROPERTY CXX_STANDARD 17)
 
 set_property(TARGET cuda_project PROPERTY CXX_STANDARD 17)
 
+# In the following cases no change is expected but due to limitations of
+# pattern-rewriter the C++ standard is updated to C++17. This will be fixed in
+# future.
 set_target_properties(${TARGETS} PROPERTIES CXX_STANDARD 17)
 
 set_target_properties(${TARGETS} PROPERTIES CXX_STANDARD 17 INCLUDE_DIRECTORIES ${INC_DIR})

--- a/clang/test/dpct/cmake_migration/case_034/input.cmake
+++ b/clang/test/dpct/cmake_migration/case_034/input.cmake
@@ -1,0 +1,32 @@
+# In the following cases no change is expected but due to limitations of
+# pattern-rewriter the C++ standard is updated to C++17. This will be fixed in
+# future.
+target_compile_features(foo PUBLIC cuda_std_03)
+
+target_compile_features(foo PUBLIC cuda_std_14)
+
+target_compile_features(foo PUBLIC cuda_std_26)
+
+# In the following cases no change is expected but due to limitations of
+# pattern-rewriter the C++ standard is updated to C++17. This will be fixed in
+# future.
+set_property(TARGET cuda_project PROPERTY CUDA_STANDARD 03)
+
+set_property(TARGET cuda_project PROPERTY CUDA_STANDARD 14)
+
+set_property(TARGET cuda_project PROPERTY CUDA_STANDARD 26)
+
+# In the following cases no change is expected but due to limitations of
+# pattern-rewriter the C++ standard is updated to C++17. This will be fixed in
+# future.
+set_target_properties(${TARGETS} PROPERTIES CUDA_STANDARD 03)
+
+set_target_properties(${TARGETS} PROPERTIES CUDA_STANDARD 03 INCLUDE_DIRECTORIES ${INC_DIR})
+
+set_target_properties(${TARGETS} PROPERTIES INCLUDE_DIRECTORIES ${INC_DIR} CUDA_STANDARD 03)
+
+set_target_properties(${TARGETS} PROPERTIES INCLUDE_DIRECTORIES ${INC_DIR} CUDA_STANDARD 26 COMPILE_FLAGS ${TARGET_COMPILE_FLAGS})
+
+set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+
+set(CMAKE_CUDA_STANDARD_REQUIRED OFF)

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -785,7 +785,7 @@
       Out: |
         \${DNN_LIB}
 
-- Rule: rule_target_compile_features-cuda_std_version
+- Rule: rule_target_compile_features_cuda_std_version
   Kind: CMakeRule
   Priority: Fallback
   CmakeSyntax: target_compile_features_cuda_std-version

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -137,13 +137,6 @@
   In: set (CMAKE_CXX_COMPILER ${version})
   Out: set (CMAKE_CXX_COMPILER icpx)
 
-- Rule: rule_set_property_cxx_standard
-  Kind: CMakeRule
-  Priority: Fallback
-  CmakeSyntax: set_property_cxx_standard
-  In: set_target_properties(${targets} PROPERTIES CXX_STANDARD ${version})
-  Out: set_target_properties(${targets} PROPERTIES CXX_STANDARD 17)
-
 - Rule: rule_set_property_cuda_seprarable_only
   Kind: CMakeRule
   Priority: Fallback
@@ -300,36 +293,6 @@
       MatchMode: Full
       In: CUDA_HAS_FP16
       Out: SYCL_HAS_FP16
-
-# Current Yaml based rule hard-code to map "cxx_std_xx" to "cxx_std_17"
-# A more flexible mapping logic should be implemented in implicit rules
-- Rule: rule_cxx_target_compile_features
-  Kind: CMakeRule
-  Priority: Fallback
-  CmakeSyntax: cxx_target_compile_features
-  MatchMode: Partial
-  In: target_compile_features(${value})
-  Out: target_compile_features(${value})
-  Subrules:
-    value:
-      In: cxx_std_${ver}
-      Out: cxx_std_17
-      RuleId: "adjust_cxx_ver"
-
-# Current Yaml based rule hard-code to map "cuda_std_xx" to "cxx_std_17"
-# A more flexible mapping logic should be implemented in implicit rules
-- Rule: rule_cuda_target_compile_features
-  Kind: CMakeRule
-  Priority: Fallback
-  CmakeSyntax: cuda_target_compile_features
-  MatchMode: Partial
-  In: target_compile_features(${value})
-  Out: target_compile_features(${value})
-  Subrules:
-    value:
-      In: cuda_std_${ver}
-      Out: cxx_std_17
-      RuleId: "adjust_cuda_ver"
 
 - Rule: rule_header_file
   Kind: CMakeRule
@@ -821,3 +784,63 @@
       In: CUDA::cublasLt_static
       Out: |
         \${DNN_LIB}
+
+- Rule: rule_target_compile_features-cuda_std_version
+  Kind: CMakeRule
+  Priority: Fallback
+  CmakeSyntax: target_compile_features_cuda_std-version
+  MatchMode: Partial
+  In: target_compile_features(${arg})
+  Out: target_compile_features(${arg})
+  Subrules:
+    arg:
+      In: cuda_std_${version}
+      Out: cxx_std_17
+      RuleId: "replace_cuda_std_version_with_cxx_std_17"
+
+- Rule: rule_set_property_cuda_standard
+  Kind: CMakeRule
+  Priority: Fallback
+  CmakeSyntax: set_property_cuda_standard
+  In: set_property(${target} PROPERTY CUDA_STANDARD ${version})
+  Out: set_property(${target} PROPERTY CXX_STANDARD 17)
+
+- Rule: rule_set_property_cxx_standard
+  Kind: CMakeRule
+  Priority: Fallback
+  CmakeSyntax: set_property_cxx_standard
+  In: set_property(${target} PROPERTY CXX_STANDARD ${version})
+  Out: set_property(${target} PROPERTY CXX_STANDARD 17)
+
+- Rule: rule_set_target_properties_cxx_standard
+  Kind: CMakeRule
+  Priority: Fallback
+  CmakeSyntax: set_cxx_target_properties
+  In: set_target_properties(${targets} PROPERTIES CXX_STANDARD ${version})
+  Out: set_target_properties(${targets} PROPERTIES CXX_STANDARD 17)
+
+- Rule: rule_set_target_properties_cuda_standard
+  Kind: CMakeRule
+  Priority: Fallback
+  CmakeSyntax: set_target_properties_cuda_standard
+  In: set_target_properties(${targets} PROPERTIES ${properties})
+  Out: set_target_properties(${targets} PROPERTIES ${properties})
+  Subrules:
+    properties:
+      In: CUDA_STANDARD ${version} ${other_properties}
+      Out: CXX_STANDARD 17 ${other_properties}
+      MatchMode: Full
+
+- Rule: rule_set_target_properties_cuda_standard-only
+  Kind: CMakeRule
+  Priority: Fallback
+  CmakeSyntax: set_target_properties_cuda_standard-only
+  In: set_target_properties(${targets} PROPERTIES${properties}CUDA_STANDARD ${version})
+  Out: set_target_properties(${targets} PROPERTIES${properties}CXX_STANDARD 17)
+
+- Rule: rule_set_cmake_cuda_required
+  Kind: CMakeRule
+  Priority: Fallback
+  CmakeSyntax: set_cmake_cuda_required
+  In: set(CMAKE_CUDA_STANDARD_REQUIRED ${value})
+  Out: set(CMAKE_CXX_STANDARD_REQUIRED ${value})

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -294,6 +294,36 @@
       In: CUDA_HAS_FP16
       Out: SYCL_HAS_FP16
 
+# Current Yaml based rule hard-code to map "cxx_std_xx" to "cxx_std_17"
+# A more flexible mapping logic should be implemented in implicit rules
+- Rule: rule_cxx_target_compile_features
+  Kind: CMakeRule
+  Priority: Fallback
+  CmakeSyntax: cxx_target_compile_features
+  MatchMode: Partial
+  In: target_compile_features(${value})
+  Out: target_compile_features(${value})
+  Subrules:
+    value:
+      In: cxx_std_${ver}
+      Out: cxx_std_17
+      RuleId: "adjust_cxx_ver"
+
+# Current Yaml based rule hard-code to map "cuda_std_xx" to "cxx_std_17"
+# A more flexible mapping logic should be implemented in implicit rules
+- Rule: rule_cuda_target_compile_features
+  Kind: CMakeRule
+  Priority: Fallback
+  CmakeSyntax: cuda_target_compile_features
+  MatchMode: Partial
+  In: target_compile_features(${value})
+  Out: target_compile_features(${value})
+  Subrules:
+    value:
+      In: cuda_std_${ver}
+      Out: cxx_std_17
+      RuleId: "adjust_cuda_ver"
+
 - Rule: rule_header_file
   Kind: CMakeRule
   Priority: Fallback
@@ -784,19 +814,6 @@
       In: CUDA::cublasLt_static
       Out: |
         \${DNN_LIB}
-
-- Rule: rule_target_compile_features_cuda_std_version
-  Kind: CMakeRule
-  Priority: Fallback
-  CmakeSyntax: target_compile_features_cuda_std-version
-  MatchMode: Partial
-  In: target_compile_features(${arg})
-  Out: target_compile_features(${arg})
-  Subrules:
-    arg:
-      In: cuda_std_${version}
-      Out: cxx_std_17
-      RuleId: "replace_cuda_std_version_with_cxx_std_17"
 
 - Rule: rule_set_property_cuda_standard
   Kind: CMakeRule


### PR DESCRIPTION
Adds migration of setting CUDA standard to CXX equivalent CMake APIs.

CUDA standard can be set in three ways:

- target_compile_options
- set_target_properties
- set_property

Signed-off-by: Daiyaan Ahmed <daiyaan.ahmed@intel.com>