### PR TITLE
[SYCLomatic][CMake Migration] Fix find_package() related to OpenMP and MPI is not commented when extra spaces exist around its argument

### DIFF
--- a/clang/test/dpct/cmake_migration/case_008/expected.txt
+++ b/clang/test/dpct/cmake_migration/case_008/expected.txt
@@ -20,3 +20,8 @@ find_package(oneDPL REQUIRED)
 #Current YAML rule comments find_package(NVJPEG) as no SYCL equivalent lib exists
 #find_package(NVJPEG)
 #find_package(NVJPEG 9.0 REQUIRED)
+#find_package(OpenMP REQUIRED)
+#find_package(MPI  )
+#find_package(MPI REQUIRED )
+#find_package(OpenMP)
+#find_package(OpenMP REQUIRED)

--- a/clang/test/dpct/cmake_migration/case_008/input.cmake
+++ b/clang/test/dpct/cmake_migration/case_008/input.cmake
@@ -16,3 +16,8 @@ FIND_PACKAGE(OpenMP REQUIRED)
 #Current YAML rule comments find_package(NVJPEG) as no SYCL equivalent lib exists
 find_package(NVJPEG)
 find_package(NVJPEG 9.0 REQUIRED)
+find_package( OpenMP REQUIRED)
+find_package( MPI  )
+find_package(  MPI REQUIRED )
+FIND_PACKAGE( OpenMP)
+FIND_PACKAGE(  OpenMP REQUIRED)

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -85,14 +85,14 @@
   Kind: CMakeRule
   Priority: Fallback
   CmakeSyntax: find_package-mpi
-  In: find_package(${prefix}MPI${args})
+  In: find_package(${empty}MPI${args})
   Out: "#find_package(MPI${args})"
 
 - Rule: rule_find_package-omp
   Kind: CMakeRule
   Priority: Fallback
   CmakeSyntax: find_package-omp
-  In: find_package(${prefix}OpenMP${args})
+  In: find_package(${empty}OpenMP${args})
   Out: "#find_package(OpenMP${args})"
 
 - Rule: rule_find_package-nvjpeg_no_args

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -81,33 +81,19 @@
   In: find_package(CUB ${args})
   Out: find_package(oneDPL REQUIRED)
 
-- Rule: rule_find_package-mpi_no_args
-  Kind: CMakeRule
-  Priority: Fallback
-  CmakeSyntax: find_package-mpi_no_args
-  In: find_package(MPI)
-  Out: "#find_package(MPI)"
-
 - Rule: rule_find_package-mpi
   Kind: CMakeRule
   Priority: Fallback
   CmakeSyntax: find_package-mpi
-  In: find_package(MPI ${args})
-  Out: "#find_package(MPI ${args})"
-
-- Rule: rule_find_package-omp_no_args
-  Kind: CMakeRule
-  Priority: Fallback
-  CmakeSyntax: find_package-omp_no_args
-  In: find_package(OpenMP)
-  Out: "#find_package(OpenMP)"
+  In: find_package(${prefix}MPI${args})
+  Out: "#find_package(MPI${args})"
 
 - Rule: rule_find_package-omp
   Kind: CMakeRule
   Priority: Fallback
   CmakeSyntax: find_package-omp
-  In: find_package(OpenMP ${args})
-  Out: "#find_package(OpenMP ${args})"
+  In: find_package(${prefix}OpenMP${args})
+  Out: "#find_package(OpenMP${args})"
 
 - Rule: rule_find_package-nvjpeg_no_args
   Kind: CMakeRule


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>