### PR TITLE
[SYCLomatic] Fix the migration of setp instruction

### DIFF
--- a/clang/lib/DPCT/AsmMigration.cpp
+++ b/clang/lib/DPCT/AsmMigration.cpp
@@ -695,7 +695,7 @@ protected:
           return SYCLGenError();
         break;
       case InstAttr::lt:
-        if (T->isSignedInt())
+        if (IsInteger)
           ExprCmp("<");
         else if (T->isFloating())
           DpctCmp("compare<{0}>({1}, {2}, std::less<>())");
@@ -703,7 +703,7 @@ protected:
           return SYCLGenError();
         break;
       case InstAttr::le:
-        if (T->isSignedInt())
+        if (IsInteger)
           ExprCmp("<=");
         else if (T->isFloating())
           DpctCmp("compare<{0}>({1}, {2}, std::less_equal<>())");
@@ -711,7 +711,7 @@ protected:
           return SYCLGenError();
         break;
       case InstAttr::gt:
-        if (T->isSignedInt())
+        if (IsInteger)
           ExprCmp(">");
         else if (T->isFloating())
           DpctCmp("compare<{0}>({1}, {2}, std::greater<>())");
@@ -719,7 +719,7 @@ protected:
           return SYCLGenError();
         break;
       case InstAttr::ge:
-        if (T->isSignedInt())
+        if (IsInteger)
           ExprCmp(">=");
         else if (T->isFloating())
           DpctCmp("compare<{0}>({1}, {2}, std::greater_equal<>())");

--- a/clang/test/dpct/asm/setp.cu
+++ b/clang/test/dpct/asm/setp.cu
@@ -49,6 +49,10 @@
 // CHECK-NEXT:     _p_q[4] = a <= b;
 // CHECK-NEXT:     _p_q[5] = a > b;
 // CHECK-NEXT:     _p_q[6] = a >= b;
+// CHECK-NEXT:     _p_q[3] = a < b;
+// CHECK-NEXT:     _p_q[4] = a <= b;
+// CHECK-NEXT:     _p_q[5] = a > b;
+// CHECK-NEXT:     _p_q[6] = a >= b;
 // CHECK-NEXT:     if (_p_p[0]) {
 // CHECK-NEXT:       y = fp;
 // CHECK-NEXT:     }
@@ -95,6 +99,10 @@ __device__ void setp() {
       " setp.le.s32 %%q4, %2, %3;\n\t"
       " setp.gt.s32 %%q5, %2, %3;\n\t"
       " setp.ge.s32 %%q6, %2, %3;\n\t"
+      " setp.lt.u32 %%q3, %2, %3;\n\t"
+      " setp.le.u32 %%q4, %2, %3;\n\t"
+      " setp.gt.u32 %%q5, %2, %3;\n\t"
+      " setp.ge.u32 %%q6, %2, %3;\n\t"
       " @%%p mov.f32 %0, fp;\n\t"
       "}"
       : "=f"(y) : "f"(x), "r"(a), "r"(b));


### PR DESCRIPTION
Allow unsigned integer use lt, le, gt, ge comparison.