### PR TITLE
[DOC] Fix formatting issues

### DIFF
--- a/docs/dev_guide/migration/API-Mapping-query-guide.rst
+++ b/docs/dev_guide/migration/API-Mapping-query-guide.rst
@@ -1,8 +1,8 @@
-API-Mapping Query Guide
-=======================
+Query CUDA* to SYCL* API Mapping
+================================
 
-Use the ``--query-api-mapping`` option to discover which SYCL API is functionally
-compatible with a specified CUDA API. The API query functionality can assist users
+Use the ``--query-api-mapping`` option to discover which SYCL\* API is functionally
+compatible with a specified CUDA\* API. The API query functionality can assist users
 on manual code migration and help users understand the SYCL API.
 
 The following example queries the functionally compatible SYCL API for the

--- a/docs/dev_guide/migration/API-Mapping-query-guide.rst
+++ b/docs/dev_guide/migration/API-Mapping-query-guide.rst
@@ -1,35 +1,45 @@
 API-Mapping Query Guide
 =======================
 
-|tool_name| provides the functionality for users to query functionally
-compatible SYCL API for some CUDA API. The API query functionality can assist
-users on manual code migration, as well as help users understand the SYCL API.
+Use the ``--query-api-mapping`` option to discover which SYCL API is functionally
+compatible with a specified CUDA API. The API query functionality can assist users
+on manual code migration and help users understand the SYCL API.
 
-API mapping query example:
+The following example queries the functionally compatible SYCL API for the
+``cudaMalloc`` function:
+
+.. code-block:: bash
+
+   $ dpct --query-api-mapping=cudaMalloc
+
+     CUDA API:
+       cudaMalloc(pDev /*void ***/, s /*size_t*/);
+     Is migrated to:
+       *pDev = (void *)sycl::malloc_device(s, dpct::get_in_order_queue());
+
+On Linux, you can use the ``tab`` key to auto-complete the CUDA API name
+specified for the ``--query-api-mapping`` option. For example :
+
+1. Specify the partial CUDA function name "cudaMa" to the ``--query-api-mapping`` option:
 
    .. code-block:: bash
 
-      $ dpct --query-api-mapping=cudaMalloc
-      CUDA API:
-        cudaMalloc(pDev /*void ***/, s /*size_t*/);
-      Is migrated to:
-        *pDev = (void *)sycl::malloc_device(s, dpct::get_in_order_queue());
+      dpct --query-api-mapping=cudaMa
+2. Press ``tab``.
 
-- On a Linux OS, you can use the ``tab`` button to auto-complete the CUDA API
-  names.
+   The CUDA API name will auto-complete to ``cudaMalloc``:
 
-    .. code-block:: bash
+   .. code-block:: bash
 
-        $ dpct --query-api-mapping=cudaMa (press tab)
-        $ dpct --query-api-mapping=cudaMalloc
+      dpct --query-api-mapping=cudaMalloc
 
-- |tool_name| supports fuzzy matching of CUDA API names.
-  For example:
+|tool_name| also supports fuzzy matching of CUDA API names. For example:
 
-    .. code-block:: bash
+.. code-block:: bash
 
-        $ dpct --query-api-mapping=cudamalloc
-        CUDA API:
-          cudaMalloc(pDev /*void ***/, s /*size_t*/);
-        Is migrated to:
-          *pDev = (void *)sycl::malloc_device(s, dpct::get_in_order_queue());
+   $ dpct --query-api-mapping=cudamalloc
+
+     CUDA API:
+       cudaMalloc(pDev /*void ***/, s /*size_t*/);
+     Is migrated to:
+       *pDev = (void *)sycl::malloc_device(s, dpct::get_in_order_queue());

--- a/docs/dev_guide/reference/diagnostic_ref/dpct1031.rst
+++ b/docs/dev_guide/reference/diagnostic_ref/dpct1031.rst
@@ -7,6 +7,7 @@ Message
 -------
 
 .. _msg-1031-start:
+
 Memory access across peer devices is an implementation-specific feature which
 may not be supported by some SYCL backends and compilers. The output parameter(s)
 are set to 0. You can migrate the code with peer access extension if you do not


### PR DESCRIPTION
Fix the following formatting issues:
- Missing new line in dpct1031, resulting in build warning (fixed)
- Incorrect indentation for code-blocks (formatting issue) in API-mapping query guide (fixed)

Also applied editorial/formatting improvements to API-mapping query guide for clarity.