### PR TITLE
[SYCLomatic] Fix synchronization issue when migrating cudaEventRecord()  related to multiple cuda stream

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -7101,15 +7101,13 @@ void EventAPICallRule::runRule(const MatchFinder::MatchResult &Result) {
              FuncName == "cuEventSynchronize") {
     if(DpctGlobalInfo::getEnablepProfilingFlag()) {
       // Option '--enable-profiling' is enabled
-      std::string ReplStr;
-      ReplStr = MapNames::getDpctNamespace() + "sycl_event_synchronize";
+      std::string ReplStr{getStmtSpelling(CE->getArg(0))};
+      ReplStr += "->wait_and_throw()";
       if (IsAssigned) {
-        emplaceTransformation(new InsertBeforeStmt(CE, "DPCT_CHECK_ERROR("));
+        ReplStr = "DPCT_CHECK_ERROR(" + ReplStr + ")";
+        requestFeature(HelperFeatureEnum::device_ext);
       }
-      emplaceTransformation(new ReplaceCalleeName(CE, std::move(ReplStr)));
-      if (IsAssigned) {
-        emplaceTransformation(new InsertAfterStmt(CE, ")"));
-      }
+      emplaceTransformation(new ReplaceStmt(CE, std::move(ReplStr)));
     } else {
       // Option '--enable-profiling' is not enabled
       bool NeedReport = false;

--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -7319,7 +7319,7 @@ void EventAPICallRule::handleEventRecordWithProfilingEnabled(
         emplaceTransformation(new ReplaceCalleeName(CE, std::move(ReplaceStr)));
         emplaceTransformation(new InsertBeforeStmt(CE, "DPCT_CHECK_ERROR("));
         emplaceTransformation(new InsertAfterStmt(CE, ")"));
-
+        report(CE->getBeginLoc(), Diagnostics::NOERROR_RETURN_ZERO, false);
         return;
 #else
         Str = "{{NEEDREPLACEQ" + std::to_string(Index) +
@@ -7430,8 +7430,15 @@ void EventAPICallRule::handleEventRecordWithProfilingEnabled(
         }
 
       } else {
+#if 1
+        std::string ReplaceStr;
+        ReplaceStr = MapNames::getDpctNamespace() + "sycl_event_record";
+        emplaceTransformation(new ReplaceCalleeName(CE, std::move(ReplaceStr)));
+        return;
+#else
         Str = "*" + ArgName + " = " + StreamName +
               "->ext_oneapi_submit_barrier()";
+#endif
       }
       ReplStr += Str;
     }

--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -7302,7 +7302,7 @@ void EventAPICallRule::handleEventRecordWithProfilingEnabled(
 
       } else {
         std::string ReplaceStr;
-        ReplaceStr = MapNames::getDpctNamespace() + "sycl_event_record";
+        ReplaceStr = MapNames::getDpctNamespace() + "sync_barrier";
         emplaceTransformation(new ReplaceCalleeName(CE, std::move(ReplaceStr)));
         emplaceTransformation(new InsertBeforeStmt(CE, "DPCT_CHECK_ERROR("));
         emplaceTransformation(new InsertAfterStmt(CE, ")"));
@@ -7378,7 +7378,7 @@ void EventAPICallRule::handleEventRecordWithProfilingEnabled(
 
       } else {
         std::string ReplaceStr;
-        ReplaceStr = MapNames::getDpctNamespace() + "sycl_event_record";
+        ReplaceStr = MapNames::getDpctNamespace() + "sync_barrier";
         emplaceTransformation(new ReplaceCalleeName(CE, std::move(ReplaceStr)));
         return;
       }
@@ -7409,7 +7409,7 @@ void EventAPICallRule::handleEventRecordWithProfilingEnabled(
 
       } else {
         std::string ReplaceStr;
-        ReplaceStr = MapNames::getDpctNamespace() + "sycl_event_record";
+        ReplaceStr = MapNames::getDpctNamespace() + "sync_barrier";
         emplaceTransformation(new ReplaceCalleeName(CE, std::move(ReplaceStr)));
         return;
       }

--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -7101,7 +7101,6 @@ void EventAPICallRule::runRule(const MatchFinder::MatchResult &Result) {
              FuncName == "cuEventSynchronize") {
     if(DpctGlobalInfo::getEnablepProfilingFlag()) {
       // Option '--enable-profiling' is enabled
-#if 1
       std::string ReplStr;
       ReplStr = MapNames::getDpctNamespace() + "sycl_event_synchronize";
       if (IsAssigned) {
@@ -7111,15 +7110,6 @@ void EventAPICallRule::runRule(const MatchFinder::MatchResult &Result) {
       if (IsAssigned) {
         emplaceTransformation(new InsertAfterStmt(CE, ")"));
       }
-#else
-      std::string ReplStr{getStmtSpelling(CE->getArg(0))};
-      ReplStr += "->wait_and_throw()";
-      if (IsAssigned) {
-        ReplStr = "DPCT_CHECK_ERROR(" + ReplStr + ")";
-        requestFeature(HelperFeatureEnum::device_ext);
-      }
-      emplaceTransformation(new ReplaceStmt(CE, std::move(ReplStr)));
-#endif
     } else {
       // Option '--enable-profiling' is not enabled
       bool NeedReport = false;
@@ -7313,7 +7303,6 @@ void EventAPICallRule::handleEventRecordWithProfilingEnabled(
         }
 
       } else {
-#if 1
         std::string ReplaceStr;
         ReplaceStr = MapNames::getDpctNamespace() + "sycl_event_record";
         emplaceTransformation(new ReplaceCalleeName(CE, std::move(ReplaceStr)));
@@ -7321,10 +7310,6 @@ void EventAPICallRule::handleEventRecordWithProfilingEnabled(
         emplaceTransformation(new InsertAfterStmt(CE, ")"));
         report(CE->getBeginLoc(), Diagnostics::NOERROR_RETURN_ZERO, false);
         return;
-#else
-        Str = "{{NEEDREPLACEQ" + std::to_string(Index) +
-              "}}.ext_oneapi_submit_barrier()";
-#endif
       }
       StmtStr = "*" + ArgName + " = " + Str;
     } else {
@@ -7394,15 +7379,10 @@ void EventAPICallRule::handleEventRecordWithProfilingEnabled(
         }
 
       } else {
-#if 1
         std::string ReplaceStr;
         ReplaceStr = MapNames::getDpctNamespace() + "sycl_event_record";
         emplaceTransformation(new ReplaceCalleeName(CE, std::move(ReplaceStr)));
         return;
-#else
-        Str = "*" + ArgName + " = {{NEEDREPLACEQ" + std::to_string(Index) +
-              "}}.ext_oneapi_submit_barrier()";
-#endif
       }
       ReplStr += Str;
     } else {
@@ -7430,15 +7410,10 @@ void EventAPICallRule::handleEventRecordWithProfilingEnabled(
         }
 
       } else {
-#if 1
         std::string ReplaceStr;
         ReplaceStr = MapNames::getDpctNamespace() + "sycl_event_record";
         emplaceTransformation(new ReplaceCalleeName(CE, std::move(ReplaceStr)));
         return;
-#else
-        Str = "*" + ArgName + " = " + StreamName +
-              "->ext_oneapi_submit_barrier()";
-#endif
       }
       ReplStr += Str;
     }

--- a/clang/runtime/dpct-rt/include/dpct/device.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/device.hpp
@@ -792,26 +792,27 @@ has_capability_or_fail(const sycl::device &dev,
   }
 }
 
-/// For USM, if \p queue is the default queue, waits all the kernel tasks
-/// in all the queues of current device completed, then stores the event of
-/// the queue specified by \p queue at the time of this call into the memory
-/// pointed by \p event_ptr. If \p queue is not the default queue, just stores
-/// the event of the queue specified by \p queue at the time of this call into
-/// the memory pointed by \p event_ptr.
-/// For usmnone, waits all the kernel tasks
-/// in all the queues of current device completed, then stores the event of the
-/// queue specified by \p queue at the time of this call into memory pointed by
-/// \p event_ptr.
-inline void sycl_event_record(dpct::event_ptr event_ptr,
-                              sycl::queue *queue = &get_default_queue()) {
-#ifdef DPCT_USM_LEVEL_NONE
-  dpct::get_current_device().queues_wait_and_throw();
-#else
+/// Util function to synchronize all the queues of current device with default
+/// queue and store the event of the specified queue at the time of this call.
+/// \param [out] event_ptr The memory to store the event.
+/// \param [in] queue The queue specified to do synchronization.
+inline void sync_barrier(dpct::event_ptr event_ptr,
+                         sycl::queue *queue = &get_default_queue()) {
   if (*queue == get_default_queue()) {
+    // Wait all the kernel tasks in all the queues of current device completed.
     dpct::get_current_device().queues_wait_and_throw();
+  }
+
+#ifdef DPCT_USM_LEVEL_NONE
+  if (*queue != get_default_queue()) {
+    // For out-of-ordered queue, wait all the kernel tasks in \p queue
+    // completed.
+    queue->wait();
   }
 #endif
 
+// Store the event of the specified queue at the time of this call into memory
+// pointed by \p event_ptr.
 #ifdef DPCT_PROFILING_ENABLED
   *event_ptr = queue->ext_oneapi_submit_barrier();
 #else

--- a/clang/runtime/dpct-rt/include/dpct/device.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/device.hpp
@@ -792,8 +792,13 @@ has_capability_or_fail(const sycl::device &dev,
   }
 }
 
-/// Util function to insert a synchronize barrier in the queue and return the
-/// event of the barrier.
+/// Util function to do implicit sync among queues of the same device then
+/// insert a synchronize barrier in the queue. For USM, If the queue is the
+/// default in-order queue, try to sync with all queues available in the current
+/// device before inserting a barrier. For USM-none, If the queue is the default
+/// out-of-order queue, try to sync with all queues available in the current
+/// device before inserting a barrier, else try to sync in the current queue
+/// before inserting a barrier.
 /// \param [out] event_ptr The memory to store the event.
 /// \param [in] queue The queue specified to do synchronization.
 inline void sync_barrier(sycl::event *event_ptr,
@@ -811,8 +816,6 @@ inline void sync_barrier(sycl::event *event_ptr,
   }
 #endif
 
-// Store the event of the specified queue at the time of this call into memory
-// pointed by \p event_ptr.
 #ifdef DPCT_PROFILING_ENABLED
   *event_ptr = queue->ext_oneapi_submit_barrier();
 #else

--- a/clang/runtime/dpct-rt/include/dpct/device.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/device.hpp
@@ -610,6 +610,10 @@ public:
     return DEFAULT_DEVICE_ID;
   }
 
+  // std::map<event_ptr, sycl::queue> &get_event2queue_map() {
+  //   return _event2queue_map;
+  // }
+
 /// Select device with a device ID.
 /// \param [in] id The id of the device which can
 /// be obtained through get_device_id(const sycl::device).
@@ -685,6 +689,11 @@ private:
   /// thread-id to device-id map.
   std::map<unsigned int, unsigned int> _thread2dev_map;
   int _cpu_device = -1;
+
+  // SYCL event to queue map.
+  std::map<event_ptr, sycl::queue> _event2queue_map;
+  friend void sycl_event_record(dpct::event_ptr event_ptr, sycl::queue &queue);
+  friend void sycl_event_synchronize(dpct::event_ptr event_ptr);
 };
 
 /// Util function to get the default queue of current selected device depends on

--- a/clang/runtime/dpct-rt/include/dpct/device.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/device.hpp
@@ -610,10 +610,6 @@ public:
     return DEFAULT_DEVICE_ID;
   }
 
-  // std::map<event_ptr, sycl::queue> &get_event2queue_map() {
-  //   return _event2queue_map;
-  // }
-
 /// Select device with a device ID.
 /// \param [in] id The id of the device which can
 /// be obtained through get_device_id(const sycl::device).

--- a/clang/runtime/dpct-rt/include/dpct/device.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/device.hpp
@@ -692,7 +692,7 @@ private:
 
   // SYCL event to queue map.
   std::map<event_ptr, sycl::queue> _event2queue_map;
-  friend void sycl_event_record(dpct::event_ptr event_ptr, sycl::queue &queue);
+  friend void sycl_event_record(dpct::event_ptr event_ptr, sycl::queue *queue);
   friend void sycl_event_synchronize(dpct::event_ptr event_ptr);
 };
 

--- a/clang/runtime/dpct-rt/include/dpct/device.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/device.hpp
@@ -564,6 +564,10 @@ private:
   void get_version(int &major, int &minor) const {
     detail::get_version(*this, major, minor);
   }
+
+  friend void sycl_event_record(dpct::event_ptr event_ptr, sycl::queue *queue);
+  friend void sycl_event_synchronize(dpct::event_ptr event_ptr);
+
   sycl::queue *_q_in_order, *_q_out_of_order;
   sycl::queue *_saved_queue;
   sycl::context _ctx;
@@ -686,8 +690,6 @@ private:
   std::map<unsigned int, unsigned int> _thread2dev_map;
   int _cpu_device = -1;
 
-  // SYCL event to queue map.
-  std::map<event_ptr, sycl::queue> _event2queue_map;
   friend void sycl_event_record(dpct::event_ptr event_ptr, sycl::queue *queue);
   friend void sycl_event_synchronize(dpct::event_ptr event_ptr);
 };

--- a/clang/runtime/dpct-rt/include/dpct/device.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/device.hpp
@@ -792,11 +792,11 @@ has_capability_or_fail(const sycl::device &dev,
   }
 }
 
-/// Util function to synchronize all the queues of current device with default
-/// queue and store the event of the specified queue at the time of this call.
+/// Util function to insert a synchronize barrier in the queue and return the
+/// event of the barrier.
 /// \param [out] event_ptr The memory to store the event.
 /// \param [in] queue The queue specified to do synchronization.
