### PR TITLE
[DOC] Add Migrate a CMake Build Script

### DIFF
--- a/docs/dev_guide/migration.rst
+++ b/docs/dev_guide/migration.rst
@@ -24,6 +24,7 @@ Features to Support Migration
 * :ref:`gen_comp_db`
 * :ref:`inc_mig`
 * :ref:`migration_rules`
+* :ref:`mig_cmake`
 * :ref:`debug_codepin`
 
 
@@ -41,6 +42,7 @@ Learn how to :ref:`query_map`.
    migration/generate-compilation-db
    migration/incremental-migration
    migration/migration-rules
+   migration/migrate-cmake-build
    migration/debug-with-codepin
    migration/API-Mapping-query-guide
 

--- a/docs/dev_guide/migration/migrate-cmake-build.rst
+++ b/docs/dev_guide/migration/migrate-cmake-build.rst
@@ -54,7 +54,8 @@ migration rules, or write a custom user-defined migration rule.
 Use Predefined Migration Rules for CMake Build Script
 *****************************************************
 
-The tool provides a set of predefined migration rules in the ``extensions/cmake``
+The tool provides a set of predefined migration rules in the ``extensions/cmake_rules``
+
 folder on the install path. These predefined rules may be helpful in migrating your
 CMake build script.
 

--- a/docs/dev_guide/migration/migrate-cmake-build.rst
+++ b/docs/dev_guide/migration/migrate-cmake-build.rst
@@ -1,0 +1,129 @@
+.. _mig_cmake:
+
+Migrate a CMake Build Script
+============================
+
+|tool_name| supports migration of CMake build scripts by migrating a CUDA\*
+specific CMake syntax to the SYCL\* version. The migration capability can be
+extended and customized with a user-defined migration rule, which can be
+loaded with option ``--rule-file``. The tool provides two command line options
+to trigger the migration of the CMake build script:
+
+.. list-table::
+   :widths: 50 50
+   :header-rows: 1
+
+   * - Option
+     - Description
+   * - ``--migrate-build-script=CMake``
+     - EXPERIMENTAL.
+       Migrate the CMake file(s).
+   * - ``--migrate-build-script-only``
+     - EXPERIMENTAL.
+       Only migrate the build script(s). Default: off.
+
+Examples
+--------
+
+**Example 1:** Migrate the CMake build script of a CUDA project:
+
+.. code-block::
+
+   dpct -in-root=./ -out-root=out  -migrate-build-script-only
+
+**Example 2:** Migrate the CMake build script of a CUDA project using a user-defined
+migration rule defined in ``rule_file.yaml``:
+
+.. code-block::
+
+   dpct -in-root=./ -out-root=out  -migrate-build-script-only  --rule-file=rule_file.yaml
+
+**Example 3:** Migrate the CMake build script of a CUDA project together with source code migration:
+
+.. code-block::
+
+   dpct -p=./ -in-root=./ -out-root=out  --migrate-build-script=CMake
+
+
+Customize Migration of CMake Build Script
+-----------------------------------------
+
+To customize migration of a CMake build script, you can use the predefined built-in
+migration rules, or write a custom user-defined migration rule.
+
+Use Predefined Migration Rules for CMake Build Script
+*****************************************************
+
+The tool provides a set of predefined migration rules in the ``extensions/cmake``
+folder on the install path. These predefined rules may be helpful in migrating your
+CMake build script.
+
+Use the ``–rule-file`` option to specify the use of a predefined migration rule.
+
+Write a Custom User-defined Migration Rule
+******************************************
+
+You can customize the migration of your CMake file by defining a user-defined
+migration rule. Detailed information about writing your own user-defined migration
+rule, is provided in the :ref:`user-def-rules` section.
+
+The following example demonstrates a user-defined CMake build script migration
+rule. The functionality of each field of the rule is detailed in the comment
+column. The example rule targets the CMake macro ``cuda_compile_ptx`` for migration,
+migrating ``cuda_compile_ptx(obj_file kernel.cu)`` to
+``dpct_helper_compile_sycl_code (obj_file kernel.dp.cpp)``.
+
+.. note::
+
+   ``dpct_helper_compile_sycl_code()`` is provided by the tool. It is located in
+   ``dpct.cmake`` in the cmake folder on the install path.
+
+.. code-block:: none
+
+   - Rule: rule_cuda_compile_ptx              # Specify the unique name of the
+                                              rule
+     Kind: CMakeRule                          # The kind of the rule
+     Priority: Fallback                       # The priority of the rule
+                                              (Takeover, Default, Fallback)
+     CmakeSyntax: cuda_compile_ptx            # The CMake syntax target to
+                                              migrate
+     In: cuda_compile_ptx(${device} ${value}) # Specify target pattern of
+                                              cuda_compile_ptx will be
+                                              migrated
+     Out: dpct_helper_compile_sycl_code(${device} ${value}) # Specify the
+                                                            content of to migrate the content specified in “In” file
+        Subrules:                             # Subrules to further process
+                                              the field(s) of pattern
+                                              specified in “In” field
+          value:                              # Process the value file of
+                                              pattern specified in “In” file
+            MatchMode: Full                   # Specify the match mode of the
+                                              sub rule Full or Partial, default is Partial
+            In: ${arg}.cu                     # Replace the file name in *.cu
+                                              pattern to *.cp.cpp
+            Out: ${arg}.dp.cpp
+
+For additional information on defining user-defined migration rules, refer to :ref:`migration_rules`.
+
+To write a user defined migration rule for CMake syntax:
+
+#. Identify the CMake CUDA specific syntax that needs to be migrated. It is
+   important to understand the usage case(s) of the CMake CUDA specific syntax.
+
+#. Figure out the functionally equivalent SYCL-side mapping for CUDA CMake syntax,
+   and test the mapping. If SYCL side functionally equivalent mapping is not available,
+   consider adding a helper function, such as the helper function available in the
+   ``dpct.cmake`` file on the tool install path.
+
+#. Abstract the CMake syntax mapping between CUDA and SYCL into a pattern-based
+   description in a yaml-based rule.
+
+#. Test the functionality of the rule with lit cases by running the following command to
+   make sure the migration rule is working as expected. If not, you may need to refine
+   the migration rule defined in step 2.
+
+   .. code-block::
+
+      dpct -in-root=./  -out-root out -rule-file=new_rule.yaml test.cmake
+
+#. Use the new rule(s) to migrate your project.

