### PR TITLE
[SYCLomatic] Add queue empty extension to the value set of option "--no-dpcpp-extensions=<value>" and refine migration of cudaStreamQuery if the queue empty extension is enabled

### DIFF
--- a/clang/include/clang/DPCT/DPCTOptions.inc
+++ b/clang/include/clang/DPCT/DPCTOptions.inc
@@ -354,7 +354,10 @@ DPCT_ENUM_OPTION(DPCT_OPT_TYPE(static llvm::cl::bits<DPCPPExtensionsDefaultEnabl
                                      false),
              DPCT_OPT_ENUM("assert",
                                      int(DPCPPExtensionsDefaultEnabled::ExtDE_Assert),
-                                     "Use the assert extension.",
+                                     "Use the assert extension.", false),
+             DPCT_OPT_ENUM("queue_empty",
+                                     int(DPCPPExtensionsDefaultEnabled::ExtDE_QueueEmpty),
+                                     "Use the queue empty extension.",
                                      false)
            ),
            llvm::cl::desc("A comma-separated list of extensions not to be used in migrated code.\n"

--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -8366,6 +8366,36 @@ void StreamAPICallRule::runRule(const MatchFinder::MatchResult &Result) {
              FuncName == "cudaStreamEndCapture" ||
              FuncName == "cudaStreamIsCapturing" ||
              FuncName == "cudaStreamQuery") {
+
+    // if extension feature sycl_ext_oneapi_queue_empty is used, member
+    // functions "ext_oneapi_empty" in SYCL queue is used to map
+    // cudaStreamQuery.
+    if (FuncName == "cudaStreamQuery" && DpctGlobalInfo::useQueueEmpty()) {
+      auto StreamArg = CE->getArg(0);
+      bool IsDefaultStream = isDefaultStream(StreamArg);
+      std::string StreamName;
+      std::string ReplStr;
+      if (IsDefaultStream) {
+        if (isPlaceholderIdxDuplicated(CE))
+          return;
+        int Index = DpctGlobalInfo::getHelperFuncReplInfoIndexThenInc();
+        buildTempVariableMap(Index, CE, HelperFuncType::HFT_DefaultQueue);
+        StreamName = "{{NEEDREPLACEQ" + std::to_string(Index) + "}}.";
+        ReplStr = StreamName + "ext_oneapi_empty()";
+      } else {
+        StreamName = getStmtSpelling(StreamArg);
+        if (needExtraParensInMemberExpr(StreamArg)) {
+          StreamName = "(" + StreamName + ")";
+        }
+        ReplStr = StreamName + "->" + "ext_oneapi_empty()";
+      }
+      if (IsAssigned) {
+        ReplStr = "DPCT_CHECK_ERROR((" + ReplStr + "))";
+      }
+      emplaceTransformation(new ReplaceStmt(CE, std::move(ReplStr)));
+      return;
+    }
+
     auto Msg = MapNames::RemovedAPIWarningMessage.find(FuncName);
     if (IsAssigned) {
       report(CE->getBeginLoc(), Diagnostics::FUNC_CALL_REMOVED_0, false,

--- a/clang/lib/DPCT/AnalysisInfo.h
+++ b/clang/lib/DPCT/AnalysisInfo.h
@@ -1232,6 +1232,10 @@ public:
     return getUsingExtensionDE(
         DPCPPExtensionsDefaultEnabled::ExtDE_EnqueueBarrier);
   }
+  static bool useQueueEmpty() {
+    return getUsingExtensionDE(
+        DPCPPExtensionsDefaultEnabled::ExtDE_QueueEmpty);
+  }
   static bool useCAndCXXStandardLibrariesExt() {
     return getUsingExtensionDD(
         DPCPPExtensionsDefaultDisabled::ExtDD_CCXXStandardLibrary);

--- a/clang/lib/DPCT/AnalysisInfo.h
+++ b/clang/lib/DPCT/AnalysisInfo.h
@@ -1233,8 +1233,7 @@ public:
         DPCPPExtensionsDefaultEnabled::ExtDE_EnqueueBarrier);
   }
   static bool useQueueEmpty() {
-    return getUsingExtensionDE(
-        DPCPPExtensionsDefaultEnabled::ExtDE_QueueEmpty);
+    return getUsingExtensionDE(DPCPPExtensionsDefaultEnabled::ExtDE_QueueEmpty);
   }
   static bool useCAndCXXStandardLibrariesExt() {
     return getUsingExtensionDD(

--- a/clang/lib/DPCT/IncrementalMigrationUtility.cpp
+++ b/clang/lib/DPCT/IncrementalMigrationUtility.cpp
@@ -200,6 +200,9 @@ bool printOptions(
         if (!(UValue & (1 << static_cast<unsigned>(
                             DPCPPExtensionsDefaultEnabled::ExtDE_Assert))))
           Str += "assert,";
+        if (!(UValue & (1 << static_cast<unsigned>(
+                            DPCPPExtensionsDefaultEnabled::ExtDE_QueueEmpty))))
+          Str += "queue_empty,";
       }
       if (!Str.empty()) {
         Str = "--no-dpcpp-extensions=" + Str;

--- a/clang/lib/DPCT/ValidateArguments.h
+++ b/clang/lib/DPCT/ValidateArguments.h
@@ -65,6 +65,7 @@ enum class DPCPPExtensionsDefaultEnabled : unsigned int {
   ExtDE_BFloat16,
   ExtDE_PeerAccess,
   ExtDE_Assert,
+  ExtDE_QueueEmpty,
   ExtDE_DPCPPExtensionsDefaultEnabledEnumSize
 };
 enum class DPCPPExtensionsDefaultDisabled : unsigned int {

--- a/clang/test/dpct/cuda-stream-api.cu
+++ b/clang/test/dpct/cuda-stream-api.cu
@@ -1,6 +1,6 @@
 // FIXME:
 // UNSUPPORTED: system-windows
-// RUN: dpct --usm-level=none -out-root %T/cuda-stream-api %s --cuda-include-path="%cuda-path/include" --sycl-named-lambda -- -std=c++14 -x cuda --cuda-host-only
+// RUN: dpct --usm-level=none --no-dpcpp-extensions=queue_empty -out-root %T/cuda-stream-api %s --cuda-include-path="%cuda-path/include" --sycl-named-lambda -- -std=c++14 -x cuda --cuda-host-only
 // RUN: FileCheck --input-file %T/cuda-stream-api/cuda-stream-api.dp.cpp --match-full-lines %s
 // RUN: %if build_lit %{icpx -c -fsycl -DBUILD_TEST  %T/cuda-stream-api/cuda-stream-api.dp.cpp -o %T/cuda-stream-api/cuda-stream-api.dp.o %}
 

--- a/clang/test/dpct/cuda-stream-use-ext-q-empty.cu
+++ b/clang/test/dpct/cuda-stream-use-ext-q-empty.cu
@@ -1,0 +1,25 @@
+// RUN: dpct --usm-level=none  -out-root %T/cuda-stream-use-ext-q-empty %s --cuda-include-path="%cuda-path/include" --sycl-named-lambda -- -std=c++14 -x cuda --cuda-host-only
+// RUN: FileCheck --input-file %T/cuda-stream-use-ext-q-empty/cuda-stream-use-ext-q-empty.dp.cpp --match-full-lines %s
+
+#include <cuda_runtime.h>
+#include <iostream>
+
+template <typename T>
+void my_error_checker(T ReturnValue, char const *const FuncName) {
+}
+
+#define MY_ERROR_CHECKER(CALL) my_error_checker((CALL), #CALL)
+
+template <typename FloatN, typename Float>
+static void func() {
+  cudaStream_t s0;
+  
+  // CHECK:  s0->ext_oneapi_empty();
+  // CHECK-NEXT:  MY_ERROR_CHECKER(DPCT_CHECK_ERROR((s0->ext_oneapi_empty())));
+  // CHECK-NEXT:  dpct::err0 status = cudaStreamQuery(stream);
+  // CHECK-NEXT:  status = DPCT_CHECK_ERROR((q_ct1.ext_oneapi_empty()));
+  cudaStreamQuery(s0);
+  MY_ERROR_CHECKER(cudaStreamQuery(s0));
+  cudaError_t status = cudaStreamQuery(stream);
+  status = cudaStreamQuery(0);
+}

--- a/clang/test/dpct/query_api_mapping/Runtime/test.cu
+++ b/clang/test/dpct/query_api_mapping/Runtime/test.cu
@@ -171,8 +171,8 @@
 // RUN: dpct --cuda-include-path="%cuda-path/include" --query-api-mapping=cudaStreamQuery | FileCheck %s -check-prefix=CUDASTREAMQUERY
 // CUDASTREAMQUERY: CUDA API:
 // CUDASTREAMQUERY-NEXT:   cudaStreamQuery(s /*cudaStream_t*/);
-// CUDASTREAMQUERY-NEXT: The API is Removed.
-// CUDASTREAMQUERY-EMPTY:
+// CUDASTREAMQUERY-NEXT: Is migrated to:
+// CUDASTREAMQUERY-NEXT:   s->ext_oneapi_empty();
 
 // RUN: dpct --cuda-include-path="%cuda-path/include" --query-api-mapping=cudaStreamSynchronize | FileCheck %s -check-prefix=CUDASTREAMSYNCHRONIZE
 // CUDASTREAMSYNCHRONIZE: CUDA API:


### PR DESCRIPTION
 Signed-off-by: chenwei.sun <chenwei.sun@intel.com>