### PR TITLE
[SYCLomatic] Fix bug that last argument in pattern rewriter does not work in CMake migration sub rules

### DIFF
--- a/clang/lib/DPCT/PatternRewriter.cpp
+++ b/clang/lib/DPCT/PatternRewriter.cpp
@@ -273,7 +273,6 @@ static int parseCodeElement(const MatchPattern &Suffix,
     }
 
     const auto Character = Input[Index];
-    printf("\t Loop: Index:%d, Value:%c\n", Index, Character);
     if(Suffix.size() == 0 && Character =='"') {
       return Index;
     }
@@ -340,8 +339,6 @@ static int parseCodeElement(const MatchPattern &Suffix,
         Index++;
       }
       if (Index >= Size) {
-        printf("Index:%d Value:[%c]\n", Index, Input[Index]);
-        printf("000000\n");
         return -1;
       }
       Index++;
@@ -375,11 +372,6 @@ static int parseCodeElement(const MatchPattern &Suffix,
 
     Index++;
   }
-  
-  if(Suffix.size() == 0) {
-    printf("Hit index [%d]\n", Index);
-  }
-
   return Suffix.size() == 0 ? Index : -1;
 }
 
@@ -591,36 +583,10 @@ static std::optional<MatchResult> findMatch(const MatchPattern &Pattern,
                           Pattern.begin() + PatternIndex + 1 +
                               Code.SuffixLength);
 
-
-#if 0 // use for debug print
-      int Count = 0;
-      printf("Suffix start:\n");
-      for (auto Element : Suffix) {
-        if (std::holds_alternative<CodeElement>(Element)) {
-          auto &Code = std::get<CodeElement>(Element);
-          printf("\t[%d]->[%s]:[%d]\n", Count, Code.Name.c_str(),
-                 Code.SuffixLength);
-        }
-        if (std::holds_alternative<LiteralElement>(Element)) {
-          const auto &Literal = std::get<LiteralElement>(Element);
-          printf("\t[%d]->[%c]\n", Count, Literal.Value);
-        }
-        if (std::holds_alternative<SpacingElement>(Element)) {
-          printf("\t[%d]->[%s]\n", Count, "space");
-        }
-        Count++;
-      }
-      printf("Suffix end.\n\n");
-#endif
-      printf("### before Index [%d] value:[%c]\n", Index, Input[Index]);
-      printf("### before Input [%s]\n", Input.c_str());
-
       int Next = parseCodeElement(Suffix, Input, Index);
-      printf("Next: [%d]\n", Next);
       if (Next == -1) {
         return {};
       }
