### PR TITLE
[SYCLomatic] Disable lit test math_functions_test.cu and texture_object_bindless_image.cu temporarily due to compiler update

### DIFF
--- a/clang/test/dpct/math-functions.cu
+++ b/clang/test/dpct/math-functions.cu
@@ -1,3 +1,5 @@
+// UNSUPPORTED: system-windows
+// UNSUPPORTED: system-linux
 // RUN: dpct --format-range=none --usm-level=none -out-root %T/math-functions %s --cuda-include-path="%cuda-path/include" --sycl-named-lambda -- -x cuda --cuda-host-only
 // RUN: FileCheck --input-file %T/math-functions/math-functions.dp.cpp --match-full-lines %s
 

--- a/clang/test/dpct/texture/texture_object_bindless_image.cu
+++ b/clang/test/dpct/texture/texture_object_bindless_image.cu
@@ -1,3 +1,5 @@
+// UNSUPPORTED: system-windows
+// UNSUPPORTED: system-linux
 // RUN: dpct --format-range=none --use-experimental-features=bindless_images -out-root %T/texture/texture_object_bindless_image %s --cuda-include-path="%cuda-path/include" -- -x cuda --cuda-host-only -std=c++14
 // RUN: FileCheck --input-file %T/texture/texture_object_bindless_image/texture_object_bindless_image.dp.cpp --match-full-lines %s
 // RUN: %if build_lit %{icpx -c -fsycl -DBUILD_TEST %T/texture/texture_object_bindless_image/texture_object_bindless_image.dp.cpp -o %T/texture/texture_object_bindless_image/texture_object_bindless_image.dp.o %}


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>