-inline void sync_barrier(dpct::event_ptr event_ptr,
+inline void sync_barrier(sycl::event *event_ptr,
                          sycl::queue *queue = &get_default_queue()) {
   if (*queue == get_default_queue()) {
     // Wait all the kernel tasks in all the queues of current device completed.

--- a/clang/runtime/dpct-rt/include/dpct/util.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/util.hpp
@@ -958,9 +958,9 @@ inline queue_ptr int_as_queue_ptr(uintptr_t x) {
 
 /// Stores current event into memory pointed by event_ptr and records the queue
 /// related to current event.
-void sycl_event_record(dpct::event_ptr event_ptr, sycl::queue &queue) {
+void sycl_event_record(dpct::event_ptr event_ptr, sycl::queue *queue) {
   auto &event2queue_map = dev_mgr::instance()._event2queue_map;
-  event2queue_map[event_ptr] = queue;
+  event2queue_map[event_ptr] = *queue;
   *event_ptr = get_out_of_order_queue().ext_oneapi_submit_barrier();
 }
 

--- a/clang/runtime/dpct-rt/include/dpct/util.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/util.hpp
@@ -958,8 +958,8 @@ inline queue_ptr int_as_queue_ptr(uintptr_t x) {
 
 /// Stores current event into memory pointed by event_ptr and records the queue
 /// related to current event.
-void sycl_event_record(dpct::event_ptr event_ptr,
-                       sycl::queue *queue = &get_default_queue()) {
+inline void sycl_event_record(dpct::event_ptr event_ptr,
+                              sycl::queue *queue = &get_default_queue()) {
   auto &event2queue_map = dev_mgr::instance()._event2queue_map;
   event2queue_map[event_ptr] = *queue;
   *event_ptr = get_out_of_order_queue().ext_oneapi_submit_barrier();
@@ -969,7 +969,7 @@ void sycl_event_record(dpct::event_ptr event_ptr,
 /// different queues of current device completed. If current event does not
 /// relate to default queue, just wait kernel tasks in current queue of current
 /// device completed.
-void sycl_event_synchronize(dpct::event_ptr event_ptr) {
+inline void sycl_event_synchronize(dpct::event_ptr event_ptr) {
   auto &event2queue_map = dev_mgr::instance()._event2queue_map;
   if (event2queue_map[event_ptr] == get_default_queue()) {
     get_current_device().queues_wait_and_throw();

--- a/clang/runtime/dpct-rt/include/dpct/util.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/util.hpp
@@ -958,7 +958,8 @@ inline queue_ptr int_as_queue_ptr(uintptr_t x) {
 
 /// Stores current event into memory pointed by event_ptr and records the queue
 /// related to current event.
-void sycl_event_record(dpct::event_ptr event_ptr, sycl::queue *queue) {
+void sycl_event_record(dpct::event_ptr event_ptr,
+                       sycl::queue *queue = &get_default_queue()) {
   auto &event2queue_map = dev_mgr::instance()._event2queue_map;
   event2queue_map[event_ptr] = *queue;
   *event_ptr = get_out_of_order_queue().ext_oneapi_submit_barrier();

--- a/clang/runtime/dpct-rt/include/dpct/util.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/util.hpp
@@ -957,7 +957,7 @@ inline queue_ptr int_as_queue_ptr(uintptr_t x) {
 }
 
 /// For USM, if \p queue is the default queue, waits all the kernel tasks
-/// in different queues of current device completed, then stores the event of
+/// in all the queues of current device completed, then stores the event of
 /// the queue specified by \p queue at the time of this call into the memory
 /// pointed by \p event_ptr. If \p queue is not the default queue, just stores
 /// the event of the queue specified by \p queue at the time of this call into
@@ -969,23 +969,10 @@ inline queue_ptr int_as_queue_ptr(uintptr_t x) {
 inline void sycl_event_record(dpct::event_ptr event_ptr,
                               sycl::queue *queue = &get_default_queue()) {
 #ifdef DPCT_USM_LEVEL_NONE
-  // For out of order queue, waits all the kernel tasks in current queue of
-  // current device completed.
   dpct::get_current_device().queues_wait_and_throw();
 #else
-  // using in-order queue
   if (*queue == get_default_queue()) {
-    auto event = queue->submit([&](sycl::handler &cgh) {
-      cgh.host_task([=] {
-        // dpct::get_current_device().queues_wait_and_throw();
-        for (auto &q :
-             dev_mgr::instance()._devs[get_current_device_id()]->_queues) {
-          if (*q != get_default_queue())
-            q->wait();
-        }
-      });
-    });
-    event.wait();
+    dpct::get_current_device().queues_wait_and_throw();
   }
 #endif
 

--- a/clang/runtime/dpct-rt/include/dpct/util.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/util.hpp
@@ -956,39 +956,6 @@ inline queue_ptr int_as_queue_ptr(uintptr_t x) {
   : reinterpret_cast<queue_ptr>(x);
 }
 
-/// For USM, if \p queue is the default queue, waits all the kernel tasks
-/// in all the queues of current device completed, then stores the event of
-/// the queue specified by \p queue at the time of this call into the memory
-/// pointed by \p event_ptr. If \p queue is not the default queue, just stores
-/// the event of the queue specified by \p queue at the time of this call into
-/// the memory pointed by \p event_ptr.
-/// For usmnone, waits all the kernel tasks
-/// in all the queues of current device completed, then stores the event of the
-/// queue specified by \p queue at the time of this call into memory pointed by
-/// \p event_ptr.
-inline void sycl_event_record(dpct::event_ptr event_ptr,
-                              sycl::queue *queue = &get_default_queue()) {
-#ifdef DPCT_USM_LEVEL_NONE
-  dpct::get_current_device().queues_wait_and_throw();
-#else
-  if (*queue == get_default_queue()) {
-    dpct::get_current_device().queues_wait_and_throw();
-  }
-#endif
-
-#ifdef DPCT_PROFILING_ENABLED
-  *event_ptr = queue->ext_oneapi_submit_barrier();
-#else
-  *event_ptr = queue->single_task([=]() {});
-#endif
-}
-
-/// Waits kernel tasks in current queue before the event specifed by \p
-/// event_ptr completed.
-inline void sycl_event_synchronize(dpct::event_ptr event_ptr) {
-  event_ptr->wait_and_throw();
-}
-
 template <int n_nondefault_params, int n_default_params, typename T>
 class args_selector;
 

--- a/clang/test/dpct/cuda-event-api-enable-profiling.cu
+++ b/clang/test/dpct/cuda-event-api-enable-profiling.cu
@@ -75,7 +75,7 @@ int main(int argc, char* argv[]) {
 // CHECK-NEXT:         });
   kernelFunc<<<blocks,threads>>>();
 
-// CHECK:   dpct::sycl_event_record(start, &q_ct1);
+// CHECK:   dpct::sync_barrier(start, &q_ct1);
   cudaEventRecord(start, 0);
 
   // kernel call without sync
@@ -87,17 +87,17 @@ int main(int argc, char* argv[]) {
   kernelFunc<<<blocks,threads>>>();
 
 
-// CHECK: dpct::sycl_event_record(start, &q_ct1);
+// CHECK: dpct::sync_barrier(start, &q_ct1);
   cudaEventRecord(start, 0);
 
-// CHECK: MY_ERROR_CHECKER(DPCT_CHECK_ERROR(dpct::sycl_event_record(start, &q_ct1)));
+// CHECK: MY_ERROR_CHECKER(DPCT_CHECK_ERROR(dpct::sync_barrier(start, &q_ct1)));
   MY_ERROR_CHECKER(cudaEventRecord(start, 0));
 
 // CHECK: if (0)
 // CHECK-NEXT:   /*
 // CHECK-NEXT:   DPCT1024:{{[0-9a-f]+}}: The original code returned the error code that was further consumed by the program logic. This original code was replaced with 0. You may need to rewrite the program logic consuming the error code.
 // CHECK-NEXT:   */
-// CHECK-NEXT:   MY_ERROR_CHECKER(DPCT_CHECK_ERROR(dpct::sycl_event_record(start, &q_ct1)));
+// CHECK-NEXT:   MY_ERROR_CHECKER(DPCT_CHECK_ERROR(dpct::sync_barrier(start, &q_ct1)));
   if (0)
     MY_ERROR_CHECKER(cudaEventRecord(start, 0));
 
@@ -115,14 +115,14 @@ int main(int argc, char* argv[]) {
 // CHECK-NEXT:         });
   kernelFunc<<<blocks,threads>>>();
 
-// CHECK:   dpct::sycl_event_record(stop, &q_ct1);
+// CHECK:   dpct::sync_barrier(stop, &q_ct1);
   cudaEventRecord(stop, 0);
 
-// CHECK: MY_ERROR_CHECKER(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop, &q_ct1)));
+// CHECK: MY_ERROR_CHECKER(DPCT_CHECK_ERROR(dpct::sync_barrier(stop, &q_ct1)));
   MY_ERROR_CHECKER(cudaEventRecord(stop, 0));
 
 
-// CHECK:   MY_ERROR_CHECKER(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop, &q_ct1)));
+// CHECK:   MY_ERROR_CHECKER(DPCT_CHECK_ERROR(dpct::sync_barrier(stop, &q_ct1)));
   if (1)
     MY_ERROR_CHECKER(cudaEventRecord(stop, 0));
 
@@ -134,24 +134,24 @@ int main(int argc, char* argv[]) {
 // CHECK-NEXT:         });
   kernelFunc<<<blocks,threads>>>();
 
-// CHECK: dpct::sycl_event_record(stop, &q_ct1);
+// CHECK: dpct::sync_barrier(stop, &q_ct1);
   cudaEventRecord(stop, 0);
 
 // CHECK: /*
 // CHECK-NEXT: DPCT1024:{{[0-9a-f]+}}: The original code returned the error code that was further consumed by the program logic. This original code was replaced with 0. You may need to rewrite the program logic consuming the error code.
 // CHECK-NEXT: */
-// CHECK-NEXT: MY_ERROR_CHECKER(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop, &q_ct1)));
+// CHECK-NEXT: MY_ERROR_CHECKER(DPCT_CHECK_ERROR(dpct::sync_barrier(stop, &q_ct1)));
   MY_ERROR_CHECKER(cudaEventRecord(stop, 0));
 
 // CHECK: if (0)
 // CHECK-NEXT:   /*
 // CHECK-NEXT:   DPCT1024:{{[0-9a-f]+}}: The original code returned the error code that was further consumed by the program logic. This original code was replaced with 0. You may need to rewrite the program logic consuming the error code.
 // CHECK-NEXT:   */
-// CHECK-NEXT:   MY_ERROR_CHECKER(DPCT_CHECK_ERROR(dpct::sycl_event_record(start, &q_ct1)));
+// CHECK-NEXT:   MY_ERROR_CHECKER(DPCT_CHECK_ERROR(dpct::sync_barrier(start, &q_ct1)));
   if (0)
     MY_ERROR_CHECKER(cudaEventRecord(start, 0));
 
-// CHECK:  MY_ERROR_CHECKER(DPCT_CHECK_ERROR(dpct::sycl_event_record(start)));
+// CHECK:  MY_ERROR_CHECKER(DPCT_CHECK_ERROR(dpct::sync_barrier(start)));
   MY_ERROR_CHECKER(cudaEventRecord(start));
 
   // kernel call without sync
@@ -164,7 +164,7 @@ int main(int argc, char* argv[]) {
 // CHECK-NEXT:        });
   kernelFunc<<<blocks,threads>>>();
 
-// CHECK:  dpct::sycl_event_record(stop, &q_ct1);
+// CHECK:  dpct::sync_barrier(stop, &q_ct1);
 // CHECK-NEXT:  stop->wait_and_throw();
 // CHECK-NEXT:  elapsed_time = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
   cudaEventRecord(stop, 0);
@@ -188,10 +188,10 @@ void foo() {
 
   int blocks = 32, threads = 32;
 
-// CHECK:  MY_CHECKER(DPCT_CHECK_ERROR(dpct::sycl_event_record(start, &q_ct1)));
+// CHECK:  MY_CHECKER(DPCT_CHECK_ERROR(dpct::sync_barrier(start, &q_ct1)));
   MY_CHECKER(cudaEventRecord(start, 0));
   kernelFunc<<<blocks,threads>>>();
-// CHECK: MY_CHECKER(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop, &q_ct1)));
+// CHECK: MY_CHECKER(DPCT_CHECK_ERROR(dpct::sync_barrier(stop, &q_ct1)));
   MY_CHECKER(cudaEventRecord(stop, 0));
 
   cudaEventSynchronize(stop);
@@ -203,9 +203,9 @@ void foo() {
   cudaEventDestroy(stop);
 
   {
-  // CHECK: dpct::err0 err = DPCT_CHECK_ERROR(dpct::sycl_event_record(start, &q_ct1));
+  // CHECK: dpct::err0 err = DPCT_CHECK_ERROR(dpct::sync_barrier(start, &q_ct1));
     cudaError_t err = cudaEventRecord(start, 0);
-  // CHECK: err = DPCT_CHECK_ERROR(dpct::sycl_event_record(stop, &q_ct1));
+  // CHECK: err = DPCT_CHECK_ERROR(dpct::sync_barrier(stop, &q_ct1));
     err = cudaEventRecord(stop, 0);
     if (cudaSuccess != err) {
       printf("%s\n", cudaGetErrorString( err));
@@ -227,10 +227,10 @@ void bar() {
 
   int blocks = 32, threads = 32;
 
-// CHECK: fun(DPCT_CHECK_ERROR(dpct::sycl_event_record(start, &q_ct1)));
+// CHECK: fun(DPCT_CHECK_ERROR(dpct::sync_barrier(start, &q_ct1)));
   fun(cudaEventRecord(start, 0));
   kernelFunc<<<blocks,threads>>>();
-// CHECK: fun(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop, &q_ct1)));
+// CHECK: fun(DPCT_CHECK_ERROR(dpct::sync_barrier(stop, &q_ct1)));
   fun(cudaEventRecord(stop, 0));
 
   cudaEventSynchronize(stop);
@@ -257,92 +257,92 @@ struct Node {
 void foo2(Node *n) {
   float elapsed_time;
 
-// CHECK: dpct::sycl_event_record(n->start, &q_ct1);
+// CHECK: dpct::sync_barrier(n->start, &q_ct1);
   cudaEventRecord(n->start, 0);
-// CHECK: dpct::sycl_event_record(n->start, &q_ct1);
+// CHECK: dpct::sync_barrier(n->start, &q_ct1);
   cudaEventRecord(n->start, 0);
   // do something
-// CHECK: dpct::sycl_event_record(n->end, &q_ct1);
+// CHECK: dpct::sync_barrier(n->end, &q_ct1);
   cudaEventRecord(n->end, 0);
-// CHECK: dpct::sycl_event_record(n->end, &q_ct1);
+// CHECK: dpct::sync_barrier(n->end, &q_ct1);
   cudaEventRecord(n->end, 0);
 // CHECK: elapsed_time = (n->end->get_profiling_info<sycl::info::event_profiling::command_end>() - n->start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
   cudaEventElapsedTime(&elapsed_time, n->start, n->end);
   {
     int errorCode;
-  // CHECK: MY_CHECKER(DPCT_CHECK_ERROR(dpct::sycl_event_record(n->start, &q_ct1)));
+  // CHECK: MY_CHECKER(DPCT_CHECK_ERROR(dpct::sync_barrier(n->start, &q_ct1)));
     MY_CHECKER(cudaEventRecord(n->start, 0));
-  // CHECK: errorCode = DPCT_CHECK_ERROR(dpct::sycl_event_record(n->start, &q_ct1));
+  // CHECK: errorCode = DPCT_CHECK_ERROR(dpct::sync_barrier(n->start, &q_ct1));
     errorCode = cudaEventRecord(n->start, 0);
   }
 
   Node node;
-// CHECK: dpct::sycl_event_record(node.start, &q_ct1);
+// CHECK: dpct::sync_barrier(node.start, &q_ct1);
   cudaEventRecord(node.start, 0);
-// CHECK: dpct::sycl_event_record(node.start, &q_ct1);
+// CHECK: dpct::sync_barrier(node.start, &q_ct1);
   cudaEventRecord(node.start, 0);
   // do something
-// CHECK: dpct::sycl_event_record(node.end, &q_ct1);
+// CHECK: dpct::sync_barrier(node.end, &q_ct1);
   cudaEventRecord(node.end, 0);
-// CHECK: dpct::sycl_event_record(node.end, &q_ct1);
+// CHECK: dpct::sync_barrier(node.end, &q_ct1);
   cudaEventRecord(node.end, 0);
 // CHECK: elapsed_time = (node.end->get_profiling_info<sycl::info::event_profiling::command_end>() - node.start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
   cudaEventElapsedTime(&elapsed_time, node.start, node.end);
   {
     int errorCode;
-  // MY_CHECKER(DPCT_CHECK_ERROR(dpct::sycl_event_record(node.start, &q_ct1)));
+  // MY_CHECKER(DPCT_CHECK_ERROR(dpct::sync_barrier(node.start, &q_ct1)));
     MY_CHECKER(cudaEventRecord(node.start, 0));
-  // CHECK: errorCode = DPCT_CHECK_ERROR(dpct::sycl_event_record(node.start, &q_ct1));
+  // CHECK: errorCode = DPCT_CHECK_ERROR(dpct::sync_barrier(node.start, &q_ct1));
     errorCode = cudaEventRecord(node.start, 0);
   }
 
   {
-  // CHECK:  dpct::sycl_event_record(node.events[0]);
+  // CHECK:  dpct::sync_barrier(node.events[0]);
     cudaEventRecord(node.events[0]);
-  // CHECK:  dpct::sycl_event_record(node.events[0]);
+  // CHECK:  dpct::sync_barrier(node.events[0]);
     cudaEventRecord(node.events[0]);
-  // CHECK:  dpct::sycl_event_record(node.events[23]);
+  // CHECK:  dpct::sync_barrier(node.events[23]);
     cudaEventRecord(node.events[23]);
-  // CHECK:  dpct::sycl_event_record(node.events[23]);
+  // CHECK:  dpct::sync_barrier(node.events[23]);
     cudaEventRecord(node.events[23]);
   // CHECK: elapsed_time = (node.events[23]->get_profiling_info<sycl::info::event_profiling::command_end>() - node.events[0]->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
     cudaEventElapsedTime(&elapsed_time, node.events[0], node.events[23]);
   }
 
   {
-  // CHECK: dpct::sycl_event_record(*node.ev[0]);
+  // CHECK: dpct::sync_barrier(*node.ev[0]);
     cudaEventRecord(*node.ev[0]);
-  // CHECK: dpct::sycl_event_record(*node.ev[0]);
+  // CHECK: dpct::sync_barrier(*node.ev[0]);
     cudaEventRecord(*node.ev[0]);
-  // CHECK: dpct::sycl_event_record(*node.ev[23]);
+  // CHECK: dpct::sync_barrier(*node.ev[23]);
     cudaEventRecord(*node.ev[23]);
-  // CHECK: dpct::sycl_event_record(*node.ev[23]);
+  // CHECK: dpct::sync_barrier(*node.ev[23]);
     cudaEventRecord(*node.ev[23]);
   // CHECK: elapsed_time = (*node.ev[23]->get_profiling_info<sycl::info::event_profiling::command_end>() - *node.ev[0]->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
     cudaEventElapsedTime(&elapsed_time, *node.ev[0], *node.ev[23]);
   }
 
   {
-  // CHECK: dpct::sycl_event_record(*(&node)->ev[0]);
+  // CHECK: dpct::sync_barrier(*(&node)->ev[0]);
     cudaEventRecord(*(&node)->ev[0]);
-  // CHECK: dpct::sycl_event_record(*(&node)->ev[0]);
+  // CHECK: dpct::sync_barrier(*(&node)->ev[0]);
     cudaEventRecord(*(&node)->ev[0]);
-  // CHECK: dpct::sycl_event_record(*(&node)->ev[23]);
+  // CHECK: dpct::sync_barrier(*(&node)->ev[23]);
     cudaEventRecord(*(&node)->ev[23]);
-  // CHECK: dpct::sycl_event_record(*(&node)->ev[23]);
+  // CHECK: dpct::sync_barrier(*(&node)->ev[23]);
     cudaEventRecord(*(&node)->ev[23]);
   // CHECK:  elapsed_time = (*(&node)->ev[23]->get_profiling_info<sycl::info::event_profiling::command_end>() - *(&node)->ev[0]->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
     cudaEventElapsedTime(&elapsed_time, *(&node)->ev[0], *(&node)->ev[23]);
   }
 
   {
-  // CHECK: dpct::sycl_event_record(n->p_events[0]);
+  // CHECK: dpct::sync_barrier(n->p_events[0]);
     cudaEventRecord(n->p_events[0]);
-  // CHECK: dpct::sycl_event_record(n->p_events[1]);
+  // CHECK: dpct::sync_barrier(n->p_events[1]);
     cudaEventRecord(n->p_events[1]);
-  // CHECK:  dpct::sycl_event_record(n->p_events[2]);
+  // CHECK:  dpct::sync_barrier(n->p_events[2]);
     cudaEventRecord(n->p_events[2]);
-  // CHECK:  dpct::sycl_event_record(n->p_events[3]);
+  // CHECK:  dpct::sync_barrier(n->p_events[3]);
     cudaEventRecord(n->p_events[3]);
   }
 }
@@ -360,7 +360,7 @@ typedef struct foo__io_stream_t {
 // CHECK:static int cuda_stream_decode_ioinstruction(foo_stream_t *ios) {
 // CHECK-NEXT:  foo__io_stream_t *cios = (foo__io_stream_t *)ios;
 // CHECK-NEXT:  dpct::queue_ptr *stream = 0;
-// CHECK-NEXT:  dpct::sycl_event_record(cios->end_events[ios->pos_wp % ios->count], *stream);
+// CHECK-NEXT:  dpct::sync_barrier(cios->end_events[ios->pos_wp % ios->count], *stream);
 // CHECK-NEXT:}
 static int cuda_stream_decode_ioinstruction(foo_stream_t *ios) {
   foo__io_stream_t *cios = (foo__io_stream_t *)ios;

--- a/clang/test/dpct/cuda-event-api-enable-profiling.cu
+++ b/clang/test/dpct/cuda-event-api-enable-profiling.cu
@@ -75,7 +75,7 @@ int main(int argc, char* argv[]) {
 // CHECK-NEXT:         });
   kernelFunc<<<blocks,threads>>>();
 
-// CHECK:   *start = q_ct1.ext_oneapi_submit_barrier();
+// CHECK:   dpct::sycl_event_record(start, &q_ct1);
   cudaEventRecord(start, 0);
 
   // kernel call without sync
@@ -87,17 +87,17 @@ int main(int argc, char* argv[]) {
   kernelFunc<<<blocks,threads>>>();
 
 
-// CHECK: *start = q_ct1.ext_oneapi_submit_barrier();
+// CHECK: dpct::sycl_event_record(start, &q_ct1);
   cudaEventRecord(start, 0);
 
-// CHECK: MY_ERROR_CHECKER(DPCT_CHECK_ERROR(*start = q_ct1.ext_oneapi_submit_barrier()));
+// CHECK: MY_ERROR_CHECKER(DPCT_CHECK_ERROR(dpct::sycl_event_record(start, &q_ct1)));
   MY_ERROR_CHECKER(cudaEventRecord(start, 0));
 
 // CHECK: if (0)
 // CHECK-NEXT:   /*
 // CHECK-NEXT:   DPCT1024:{{[0-9a-f]+}}: The original code returned the error code that was further consumed by the program logic. This original code was replaced with 0. You may need to rewrite the program logic consuming the error code.
 // CHECK-NEXT:   */
-// CHECK-NEXT:   MY_ERROR_CHECKER(DPCT_CHECK_ERROR(*start = q_ct1.ext_oneapi_submit_barrier()));
+// CHECK-NEXT:   MY_ERROR_CHECKER(DPCT_CHECK_ERROR(dpct::sycl_event_record(start, &q_ct1)));
   if (0)
     MY_ERROR_CHECKER(cudaEventRecord(start, 0));
 
@@ -115,14 +115,14 @@ int main(int argc, char* argv[]) {
 // CHECK-NEXT:         });
   kernelFunc<<<blocks,threads>>>();
 
-// CHECK:   *stop = q_ct1.ext_oneapi_submit_barrier();
+// CHECK:   dpct::sycl_event_record(stop, &q_ct1);
   cudaEventRecord(stop, 0);
 
-// CHECK: MY_ERROR_CHECKER(DPCT_CHECK_ERROR(*stop = q_ct1.ext_oneapi_submit_barrier()));
+// CHECK: MY_ERROR_CHECKER(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop, &q_ct1)));
   MY_ERROR_CHECKER(cudaEventRecord(stop, 0));
 
 
-// CHECK:   MY_ERROR_CHECKER(DPCT_CHECK_ERROR(*stop = q_ct1.ext_oneapi_submit_barrier()));
+// CHECK:   MY_ERROR_CHECKER(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop, &q_ct1)));
   if (1)
     MY_ERROR_CHECKER(cudaEventRecord(stop, 0));
 
@@ -134,24 +134,24 @@ int main(int argc, char* argv[]) {
 // CHECK-NEXT:         });
   kernelFunc<<<blocks,threads>>>();
 
-// CHECK: *stop = q_ct1.ext_oneapi_submit_barrier();
+// CHECK: dpct::sycl_event_record(stop, &q_ct1);
   cudaEventRecord(stop, 0);
 
 // CHECK: /*
 // CHECK-NEXT: DPCT1024:{{[0-9a-f]+}}: The original code returned the error code that was further consumed by the program logic. This original code was replaced with 0. You may need to rewrite the program logic consuming the error code.
 // CHECK-NEXT: */
-// CHECK-NEXT: MY_ERROR_CHECKER(DPCT_CHECK_ERROR(*stop = q_ct1.ext_oneapi_submit_barrier()));
+// CHECK-NEXT: MY_ERROR_CHECKER(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop, &q_ct1)));
   MY_ERROR_CHECKER(cudaEventRecord(stop, 0));
 
 // CHECK: if (0)
 // CHECK-NEXT:   /*
 // CHECK-NEXT:   DPCT1024:{{[0-9a-f]+}}: The original code returned the error code that was further consumed by the program logic. This original code was replaced with 0. You may need to rewrite the program logic consuming the error code.
 // CHECK-NEXT:   */
-// CHECK-NEXT:   MY_ERROR_CHECKER(DPCT_CHECK_ERROR(*start = q_ct1.ext_oneapi_submit_barrier()));
+// CHECK-NEXT:   MY_ERROR_CHECKER(DPCT_CHECK_ERROR(dpct::sycl_event_record(start, &q_ct1)));
   if (0)
     MY_ERROR_CHECKER(cudaEventRecord(start, 0));
 
-// CHECK:  MY_ERROR_CHECKER(DPCT_CHECK_ERROR(*start = q_ct1.ext_oneapi_submit_barrier()));
+// CHECK:  MY_ERROR_CHECKER(DPCT_CHECK_ERROR(dpct::sycl_event_record(start)));
   MY_ERROR_CHECKER(cudaEventRecord(start));
 
   // kernel call without sync
@@ -164,8 +164,8 @@ int main(int argc, char* argv[]) {
 // CHECK-NEXT:        });
   kernelFunc<<<blocks,threads>>>();
 
-// CHECK:  *stop = q_ct1.ext_oneapi_submit_barrier();
-// CHECK-NEXT:  stop->wait_and_throw();
+// CHECK:  dpct::sycl_event_record(stop, &q_ct1);
+// CHECK-NEXT:  dpct::sycl_event_synchronize(stop);
 // CHECK-NEXT:  elapsed_time = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
   cudaEventRecord(stop, 0);
   cudaEventSynchronize(stop);
@@ -188,10 +188,10 @@ void foo() {
 
   int blocks = 32, threads = 32;
 
-// CHECK:  MY_CHECKER(DPCT_CHECK_ERROR(*start = q_ct1.ext_oneapi_submit_barrier()));
+// CHECK:  MY_CHECKER(DPCT_CHECK_ERROR(dpct::sycl_event_record(start, &q_ct1)));
   MY_CHECKER(cudaEventRecord(start, 0));
   kernelFunc<<<blocks,threads>>>();
-// CHECK: MY_CHECKER(DPCT_CHECK_ERROR(*stop = q_ct1.ext_oneapi_submit_barrier()));
+// CHECK: MY_CHECKER(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop, &q_ct1)));
   MY_CHECKER(cudaEventRecord(stop, 0));
 
   cudaEventSynchronize(stop);
@@ -203,9 +203,9 @@ void foo() {
   cudaEventDestroy(stop);
 
   {
-  // CHECK: dpct::err0 err = DPCT_CHECK_ERROR(*start = q_ct1.ext_oneapi_submit_barrier());
+  // CHECK: dpct::err0 err = DPCT_CHECK_ERROR(dpct::sycl_event_record(start, &q_ct1));
     cudaError_t err = cudaEventRecord(start, 0);
-  // CHECK: err = DPCT_CHECK_ERROR(*stop = q_ct1.ext_oneapi_submit_barrier());
+  // CHECK: err = DPCT_CHECK_ERROR(dpct::sycl_event_record(stop, &q_ct1));
     err = cudaEventRecord(stop, 0);
     if (cudaSuccess != err) {
       printf("%s\n", cudaGetErrorString( err));
@@ -227,10 +227,10 @@ void bar() {
 
   int blocks = 32, threads = 32;
 
-// CHECK: fun(DPCT_CHECK_ERROR(*start = q_ct1.ext_oneapi_submit_barrier()));
+// CHECK: fun(DPCT_CHECK_ERROR(dpct::sycl_event_record(start, &q_ct1)));
   fun(cudaEventRecord(start, 0));
   kernelFunc<<<blocks,threads>>>();
-// CHECK: fun(DPCT_CHECK_ERROR(*stop = q_ct1.ext_oneapi_submit_barrier()));
+// CHECK: fun(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop, &q_ct1)));
   fun(cudaEventRecord(stop, 0));
 
   cudaEventSynchronize(stop);
@@ -257,92 +257,92 @@ struct Node {
 void foo2(Node *n) {
   float elapsed_time;
 
-// CHECK: *n->start = q_ct1.ext_oneapi_submit_barrier();
+// CHECK: dpct::sycl_event_record(n->start, &q_ct1);
   cudaEventRecord(n->start, 0);
-// CHECK: *n->start = q_ct1.ext_oneapi_submit_barrier();
+// CHECK: dpct::sycl_event_record(n->start, &q_ct1);
   cudaEventRecord(n->start, 0);
   // do something
-// CHECK: *n->end = q_ct1.ext_oneapi_submit_barrier();
+// CHECK: dpct::sycl_event_record(n->end, &q_ct1);
   cudaEventRecord(n->end, 0);
-// CHECK: *n->end = q_ct1.ext_oneapi_submit_barrier();
+// CHECK: dpct::sycl_event_record(n->end, &q_ct1);
   cudaEventRecord(n->end, 0);
 // CHECK: elapsed_time = (n->end->get_profiling_info<sycl::info::event_profiling::command_end>() - n->start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
   cudaEventElapsedTime(&elapsed_time, n->start, n->end);
   {
     int errorCode;
-  // CHECK: MY_CHECKER(DPCT_CHECK_ERROR(*n->start = q_ct1.ext_oneapi_submit_barrier()));
+  // CHECK: MY_CHECKER(DPCT_CHECK_ERROR(dpct::sycl_event_record(n->start, &q_ct1)));
     MY_CHECKER(cudaEventRecord(n->start, 0));
-  // CHECK: errorCode = DPCT_CHECK_ERROR(*n->start = q_ct1.ext_oneapi_submit_barrier());
+  // CHECK: errorCode = DPCT_CHECK_ERROR(dpct::sycl_event_record(n->start, &q_ct1));
     errorCode = cudaEventRecord(n->start, 0);
   }
 
   Node node;
-// CHECK: *node.start = q_ct1.ext_oneapi_submit_barrier();
+// CHECK: dpct::sycl_event_record(node.start, &q_ct1);
   cudaEventRecord(node.start, 0);
-// CHECK: *node.start = q_ct1.ext_oneapi_submit_barrier();
+// CHECK: dpct::sycl_event_record(node.start, &q_ct1);
   cudaEventRecord(node.start, 0);
   // do something
-// CHECK: *node.end = q_ct1.ext_oneapi_submit_barrier();
+// CHECK: dpct::sycl_event_record(node.end, &q_ct1);
   cudaEventRecord(node.end, 0);
-// CHECK: *node.end = q_ct1.ext_oneapi_submit_barrier();
+// CHECK: dpct::sycl_event_record(node.end, &q_ct1);
   cudaEventRecord(node.end, 0);
 // CHECK: elapsed_time = (node.end->get_profiling_info<sycl::info::event_profiling::command_end>() - node.start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
   cudaEventElapsedTime(&elapsed_time, node.start, node.end);
   {
     int errorCode;
-  // CHECK: MY_CHECKER(DPCT_CHECK_ERROR(*node.start = q_ct1.ext_oneapi_submit_barrier()));
+  // MY_CHECKER(DPCT_CHECK_ERROR(dpct::sycl_event_record(node.start, &q_ct1)));
     MY_CHECKER(cudaEventRecord(node.start, 0));
-  // CHECK: errorCode = DPCT_CHECK_ERROR(*node.start = q_ct1.ext_oneapi_submit_barrier());
+  // CHECK: errorCode = DPCT_CHECK_ERROR(dpct::sycl_event_record(node.start, &q_ct1));
     errorCode = cudaEventRecord(node.start, 0);
   }
 
   {
-  // CHECK: *node.events[0] = q_ct1.ext_oneapi_submit_barrier();
+  // CHECK:  dpct::sycl_event_record(node.events[0]);
     cudaEventRecord(node.events[0]);
-  // CHECK: *node.events[0] = q_ct1.ext_oneapi_submit_barrier();
+  // CHECK:  dpct::sycl_event_record(node.events[0]);
     cudaEventRecord(node.events[0]);
-  // CHECK: *node.events[23] = q_ct1.ext_oneapi_submit_barrier();
+  // CHECK:  dpct::sycl_event_record(node.events[23]);
     cudaEventRecord(node.events[23]);
-  // CHECK: *node.events[23] = q_ct1.ext_oneapi_submit_barrier();
+  // CHECK:  dpct::sycl_event_record(node.events[23]);
     cudaEventRecord(node.events[23]);
   // CHECK: elapsed_time = (node.events[23]->get_profiling_info<sycl::info::event_profiling::command_end>() - node.events[0]->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
     cudaEventElapsedTime(&elapsed_time, node.events[0], node.events[23]);
   }
 
   {
-  // CHECK: *(*node.ev[0]) = q_ct1.ext_oneapi_submit_barrier();
+  // CHECK: dpct::sycl_event_record(*node.ev[0]);
     cudaEventRecord(*node.ev[0]);
-  // CHECK: *(*node.ev[0]) = q_ct1.ext_oneapi_submit_barrier();
+  // CHECK: dpct::sycl_event_record(*node.ev[0]);
     cudaEventRecord(*node.ev[0]);
-  // CHECK: *(*node.ev[23]) = q_ct1.ext_oneapi_submit_barrier();
+  // CHECK: dpct::sycl_event_record(*node.ev[23]);
     cudaEventRecord(*node.ev[23]);
-  // CHECK: *(*node.ev[23]) = q_ct1.ext_oneapi_submit_barrier();
+  // CHECK: dpct::sycl_event_record(*node.ev[23]);
     cudaEventRecord(*node.ev[23]);
   // CHECK: elapsed_time = (*node.ev[23]->get_profiling_info<sycl::info::event_profiling::command_end>() - *node.ev[0]->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
     cudaEventElapsedTime(&elapsed_time, *node.ev[0], *node.ev[23]);
   }
 
   {
-  // CHECK: *(*(&node)->ev[0]) = q_ct1.ext_oneapi_submit_barrier();
+  // CHECK: dpct::sycl_event_record(*(&node)->ev[0]);
     cudaEventRecord(*(&node)->ev[0]);
-  // CHECK: *(*(&node)->ev[0]) = q_ct1.ext_oneapi_submit_barrier();
+  // CHECK: dpct::sycl_event_record(*(&node)->ev[0]);
     cudaEventRecord(*(&node)->ev[0]);
-  // CHECK: *(*(&node)->ev[23]) = q_ct1.ext_oneapi_submit_barrier();
+  // CHECK: dpct::sycl_event_record(*(&node)->ev[23]);
     cudaEventRecord(*(&node)->ev[23]);
-  // CHECK: *(*(&node)->ev[23]) = q_ct1.ext_oneapi_submit_barrier();
+  // CHECK: dpct::sycl_event_record(*(&node)->ev[23]);
     cudaEventRecord(*(&node)->ev[23]);
   // CHECK:  elapsed_time = (*(&node)->ev[23]->get_profiling_info<sycl::info::event_profiling::command_end>() - *(&node)->ev[0]->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
     cudaEventElapsedTime(&elapsed_time, *(&node)->ev[0], *(&node)->ev[23]);
   }
 
   {
-  // CHECK: *n->p_events[0] = q_ct1.ext_oneapi_submit_barrier();
+  // CHECK: dpct::sycl_event_record(n->p_events[0]);
     cudaEventRecord(n->p_events[0]);
-  // CHECK: *n->p_events[1] = q_ct1.ext_oneapi_submit_barrier();
+  // CHECK: dpct::sycl_event_record(n->p_events[1]);
     cudaEventRecord(n->p_events[1]);
-  // CHECK:  *n->p_events[2] = q_ct1.ext_oneapi_submit_barrier();
+  // CHECK:  dpct::sycl_event_record(n->p_events[2]);
     cudaEventRecord(n->p_events[2]);
-  // CHECK:  *n->p_events[3] = q_ct1.ext_oneapi_submit_barrier();
+  // CHECK:  dpct::sycl_event_record(n->p_events[3]);
     cudaEventRecord(n->p_events[3]);
   }
 }
@@ -360,7 +360,7 @@ typedef struct foo__io_stream_t {
 // CHECK:static int cuda_stream_decode_ioinstruction(foo_stream_t *ios) {
 // CHECK-NEXT:  foo__io_stream_t *cios = (foo__io_stream_t *)ios;
 // CHECK-NEXT:  dpct::queue_ptr *stream = 0;
-// CHECK-NEXT:  *cios->end_events[ios->pos_wp % ios->count] = (*stream)->ext_oneapi_submit_barrier();
+// CHECK-NEXT:  dpct::sycl_event_record(cios->end_events[ios->pos_wp % ios->count], *stream);
 // CHECK-NEXT:}
 static int cuda_stream_decode_ioinstruction(foo_stream_t *ios) {
   foo__io_stream_t *cios = (foo__io_stream_t *)ios;

--- a/clang/test/dpct/cuda-event-api-enable-profiling.cu
+++ b/clang/test/dpct/cuda-event-api-enable-profiling.cu
@@ -165,7 +165,7 @@ int main(int argc, char* argv[]) {
   kernelFunc<<<blocks,threads>>>();
 
 // CHECK:  dpct::sycl_event_record(stop, &q_ct1);
-// CHECK-NEXT:  dpct::sycl_event_synchronize(stop);
+// CHECK-NEXT:  stop->wait_and_throw();
 // CHECK-NEXT:  elapsed_time = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
   cudaEventRecord(stop, 0);
   cudaEventSynchronize(stop);

--- a/clang/test/dpct/driver-stream-and-event-enable-profiling.cu
+++ b/clang/test/dpct/driver-stream-and-event-enable-profiling.cu
@@ -25,7 +25,7 @@ void foo(){
   cuStreamWaitEvent(s, e, 0);
 
 // CHECK: dpct::sycl_event_record(e, s);
-// CHECK-NEXT: dpct::sycl_event_synchronize(e);
+// CHECK-NEXT: e->wait_and_throw();
   cuEventRecord(e, s);
   cuEventSynchronize(e);
 
@@ -37,8 +37,8 @@ void foo(){
 // CHECK: dpct::event_ptr start, end;
 // CHECK: dpct::sycl_event_record(start, s);
 // CHECK: dpct::sycl_event_record(end, s);
-// CHECK: dpct::sycl_event_synchronize(start);
-// CHECK: dpct::sycl_event_synchronize(end);
+// CHECK: start->wait_and_throw();
+// CHECK: end->wait_and_throw();
 // CHECK: float result_time;
 // CHECK: result_time = (end->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
   CUevent start, end;

--- a/clang/test/dpct/driver-stream-and-event-enable-profiling.cu
+++ b/clang/test/dpct/driver-stream-and-event-enable-profiling.cu
@@ -24,8 +24,8 @@ void foo(){
   cuEventCreate(&e, CU_EVENT_DEFAULT);
   cuStreamWaitEvent(s, e, 0);
 
-// CHECK: *e = s->ext_oneapi_submit_barrier();
-// CHECK-NEXT: e->wait_and_throw();
+// CHECK: dpct::sycl_event_record(e, s);
+// CHECK-NEXT: dpct::sycl_event_synchronize(e);
   cuEventRecord(e, s);
   cuEventSynchronize(e);
 
@@ -35,10 +35,10 @@ void foo(){
   r = cuEventQuery(e);
 
 // CHECK: dpct::event_ptr start, end;
-// CHECK: *start = s->ext_oneapi_submit_barrier();
-// CHECK: *end = s->ext_oneapi_submit_barrier();
-// CHECK: start->wait_and_throw();
-// CHECK: end->wait_and_throw();
+// CHECK: dpct::sycl_event_record(start, s);
+// CHECK: dpct::sycl_event_record(end, s);
+// CHECK: dpct::sycl_event_synchronize(start);
+// CHECK: dpct::sycl_event_synchronize(end);
 // CHECK: float result_time;
 // CHECK: result_time = (end->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
   CUevent start, end;
@@ -54,7 +54,7 @@ void foo(){
 // CHECK-NEXT:void foo(int idx) {
 // CHECK-NEXT:  dpct::device_ext &dev_ct1 = dpct::get_current_device();
 // CHECK-NEXT:  sycl::queue &q_ct1 = dev_ct1.in_order_queue();
-// CHECK-NEXT:  *cuda_gpu_benchmark_stop_times[idx] = q_ct1.ext_oneapi_submit_barrier();
+// CHECK-NEXT:  dpct::sycl_event_record(cuda_gpu_benchmark_stop_times[idx], &q_ct1);
 // CHECK-NEXT:}
 std::vector<cudaEvent_t> cuda_gpu_benchmark_stop_times;
 void foo(int idx) {

--- a/clang/test/dpct/driver-stream-and-event-enable-profiling.cu
+++ b/clang/test/dpct/driver-stream-and-event-enable-profiling.cu
@@ -24,7 +24,7 @@ void foo(){
   cuEventCreate(&e, CU_EVENT_DEFAULT);
   cuStreamWaitEvent(s, e, 0);
 
-// CHECK: dpct::sycl_event_record(e, s);
+// CHECK: dpct::sync_barrier(e, s);
 // CHECK-NEXT: e->wait_and_throw();
   cuEventRecord(e, s);
   cuEventSynchronize(e);
@@ -35,8 +35,8 @@ void foo(){
   r = cuEventQuery(e);
 
 // CHECK: dpct::event_ptr start, end;
-// CHECK: dpct::sycl_event_record(start, s);
-// CHECK: dpct::sycl_event_record(end, s);
+// CHECK: dpct::sync_barrier(start, s);
+// CHECK: dpct::sync_barrier(end, s);
 // CHECK: start->wait_and_throw();
 // CHECK: end->wait_and_throw();
 // CHECK: float result_time;
@@ -54,7 +54,7 @@ void foo(){
 // CHECK-NEXT:void foo(int idx) {
 // CHECK-NEXT:  dpct::device_ext &dev_ct1 = dpct::get_current_device();
 // CHECK-NEXT:  sycl::queue &q_ct1 = dev_ct1.in_order_queue();
-// CHECK-NEXT:  dpct::sycl_event_record(cuda_gpu_benchmark_stop_times[idx], &q_ct1);
+// CHECK-NEXT:  dpct::sync_barrier(cuda_gpu_benchmark_stop_times[idx], &q_ct1);
 // CHECK-NEXT:}
 std::vector<cudaEvent_t> cuda_gpu_benchmark_stop_times;
 void foo(int idx) {

--- a/clang/test/dpct/macro_test.cu
+++ b/clang/test/dpct/macro_test.cu
@@ -815,7 +815,7 @@ typedef CONCATE(Event_t) event_t2;
 //CHECK: void foo18() {
 //CHECK-NEXT:   dpct::device_ext &dev_ct1 = dpct::get_current_device();
 //CHECK-NEXT:   dpct::event_ptr event;
-//CHECK-NEXT:   dpct::sycl_event_synchronize(EventSynchronize)(event);
+//CHECK-NEXT:   event->wait_and_throw();
 //CHECK-NEXT:   stream_t2 *stream;
 //CHECK-NEXT:   stream_t2 stream2;
 //CHECK-NEXT:   *(stream) = dev_ct1.create_queue();
@@ -879,7 +879,7 @@ static const cudaStream_t streamDefault4 = CALL(cudaStreamDefault);
 //CHECK-NEXT:  if (CMC_profile)                                                             \
 //CHECK-NEXT:  {                                                                            \
 //CHECK-NEXT:    dpct::sycl_event_record(stop);                                             \
-//CHECK-NEXT:    dpct::sycl_event_synchronize(stop);                                        \
+//CHECK-NEXT:    stop->wait_and_throw();                                                    \
 //CHECK-NEXT:    float time = 0.0f;                                                         \
 //CHECK-NEXT:    time = (stop->get_profiling_info<                                          \
 //CHECK-NEXT:                sycl::info::event_profiling::command_end>() -                  \

--- a/clang/test/dpct/macro_test.cu
+++ b/clang/test/dpct/macro_test.cu
@@ -862,7 +862,7 @@ static const cudaStream_t streamDefault4 = CALL(cudaStreamDefault);
 //CHECK-NEXT:  {                                                                            \
 //CHECK-NEXT:    start = new sycl::event();                                                 \
 //CHECK-NEXT:    stop = new sycl::event();                                                  \
-//CHECK-NEXT:    dpct::sycl_event_record(start);                                            \
+//CHECK-NEXT:    dpct::sync_barrier(start);                                            \
 //CHECK-NEXT:  }
 #define CMC_PROFILING_BEGIN()                                                                                      \
   cudaEvent_t start;                                                                                               \
@@ -878,7 +878,7 @@ static const cudaStream_t streamDefault4 = CALL(cudaStreamDefault);
 //     CHECK:#define CMC_PROFILING_END(lineno)                                              \
 //CHECK-NEXT:  if (CMC_profile)                                                             \
 //CHECK-NEXT:  {                                                                            \
-//CHECK-NEXT:    dpct::sycl_event_record(stop);                                             \
+//CHECK-NEXT:    dpct::sync_barrier(stop);                                             \
 //CHECK-NEXT:    stop->wait_and_throw();                                                    \
 //CHECK-NEXT:    float time = 0.0f;                                                         \
 //CHECK-NEXT:    time = (stop->get_profiling_info<                                          \

--- a/clang/test/dpct/macro_test.cu
+++ b/clang/test/dpct/macro_test.cu
@@ -815,7 +815,7 @@ typedef CONCATE(Event_t) event_t2;
 //CHECK: void foo18() {
 //CHECK-NEXT:   dpct::device_ext &dev_ct1 = dpct::get_current_device();
 //CHECK-NEXT:   dpct::event_ptr event;
-//CHECK-NEXT:   event->wait_and_throw();
+//CHECK-NEXT:   dpct::sycl_event_synchronize(EventSynchronize)(event);
 //CHECK-NEXT:   stream_t2 *stream;
 //CHECK-NEXT:   stream_t2 stream2;
 //CHECK-NEXT:   *(stream) = dev_ct1.create_queue();
@@ -862,7 +862,7 @@ static const cudaStream_t streamDefault4 = CALL(cudaStreamDefault);
 //CHECK-NEXT:  {                                                                            \
 //CHECK-NEXT:    start = new sycl::event();                                                 \
 //CHECK-NEXT:    stop = new sycl::event();                                                  \
-//CHECK-NEXT:    *start = q_ct1.ext_oneapi_submit_barrier();                                \
+//CHECK-NEXT:    dpct::sycl_event_record(start);                                            \
 //CHECK-NEXT:  }
 #define CMC_PROFILING_BEGIN()                                                                                      \
   cudaEvent_t start;                                                                                               \
@@ -878,8 +878,8 @@ static const cudaStream_t streamDefault4 = CALL(cudaStreamDefault);
 //     CHECK:#define CMC_PROFILING_END(lineno)                                              \
 //CHECK-NEXT:  if (CMC_profile)                                                             \
 //CHECK-NEXT:  {                                                                            \
-//CHECK-NEXT:    *stop = q_ct1.ext_oneapi_submit_barrier();                                 \
-//CHECK-NEXT:    stop->wait_and_throw();                                                    \
+//CHECK-NEXT:    dpct::sycl_event_record(stop);                                             \
+//CHECK-NEXT:    dpct::sycl_event_synchronize(stop);                                        \
 //CHECK-NEXT:    float time = 0.0f;                                                         \
 //CHECK-NEXT:    time = (stop->get_profiling_info<                                          \
 //CHECK-NEXT:                sycl::info::event_profiling::command_end>() -                  \

--- a/clang/test/dpct/macro_test_enable_profiling.cu
+++ b/clang/test/dpct/macro_test_enable_profiling.cu
@@ -63,7 +63,7 @@
 //CHECK-NEXT:  if (CMC_profile)                                                                                                                                                        \
 //CHECK-NEXT:  {                                                                                                                                                                       \
 //CHECK-NEXT:    dpct::sycl_event_record(stop);                                                                                                                                        \
-//CHECK-NEXT:    dpct::sycl_event_synchronize(stop);                                                                                                                                   \
+//CHECK-NEXT:    stop->wait_and_throw();                                                                                                                                   \
 //CHECK-NEXT:    float time = 0.0f;                                                                                                                                                    \
 //CHECK-NEXT:    time = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f; \
 //CHECK-NEXT:    dpct::destroy_event(start);                                                                                                                                           \

--- a/clang/test/dpct/macro_test_enable_profiling.cu
+++ b/clang/test/dpct/macro_test_enable_profiling.cu
@@ -46,7 +46,7 @@
 //CHECK-NEXT:  {                                                                            \
 //CHECK-NEXT:    start = new sycl::event();                                                 \
 //CHECK-NEXT:    stop = new sycl::event();                                                  \
-//CHECK-NEXT:    dpct::sycl_event_record(start);                                            \
+//CHECK-NEXT:    dpct::sync_barrier(start);                                            \
 //CHECK-NEXT:  }
 #define CMC_PROFILING_BEGIN()                                                                                      \
   cudaEvent_t start;                                                                                               \
@@ -62,7 +62,7 @@
 //     CHECK:#define CMC_PROFILING_END(lineno)                                                                                                                                         \
 //CHECK-NEXT:  if (CMC_profile)                                                                                                                                                        \
 //CHECK-NEXT:  {                                                                                                                                                                       \
-//CHECK-NEXT:    dpct::sycl_event_record(stop);                                                                                                                                        \
+//CHECK-NEXT:    dpct::sync_barrier(stop);                                                                                                                                        \
 //CHECK-NEXT:    stop->wait_and_throw();                                                                                                                                   \
 //CHECK-NEXT:    float time = 0.0f;                                                                                                                                                    \
 //CHECK-NEXT:    time = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f; \

--- a/clang/test/dpct/macro_test_enable_profiling.cu
+++ b/clang/test/dpct/macro_test_enable_profiling.cu
@@ -46,7 +46,7 @@
 //CHECK-NEXT:  {                                                                            \
 //CHECK-NEXT:    start = new sycl::event();                                                 \
 //CHECK-NEXT:    stop = new sycl::event();                                                  \
-//CHECK-NEXT:    *start = q_ct1.ext_oneapi_submit_barrier();                                \
+//CHECK-NEXT:    dpct::sycl_event_record(start);                                            \
 //CHECK-NEXT:  }
 #define CMC_PROFILING_BEGIN()                                                                                      \
   cudaEvent_t start;                                                                                               \
@@ -62,8 +62,8 @@
 //     CHECK:#define CMC_PROFILING_END(lineno)                                                                                                                                         \
 //CHECK-NEXT:  if (CMC_profile)                                                                                                                                                        \
 //CHECK-NEXT:  {                                                                                                                                                                       \
-//CHECK-NEXT:    *stop = q_ct1.ext_oneapi_submit_barrier();                                                                                                                            \
-//CHECK-NEXT:    stop->wait_and_throw();                                                                                                                                               \
+//CHECK-NEXT:    dpct::sycl_event_record(stop);                                                                                                                                        \
+//CHECK-NEXT:    dpct::sycl_event_synchronize(stop);                                                                                                                                   \
 //CHECK-NEXT:    float time = 0.0f;                                                                                                                                                    \
 //CHECK-NEXT:    time = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f; \
 //CHECK-NEXT:    dpct::destroy_event(start);                                                                                                                                           \

--- a/clang/test/dpct/query_api_mapping/Runtime/test.cu
+++ b/clang/test/dpct/query_api_mapping/Runtime/test.cu
@@ -231,7 +231,7 @@
 // CUDAEVENTRECORD-NEXT:   cudaEventRecord(e /*cudaEvent_t*/, s /*cudaStream_t*/);
 // CUDAEVENTRECORD-NEXT: Is migrated to:
 // CUDAEVENTRECORD-NEXT:   dpct::queue_ptr s;
-// CUDAEVENTRECORD-NEXT:   dpct::sycl_event_record(e /*cudaEvent_t*/, s /*cudaStream_t*/);
+// CUDAEVENTRECORD-NEXT:   dpct::sync_barrier(e /*cudaEvent_t*/, s /*cudaStream_t*/);
 
 // RUN: dpct --cuda-include-path="%cuda-path/include" --query-api-mapping=cudaEventSynchronize | FileCheck %s -check-prefix=CUDAEVENTSYNCHRONIZE
 // CUDAEVENTSYNCHRONIZE: CUDA API:

--- a/clang/test/dpct/query_api_mapping/Runtime/test.cu
+++ b/clang/test/dpct/query_api_mapping/Runtime/test.cu
@@ -231,7 +231,7 @@
 // CUDAEVENTRECORD-NEXT:   cudaEventRecord(e /*cudaEvent_t*/, s /*cudaStream_t*/);
 // CUDAEVENTRECORD-NEXT: Is migrated to:
 // CUDAEVENTRECORD-NEXT:   dpct::queue_ptr s;
-// CUDAEVENTRECORD-NEXT:   *e = s->ext_oneapi_submit_barrier();
+// CUDAEVENTRECORD-NEXT:   dpct::sycl_event_record(e /*cudaEvent_t*/, s /*cudaStream_t*/);
 
 // RUN: dpct --cuda-include-path="%cuda-path/include" --query-api-mapping=cudaEventSynchronize | FileCheck %s -check-prefix=CUDAEVENTSYNCHRONIZE
 // CUDAEVENTSYNCHRONIZE: CUDA API:

--- a/clang/test/dpct/tm-complex-profiling.cu
+++ b/clang/test/dpct/tm-complex-profiling.cu
@@ -102,7 +102,7 @@ int main(int argc, char **argv)
     }
 
     // record start event
-    // CHECK:     dpct::sycl_event_record(start, &dpct::get_in_order_queue());
+    // CHECK:     dpct::sync_barrier(start, &dpct::get_in_order_queue());
     cudaEventRecord(start, 0);
 
     // dispatch job with depth first ordering
@@ -113,14 +113,14 @@ int main(int argc, char **argv)
         kernel_3<<<grid, block, 0, streams[i]>>>();
         kernel_4<<<grid, block, 0, streams[i]>>>();
 
-        // CHECK:        dpct::sycl_event_record(kernelEvent[i], streams[i]);
+        // CHECK:        dpct::sync_barrier(kernelEvent[i], streams[i]);
         cudaEventRecord(kernelEvent[i], streams[i]);
         // CHECK:         streams[n_streams - 1]->ext_oneapi_submit_barrier({*kernelEvent[i]});
         cudaStreamWaitEvent(streams[n_streams - 1], kernelEvent[i], 0);
     }
 
     // record stop event
-    // CHECK:    dpct::sycl_event_record(stop, &dpct::get_in_order_queue());
+    // CHECK:    dpct::sync_barrier(stop, &dpct::get_in_order_queue());
     // CHECK-NEXT:    stop->wait_and_throw();
     // CHECK-NEXT:    elapsed_time = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
     cudaEventRecord(stop, 0);
@@ -178,7 +178,7 @@ void foo_test_1() {
 // CHECK-NEXT:  /*
 // CHECK-NEXT:    DPCT1024:{{[0-9]+}}: The original code returned the error code that was further consumed by the program logic. This original code was replaced with 0. You may need to rewrite the program logic consuming the error code.
 // CHECK-NEXT:    */
-// CHECK-NEXT:  CHECK_FOO(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop)));
+// CHECK-NEXT:  CHECK_FOO(DPCT_CHECK_ERROR(dpct::sync_barrier(stop)));
 // CHECK-NEXT:  stop->wait_and_throw();
 // CHECK-NEXT:  MY_ERROR_CHECKER(DPCT_CHECK_ERROR(stop->wait_and_throw()));
 // CHECK-NEXT:  MY_CHECKER(DPCT_CHECK_ERROR(stop->wait_and_throw()));
@@ -245,7 +245,7 @@ int foo_test_2()
 // CHECK:    /*
 // CHECK-NEXT:    DPCT1024:{{[0-9]+}}: The original code returned the error code that was further consumed by the program logic. This original code was replaced with 0. You may need to rewrite the program logic consuming the error code.
 // CHECK-NEXT:    */
-// CHECK-NEXT:    CHECK(DPCT_CHECK_ERROR(dpct::sycl_event_record(start, &dpct::get_in_order_queue())));
+// CHECK-NEXT:    CHECK(DPCT_CHECK_ERROR(dpct::sync_barrier(start, &dpct::get_in_order_queue())));
     CHECK(cudaEventRecord(start, 0));
 
     // dispatch job with depth first ordering
@@ -307,7 +307,7 @@ void foo_test_3()
 // CHECK-NEXT:    /*
 // CHECK-NEXT:    DPCT1024:{{[0-9]+}}: The original code returned the error code that was further consumed by the program logic. This original code was replaced with 0. You may need to rewrite the program logic consuming the error code.
 // CHECK-NEXT:    */
-// CHECK-NEXT:    CHECK(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop)));
+// CHECK-NEXT:    CHECK(DPCT_CHECK_ERROR(dpct::sync_barrier(stop)));
     CHECK(cudaMemcpyAsync(d_a, h_a, nbytes, cudaMemcpyHostToDevice));
     kernel<<<grid, block>>>(d_a, value);
     CHECK(cudaMemcpyAsync(h_a, d_a, nbytes, cudaMemcpyDeviceToHost));
@@ -369,7 +369,7 @@ void foo_test_4() {
   cudaEventCreate(&stop);
 
   for (k = 0; k < NTIMES; k++) {
-    // CHECK:    dpct::sycl_event_record(start, &dpct::get_in_order_queue());
+    // CHECK:    dpct::sync_barrier(start, &dpct::get_in_order_queue());
     // CHECK-NEXT:    /*
     // CHECK-NEXT:    DPCT1049:{{[0-9]+}}: The work-group size passed to the SYCL kernel may exceed the limit. To get the device limit, query info::device::max_work_group_size. Adjust the work-group size if needed.
     // CHECK-NEXT:    */
@@ -382,7 +382,7 @@ void foo_test_4() {
     // CHECK-NEXT:                        STREAM_Copy(d_a, d_c, N);
     // CHECK-NEXT:                    });
     // CHECK-NEXT:    }
-    // CHECK-NEXT:    dpct::sycl_event_record(stop, &dpct::get_in_order_queue());
+    // CHECK-NEXT:    dpct::sync_barrier(stop, &dpct::get_in_order_queue());
     // CHECK-NEXT:    stop->wait_and_throw();
     // CHECK-NEXT:    times[0][k] = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
     cudaEventRecord(start, 0);
@@ -391,7 +391,7 @@ void foo_test_4() {
     cudaEventSynchronize(stop);
     cudaEventElapsedTime(&times[0][k], start, stop);
 
-    // CHECK:    dpct::sycl_event_record(start, &dpct::get_in_order_queue());
+    // CHECK:    dpct::sync_barrier(start, &dpct::get_in_order_queue());
     // CHECK-NEXT:    /*
     // CHECK-NEXT:    DPCT1049:{{[0-9]+}}: The work-group size passed to the SYCL kernel may exceed the limit. To get the device limit, query info::device::max_work_group_size. Adjust the work-group size if needed.
     // CHECK-NEXT:    */
@@ -404,7 +404,7 @@ void foo_test_4() {
     // CHECK-NEXT:                        STREAM_Copy_Optimized(d_a, d_c, N);
     // CHECK-NEXT:                    });
     // CHECK-NEXT:    }
-    // CHECK-NEXT:    dpct::sycl_event_record(stop, &dpct::get_in_order_queue());
+    // CHECK-NEXT:    dpct::sync_barrier(stop, &dpct::get_in_order_queue());
     // CHECK-NEXT:    stop->wait_and_throw();
     // CHECK-NEXT:    times[1][k] = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
     cudaEventRecord(start, 0);
@@ -432,13 +432,13 @@ void foo_test_2184() {
   CHECK(cudaEventCreate(&start));
   CHECK(cudaEventCreate(&stop));
 
-  // CHECK:  CHECK(DPCT_CHECK_ERROR(dpct::sycl_event_record(start)));
+  // CHECK:  CHECK(DPCT_CHECK_ERROR(dpct::sync_barrier(start)));
   CHECK(cudaEventRecord(start));
   CHECK(cudaMemcpyAsync(d_a, h_a, nbytes, cudaMemcpyHostToDevice));
   kernel_test_2184<<<1, 1>>>();
   CHECK(cudaMemcpyAsync(h_a, d_a, nbytes, cudaMemcpyDeviceToHost));
 
-  // CHECK: CHECK(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop)));
+  // CHECK: CHECK(DPCT_CHECK_ERROR(dpct::sync_barrier(stop)));
   CHECK(cudaEventRecord(stop));
 
   unsigned long int counter = 0;

--- a/clang/test/dpct/tm-complex-profiling.cu
+++ b/clang/test/dpct/tm-complex-profiling.cu
@@ -121,7 +121,7 @@ int main(int argc, char **argv)
 
     // record stop event
     // CHECK:    dpct::sycl_event_record(stop, &dpct::get_in_order_queue());
-    // CHECK-NEXT:    dpct::sycl_event_synchronize(stop);
+    // CHECK-NEXT:    stop->wait_and_throw();
     // CHECK-NEXT:    elapsed_time = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
     cudaEventRecord(stop, 0);
     cudaEventSynchronize(stop);
@@ -179,13 +179,13 @@ void foo_test_1() {
 // CHECK-NEXT:    DPCT1024:{{[0-9]+}}: The original code returned the error code that was further consumed by the program logic. This original code was replaced with 0. You may need to rewrite the program logic consuming the error code.
 // CHECK-NEXT:    */
 // CHECK-NEXT:  CHECK_FOO(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop)));
-// CHECK-NEXT:  dpct::sycl_event_synchronize(stop);
-// CHECK-NEXT:  MY_ERROR_CHECKER(DPCT_CHECK_ERROR(dpct::sycl_event_synchronize(stop)));
-// CHECK-NEXT:  MY_CHECKER(DPCT_CHECK_ERROR(dpct::sycl_event_synchronize(stop)));
-// CHECK-NEXT:  (DPCT_CHECK_ERROR(dpct::sycl_event_synchronize(stop)));
+// CHECK-NEXT:  stop->wait_and_throw();
+// CHECK-NEXT:  MY_ERROR_CHECKER(DPCT_CHECK_ERROR(stop->wait_and_throw()));
+// CHECK-NEXT:  MY_CHECKER(DPCT_CHECK_ERROR(stop->wait_and_throw()));
+// CHECK-NEXT:  (DPCT_CHECK_ERROR(stop->wait_and_throw()));
 // CHECK-NEXT:  int ret;
-// CHECK-NEXT:  ret = (DPCT_CHECK_ERROR(dpct::sycl_event_synchronize(stop)));
-// CHECK-NEXT:  int a = (DPCT_CHECK_ERROR(dpct::sycl_event_synchronize(stop)));
+// CHECK-NEXT:  ret = (DPCT_CHECK_ERROR(stop->wait_and_throw()));
+// CHECK-NEXT:  int a = (DPCT_CHECK_ERROR(stop->wait_and_throw()));
 // CHECK-NEXT:  et = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
   kernel_1<<<1, 1>>>();
   CHECK_FOO(cudaEventRecord(stop));
@@ -383,7 +383,7 @@ void foo_test_4() {
     // CHECK-NEXT:                    });
     // CHECK-NEXT:    }
     // CHECK-NEXT:    dpct::sycl_event_record(stop, &dpct::get_in_order_queue());
-    // CHECK-NEXT:    dpct::sycl_event_synchronize(stop);
+    // CHECK-NEXT:    stop->wait_and_throw();
     // CHECK-NEXT:    times[0][k] = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
     cudaEventRecord(start, 0);
     STREAM_Copy<<<dimGrid, dimBlock>>>(d_a, d_c, N);
@@ -405,7 +405,7 @@ void foo_test_4() {
     // CHECK-NEXT:                    });
     // CHECK-NEXT:    }
     // CHECK-NEXT:    dpct::sycl_event_record(stop, &dpct::get_in_order_queue());
-    // CHECK-NEXT:    dpct::sycl_event_synchronize(stop);
+    // CHECK-NEXT:    stop->wait_and_throw();
     // CHECK-NEXT:    times[1][k] = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
     cudaEventRecord(start, 0);
     STREAM_Copy_Optimized<<<dimGrid, dimBlock>>>(d_a, d_c, N);

--- a/clang/test/dpct/tm-nonusm-no-submit-barrier-profiling.cu
+++ b/clang/test/dpct/tm-nonusm-no-submit-barrier-profiling.cu
@@ -70,7 +70,7 @@ int main() {
     // CHECK:    dpct::get_current_device().queues_wait_and_throw();
     // CHECK-NEXT:    *stop = q_ct1.single_task([=](){});
     // CHECK-NEXT:    dpct::get_current_device().queues_wait_and_throw();
-    // CHECK-NEXT:    stop->wait_and_throw();
+    // CHECK-NEXT:     dpct::sycl_event_synchronize(stop);
     // CHECK-NEXT:    elapsedTime = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
     cudaEventRecord(stop, 0);
     cudaEventSynchronize(stop);
@@ -119,7 +119,7 @@ void foo_test_1() {
 // CHECK:    dpct::get_current_device().queues_wait_and_throw();
 // CHECK-NEXT:    *stop = q_ct1.single_task([=](){});
 // CHECK-NEXT:    dpct::get_current_device().queues_wait_and_throw() ;
-// CHECK-NEXT:    stop->wait_and_throw() ;
+// CHECK-NEXT:    dpct::sycl_event_synchronize( stop ) ;
 // CHECK-NEXT:    float   elapsedTime;
 // CHECK-NEXT:    elapsedTime = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f ;
     cudaEventRecord( stop, 0 ) ;
@@ -236,7 +236,7 @@ void foo_test_3() {
   // CHECK-NEXT:  *stop = q_ct1.single_task([=](){});
   // CHECK-NEXT:  dpct::get_current_device().queues_wait_and_throw();
   // CHECK-NEXT:  return 0;}());
-  // CHECK-NEXT:  CHECK(DPCT_CHECK_ERROR(stop->wait_and_throw()));
+  // CHECK-NEXT:  CHECK(DPCT_CHECK_ERROR(dpct::sycl_event_synchronize(stop)));
   CHECK(cudaEventRecord(stop, 0));
   CHECK(cudaEventSynchronize(stop));
   float execution_time;
@@ -267,7 +267,7 @@ void foo_usm() {
   // CHECK-NEXT:  *stop = q_ct1.single_task([=](){});
   // CHECK-NEXT:  dpct::get_current_device().queues_wait_and_throw();
   // CHECK-NEXT:  return 0;}());
-  // CHECK-NEXT:  SAFE_CALL(DPCT_CHECK_ERROR(stop->wait_and_throw()));
+  // CHECK-NEXT:  SAFE_CALL(DPCT_CHECK_ERROR(dpct::sycl_event_synchronize(stop)));
   // CHECK-NEXT:  float Time = 0.0f;
   // CHECK-NEXT:  Time = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
   SAFE_CALL(cudaEventRecord(stop, 0));
@@ -344,7 +344,7 @@ void foo()
 // CHECK:             dpct::get_current_device().queues_wait_and_throw();
 // CHECK-NEXT:            *stop = q_ct1.single_task([=](){});
 // CHECK-NEXT:            dpct::get_current_device().queues_wait_and_throw();
-// CHECK-NEXT:            stop->wait_and_throw();
+// CHECK-NEXT:            dpct::sycl_event_synchronize(stop);
 // CHECK-NEXT:            t = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
             cudaEventRecord(stop, 0);
             cudaEventSynchronize(stop);
@@ -364,7 +364,7 @@ void foo()
                 readTexelsFoo1<<<gridSize, blockSize>>> (kernelRepFactor, d_out);
             }
 
-// CHECK:            stop->wait_and_throw();
+// CHECK:            dpct::sycl_event_synchronize(stop);
 // CHECK-NEXT:            t = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
             cudaEventSynchronize(stop);
             cudaEventElapsedTime(&t, start, stop);
@@ -387,7 +387,7 @@ void foo()
 // CHECK:            dpct::get_current_device().queues_wait_and_throw();
 // CHECK-NEXT:            *stop = q_ct1.single_task([=](){});
 // CHECK-NEXT:            dpct::get_current_device().queues_wait_and_throw();
-// CHECK-NEXT:            stop->wait_and_throw();
+// CHECK-NEXT:            dpct::sycl_event_synchronize(stop);
 // CHECK-NEXT:            t = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
             cudaEventRecord(stop, 0);
             cudaEventSynchronize(stop);
@@ -470,7 +470,7 @@ int foo_test_4()
 // CHECK-NEXT:    *stop = q_ct1.single_task([=](){});
 // CHECK-NEXT:    dpct::get_current_device().queues_wait_and_throw();
 // CHECK-NEXT:    return 0;}());
-// CHECK-NEXT:    CHECK(DPCT_CHECK_ERROR(stop->wait_and_throw()));
+// CHECK-NEXT:    CHECK(DPCT_CHECK_ERROR(dpct::sycl_event_synchronize(stop)));
 // CHECK-NEXT:    CHECK(DPCT_CHECK_ERROR(elapsed_time = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f));
     CHECK(cudaEventRecord(stop, 0));
     CHECK(cudaEventSynchronize(stop));

--- a/clang/test/dpct/tm-nonusm-no-submit-barrier-profiling.cu
+++ b/clang/test/dpct/tm-nonusm-no-submit-barrier-profiling.cu
@@ -70,7 +70,7 @@ int main() {
     // CHECK:    dpct::get_current_device().queues_wait_and_throw();
     // CHECK-NEXT:    *stop = q_ct1.single_task([=](){});
     // CHECK-NEXT:    dpct::get_current_device().queues_wait_and_throw();
-    // CHECK-NEXT:     dpct::sycl_event_synchronize(stop);
+    // CHECK-NEXT:     stop->wait_and_throw();
     // CHECK-NEXT:    elapsedTime = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
     cudaEventRecord(stop, 0);
     cudaEventSynchronize(stop);
@@ -119,7 +119,7 @@ void foo_test_1() {
 // CHECK:    dpct::get_current_device().queues_wait_and_throw();
 // CHECK-NEXT:    *stop = q_ct1.single_task([=](){});
 // CHECK-NEXT:    dpct::get_current_device().queues_wait_and_throw() ;
-// CHECK-NEXT:    dpct::sycl_event_synchronize( stop ) ;
+// CHECK-NEXT:    stop->wait_and_throw() ;
 // CHECK-NEXT:    float   elapsedTime;
 // CHECK-NEXT:    elapsedTime = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f ;
     cudaEventRecord( stop, 0 ) ;
@@ -236,7 +236,7 @@ void foo_test_3() {
   // CHECK-NEXT:  *stop = q_ct1.single_task([=](){});
   // CHECK-NEXT:  dpct::get_current_device().queues_wait_and_throw();
   // CHECK-NEXT:  return 0;}());
-  // CHECK-NEXT:  CHECK(DPCT_CHECK_ERROR(dpct::sycl_event_synchronize(stop)));
+  // CHECK-NEXT:  CHECK(DPCT_CHECK_ERROR(stop->wait_and_throw()));
   CHECK(cudaEventRecord(stop, 0));
   CHECK(cudaEventSynchronize(stop));
   float execution_time;
@@ -267,7 +267,7 @@ void foo_usm() {
   // CHECK-NEXT:  *stop = q_ct1.single_task([=](){});
   // CHECK-NEXT:  dpct::get_current_device().queues_wait_and_throw();
   // CHECK-NEXT:  return 0;}());
-  // CHECK-NEXT:  SAFE_CALL(DPCT_CHECK_ERROR(dpct::sycl_event_synchronize(stop)));
+  // CHECK-NEXT:  SAFE_CALL(DPCT_CHECK_ERROR(stop->wait_and_throw()));
   // CHECK-NEXT:  float Time = 0.0f;
   // CHECK-NEXT:  Time = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
   SAFE_CALL(cudaEventRecord(stop, 0));
@@ -282,7 +282,6 @@ __global__ void readTexelsFoo1(int n, float *d_out){
 }
 __global__ void readTexelsFoo2(int n, float *d_out, int width, int height){
 }
-texture<float4, 2, cudaReadModeElementType> texA;
 
 void foo()
 {
@@ -344,7 +343,7 @@ void foo()
 // CHECK:             dpct::get_current_device().queues_wait_and_throw();
 // CHECK-NEXT:            *stop = q_ct1.single_task([=](){});
 // CHECK-NEXT:            dpct::get_current_device().queues_wait_and_throw();
-// CHECK-NEXT:            dpct::sycl_event_synchronize(stop);
+// CHECK-NEXT:            stop->wait_and_throw();
 // CHECK-NEXT:            t = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
             cudaEventRecord(stop, 0);
             cudaEventSynchronize(stop);
@@ -364,7 +363,7 @@ void foo()
                 readTexelsFoo1<<<gridSize, blockSize>>> (kernelRepFactor, d_out);
             }
 
-// CHECK:            dpct::sycl_event_synchronize(stop);
+// CHECK:            stop->wait_and_throw();
 // CHECK-NEXT:            t = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
             cudaEventSynchronize(stop);
             cudaEventElapsedTime(&t, start, stop);
@@ -387,7 +386,7 @@ void foo()
 // CHECK:            dpct::get_current_device().queues_wait_and_throw();
 // CHECK-NEXT:            *stop = q_ct1.single_task([=](){});
 // CHECK-NEXT:            dpct::get_current_device().queues_wait_and_throw();
-// CHECK-NEXT:            dpct::sycl_event_synchronize(stop);
+// CHECK-NEXT:            stop->wait_and_throw();
 // CHECK-NEXT:            t = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
             cudaEventRecord(stop, 0);
             cudaEventSynchronize(stop);
@@ -470,7 +469,7 @@ int foo_test_4()
 // CHECK-NEXT:    *stop = q_ct1.single_task([=](){});
 // CHECK-NEXT:    dpct::get_current_device().queues_wait_and_throw();
 // CHECK-NEXT:    return 0;}());
-// CHECK-NEXT:    CHECK(DPCT_CHECK_ERROR(dpct::sycl_event_synchronize(stop)));
+// CHECK-NEXT:    CHECK(DPCT_CHECK_ERROR(stop->wait_and_throw()));
 // CHECK-NEXT:    CHECK(DPCT_CHECK_ERROR(elapsed_time = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f));
     CHECK(cudaEventRecord(stop, 0));
     CHECK(cudaEventSynchronize(stop));

--- a/clang/test/dpct/tm-nonusm-profiling.cu
+++ b/clang/test/dpct/tm-nonusm-profiling.cu
@@ -65,7 +65,7 @@ int main() {
     cudaMemcpyAsync(da, ha, N*sizeof(int), cudaMemcpyHostToDevice, stream);
 
     // CHECK:    dpct::sycl_event_record(stop, &q_ct1);
-    // CHECK:    dpct::sycl_event_synchronize(stop);
+    // CHECK:    stop->wait_and_throw();
     // CHECK:    elapsedTime = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
     cudaEventRecord(stop, 0);
     cudaEventSynchronize(stop);
@@ -117,7 +117,7 @@ void foo_test_1() {
     cudaThreadSynchronize();
 
 // CHECK:    dpct::sycl_event_record( stop, &q_ct1 ) ;
-// CHECK-NEXT:    dpct::sycl_event_synchronize( stop ) ;
+// CHECK-NEXT:    stop->wait_and_throw() ;
 // CHECK-NEXT:    float   elapsedTime;
 // CHECK-NEXT:    elapsedTime = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f ;
     cudaEventRecord( stop, 0 ) ;
@@ -228,7 +228,7 @@ void foo_test_3() {
   // CHECK-NEXT:  DPCT1024:{{[0-9]+}}: The original code returned the error code that was further consumed by the program logic. This original code was replaced with 0. You may need to rewrite the program logic consuming the error code.
   // CHECK-NEXT:  */
   // CHECK-NEXT:  CHECK(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop, &q_ct1)));
-  // CHECK-NEXT:  CHECK(DPCT_CHECK_ERROR(dpct::sycl_event_synchronize(stop)));
+  // CHECK-NEXT:  CHECK(DPCT_CHECK_ERROR(stop->wait_and_throw()));
   // CHECK-NEXT:  float execution_time;
   // CHECK-NEXT:  CHECK(DPCT_CHECK_ERROR(execution_time = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f));  
     CHECK(cudaEventRecord(stop, 0));
@@ -254,7 +254,7 @@ void foo_usm() {
   SAFE_CALL(cudaMemcpyAsync(gpu_t, host_t, n * sizeof(int), cudaMemcpyHostToDevice, s1));
 
   // CHECK:  SAFE_CALL(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop, &q_ct1)));
-  // CHECK:  SAFE_CALL(DPCT_CHECK_ERROR(dpct::sycl_event_synchronize(stop)));
+  // CHECK:  SAFE_CALL(DPCT_CHECK_ERROR(stop->wait_and_throw()));
   // CHECK:  float Time = 0.0f;
   // CHECK:  Time = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
   SAFE_CALL(cudaEventRecord(stop, 0));
@@ -269,7 +269,6 @@ __global__ void readTexelsFoo1(int n, float *d_out){
 }
 __global__ void readTexelsFoo2(int n, float *d_out, int width, int height){
 }
-texture<float4, 2, cudaReadModeElementType> texA;
 
 void foo()
 {
@@ -340,7 +339,7 @@ void foo()
             }
 
 // CHECK:            dpct::sycl_event_record(stop, &q_ct1);
-// CHECK-NEXT:             dpct::sycl_event_synchronize(stop);
+// CHECK-NEXT:             stop->wait_and_throw();
 // CHECK-NEXT:             t = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
             cudaEventRecord(stop, 0);
             cudaEventSynchronize(stop);
@@ -373,7 +372,7 @@ void foo()
             }
 
 // CHECK:             dpct::sycl_event_record(stop, &q_ct1);
-// CHECK-NEXT:            dpct::sycl_event_synchronize(stop);
+// CHECK-NEXT:            stop->wait_and_throw();
 // CHECK-NEXT:            t = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
             cudaEventRecord(stop, 0);
             cudaEventSynchronize(stop);
@@ -408,7 +407,7 @@ void foo()
 
 
 // CHECK:            dpct::sycl_event_record(stop, &q_ct1);
-// CHECK-NEXT:            dpct::sycl_event_synchronize(stop);
+// CHECK-NEXT:            stop->wait_and_throw();
 // CHECK-NEXT:            t = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
             cudaEventRecord(stop, 0);
             cudaEventSynchronize(stop);
@@ -487,7 +486,7 @@ int foo_test_4()
 
 
 // CHECK:    CHECK(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop, &q_ct1)));
-// CHECK:    CHECK(DPCT_CHECK_ERROR(dpct::sycl_event_synchronize(stop)));
+// CHECK:    CHECK(DPCT_CHECK_ERROR(stop->wait_and_throw()));
     CHECK(cudaEventRecord(stop, 0));
     CHECK(cudaEventSynchronize(stop));
     CHECK(cudaEventElapsedTime(&elapsed_time, start, stop));
@@ -707,8 +706,8 @@ void foo_test_1983() {
     kernel<<<1, 1, 0, stream2>>>();
 
 // CHECK:    dpct::sycl_event_record(event2, stream2);
-// CHECK-NEXT:    dpct::sycl_event_synchronize(event1);
-// CHECK-NEXT:    dpct::sycl_event_synchronize(event2);
+// CHECK-NEXT:    event1->wait_and_throw();
+// CHECK-NEXT:    event2->wait_and_throw();
     cudaEventRecord(event2, stream2);
     cudaEventSynchronize(event1);
     cudaEventSynchronize(event2);
@@ -773,7 +772,7 @@ template <class T, class vecT> void foo_test_2131() {
 
 
     // CHECK:    SAFE_CALL(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop, &q_ct1)));
-    // CHECK:    SAFE_CALL(DPCT_CHECK_ERROR(dpct::sycl_event_synchronize(stop)));
+    // CHECK:    SAFE_CALL(DPCT_CHECK_ERROR(stop->wait_and_throw()));
     // CHECK:    totalScanTime = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
     SAFE_CALL(cudaEventRecord(stop, 0));
     SAFE_CALL(cudaEventSynchronize(stop));

--- a/clang/test/dpct/tm-nonusm-profiling.cu
+++ b/clang/test/dpct/tm-nonusm-profiling.cu
@@ -57,14 +57,14 @@ int main() {
     cudaEventCreate(&start);
     cudaEventCreate(&stop);
 
-    // dpct::sycl_event_record(start, &q_ct1);
+    // dpct::sync_barrier(start, &q_ct1);
     cudaEventRecord(start, 0);
 
     cudaMemcpyAsync(da, ha, N*sizeof(int), cudaMemcpyHostToDevice);
     cudaMemcpyAsync(da, ha, N*sizeof(int), cudaMemcpyHostToDevice, 0);
     cudaMemcpyAsync(da, ha, N*sizeof(int), cudaMemcpyHostToDevice, stream);
 
-    // CHECK:    dpct::sycl_event_record(stop, &q_ct1);
+    // CHECK:    dpct::sync_barrier(stop, &q_ct1);
     // CHECK:    stop->wait_and_throw();
     // CHECK:    elapsedTime = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
     cudaEventRecord(stop, 0);
@@ -101,7 +101,7 @@ void foo_test_1() {
     cudaEventCreate(&start);
     cudaEventCreate(&stop);
 
-// CHECK:    dpct::sycl_event_record( start, &q_ct1 );
+// CHECK:    dpct::sync_barrier( start, &q_ct1 );
 // CHECK-NEXT:        for (int i=0; i<4; i++) {
 // CHECK-NEXT:            q_ct1.parallel_for<dpct_kernel_name<class kernel_foo_{{[a-z0-9]+}}>>(
 // CHECK-NEXT:                  sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
@@ -116,7 +116,7 @@ void foo_test_1() {
         }
     cudaThreadSynchronize();
 
-// CHECK:    dpct::sycl_event_record( stop, &q_ct1 ) ;
+// CHECK:    dpct::sync_barrier( stop, &q_ct1 ) ;
 // CHECK-NEXT:    stop->wait_and_throw() ;
 // CHECK-NEXT:    float   elapsedTime;
 // CHECK-NEXT:    elapsedTime = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f ;
@@ -151,7 +151,7 @@ void foo_test_2() {
     kernel<<<grid, block>>>(d_a, value);
     CHECK(cudaMemcpyAsync(h_a, d_a, nbytes, cudaMemcpyDeviceToHost));
 
-    // CHECK:    CHECK(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop)));
+    // CHECK:    CHECK(DPCT_CHECK_ERROR(dpct::sync_barrier(stop)));
     CHECK(cudaEventRecord(stop));
 
     // have CPU do some work while waiting for stage 1 to finish
@@ -206,7 +206,7 @@ void foo_test_3() {
     CHECK(cudaStreamCreate(&stream[i]));
   }
 
-// CHECK:  CHECK(DPCT_CHECK_ERROR(dpct::sycl_event_record(start, &q_ct1)));
+// CHECK:  CHECK(DPCT_CHECK_ERROR(dpct::sync_barrier(start, &q_ct1)));
   CHECK(cudaEventRecord(start, 0));
 
   // initiate all work on the device asynchronously in depth-first order
@@ -227,7 +227,7 @@ void foo_test_3() {
   // CHECK:  /*
   // CHECK-NEXT:  DPCT1024:{{[0-9]+}}: The original code returned the error code that was further consumed by the program logic. This original code was replaced with 0. You may need to rewrite the program logic consuming the error code.
   // CHECK-NEXT:  */
-  // CHECK-NEXT:  CHECK(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop, &q_ct1)));
+  // CHECK-NEXT:  CHECK(DPCT_CHECK_ERROR(dpct::sync_barrier(stop, &q_ct1)));
   // CHECK-NEXT:  CHECK(DPCT_CHECK_ERROR(stop->wait_and_throw()));
   // CHECK-NEXT:  float execution_time;
   // CHECK-NEXT:  CHECK(DPCT_CHECK_ERROR(execution_time = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f));  
@@ -247,13 +247,13 @@ void foo_usm() {
   int *gpu_t, *host_t, n = 10;
   cudaEvent_t start, stop;
 
-// CHECK: SAFE_CALL(DPCT_CHECK_ERROR(dpct::sycl_event_record(start, &q_ct1)));
+// CHECK: SAFE_CALL(DPCT_CHECK_ERROR(dpct::sync_barrier(start, &q_ct1)));
   SAFE_CALL(cudaEventRecord(start, 0));
 
   // CHECK:  SAFE_CALL(DPCT_CHECK_ERROR(dpct::async_dpct_memcpy(gpu_t, host_t, n * sizeof(int), dpct::host_to_device, *s1)));
   SAFE_CALL(cudaMemcpyAsync(gpu_t, host_t, n * sizeof(int), cudaMemcpyHostToDevice, s1));
 
-  // CHECK:  SAFE_CALL(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop, &q_ct1)));
+  // CHECK:  SAFE_CALL(DPCT_CHECK_ERROR(dpct::sync_barrier(stop, &q_ct1)));
   // CHECK:  SAFE_CALL(DPCT_CHECK_ERROR(stop->wait_and_throw()));
   // CHECK:  float Time = 0.0f;
   // CHECK:  Time = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
@@ -317,7 +317,7 @@ void foo()
         {
             // Test 1: Repeated Linear Access
             float t = 0.0f;
-// CHECK:            dpct::sycl_event_record(start, &q_ct1);
+// CHECK:            dpct::sync_barrier(start, &q_ct1);
             cudaEventRecord(start, 0);
             // read texels from texture
             for (int iter = 0; iter < iterations; iter++)
@@ -338,7 +338,7 @@ void foo()
                                                     width);
             }
 
-// CHECK:            dpct::sycl_event_record(stop, &q_ct1);
+// CHECK:            dpct::sync_barrier(stop, &q_ct1);
 // CHECK-NEXT:             stop->wait_and_throw();
 // CHECK-NEXT:             t = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
             cudaEventRecord(stop, 0);
@@ -351,7 +351,7 @@ void foo()
                     cudaMemcpyDeviceToHost);
 
             // Test 2 Repeated Cache Access
-// CHECK:            dpct::sycl_event_record(start, &q_ct1);
+// CHECK:            dpct::sync_barrier(start, &q_ct1);
             cudaEventRecord(start, 0);
             for (int iter = 0; iter < iterations; iter++)
             {
@@ -371,7 +371,7 @@ void foo()
                         (kernelRepFactor, d_out);
             }
 
-// CHECK:             dpct::sycl_event_record(stop, &q_ct1);
+// CHECK:             dpct::sync_barrier(stop, &q_ct1);
 // CHECK-NEXT:            stop->wait_and_throw();
 // CHECK-NEXT:            t = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
             cudaEventRecord(stop, 0);
@@ -383,7 +383,7 @@ void foo()
                     cudaMemcpyDeviceToHost);
 
             // Test 3 Repeated "Random" Access
-// CHECK:            dpct::sycl_event_record(start, &q_ct1);
+// CHECK:            dpct::sync_barrier(start, &q_ct1);
             cudaEventRecord(start, 0);
 
             // read texels from texture
@@ -406,7 +406,7 @@ void foo()
             }
 
 
-// CHECK:            dpct::sycl_event_record(stop, &q_ct1);
+// CHECK:            dpct::sync_barrier(stop, &q_ct1);
 // CHECK-NEXT:            stop->wait_and_throw();
 // CHECK-NEXT:            t = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
             cudaEventRecord(stop, 0);
@@ -459,7 +459,7 @@ int foo_test_4()
 
 // CHECK:    DPCT1024:{{[0-9]+}}: The original code returned the error code that was further consumed by the program logic. This original code was replaced with 0. You may need to rewrite the program logic consuming the error code.
 // CHECK-NEXT:    */
-// CHECK-NEXT:    CHECK(DPCT_CHECK_ERROR(dpct::sycl_event_record(start, &q_ct1)));
+// CHECK-NEXT:    CHECK(DPCT_CHECK_ERROR(dpct::sync_barrier(start, &q_ct1)));
 // record start event
     CHECK(cudaEventRecord(start, 0));
 
@@ -485,7 +485,7 @@ int foo_test_4()
     }
 
 
-// CHECK:    CHECK(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop, &q_ct1)));
+// CHECK:    CHECK(DPCT_CHECK_ERROR(dpct::sync_barrier(stop, &q_ct1)));
 // CHECK:    CHECK(DPCT_CHECK_ERROR(stop->wait_and_throw()));
     CHECK(cudaEventRecord(stop, 0));
     CHECK(cudaEventSynchronize(stop));
@@ -530,7 +530,7 @@ void RunTest()
     {
         float totalScanTime = 0.0f;
 
-// CHECK:         SAFE_CALL(DPCT_CHECK_ERROR(dpct::sycl_event_record(start, &q_ct1)));
+// CHECK:         SAFE_CALL(DPCT_CHECK_ERROR(dpct::sync_barrier(start, &q_ct1)));
         SAFE_CALL(cudaEventRecord(start, 0));
         for (int j = 0; j < iters; j++)
         {
@@ -593,7 +593,7 @@ void test_1999(void* ref_image, void* cur_image,
     cudaEvent_t sad_calc_start, sad_calc_stop;
     cudaEventCreate(&sad_calc_start);
     cudaEventCreate(&sad_calc_stop);
-// CHECK:    dpct::sycl_event_record(sad_calc_start);
+// CHECK:    dpct::sync_barrier(sad_calc_start);
     cudaEventRecord(sad_calc_start);
     dim3 foo_kernel_1_threads_in_block;
     dim3 foo_kernel_1_blocks_in_grid;
@@ -616,7 +616,7 @@ void test_1999(void* ref_image, void* cur_image,
                                                   image_height_macroblocks,
                                                   imgRef);
 
-// CHECK:    dpct::sycl_event_record(sad_calc_stop);
+// CHECK:    dpct::sync_barrier(sad_calc_stop);
     cudaEventRecord(sad_calc_stop);
 
 // CHECK:    dpct::event_ptr sad_calc_8_start, sad_calc_8_stop;
@@ -624,7 +624,7 @@ void test_1999(void* ref_image, void* cur_image,
 
     cudaEventCreate(&sad_calc_8_start);
     cudaEventCreate(&sad_calc_8_stop);
-// CHECK:     dpct::sycl_event_record(sad_calc_8_start);
+// CHECK:     dpct::sync_barrier(sad_calc_8_start);
     cudaEventRecord(sad_calc_8_start);
     dim3 foo_kernel_2_threads_in_block;
     dim3 foo_kernel_2_blocks_in_grid;
@@ -643,7 +643,7 @@ void test_1999(void* ref_image, void* cur_image,
       foo_kernel_2_blocks_in_grid,
       foo_kernel_2_threads_in_block>>>(d_sads, image_width_macroblocks,
                                             image_height_macroblocks);
-// CHECK:    dpct::sycl_event_record(sad_calc_8_stop);
+// CHECK:    dpct::sync_barrier(sad_calc_8_stop);
     cudaEventRecord(sad_calc_8_stop);
 
 
@@ -670,7 +670,7 @@ void test_1999(void* ref_image, void* cur_image,
       foo_kernel_3_blocks_in_grid,
       foo_kernel_3_threads_in_block>>>(d_sads, image_width_macroblocks,
                                              image_height_macroblocks);
-// CHECK:    dpct::sycl_event_record(sad_calc_16_stop);
+// CHECK:    dpct::sync_barrier(sad_calc_16_stop);
     cudaEventRecord(sad_calc_16_stop);
 
     cudaMallocHost((void **)h_sads, nsads * sizeof(unsigned short));
@@ -701,11 +701,11 @@ void foo_test_1983() {
 
   for (int i = 0; i < repeat; i++) {
     kernel<<<1, 1, 0, stream1>>>();
-// CHECK:    dpct::sycl_event_record(event1, stream1);
+// CHECK:    dpct::sync_barrier(event1, stream1);
     cudaEventRecord(event1, stream1);
     kernel<<<1, 1, 0, stream2>>>();
 
-// CHECK:    dpct::sycl_event_record(event2, stream2);
+// CHECK:    dpct::sync_barrier(event2, stream2);
 // CHECK-NEXT:    event1->wait_and_throw();
 // CHECK-NEXT:    event2->wait_and_throw();
     cudaEventRecord(event2, stream2);
@@ -731,13 +731,13 @@ void foo_test_2184() {
   CHECK(cudaEventCreate(&start));
   CHECK(cudaEventCreate(&stop));
 
-  // CHECK:  CHECK(DPCT_CHECK_ERROR(dpct::sycl_event_record(start)));
+  // CHECK:  CHECK(DPCT_CHECK_ERROR(dpct::sync_barrier(start)));
   CHECK(cudaEventRecord(start));
   CHECK(cudaMemcpyAsync(d_a, h_a, nbytes, cudaMemcpyHostToDevice));
   kernel_test_2184<<<1, 1>>>();
   CHECK(cudaMemcpyAsync(h_a, d_a, nbytes, cudaMemcpyDeviceToHost));
 
-  // CHECK:  CHECK(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop)));
+  // CHECK:  CHECK(DPCT_CHECK_ERROR(dpct::sync_barrier(stop)));
   CHECK(cudaEventRecord(stop));
 
   unsigned long int counter = 0;
@@ -771,7 +771,7 @@ template <class T, class vecT> void foo_test_2131() {
     }
 
 
-    // CHECK:    SAFE_CALL(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop, &q_ct1)));
+    // CHECK:    SAFE_CALL(DPCT_CHECK_ERROR(dpct::sync_barrier(stop, &q_ct1)));
     // CHECK:    SAFE_CALL(DPCT_CHECK_ERROR(stop->wait_and_throw()));
     // CHECK:    totalScanTime = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
     SAFE_CALL(cudaEventRecord(stop, 0));

--- a/clang/test/dpct/tm-usm-no-submit-barrier-profiling.cu
+++ b/clang/test/dpct/tm-usm-no-submit-barrier-profiling.cu
@@ -50,7 +50,7 @@ int main() {
     cudaMemcpyAsync(da, ha, N*sizeof(int), cudaMemcpyHostToDevice, stream);
 
     // CHECK:    *stop = q_ct1.single_task([=](){});
-    // CHECK:    dpct::sycl_event_synchronize(stop);
+    // CHECK:    stop->wait_and_throw();
     // CHECK:    elapsedTime = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
     cudaEventRecord(stop, 0);
     cudaEventSynchronize(stop);
@@ -95,7 +95,7 @@ void foo_usm() {
   // CHECK-NEXT:  DPCT1024:{{[0-9]+}}: The original code returned the error code that was further consumed by the program logic. This original code was replaced with 0. You may need to rewrite the program logic consuming the error code.
   // CHECK-NEXT:  */
   // CHECK-NEXT:  SAFE_CALL(DPCT_CHECK_ERROR(*stop = q_ct1.single_task([=](){})));
-  // CHECK-NEXT:  SAFE_CALL(DPCT_CHECK_ERROR(dpct::sycl_event_synchronize(stop)));
+  // CHECK-NEXT:  SAFE_CALL(DPCT_CHECK_ERROR(stop->wait_and_throw()));
   // CHECK-NEXT:  float Time = 0.0f;
   // CHECK-NEXT:  Time = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
   SAFE_CALL(cudaEventRecord(stop, 0));
@@ -107,7 +107,6 @@ void foo_usm() {
 __global__ void readTexels(int n, float *d_out, int width){}
 __global__ void readTexelsFoo1(int n, float *d_out){}
 __global__ void readTexelsFoo2(int n, float *d_out, int width, int height){}
-texture<float4, 2, cudaReadModeElementType> texA;
 
 void foo()
 {
@@ -173,7 +172,7 @@ void foo()
             }
 
 // CHECK:            *stop = q_ct1.single_task([=](){});
-// CHECK-NEXT:             dpct::sycl_event_synchronize(stop);
+// CHECK-NEXT:             stop->wait_and_throw();
 // CHECK-NEXT:             t = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
             cudaEventRecord(stop, 0);
             cudaEventSynchronize(stop);
@@ -200,7 +199,7 @@ void foo()
             }
 
 // CHECK:            *stop = q_ct1.single_task([=](){});
-// CHECK-NEXT:            dpct::sycl_event_synchronize(stop);
+// CHECK-NEXT:            stop->wait_and_throw();
 // CHECK-NEXT:            t = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
             cudaEventRecord(stop, 0);
             cudaEventSynchronize(stop);
@@ -229,7 +228,7 @@ void foo()
             }
 
 // CHECK:             *stop = q_ct1.single_task([=](){});
-// CHECK-NEXT:            dpct::sycl_event_synchronize(stop);
+// CHECK-NEXT:            stop->wait_and_throw();
 // CHECK-NEXT:            t = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
             cudaEventRecord(stop, 0);
             cudaEventSynchronize(stop);

--- a/clang/test/dpct/tm-usm-no-submit-barrier-profiling.cu
+++ b/clang/test/dpct/tm-usm-no-submit-barrier-profiling.cu
@@ -50,7 +50,7 @@ int main() {
     cudaMemcpyAsync(da, ha, N*sizeof(int), cudaMemcpyHostToDevice, stream);
 
     // CHECK:    *stop = q_ct1.single_task([=](){});
-    // CHECK:    stop->wait_and_throw();
+    // CHECK:    dpct::sycl_event_synchronize(stop);
     // CHECK:    elapsedTime = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
     cudaEventRecord(stop, 0);
     cudaEventSynchronize(stop);
@@ -95,7 +95,7 @@ void foo_usm() {
   // CHECK-NEXT:  DPCT1024:{{[0-9]+}}: The original code returned the error code that was further consumed by the program logic. This original code was replaced with 0. You may need to rewrite the program logic consuming the error code.
   // CHECK-NEXT:  */
   // CHECK-NEXT:  SAFE_CALL(DPCT_CHECK_ERROR(*stop = q_ct1.single_task([=](){})));
-  // CHECK-NEXT:  SAFE_CALL(DPCT_CHECK_ERROR(stop->wait_and_throw()));
+  // CHECK-NEXT:  SAFE_CALL(DPCT_CHECK_ERROR(dpct::sycl_event_synchronize(stop)));
   // CHECK-NEXT:  float Time = 0.0f;
   // CHECK-NEXT:  Time = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
   SAFE_CALL(cudaEventRecord(stop, 0));
@@ -173,7 +173,7 @@ void foo()
             }
 
 // CHECK:            *stop = q_ct1.single_task([=](){});
-// CHECK-NEXT:             stop->wait_and_throw();
+// CHECK-NEXT:             dpct::sycl_event_synchronize(stop);
 // CHECK-NEXT:             t = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
             cudaEventRecord(stop, 0);
             cudaEventSynchronize(stop);
@@ -200,7 +200,7 @@ void foo()
             }
 
 // CHECK:            *stop = q_ct1.single_task([=](){});
-// CHECK-NEXT:            stop->wait_and_throw();
+// CHECK-NEXT:            dpct::sycl_event_synchronize(stop);
 // CHECK-NEXT:            t = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
             cudaEventRecord(stop, 0);
             cudaEventSynchronize(stop);
@@ -229,7 +229,7 @@ void foo()
             }
 
 // CHECK:             *stop = q_ct1.single_task([=](){});
-// CHECK-NEXT:            stop->wait_and_throw();
+// CHECK-NEXT:            dpct::sycl_event_synchronize(stop);
 // CHECK-NEXT:            t = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
             cudaEventRecord(stop, 0);
             cudaEventSynchronize(stop);

--- a/clang/test/dpct/tm-usm-restricted-profiling.cu
+++ b/clang/test/dpct/tm-usm-restricted-profiling.cu
@@ -54,7 +54,7 @@ int main() {
     cudaMemcpyAsync(da, ha, N*sizeof(int), cudaMemcpyHostToDevice, stream);
 
   // CHECK:    dpct::sycl_event_record(stop, &q_ct1);
-  // CHECK-NEXT:   dpct::sycl_event_synchronize(stop);
+  // CHECK-NEXT:   stop->wait_and_throw();
   // CHECK-NEXT:   elapsedTime = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
     cudaEventRecord(stop, 0);
     cudaEventSynchronize(stop);
@@ -101,7 +101,7 @@ void foo_usm() {
 // CHECK-NEXT:  DPCT1024:{{[0-9]+}}: The original code returned the error code that was further consumed by the program logic. This original code was replaced with 0. You may need to rewrite the program logic consuming the error code.
 // CHECK-NEXT:  */
 // CHECK-NEXT:  SAFE_CALL(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop, &q_ct1)));
-// CHECK-NEXT:  SAFE_CALL(DPCT_CHECK_ERROR(dpct::sycl_event_synchronize(stop)));
+// CHECK-NEXT:  SAFE_CALL(DPCT_CHECK_ERROR(stop->wait_and_throw()));
   SAFE_CALL(cudaEventRecord(stop, 0));
   SAFE_CALL(cudaEventSynchronize(stop));
   float Time = 0.0f;
@@ -177,7 +177,7 @@ void foo()
             }
 
 // CHECK:             dpct::sycl_event_record(stop, &q_ct1);
-// CHECK-NEXT:             dpct::sycl_event_synchronize(stop);
+// CHECK-NEXT:             stop->wait_and_throw();
 // CHECK-NEXT:             t = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
             cudaEventRecord(stop, 0);
             cudaEventSynchronize(stop);
@@ -205,7 +205,7 @@ void foo()
             }
 
 // CHECK:            dpct::sycl_event_record(stop, &q_ct1);
-// CHECK-NEXT:            dpct::sycl_event_synchronize(stop);
+// CHECK-NEXT:            stop->wait_and_throw();
 // CHECK-NEXT:            t = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
             cudaEventRecord(stop, 0);
             cudaEventSynchronize(stop);
@@ -235,7 +235,7 @@ void foo()
             }
 
 // CHECK:            dpct::sycl_event_record(stop, &q_ct1);
-// CHECK-NEXT:            dpct::sycl_event_synchronize(stop);
+// CHECK-NEXT:            stop->wait_and_throw();
 // CHECK-NEXT:            t = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
             cudaEventRecord(stop, 0);
             cudaEventSynchronize(stop);
@@ -481,8 +481,8 @@ void foo_test_1983() {
     kernel<<<1, 1, 0, stream2>>>();
 
 // CHECK:    dpct::sycl_event_record(event2, stream2);
-// CHECK-NEXT:    dpct::sycl_event_synchronize(event1);
-// CHECK-NEXT:    dpct::sycl_event_synchronize(event2);
+// CHECK-NEXT:    event1->wait_and_throw();
+// CHECK-NEXT:    event2->wait_and_throw();
     cudaEventRecord(event2, stream2);
     cudaEventSynchronize(event1);
     cudaEventSynchronize(event2);
@@ -514,7 +514,7 @@ template <class T, class vecT> void foo_test_2131() {
     }
 
   // CHECK: SAFE_CALL(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop, &q_ct1)));
-  // CHECK: SAFE_CALL(DPCT_CHECK_ERROR(dpct::sycl_event_synchronize(stop)));
+  // CHECK: SAFE_CALL(DPCT_CHECK_ERROR(stop->wait_and_throw()));
   // CHECK: totalScanTime = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
     SAFE_CALL(cudaEventRecord(stop, 0));
     SAFE_CALL(cudaEventSynchronize(stop));

--- a/clang/test/dpct/tm-usm-restricted-profiling.cu
+++ b/clang/test/dpct/tm-usm-restricted-profiling.cu
@@ -43,7 +43,7 @@ int main() {
     cudaEventCreate(&start);
     cudaEventCreate(&stop);
 
- // CHECK:    *start = q_ct1.ext_oneapi_submit_barrier();
+ // CHECK:    dpct::sycl_event_record(start, &q_ct1);
     cudaEventRecord(start, 0);
 
   // CHECK: q_ct1.memcpy(da, ha, N*sizeof(int));
@@ -53,8 +53,8 @@ int main() {
   // CHECK: stream->memcpy(da, ha, N*sizeof(int));
     cudaMemcpyAsync(da, ha, N*sizeof(int), cudaMemcpyHostToDevice, stream);
 
-  // CHECK:    *stop = q_ct1.ext_oneapi_submit_barrier();
-  // CHECK-NEXT:    stop->wait_and_throw();
+  // CHECK:    dpct::sycl_event_record(stop, &q_ct1);
+  // CHECK-NEXT:   dpct::sycl_event_synchronize(stop);
   // CHECK-NEXT:   elapsedTime = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
     cudaEventRecord(stop, 0);
     cudaEventSynchronize(stop);
@@ -91,17 +91,17 @@ void foo_usm() {
   int *gpu_t, *host_t, n = 10;
   cudaEvent_t start, stop;
 
-// CHECK:  SAFE_CALL(DPCT_CHECK_ERROR(*start = q_ct1.ext_oneapi_submit_barrier()));
+// CHECK:  SAFE_CALL(DPCT_CHECK_ERROR(dpct::sycl_event_record(start, &q_ct1)));
   SAFE_CALL(cudaEventRecord(start, 0));
 
-// CHECK:SAFE_CALL(DPCT_CHECK_ERROR(s1->memcpy(gpu_t, host_t, n * sizeof(int))));
+// CHECK:  SAFE_CALL(DPCT_CHECK_ERROR(s1->memcpy(gpu_t, host_t, n * sizeof(int))));
   SAFE_CALL(cudaMemcpyAsync(gpu_t, host_t, n * sizeof(int), cudaMemcpyHostToDevice, s1));
 
 // CHECK:  /*
 // CHECK-NEXT:  DPCT1024:{{[0-9]+}}: The original code returned the error code that was further consumed by the program logic. This original code was replaced with 0. You may need to rewrite the program logic consuming the error code.
 // CHECK-NEXT:  */
-// CHECK-NEXT:  SAFE_CALL(DPCT_CHECK_ERROR(*stop = q_ct1.ext_oneapi_submit_barrier()));
-// CHECK-NEXT:  SAFE_CALL(DPCT_CHECK_ERROR(stop->wait_and_throw()));
+// CHECK-NEXT:  SAFE_CALL(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop, &q_ct1)));
+// CHECK-NEXT:  SAFE_CALL(DPCT_CHECK_ERROR(dpct::sycl_event_synchronize(stop)));
   SAFE_CALL(cudaEventRecord(stop, 0));
   SAFE_CALL(cudaEventSynchronize(stop));
   float Time = 0.0f;
@@ -111,7 +111,6 @@ void foo_usm() {
 __global__ void readTexels(int n, float *d_out, int width){}
 __global__ void readTexelsFoo1(int n, float *d_out){}
 __global__ void readTexelsFoo2(int n, float *d_out, int width, int height){}
-texture<float4, 2, cudaReadModeElementType> texA;
 
 void foo()
 {
@@ -161,7 +160,7 @@ void foo()
             // Test 1: Repeated Linear Access
             float t = 0.0f;
 
-// CHECK:            *start = q_ct1.ext_oneapi_submit_barrier();
+// CHECK:            dpct::sycl_event_record(start, &q_ct1);
             cudaEventRecord(start, 0);
             // read texels from texture
             for (int iter = 0; iter < iterations; iter++)
@@ -177,8 +176,8 @@ void foo()
                                                     width);
             }
 
-// CHECK:             *stop = q_ct1.ext_oneapi_submit_barrier();
-// CHECK-NEXT:             stop->wait_and_throw();
+// CHECK:             dpct::sycl_event_record(stop, &q_ct1);
+// CHECK-NEXT:             dpct::sycl_event_synchronize(stop);
 // CHECK-NEXT:             t = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
             cudaEventRecord(stop, 0);
             cudaEventSynchronize(stop);
@@ -189,7 +188,7 @@ void foo()
                     cudaMemcpyDeviceToHost);
 
             // Test 2 Repeated Cache Access
-// CHECK:            *start = q_ct1.ext_oneapi_submit_barrier();
+// CHECK:            dpct::sycl_event_record(start, &q_ct1);
             cudaEventRecord(start, 0);
             for (int iter = 0; iter < iterations; iter++)
             {
@@ -205,8 +204,8 @@ void foo()
                         (kernelRepFactor, d_out);
             }
 
-// CHECK:            *stop = q_ct1.ext_oneapi_submit_barrier();
-// CHECK-NEXT:            stop->wait_and_throw();
+// CHECK:            dpct::sycl_event_record(stop, &q_ct1);
+// CHECK-NEXT:            dpct::sycl_event_synchronize(stop);
 // CHECK-NEXT:            t = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
             cudaEventRecord(stop, 0);
             cudaEventSynchronize(stop);
@@ -217,7 +216,7 @@ void foo()
                     cudaMemcpyDeviceToHost);
 
             // Test 3 Repeated "Random" Access
-// CHECK:            *start = q_ct1.ext_oneapi_submit_barrier();
+// CHECK:            dpct::sycl_event_record(start, &q_ct1);
             cudaEventRecord(start, 0);
 
             // read texels from texture
@@ -235,8 +234,8 @@ void foo()
                                 (kernelRepFactor, d_out, width, height);
             }
 
-// CHECK:            *stop = q_ct1.ext_oneapi_submit_barrier();
-// CHECK-NEXT:            stop->wait_and_throw();
+// CHECK:            dpct::sycl_event_record(stop, &q_ct1);
+// CHECK-NEXT:            dpct::sycl_event_synchronize(stop);
 // CHECK-NEXT:            t = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
             cudaEventRecord(stop, 0);
             cudaEventSynchronize(stop);
@@ -266,23 +265,23 @@ void barr(int maxCalls) {
     time[i] = 0.0;
   }
 
-// CHECK: *evtStart[0] = q_ct1.ext_oneapi_submit_barrier();
+// CHECK: dpct::sycl_event_record( evtStart[0], &q_ct1 );
   cudaEventRecord( evtStart[0], 0 );
   kernelFunc<<<1, 1>>>();
-// CHECK:   *evtEnd[0] = q_ct1.ext_oneapi_submit_barrier();
+// CHECK:   dpct::sycl_event_record( evtEnd[0], &q_ct1 );
   cudaEventRecord( evtEnd[0], 0 );
 
-// CHECK: *evtStart[1] = q_ct1.ext_oneapi_submit_barrier();
+// CHECK: dpct::sycl_event_record( evtStart[1], &q_ct1 );
   cudaEventRecord( evtStart[1], 0 );
 
   kernelFunc<<<1, 1>>>();
-// CHECK: *evtEnd[1] = q_ct1.ext_oneapi_submit_barrier();
+// CHECK: dpct::sycl_event_record( evtEnd[1], &q_ct1 );
   cudaEventRecord( evtEnd[1], 0 );
 
-// CHECK: *evtStart[2] = q_ct1.ext_oneapi_submit_barrier();
+// CHECK: dpct::sycl_event_record( evtStart[2], &q_ct1 );
   cudaEventRecord( evtStart[2], 0 );
   kernelFunc<<<1, 1>>>();
-// CHECK: *evtEnd[2] = q_ct1.ext_oneapi_submit_barrier();
+// CHECK: dpct::sycl_event_record( evtEnd[2], &q_ct1 );
   cudaEventRecord( evtEnd[2], 0 );
 
 // CHECK: dev_ct1.queues_wait_and_throw();
@@ -386,7 +385,7 @@ void test_1999(void* ref_image, void* cur_image,
     cudaEvent_t sad_calc_start, sad_calc_stop;
     cudaEventCreate(&sad_calc_start);
     cudaEventCreate(&sad_calc_stop);
-// CHECK:    *sad_calc_start = q_ct1.ext_oneapi_submit_barrier();
+// CHECK:    dpct::sycl_event_record(sad_calc_start);
     cudaEventRecord(sad_calc_start);
     dim3 foo_kernel_1_threads_in_block;
     dim3 foo_kernel_1_blocks_in_grid;
@@ -402,7 +401,7 @@ void test_1999(void* ref_image, void* cur_image,
                                                   image_height_macroblocks,
                                                   imgRef);
 
-// CHECK:    *sad_calc_stop = q_ct1.ext_oneapi_submit_barrier();
+// CHECK:    dpct::sycl_event_record(sad_calc_stop);
     cudaEventRecord(sad_calc_stop);
 
 // CHECK:    dpct::event_ptr sad_calc_8_start, sad_calc_8_stop;
@@ -410,7 +409,7 @@ void test_1999(void* ref_image, void* cur_image,
 
     cudaEventCreate(&sad_calc_8_start);
     cudaEventCreate(&sad_calc_8_stop);
-// CHECK:    *sad_calc_8_start = q_ct1.ext_oneapi_submit_barrier();
+// CHECK:    dpct::sycl_event_record(sad_calc_8_start);
     cudaEventRecord(sad_calc_8_start);
     dim3 foo_kernel_2_threads_in_block;
     dim3 foo_kernel_2_blocks_in_grid;
@@ -424,7 +423,7 @@ void test_1999(void* ref_image, void* cur_image,
       foo_kernel_2_blocks_in_grid,
       foo_kernel_2_threads_in_block>>>(d_sads, image_width_macroblocks,
                                             image_height_macroblocks);
-// CHECK:    *sad_calc_8_stop = q_ct1.ext_oneapi_submit_barrier();
+// CHECK:    dpct::sycl_event_record(sad_calc_8_stop);
     cudaEventRecord(sad_calc_8_stop);
 
 
@@ -446,7 +445,7 @@ void test_1999(void* ref_image, void* cur_image,
       foo_kernel_3_blocks_in_grid,
       foo_kernel_3_threads_in_block>>>(d_sads, image_width_macroblocks,
                                              image_height_macroblocks);
-// CHECK:    *sad_calc_16_stop = q_ct1.ext_oneapi_submit_barrier();
+// CHECK:    dpct::sycl_event_record(sad_calc_16_stop);
     cudaEventRecord(sad_calc_16_stop);
 
     cudaMallocHost((void **)h_sads, nsads * sizeof(unsigned short));
@@ -477,13 +476,13 @@ void foo_test_1983() {
 
   for (int i = 0; i < repeat; i++) {
     kernel<<<1, 1, 0, stream1>>>();
-// CHECK:    *event1 = stream1->ext_oneapi_submit_barrier();
+// CHECK:    dpct::sycl_event_record(event1, stream1);
     cudaEventRecord(event1, stream1);
     kernel<<<1, 1, 0, stream2>>>();
 
-// CHECK:    *event2 = stream2->ext_oneapi_submit_barrier();
-// CHECK-NEXT:    event1->wait_and_throw();
-// CHECK-NEXT:    event2->wait_and_throw();
+// CHECK:    dpct::sycl_event_record(event2, stream2);
+// CHECK-NEXT:    dpct::sycl_event_synchronize(event1);
+// CHECK-NEXT:    dpct::sycl_event_synchronize(event2);
     cudaEventRecord(event2, stream2);
     cudaEventSynchronize(event1);
     cudaEventSynchronize(event2);
@@ -507,15 +506,15 @@ template <class T, class vecT> void foo_test_2131() {
 
   for (int k = 0; k < passes; k++) {
     float totalScanTime = 0.0f;
-  // CHECK:     SAFE_CALL(DPCT_CHECK_ERROR(*start = q_ct1.ext_oneapi_submit_barrier()));
+  // CHECK:     SAFE_CALL(DPCT_CHECK_ERROR(dpct::sycl_event_record(start, &q_ct1)));
     SAFE_CALL(cudaEventRecord(start, 0));
     for (int j = 0; j < iters; j++) {
       reduce<T, 256>
           <<<num_blocks, num_threads, smem_size>>>(d_idata, d_block_sums, size);
     }
 
-  // CHECK: SAFE_CALL(DPCT_CHECK_ERROR(*stop = q_ct1.ext_oneapi_submit_barrier()));
-  // CHECK: SAFE_CALL(DPCT_CHECK_ERROR(stop->wait_and_throw()));
+  // CHECK: SAFE_CALL(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop, &q_ct1)));
+  // CHECK: SAFE_CALL(DPCT_CHECK_ERROR(dpct::sycl_event_synchronize(stop)));
   // CHECK: totalScanTime = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
     SAFE_CALL(cudaEventRecord(stop, 0));
     SAFE_CALL(cudaEventSynchronize(stop));

--- a/clang/test/dpct/tm-usm-restricted-profiling.cu
+++ b/clang/test/dpct/tm-usm-restricted-profiling.cu
@@ -43,7 +43,7 @@ int main() {
     cudaEventCreate(&start);
     cudaEventCreate(&stop);
 
- // CHECK:    dpct::sycl_event_record(start, &q_ct1);
+ // CHECK:    dpct::sync_barrier(start, &q_ct1);
     cudaEventRecord(start, 0);
 
   // CHECK: q_ct1.memcpy(da, ha, N*sizeof(int));
@@ -53,7 +53,7 @@ int main() {
   // CHECK: stream->memcpy(da, ha, N*sizeof(int));
     cudaMemcpyAsync(da, ha, N*sizeof(int), cudaMemcpyHostToDevice, stream);
 
-  // CHECK:    dpct::sycl_event_record(stop, &q_ct1);
+  // CHECK:    dpct::sync_barrier(stop, &q_ct1);
   // CHECK-NEXT:   stop->wait_and_throw();
   // CHECK-NEXT:   elapsedTime = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
     cudaEventRecord(stop, 0);
@@ -91,7 +91,7 @@ void foo_usm() {
   int *gpu_t, *host_t, n = 10;
   cudaEvent_t start, stop;
 
-// CHECK:  SAFE_CALL(DPCT_CHECK_ERROR(dpct::sycl_event_record(start, &q_ct1)));
+// CHECK:  SAFE_CALL(DPCT_CHECK_ERROR(dpct::sync_barrier(start, &q_ct1)));
   SAFE_CALL(cudaEventRecord(start, 0));
 
 // CHECK:  SAFE_CALL(DPCT_CHECK_ERROR(s1->memcpy(gpu_t, host_t, n * sizeof(int))));
@@ -100,7 +100,7 @@ void foo_usm() {
 // CHECK:  /*
 // CHECK-NEXT:  DPCT1024:{{[0-9]+}}: The original code returned the error code that was further consumed by the program logic. This original code was replaced with 0. You may need to rewrite the program logic consuming the error code.
 // CHECK-NEXT:  */
-// CHECK-NEXT:  SAFE_CALL(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop, &q_ct1)));
+// CHECK-NEXT:  SAFE_CALL(DPCT_CHECK_ERROR(dpct::sync_barrier(stop, &q_ct1)));
 // CHECK-NEXT:  SAFE_CALL(DPCT_CHECK_ERROR(stop->wait_and_throw()));
   SAFE_CALL(cudaEventRecord(stop, 0));
   SAFE_CALL(cudaEventSynchronize(stop));
@@ -160,7 +160,7 @@ void foo()
             // Test 1: Repeated Linear Access
             float t = 0.0f;
 
-// CHECK:            dpct::sycl_event_record(start, &q_ct1);
+// CHECK:            dpct::sync_barrier(start, &q_ct1);
             cudaEventRecord(start, 0);
             // read texels from texture
             for (int iter = 0; iter < iterations; iter++)
@@ -176,7 +176,7 @@ void foo()
                                                     width);
             }
 
-// CHECK:             dpct::sycl_event_record(stop, &q_ct1);
+// CHECK:             dpct::sync_barrier(stop, &q_ct1);
 // CHECK-NEXT:             stop->wait_and_throw();
 // CHECK-NEXT:             t = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
             cudaEventRecord(stop, 0);
@@ -188,7 +188,7 @@ void foo()
                     cudaMemcpyDeviceToHost);
 
             // Test 2 Repeated Cache Access
-// CHECK:            dpct::sycl_event_record(start, &q_ct1);
+// CHECK:            dpct::sync_barrier(start, &q_ct1);
             cudaEventRecord(start, 0);
             for (int iter = 0; iter < iterations; iter++)
             {
@@ -204,7 +204,7 @@ void foo()
                         (kernelRepFactor, d_out);
             }
 
-// CHECK:            dpct::sycl_event_record(stop, &q_ct1);
+// CHECK:            dpct::sync_barrier(stop, &q_ct1);
 // CHECK-NEXT:            stop->wait_and_throw();
 // CHECK-NEXT:            t = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
             cudaEventRecord(stop, 0);
@@ -216,7 +216,7 @@ void foo()
                     cudaMemcpyDeviceToHost);
 
             // Test 3 Repeated "Random" Access
-// CHECK:            dpct::sycl_event_record(start, &q_ct1);
+// CHECK:            dpct::sync_barrier(start, &q_ct1);
             cudaEventRecord(start, 0);
 
             // read texels from texture
@@ -234,7 +234,7 @@ void foo()
                                 (kernelRepFactor, d_out, width, height);
             }
 
-// CHECK:            dpct::sycl_event_record(stop, &q_ct1);
+// CHECK:            dpct::sync_barrier(stop, &q_ct1);
 // CHECK-NEXT:            stop->wait_and_throw();
 // CHECK-NEXT:            t = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
             cudaEventRecord(stop, 0);
@@ -265,23 +265,23 @@ void barr(int maxCalls) {
     time[i] = 0.0;
   }
 
-// CHECK: dpct::sycl_event_record( evtStart[0], &q_ct1 );
+// CHECK: dpct::sync_barrier( evtStart[0], &q_ct1 );
   cudaEventRecord( evtStart[0], 0 );
   kernelFunc<<<1, 1>>>();
-// CHECK:   dpct::sycl_event_record( evtEnd[0], &q_ct1 );
+// CHECK:   dpct::sync_barrier( evtEnd[0], &q_ct1 );
   cudaEventRecord( evtEnd[0], 0 );
 
-// CHECK: dpct::sycl_event_record( evtStart[1], &q_ct1 );
+// CHECK: dpct::sync_barrier( evtStart[1], &q_ct1 );
   cudaEventRecord( evtStart[1], 0 );
 
   kernelFunc<<<1, 1>>>();
-// CHECK: dpct::sycl_event_record( evtEnd[1], &q_ct1 );
+// CHECK: dpct::sync_barrier( evtEnd[1], &q_ct1 );
   cudaEventRecord( evtEnd[1], 0 );
 
-// CHECK: dpct::sycl_event_record( evtStart[2], &q_ct1 );
+// CHECK: dpct::sync_barrier( evtStart[2], &q_ct1 );
   cudaEventRecord( evtStart[2], 0 );
   kernelFunc<<<1, 1>>>();
-// CHECK: dpct::sycl_event_record( evtEnd[2], &q_ct1 );
+// CHECK: dpct::sync_barrier( evtEnd[2], &q_ct1 );
   cudaEventRecord( evtEnd[2], 0 );
 
 // CHECK: dev_ct1.queues_wait_and_throw();
@@ -385,7 +385,7 @@ void test_1999(void* ref_image, void* cur_image,
     cudaEvent_t sad_calc_start, sad_calc_stop;
     cudaEventCreate(&sad_calc_start);
     cudaEventCreate(&sad_calc_stop);
-// CHECK:    dpct::sycl_event_record(sad_calc_start);
+// CHECK:    dpct::sync_barrier(sad_calc_start);
     cudaEventRecord(sad_calc_start);
     dim3 foo_kernel_1_threads_in_block;
     dim3 foo_kernel_1_blocks_in_grid;
@@ -401,7 +401,7 @@ void test_1999(void* ref_image, void* cur_image,
                                                   image_height_macroblocks,
                                                   imgRef);
 
-// CHECK:    dpct::sycl_event_record(sad_calc_stop);
+// CHECK:    dpct::sync_barrier(sad_calc_stop);
     cudaEventRecord(sad_calc_stop);
 
 // CHECK:    dpct::event_ptr sad_calc_8_start, sad_calc_8_stop;
@@ -409,7 +409,7 @@ void test_1999(void* ref_image, void* cur_image,
 
     cudaEventCreate(&sad_calc_8_start);
     cudaEventCreate(&sad_calc_8_stop);
-// CHECK:    dpct::sycl_event_record(sad_calc_8_start);
+// CHECK:    dpct::sync_barrier(sad_calc_8_start);
     cudaEventRecord(sad_calc_8_start);
     dim3 foo_kernel_2_threads_in_block;
     dim3 foo_kernel_2_blocks_in_grid;
@@ -423,7 +423,7 @@ void test_1999(void* ref_image, void* cur_image,
       foo_kernel_2_blocks_in_grid,
       foo_kernel_2_threads_in_block>>>(d_sads, image_width_macroblocks,
                                             image_height_macroblocks);
-// CHECK:    dpct::sycl_event_record(sad_calc_8_stop);
+// CHECK:    dpct::sync_barrier(sad_calc_8_stop);
     cudaEventRecord(sad_calc_8_stop);
 
 
@@ -445,7 +445,7 @@ void test_1999(void* ref_image, void* cur_image,
       foo_kernel_3_blocks_in_grid,
       foo_kernel_3_threads_in_block>>>(d_sads, image_width_macroblocks,
                                              image_height_macroblocks);
-// CHECK:    dpct::sycl_event_record(sad_calc_16_stop);
+// CHECK:    dpct::sync_barrier(sad_calc_16_stop);
     cudaEventRecord(sad_calc_16_stop);
 
     cudaMallocHost((void **)h_sads, nsads * sizeof(unsigned short));
@@ -476,11 +476,11 @@ void foo_test_1983() {
 
   for (int i = 0; i < repeat; i++) {
     kernel<<<1, 1, 0, stream1>>>();
-// CHECK:    dpct::sycl_event_record(event1, stream1);
+// CHECK:    dpct::sync_barrier(event1, stream1);
     cudaEventRecord(event1, stream1);
     kernel<<<1, 1, 0, stream2>>>();
 
-// CHECK:    dpct::sycl_event_record(event2, stream2);
+// CHECK:    dpct::sync_barrier(event2, stream2);
 // CHECK-NEXT:    event1->wait_and_throw();
 // CHECK-NEXT:    event2->wait_and_throw();
     cudaEventRecord(event2, stream2);
@@ -506,14 +506,14 @@ template <class T, class vecT> void foo_test_2131() {
 
   for (int k = 0; k < passes; k++) {
     float totalScanTime = 0.0f;
-  // CHECK:     SAFE_CALL(DPCT_CHECK_ERROR(dpct::sycl_event_record(start, &q_ct1)));
+  // CHECK:     SAFE_CALL(DPCT_CHECK_ERROR(dpct::sync_barrier(start, &q_ct1)));
     SAFE_CALL(cudaEventRecord(start, 0));
     for (int j = 0; j < iters; j++) {
       reduce<T, 256>
           <<<num_blocks, num_threads, smem_size>>>(d_idata, d_block_sums, size);
     }
 
-  // CHECK: SAFE_CALL(DPCT_CHECK_ERROR(dpct::sycl_event_record(stop, &q_ct1)));
+  // CHECK: SAFE_CALL(DPCT_CHECK_ERROR(dpct::sync_barrier(stop, &q_ct1)));
   // CHECK: SAFE_CALL(DPCT_CHECK_ERROR(stop->wait_and_throw()));
   // CHECK: totalScanTime = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
     SAFE_CALL(cudaEventRecord(stop, 0));


### PR DESCRIPTION
Add one new helper function sycl_event_record() to map cudaEventRecord()