--- a/docs/dev_guide/migration/migration-rules.rst
+++ b/docs/dev_guide/migration/migration-rules.rst
@@ -33,6 +33,8 @@ specify multiple migration rule files. For example:
 
 See the :ref:`cmd_opt_ref` for additional information.
 
+.. _user-def-rules:
+
 Write User-defined Migration Rules
 ----------------------------------
 

--- a/docs/dev_guide/migration/migration-rules.rst
+++ b/docs/dev_guide/migration/migration-rules.rst
@@ -56,8 +56,14 @@ Migration rules are specified in YAML files. A single rule file may contain mult
      - Required. Specifies the priority of the rule: ``Takeover`` > ``Default`` > ``Fallback``.
        When there are rule conflicts, the rule with higher priority will take precedence.
    * - Kind
-     - ``Macro`` | ``API`` | ``Header`` | ``Type`` | ``Class`` | ``Enum`` | ``DisableAPIMigration`` | ``PatternRewriter``
+     - ``Macro`` | ``API`` | ``Header`` | ``Type`` | ``Class`` | ``Enum`` | ``DisableAPIMigration`` | ``PatternRewriter`` | ``CMakeRule``
      - Required. Specifies the rule type.
+   * - CmakeSyntax
+     - String value
+     - Required. Specify the CMake syntax name that will be migrated. Use the unique name for the CMake syntax.
+   * - MatchMode
+     - ``Partial`` | ``Full``
+     - Required. Specify the match mode with full word match or partial word match. If not specified, partial match mode will be used.
    * - In
      - String value
      - Required. Specifies the target name in the input source code.


### PR DESCRIPTION
Add new topic Migrate a CMake Build Script.
Small edits to formatting/text for clarity, scannability, and consistency with existing content.