### PR TITLE
[SYCLomatic][CMake] Fix space separator is missed when migrating CMake project command

### DIFF
--- a/clang/lib/DPCT/PatternRewriter.cpp
+++ b/clang/lib/DPCT/PatternRewriter.cpp
@@ -111,27 +111,6 @@ static std::string indent(const std::string &Input, int Indentation) {
   return Str;
 }
 
-static std::string dedent(const std::string &Input, int Indentation) {
-  std::stringstream OutputStream;
-  const int Size = Input.size();
-  int Index = 0;
-  int Skip = 0;
-  while (Index < Size) {
-    char Character = Input[Index];
-    if (Skip > 0 && Character == ' ') {
-      Skip--;
-      Index++;
-      continue;
-    }
-    if (Character == '\n') {
-      Skip = Indentation;
-    }
-    OutputStream << Character;
-    Index++;
-  }
-  return OutputStream.str();
-}
-
 /*
 Determines the number of pattern elements that form the suffix of a code
 element. The suffix of a code element extends up to the next code element, an
@@ -527,9 +506,8 @@ static std::optional<MatchResult> findFullMatch(const MatchPattern &Pattern,
       if (Next == -1) {
         return {};
       }
-      const int Indentation = detectIndentation(Input, Index);
-      std::string ElementContents =
-          dedent(Input.substr(Index, Next - Index), Indentation);
+
+      std::string ElementContents = Input.substr(Index, Next - Index);
 
       if (SrcFileType == SourceFileType::SFT_CMakeScript) {
         updateExtentionName(Input, Next, Result.Bindings);
@@ -607,9 +585,7 @@ static std::optional<MatchResult> findMatch(const MatchPattern &Pattern,
       if (Next == -1) {
         return {};
       }
-      const int Indentation = detectIndentation(Input, Index);
-      std::string ElementContents =
-          dedent(Input.substr(Index, Next - Index), Indentation);
+      std::string ElementContents = Input.substr(Index, Next - Index);
       if (Result.Bindings.count(Code.Name)) {
         if (Result.Bindings[Code.Name] != ElementContents) {
           return {};

--- a/clang/test/dpct/cmake_migration/case_002/expected.txt
+++ b/clang/test/dpct/cmake_migration/case_002/expected.txt
@@ -36,3 +36,14 @@ find_program(dpct_bin_path NAMES dpct PATHS)
 get_filename_component(bin_path_of_dpct ${dpct_bin_path} DIRECTORY)
 set(dpct_cmake_file_path "${bin_path_of_dpct}/../cmake/dpct.cmake")
 include(${dpct_cmake_file_path})
+
+project( tiny-cuda-nn
+	VERSION 1.7
+	DESCRIPTION "Lightning fast & tiny C++/ neural network framework"
+	LANGUAGES CXX 
+)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsycl")
+find_program(dpct_bin_path NAMES dpct PATHS)
+get_filename_component(bin_path_of_dpct ${dpct_bin_path} DIRECTORY)
+set(dpct_cmake_file_path "${bin_path_of_dpct}/../cmake/dpct.cmake")
+include(${dpct_cmake_file_path})

--- a/clang/test/dpct/cmake_migration/case_002/input.cmake
+++ b/clang/test/dpct/cmake_migration/case_002/input.cmake
@@ -13,3 +13,10 @@ VERSION 1.1.0
 LANGUAGES)
 
 project(foo)
+
+project(
+	tiny-cuda-nn
+	VERSION 1.7
+	DESCRIPTION "Lightning fast & tiny C++/CUDA neural network framework"
+	LANGUAGES CXX CUDA
+)

--- a/clang/test/dpct/cmake_migration/case_013/expected.txt
+++ b/clang/test/dpct/cmake_migration/case_013/expected.txt
@@ -1,10 +1,10 @@
 dpct_helper_compile_sycl_code(cubinfile_1 ${cufile})
 dpct_helper_compile_sycl_code( cubinfile_2 
-${cufile}
+  ${cufile}
 )
 
 dpct_helper_compile_sycl_code(cubinfiles_1 file1.dp.cpp file2.dp.cpp)
 dpct_helper_compile_sycl_code(cubinfiles_2 file1.dp.cpp 
-file2.dp.cpp)
+  file2.dp.cpp)
 
 dpct_helper_compile_sycl_code(cubinfile_1 file1.dp.cpp)


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>