-      printf("### after Next [%d] value:[%c]\n", Index, Input[Next]);
       std::string ElementContents = Input.substr(Index, Next - Index);
       if (Result.Bindings.count(Code.Name)) {
         if (Result.Bindings[Code.Name] != ElementContents) {
@@ -755,31 +721,6 @@ std::string applyPatternRewriter(const MetaRuleObject::PatternRewriter &PP,
   }
 
   const auto Pattern = parseMatchPattern(PP.In);
-
-
-printf("Input: [%s]\n", Input.c_str());
-#if 0 // use for debug print
-  int Count = 0;
-  printf("Pattern start:\n");
-  for (auto Element : Pattern) {
-    if (std::holds_alternative<CodeElement>(Element)) {
-      auto &Code = std::get<CodeElement>(Element);
-      printf("\t[%d]->[%s]:[%d]\n", Count, Code.Name.c_str(),
-             Code.SuffixLength);
-    }
-    if (std::holds_alternative<LiteralElement>(Element)) {
-      const auto &Literal = std::get<LiteralElement>(Element);
-      printf("\t[%d]->[%c]\n", Count, Literal.Value);
-    }
-    if (std::holds_alternative<SpacingElement>(Element)) {
-      printf("\t[%d]->[%s]\n", Count, "space");
-    }
-    Count++;
-  }
-  printf("Pattern end.\n\n");
-#endif
-
-
   const int Size = Input.size();
   int Index = 0;
   while (Index < Size) {
@@ -800,7 +741,6 @@ printf("Input: [%s]\n", Input.c_str());
     if (Result.has_value()) {
       auto &Match = Result.value();
       for (const auto &[Name, Value] : Match.Bindings) {
-        printf("### Name [%s] --> Value[%s]\n", Name.c_str(), Value.c_str());
         const auto &SubruleIterator = PP.Subrules.find(Name);
         if (SubruleIterator != PP.Subrules.end()) {
           Match.Bindings[Name] =

--- a/clang/lib/DPCT/PatternRewriter.cpp
+++ b/clang/lib/DPCT/PatternRewriter.cpp
@@ -273,7 +273,10 @@ static int parseCodeElement(const MatchPattern &Suffix,
     }
 
     const auto Character = Input[Index];
-
+    printf("\t Loop: Index:%d, Value:%c\n", Index, Character);
+    if(Suffix.size() == 0 && Character =='"') {
+      return Index;
+    }
     if (Suffix.size() > 0) {
       std::optional<MatchResult> SuffixMatch;
 
@@ -337,6 +340,8 @@ static int parseCodeElement(const MatchPattern &Suffix,
         Index++;
       }
       if (Index >= Size) {
+        printf("Index:%d Value:[%c]\n", Index, Input[Index]);
+        printf("000000\n");
         return -1;
       }
       Index++;
@@ -370,6 +375,11 @@ static int parseCodeElement(const MatchPattern &Suffix,
 
     Index++;
   }
+  
+  if(Suffix.size() == 0) {
+    printf("Hit index [%d]\n", Index);
+  }
+
   return Suffix.size() == 0 ? Index : -1;
 }
 
@@ -581,10 +591,36 @@ static std::optional<MatchResult> findMatch(const MatchPattern &Pattern,
                           Pattern.begin() + PatternIndex + 1 +
                               Code.SuffixLength);
 
+
+#if 0 // use for debug print
+      int Count = 0;
+      printf("Suffix start:\n");
+      for (auto Element : Suffix) {
+        if (std::holds_alternative<CodeElement>(Element)) {
+          auto &Code = std::get<CodeElement>(Element);
+          printf("\t[%d]->[%s]:[%d]\n", Count, Code.Name.c_str(),
+                 Code.SuffixLength);
+        }
+        if (std::holds_alternative<LiteralElement>(Element)) {
+          const auto &Literal = std::get<LiteralElement>(Element);
+          printf("\t[%d]->[%c]\n", Count, Literal.Value);
+        }
+        if (std::holds_alternative<SpacingElement>(Element)) {
+          printf("\t[%d]->[%s]\n", Count, "space");
+        }
+        Count++;
+      }
+      printf("Suffix end.\n\n");
+#endif
+      printf("### before Index [%d] value:[%c]\n", Index, Input[Index]);
+      printf("### before Input [%s]\n", Input.c_str());
+
       int Next = parseCodeElement(Suffix, Input, Index);
+      printf("Next: [%d]\n", Next);
       if (Next == -1) {
         return {};
       }
+      printf("### after Next [%d] value:[%c]\n", Index, Input[Next]);
       std::string ElementContents = Input.substr(Index, Next - Index);
       if (Result.Bindings.count(Code.Name)) {
         if (Result.Bindings[Code.Name] != ElementContents) {
@@ -719,6 +755,31 @@ std::string applyPatternRewriter(const MetaRuleObject::PatternRewriter &PP,
   }
 
   const auto Pattern = parseMatchPattern(PP.In);
+
+
+printf("Input: [%s]\n", Input.c_str());
+#if 0 // use for debug print
+  int Count = 0;
+  printf("Pattern start:\n");
+  for (auto Element : Pattern) {
+    if (std::holds_alternative<CodeElement>(Element)) {
+      auto &Code = std::get<CodeElement>(Element);
+      printf("\t[%d]->[%s]:[%d]\n", Count, Code.Name.c_str(),
+             Code.SuffixLength);
+    }
+    if (std::holds_alternative<LiteralElement>(Element)) {
+      const auto &Literal = std::get<LiteralElement>(Element);
+      printf("\t[%d]->[%c]\n", Count, Literal.Value);
+    }
+    if (std::holds_alternative<SpacingElement>(Element)) {
+      printf("\t[%d]->[%s]\n", Count, "space");
+    }
+    Count++;
+  }
+  printf("Pattern end.\n\n");
+#endif
+
+
   const int Size = Input.size();
   int Index = 0;
   while (Index < Size) {
@@ -739,6 +800,7 @@ std::string applyPatternRewriter(const MetaRuleObject::PatternRewriter &PP,
     if (Result.has_value()) {
       auto &Match = Result.value();
       for (const auto &[Name, Value] : Match.Bindings) {
+        printf("### Name [%s] --> Value[%s]\n", Name.c_str(), Value.c_str());
         const auto &SubruleIterator = PP.Subrules.find(Name);
         if (SubruleIterator != PP.Subrules.end()) {
           Match.Bindings[Name] =

--- a/clang/test/dpct/cmake_migration/case_021/expected.txt
+++ b/clang/test/dpct/cmake_migration/case_021/expected.txt
@@ -5,3 +5,8 @@ add_compile_options(-std=c++17)
 #Currently we use Yaml based migartion rule to migarte -std=c++22 down to -std=c++17.
 #We will implement an implicit migration rule to fix this issue in future.
 #add_compile_options(-std=c++22)
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++22")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+add_link_options("")

--- a/clang/test/dpct/cmake_migration/case_021/input.cmake
+++ b/clang/test/dpct/cmake_migration/case_021/input.cmake
@@ -5,3 +5,8 @@ add_compile_options(-std=c++17)
 #Currently we use Yaml based migartion rule to migarte -std=c++22 down to -std=c++17.
 #We will implement an implicit migration rule to fix this issue in future.
 #add_compile_options(-std=c++22)
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++22")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+add_link_options("--add-arch=sm_70")

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -881,7 +881,6 @@
       In:  -std=c++${version}
       Out: -std=c++17
 
-
 - Rule: rule_add_link_options_add_arch
   Kind: CMakeRule
   Priority: Fallback

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -868,3 +868,29 @@
   CmakeSyntax: CUDA_VERSION
   In: ${command_name}(CUDA_VERSION ${rest_args})
   Out: ${command_name}(COMPATIBILITY_VERSION ${rest_args})
+
+- Rule: rule_user_defined_variable
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: user_defined_variable
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      In:  -std=c++${version}
+      Out: -std=c++17
+
+
+- Rule: rule_add_link_options_add_arch
+  Kind: CMakeRule
+  Priority: Fallback
+  CmakeSyntax: add_arch_add_link_options
+  In: add_link_options(${options})
+  Out: add_link_options(${options})
+  Subrules:
+    options:
+      In: --add-arch=${arch}
+      Out: ""
+      MatchMode: Partial
+      RuleId: "remove_add_arch"


### PR DESCRIPTION
 Signed-off-by: chenwei.sun <chenwei.sun@intel.com>
