### PR TITLE
Added migration support for CMake CUDA library variables and targets

### DIFF
--- a/clang/test/dpct/cmake_migration/case_032/expected.txt
+++ b/clang/test/dpct/cmake_migration/case_032/expected.txt
@@ -29,3 +29,108 @@ else ()
     set(LLAMA_EXTRA_LIBS ${LLAMA_EXTRA_LIBS}  ${MKL_LIB} ${DNN_LIB})
 endif()
 set(LLAMA_EXTRA_LIBS ${LLAMA_EXTRA_LIBS}  ${MKL_LIB} ${DNN_LIB})
+
+set(LIBS ${LIBS}
+    
+    
+    ${MKL_LIB}
+    
+    
+    
+    
+    
+)
+
+target_link_libraries(${target}
+    
+    ${MKL_LIB}
+    ${MKL_LIB}
+    
+    
+    
+    
+    
+    
+)
+
+link_libraries(PUBLIC
+    ${MKL_LIB}
+    ${MKL_LIB}
+    
+    
+    
+    
+    
+    
+    
+    
+)
+
+set(LIBS ${LIBS}
+    
+    
+    
+    
+    
+    ${MKL_LIB}
+    
+    
+    
+    
+    
+    
+    
+    ${MKL_LIB}
+    
+    
+    
+    ${MKL_LIB}
+    
+    
+)
+
+target_link_libraries(${target}
+    
+    
+    
+    ${MKL_LIB}
+    
+    
+    ${MKL_LIB}
+    
+    
+    
+    
+    
+    ${MKL_LIB}
+    
+    
+    
+    
+    
+    ${MKL_LIB}
+    
+    
+)
+
+link_libraries(PUBLIC
+    ${MKL_LIB}
+    
+    
+    
+    
+    
+    
+    
+    
+    ${MKL_LIB}
+    
+    
+    
+    
+    ${MKL_LIB}
+    
+    
+    
+    ${MKL_LIB}
+)

--- a/clang/test/dpct/cmake_migration/case_032/input.cmake
+++ b/clang/test/dpct/cmake_migration/case_032/input.cmake
@@ -29,3 +29,108 @@ else ()
     set(LLAMA_EXTRA_LIBS ${LLAMA_EXTRA_LIBS} CUDA::cudart_static CUDA::cublas_static CUDA::cublasLt_static)
 endif()
 set(LLAMA_EXTRA_LIBS ${LLAMA_EXTRA_LIBS} CUDA::cudart CUDA::cublas CUDA::cublasLt)
+
+set(LIBS ${LIBS}
+    ${CUDA_LIBRARIES}
+    ${CUDA_cudart_static_LIBRARY}
+    ${CUDA_cusolver_LIBRARY}
+    ${CUDA_nppc_LIBRARY}
+    ${CUDA_nppif_LIBRARY}
+    ${CUDA_nppim_LIBRARY}
+    ${CUDA_npps_LIBRARY}
+    ${CUDA_nvcuvenc_LIBRARY}
+)
+
+target_link_libraries(${target}
+    ${CUDA_cudadevrt_LIBRARY}
+    ${CUDA_CUFFT_LIBRARIES}
+    ${CUDA_curand_LIBRARY}
+    ${CUDA_nppial_LIBRARY}
+    ${CUDA_nppicc_LIBRARY}
+    ${CUDA_nppist_LIBRARY}
+    ${CUDA_nppisu_LIBRARY}
+    ${CUDA_nvcuvid_LIBRARY}
+    ${CUDA_nvToolsExt_LIBRARY}
+)
+
+link_libraries(PUBLIC
+    ${CUDA_CUBLAS_LIBRARIES}
+    ${CUDA_cusparse_LIBRARY}
+    ${CUDA_cupti_LIBRARY}
+    ${CUDA_CUT_LIBRARY}
+    ${CUDA_npp_LIBRARY}
+    ${CUDA_nppi_LIBRARY}
+    ${CUDA_nppicom_LIBRARY}
+    ${CUDA_nppidei_LIBRARY}
+    ${CUDA_nppig_LIBRARY}
+    ${CUDA_nppitc_LIBRARY}
+)
+
+set(LIBS ${LIBS}
+    CUDA::cudla
+    CUDA::cuFile
+    CUDA::cuFile_static
+    CUDA::cuFile_rdma
+    CUDA::cupti
+    CUDA::cufft
+    CUDA::nvperf_host
+    CUDA::nvperf_target
+    CUDA::pcsamplingutil
+    CUDA::nppc
+    CUDA::nppial
+    CUDA::nppicc
+    CUDA::nppicom
+    CUDA::cufftw
+    CUDA::nppidei
+    CUDA::nppif
+    CUDA::nppig
+    CUDA::cusparse
+    CUDA::nppim
+    CUDA::nppist
+)
+
+target_link_libraries(${target}
+    CUDA::cuFile_rdma_static
+    CUDA::cupti_static
+    CUDA::nvperf_host_static
+    CUDA::cusparse_static
+    CUDA::nppc_static
+    CUDA::nppial_static
+    CUDA::cufft_static
+    CUDA::nppicc_static
+    CUDA::nppicom_static
+    CUDA::nppidei_static
+    CUDA::nppif_static
+    CUDA::nppig_static
+    CUDA::cufft_static_nocallback
+    CUDA::nppim_static
+    CUDA::nppist_static
+    CUDA::nppisu
+    CUDA::nppitc
+    CUDA::npps
+    CUDA::cufftw_static
+    CUDA::nvblas
+    CUDA::nvgraph
+)
+
+link_libraries(PUBLIC
+    CUDA::curand
+    CUDA::nppisu_static
+    CUDA::nppitc_static
+    CUDA::npps_static
+    CUDA::nvgraph_static
+    CUDA::nvjpeg
+    CUDA::nvjpeg_static
+    CUDA::nvptxcompiler_static
+    CUDA::nvrtc_builtins
+    CUDA::curand_static
+    CUDA::nvrtc_static
+    CUDA::nvrtc_builtins_static
+    CUDA::nvJitLink
+    CUDA::nvJitLink_static
+    CUDA::cusolver
+    CUDA::nvml
+    CUDA::nvtx3
+    CUDA::OpenCL
+    CUDA::cusolver_static
+)

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -325,7 +325,6 @@
       Out: ""
       RuleId: "remove_CUDA_cupti_LIBRARY"
 
-# No SYCL equivalent currently exists for CUDA_CUT_LIBRARY and hence is removed in the migrated CMake.
 - Rule: CUDA_CUT_LIBRARY_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -340,7 +339,6 @@
       Out: ""
       RuleId: "remove_CUDA_CUT_LIBRARY"
 
-# No SYCL equivalent currently exists for CUDA_npp_LIBRARY and hence is removed in the migrated CMake.
 - Rule: CUDA_npp_LIBRARY_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -355,7 +353,6 @@
       Out: ""
       RuleId: "remove_CUDA_npp_LIBRARY"
 
-# No SYCL equivalent currently exists for CUDA_nppc_LIBRARY and hence is removed in the migrated CMake.
 - Rule: CUDA_nppc_LIBRARY_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -370,7 +367,6 @@
       Out: ""
       RuleId: "remove_CUDA_nppc_LIBRARY"
 
-# No SYCL equivalent currently exists for CUDA_nppi_LIBRARY and hence is removed in the migrated CMake.
 - Rule: CUDA_nppi_LIBRARY_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -385,7 +381,6 @@
       Out: ""
       RuleId: "remove_CUDA_nppi_LIBRARY"
 
-# No SYCL equivalent currently exists for CUDA_nppial_LIBRARY and hence is removed in the migrated CMake.
 - Rule: CUDA_nppial_LIBRARY_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -400,7 +395,6 @@
       Out: ""
       RuleId: "remove_CUDA_nppial_LIBRARY"
 
-# No SYCL equivalent currently exists for CUDA_nppicc_LIBRARY and hence is removed in the migrated CMake.
 - Rule: CUDA_nppicc_LIBRARY_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -415,7 +409,6 @@
       Out: ""
       RuleId: "remove_CUDA_nppicc_LIBRARY"
 
-# No SYCL equivalent currently exists for CUDA_nppicom_LIBRARY and hence is removed in the migrated CMake.
 - Rule: CUDA_nppicom_LIBRARY_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -430,7 +423,6 @@
       Out: ""
       RuleId: "remove_CUDA_nppicom_LIBRARY"
 
-# No SYCL equivalent currently exists for CUDA_nppidei_LIBRARY and hence is removed in the migrated CMake.
 - Rule: CUDA_nppidei_LIBRARY_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -445,7 +437,6 @@
       Out: ""
       RuleId: "remove_CUDA_nppidei_LIBRARY"
 
-# No SYCL equivalent currently exists for CUDA_nppif_LIBRARY and hence is removed in the migrated CMake.
 - Rule: CUDA_nppif_LIBRARY_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -460,7 +451,6 @@
       Out: ""
       RuleId: "remove_CUDA_nppif_LIBRARY"
 
-# No SYCL equivalent currently exists for CUDA_nppig_LIBRARY and hence is removed in the migrated CMake.
 - Rule: CUDA_nppig_LIBRARY_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -475,7 +465,6 @@
       Out: ""
       RuleId: "remove_CUDA_nppig_LIBRARY"
 
-# No SYCL equivalent currently exists for CUDA_nppim_LIBRARY and hence is removed in the migrated CMake.
 - Rule: CUDA_nppim_LIBRARY_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -490,7 +479,6 @@
       Out: ""
       RuleId: "remove_CUDA_nppim_LIBRARY"
 
-# No SYCL equivalent currently exists for CUDA_nppist_LIBRARY and hence is removed in the migrated CMake.
 - Rule: CUDA_nppist_LIBRARY_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -505,7 +493,6 @@
       Out: ""
       RuleId: "remove_CUDA_nppist_LIBRARY"
 
-# No SYCL equivalent currently exists for CUDA_nppsu_LIBRARY and hence is removed in the migrated CMake.
 - Rule: CUDA_nppisu_LIBRARY_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -520,7 +507,6 @@
       Out: ""
       RuleId: "remove_CUDA_nppisu_LIBRARY"
 
-# No SYCL equivalent currently exists for CUDA_nppitc_LIBRARY and hence is removed in the migrated CMake.
 - Rule: CUDA_nppitc_LIBRARY_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -535,7 +521,6 @@
       Out: ""
       RuleId: "remove_CUDA_nppitc_LIBRARY"
 
-# No SYCL equivalent currently exists for CUDA_npps_LIBRARY and hence is removed in the migrated CMake.
 - Rule: CUDA_npps_LIBRARY_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -550,7 +535,6 @@
       Out: ""
       RuleId: "remove_CUDA_npps_LIBRARY"
 
-# No SYCL equivalent currently exists for CUDA_nvcuvenc_LIBRARY and hence is removed in the migrated CMake.
 - Rule: CUDA_nvcuvenc_LIBRARY_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -565,7 +549,6 @@
       Out: ""
       RuleId: "remove_CUDA_nvcuvenc_LIBRARY"
 
-# No SYCL equivalent currently exists for CUDA_nvcuvid_LIBRARY and hence is removed in the migrated CMake.
 - Rule: CUDA_nvcuvid_LIBRARY_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -580,7 +563,6 @@
       Out: ""
       RuleId: "remove_CUDA_nvcuvid_LIBRARY"
 
-# No SYCL equivalent currently exists for CUDA_nvToolsExt_LIBRARY and hence is removed in the migrated CMake.
 - Rule: CUDA_nvToolsExt_LIBRARY_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1270,7 +1252,6 @@
         \${MKL_LIB}
       RuleId: "replace_cusparse_static_with_MKL"
 
-# No SYCL equivalent exists for cudla currently and hence is removed in migrate CMake
 - Rule: cudla_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1285,7 +1266,6 @@
       Out: ""
       RuleId: "remove_cudla"
 
-# No SYCL equivalent exists for cuFile currently and hence is removed in migrate CMake
 - Rule: cuFile_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1300,7 +1280,6 @@
       Out: ""
       RuleId: "remove_cuFile"
 
-# No SYCL equivalent exists for cuFile_static currently and hence is removed in migrate CMake
 - Rule: cuFile_static_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1315,7 +1294,6 @@
       Out: ""
       RuleId: "remove_cuFile_static"
 
-# No SYCL equivalent exists for cuFile_rdma currently and hence is removed in migrate CMake
 - Rule: cuFile_rdma_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1330,7 +1308,6 @@
       Out: ""
       RuleId: "remove_cuFile_rdma"
 
-# No SYCL equivalent exists for cuFile_rdma_static currently and hence is removed in migrate CMake
 - Rule: cuFile_rdma_static_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1345,7 +1322,6 @@
       Out: ""
       RuleId: "remove_cuFile_rdma_static"
 
-# No SYCL equivalent exists for cupti currently and hence is removed in migrate CMake
 - Rule: cupti_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1360,7 +1336,6 @@
       Out: ""
       RuleId: "remove_cupti"
 
-# No SYCL equivalent exists for cupti_static currently and hence is removed in migrate CMake
 - Rule: cupti_static_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1375,7 +1350,6 @@
       Out: ""
       RuleId: "remove_cupti_static"
 
-# No SYCL equivalent exists for nvperf_host currently and hence is removed in migrate CMake
 - Rule: nvperf_host_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1390,7 +1364,6 @@
       Out: ""
       RuleId: "remove_nvperf_host"
 
-# No SYCL equivalent exists for nvperf_host_static currently and hence is removed in migrate CMake
 - Rule: nvperf_host_static_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1405,7 +1378,6 @@
       Out: ""
       RuleId: "remove_nvperf_host_static"
 
-# No SYCL equivalent exists for nvperf_target currently and hence is removed in migrate CMake
 - Rule: nvperf_target_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1420,7 +1392,6 @@
       Out: ""
       RuleId: "remove_nvperf_target"
 
-# No SYCL equivalent exists for pcsamplingutil currently and hence is removed in migrate CMake
 - Rule: pcsamplingutil_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1435,7 +1406,6 @@
       Out: ""
       RuleId: "remove_pcsamplingutil"
 
-# No SYCL equivalent exists for nppc currently and hence is removed in migrate CMake
 - Rule: nppc_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1450,7 +1420,6 @@
       Out: ""
       RuleId: "remove_nppc"
 
-# No SYCL equivalent exists for nppc_static currently and hence is removed in migrate CMake
 - Rule: nppc_static_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1465,7 +1434,6 @@
       Out: ""
       RuleId: "remove_nppc_static"
 
-# No SYCL equivalent exists for nppial currently and hence is removed in migrate CMake
 - Rule: nppial_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1480,7 +1448,6 @@
       Out: ""
       RuleId: "remove_nppial"
 
-# No SYCL equivalent exists for nppial_static currently and hence is removed in migrate CMake
 - Rule: nppial_static_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1495,7 +1462,6 @@
       Out: ""
       RuleId: "remove_nppial_static"
 
-# No SYCL equivalent exists for nppicc currently and hence is removed in migrate CMake
 - Rule: nppicc_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1510,7 +1476,6 @@
       Out: ""
       RuleId: "remove_nppicc"
 
-# No SYCL equivalent exists for nppicc_static currently and hence is removed in migrate CMake
 - Rule: nppicc_static_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1525,7 +1490,6 @@
       Out: ""
       RuleId: "remove_nppicc_static"
 
-# No SYCL equivalent exists for nppicom currently and hence is removed in migrate CMake
 - Rule: nppicom_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1540,7 +1504,6 @@
       Out: ""
       RuleId: "remove_nppicom"
 
-# No SYCL equivalent exists for nppicom_static currently and hence is removed in migrate CMake
 - Rule: nppicom_static_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1555,7 +1518,6 @@
       Out: ""
       RuleId: "remove_nppicom_static"
 
-# No SYCL equivalent exists for nppidei currently and hence is removed in migrate CMake
 - Rule: nppidei_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1570,7 +1532,6 @@
       Out: ""
       RuleId: "remove_nppidei"
 
-# No SYCL equivalent exists for nppidei_static currently and hence is removed in migrate CMake
 - Rule: nppidei_static_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1585,7 +1546,6 @@
       Out: ""
       RuleId: "remove_nppidei_static"
 
-# No SYCL equivalent exists for nppif currently and hence is removed in migrate CMake
 - Rule: nppif_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1600,7 +1560,6 @@
       Out: ""
       RuleId: "remove_nppif"
 
-# No SYCL equivalent exists for nppif_static currently and hence is removed in migrate CMake
 - Rule: nppif_static_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1615,7 +1574,6 @@
       Out: ""
       RuleId: "remove_nppif_static"
 
-# No SYCL equivalent exists for nppig currently and hence is removed in migrate CMake
 - Rule: nppig_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1630,7 +1588,6 @@
       Out: ""
       RuleId: "remove_nppig"
 
-# No SYCL equivalent exists for nppig_static currently and hence is removed in migrate CMake
 - Rule: nppig_static_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1645,7 +1602,6 @@
       Out: ""
       RuleId: "remove_nppig_static"
 
-# No SYCL equivalent exists for nppim currently and hence is removed in migrate CMake
 - Rule: nppim_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1660,7 +1616,6 @@
       Out: ""
       RuleId: "remove_nppim"
 
-# No SYCL equivalent exists for nppim_static currently and hence is removed in migrate CMake
 - Rule: nppim_static_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1675,7 +1630,6 @@
       Out: ""
       RuleId: "remove_nppim_static"
 
-# No SYCL equivalent exists for nppist currently and hence is removed in migrate CMake
 - Rule: nppist_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1690,7 +1644,6 @@
       Out: ""
       RuleId: "remove_nppist"
 
-# No SYCL equivalent exists for nppist_static currently and hence is removed in migrate CMake
 - Rule: nppist_static_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1705,7 +1658,6 @@
       Out: ""
       RuleId: "remove_nppist_static"
 
-# No SYCL equivalent exists for nppisu currently and hence is removed in migrate CMake
 - Rule: nppisu_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1720,7 +1672,6 @@
       Out: ""
       RuleId: "remove_nppisu"
 
-# No SYCL equivalent exists for nppisu_static currently and hence is removed in migrate CMake
 - Rule: nppisu_static_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1735,7 +1686,6 @@
       Out: ""
       RuleId: "remove_nppisu_static"
 
-# No SYCL equivalent exists for nppitc currently and hence is removed in migrate CMake
 - Rule: nppitc_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1750,7 +1700,6 @@
       Out: ""
       RuleId: "remove_nppitc"
 
-# No SYCL equivalent exists for nppitc_static currently and hence is removed in migrate CMake
 - Rule: nppitc_static_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1765,7 +1714,6 @@
       Out: ""
       RuleId: "remove_nppitc_static"
 
-# No SYCL equivalent exists for npps currently and hence is removed in migrate CMake
 - Rule: npps_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1780,7 +1728,6 @@
       Out: ""
       RuleId: "remove_npps"
 
-# No SYCL equivalent exists for npps_static currently and hence is removed in migrate CMake
 - Rule: npps_static_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1795,7 +1742,6 @@
       Out: ""
       RuleId: "remove_npps_static"
 
-# No SYCL equivalent exists for nvblas currently and hence is removed in migrate CMake
 - Rule: nvblas_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1810,7 +1756,6 @@
       Out: ""
       RuleId: "remove_nvblas"
 
-# No SYCL equivalent exists for nvgraph currently and hence is removed in migrate CMake
 - Rule: nvgraph_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1825,7 +1770,6 @@
       Out: ""
       RuleId: "remove_nvgraph"
 
-# No SYCL equivalent exists for nvgraph_static currently and hence is removed in migrate CMake
 - Rule: nvgraph_static_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1840,7 +1784,6 @@
       Out: ""
       RuleId: "remove_nvgraph_static"
 
-# No SYCL equivalent exists for nvjpeg currently and hence is removed in migrate CMake
 - Rule: nvjpeg_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1855,7 +1798,6 @@
       Out: ""
       RuleId: "remove_nvjpeg"
 
-# No SYCL equivalent exists for nvjpeg_static currently and hence is removed in migrate CMake
 - Rule: nvjpeg_static_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1870,7 +1812,6 @@
       Out: ""
       RuleId: "remove_nvjpeg_static"
 
-# No SYCL equivalent exists for nvptxcompiler_static currently and hence is removed in migrate CMake
 - Rule: nvptxcompiler_static_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1885,7 +1826,6 @@
       Out: ""
       RuleId: "remove_nvptxcompiler_static"
 
-# No SYCL equivalent exists for nvrtc currently and hence is removed in migrate CMake
 - Rule: nvrtc_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1900,7 +1840,6 @@
       Out: ""
       RuleId: "remove_nvrtc"
 
-# No SYCL equivalent exists for nvrtc_builtins currently and hence is removed in migrate CMake
 - Rule: nvrtc_builtins_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1915,7 +1854,6 @@
       Out: ""
       RuleId: "remove_nvrtc_builtins"
 
-# No SYCL equivalent exists for nvrtc_static currently and hence is removed in migrate CMake
 - Rule: nvrtc_static_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1930,7 +1868,6 @@
       Out: ""
       RuleId: "remove_nvrtc_static"
 
-# No SYCL equivalent exists for nvrtc_builtins_static currently and hence is removed in migrate CMake
 - Rule: nvrtc_builtins_static_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1945,7 +1882,6 @@
       Out: ""
       RuleId: "remove_nvrtc_builtins_static"
 
-# No SYCL equivalent exists for nvJitLink currently and hence is removed in migrate CMake
 - Rule: nvJitLink_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1960,7 +1896,6 @@
       Out: ""
       RuleId: "remove_nvJitLink"
 
-# No SYCL equivalent exists for nvJitLink_static currently and hence is removed in migrate CMake
 - Rule: nvJitLink_static_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1975,7 +1910,6 @@
       Out: ""
       RuleId: "remove_nvJitLink_static"
 
-# No SYCL equivalent exists for nvml currently and hence is removed in migrate CMake
 - Rule: nvml_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -1990,7 +1924,6 @@
       Out: ""
       RuleId: "remove_nvml"
 
-# No SYCL equivalent exists for nvToolsExt currently and hence is removed in migrate CMake
 - Rule: nvtx3_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -2005,7 +1938,6 @@
       Out: ""
       RuleId: "remove_nvToolsExt"
 
-# No SYCL equivalent exists for nvtx3 currently and hence is removed in migrate CMake
 - Rule: nvtx3_removed
   Kind: CMakeRule
   Priority: Fallback
@@ -2020,7 +1952,6 @@
       Out: ""
       RuleId: "remove_nvtx3"
 
-# No SYCL equivalent exists for OpenCL currently and hence is removed in migrate CMake
 - Rule: OpenCL_removed
   Kind: CMakeRule
   Priority: Fallback

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -865,34 +865,6 @@
       MatchMode: Full
       RuleId: "replace_cudnn_with_libdnn"
 
-# SYCL does not have mapping for nvrtc currently, so removing here
-- Rule: rule_target_link_libraries_nvrtc
-  Kind: CMakeRule
-  Priority: Fallback
-  CmakeSyntax: nvrtc_target_link_libraries
-  In: ${prefix}link_libraries(${CUDALibraries})
-  Out: ${prefix}link_libraries(${CUDALibraries})
-  Subrules:
-    CUDALibraries:
-      In: "CUDA::nvrtc"
-      Out: ""
-      MatchMode: Full
-      RuleId: "remove_nvrtc"
-
-# SYCL does not have mapping for nvToolsExt currently, so removing here
-- Rule: rule_target_link_libraries_nvToolsExt
-  Kind: CMakeRule
-  Priority: Fallback
-  CmakeSyntax: nvToolsExt_target_link_libraries
-  In: ${prefix}link_libraries(${CUDALibraries})
-  Out: ${prefix}link_libraries(${CUDALibraries})
-  Subrules:
-    CUDALibraries:
-      In: "CUDA::nvToolsExt"
-      Out: ""
-      MatchMode: Full
-      RuleId: "remove_nvToolsExt"
-
 # SYCL does not have mapping for libnvinfer currently, so removing here
 - Rule: rule_target_link_libraries_libnvinfer
   Kind: CMakeRule
@@ -1956,6 +1928,21 @@
       Out: ""
       RuleId: "remove_nvptxcompiler_static"
 
+# No SYCL equivalent exists for nvrtc currently and hence is removed in migrate CMake
+- Rule: nvrtc_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nvrtc
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nvrtc
+      Out: ""
+      RuleId: "remove_nvrtc"
+
 # No SYCL equivalent exists for nvrtc_builtins currently and hence is removed in migrate CMake
 - Rule: nvrtc_builtins_removed
   Kind: CMakeRule
@@ -2045,6 +2032,21 @@
       In: CUDA::nvml
       Out: ""
       RuleId: "remove_nvml"
+
+# No SYCL equivalent exists for nvToolsExt currently and hence is removed in migrate CMake
+- Rule: nvtx3_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nvToolsExt
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nvToolsExt
+      Out: ""
+      RuleId: "remove_nvToolsExt"
 
 # No SYCL equivalent exists for nvtx3 currently and hence is removed in migrate CMake
 - Rule: nvtx3_removed

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -655,7 +655,6 @@
       Out: SYCL_HAS_FP16
 
 # Current Yaml based rule hard-code to map "cxx_std_xx" to "cxx_std_17"
-# A more flexible mapping logic should be implemented in implicit rules
 - Rule: rule_cxx_target_compile_features
   Kind: CMakeRule
   Priority: Fallback
@@ -670,7 +669,6 @@
       RuleId: "adjust_cxx_ver"
 
 # Current Yaml based rule hard-code to map "cuda_std_xx" to "cxx_std_17"
-# A more flexible mapping logic should be implemented in implicit rules
 - Rule: rule_cuda_target_compile_features
   Kind: CMakeRule
   Priority: Fallback
@@ -804,7 +802,6 @@
       MatchMode: Full
       RuleId: "replace_cudnn_with_libdnn"
 
-# SYCL does not have mapping for libnvinfer currently, so removing here
 - Rule: rule_target_link_libraries_libnvinfer
   Kind: CMakeRule
   Priority: Fallback
@@ -818,7 +815,6 @@
       MatchMode: Full
       RuleId: "remove_libnvinfer"
 
-# SYCL does not have mapping for libnvonnxparser currently, so removing here
 - Rule: rule_target_link_libraries_libnvonnxparser
   Kind: CMakeRule
   Priority: Fallback

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -188,7 +188,7 @@
       In: ${arg}.cu
       Out: ${arg}.${rewrite_extention_name}
 
-# ${CUDA_LIBRARIES} is cmake reserved variable for static version of the CUDA runtime library.
+# ${CUDA_LIBRARIES} is cmake reserved variable for the CUDA runtime library.
 # In SYCL side, SYCL runtime is default auto-loaded when option "-fsycl" is specified, so we remove it in SYCL side.
 - Rule: CUDA_LIBRARIES_removed
   Kind: CMakeRule
@@ -202,6 +202,396 @@
       MatchMode: Full
       In: \${CUDA_LIBRARIES}
       Out: ""
+
+# ${CUDA_cudart_static_LIBRARY} is cmake reserved variable for static version of the CUDA runtime library.
+# SYCL runtime is auto-loaded when "-fsycl" flag is specified, so this variable is removed in the migrated CMake.
+- Rule: CUDA_cudart_static_LIBRARY_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_cudart_static_LIBRARY
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: \${CUDA_cudart_static_LIBRARY}
+      Out: ""
+
+# ${CUDA_cudart_static_LIBRARY} is cmake reserved variable for CUDA device runtime library.
+# SYCL runtime is auto-loaded when "-fsycl" flag is specified, so this variable is removed in the migrated CMake.
+- Rule: CUDA_cudadevrt_LIBRARY_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_cudadevrt_LIBRARY
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: \${CUDA_cudadevrt_LIBRARY}
+      Out: ""
+
+- Rule: CUDA_CUFFT_LIBRARIES_rule
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_CUFFT_LIBRARIES
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: \${CUDA_CUFFT_LIBRARIES}
+      Out: |
+        \${MKL_LIB}
+      RuleId: "replace_CUDA_CUFFT_LIBRARIES_with_MKL"
+
+- Rule: CUDA_CUBLAS_LIBRARIES_rule
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_CUBLAS_LIBRARIES
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: \${CUDA_CUBLAS_LIBRARIES}
+      Out: |
+        \${MKL_LIB}
+      RuleId: "replace_CUDA_CUBLAS_LIBRARIES_with_MKL"
+
+- Rule: CUDA_curand_LIBRARY_rule
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_curand_LIBRARY
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: \${CUDA_curand_LIBRARY}
+      Out: |
+        \${MKL_LIB}
+      RuleId: "replace_CUDA_curand_LIBRARY_with_MKL"
+
+- Rule: CUDA_cusolver_LIBRARY_rule
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_cusolver_LIBRARY
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: \${CUDA_cusolver_LIBRARY}
+      Out: |
+        \${MKL_LIB}
+      RuleId: "replace_CUDA_cusolver_LIBRARY_with_MKL"
+
+- Rule: CUDA_cusparse_LIBRARY_rule
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_cusparse_LIBRARY
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: \${CUDA_cusparse_LIBRARY}
+      Out: |
+        \${MKL_LIB}
+      RuleId: "replace_CUDA_cusparse_LIBRARY_with_MKL"
+
+
+- Rule: CUDA_cupti_LIBRARY_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_cupti_LIBRARY
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: \${CUDA_cupti_LIBRARY}
+      Out: ""
+      RuleId: "remove_CUDA_cupti_LIBRARY"
+
+# No SYCL equivalent currently exists for CUDA_CUT_LIBRARY and hence is removed in the migrated CMake.
+- Rule: CUDA_CUT_LIBRARY_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_CUT_LIBRARY
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: \${CUDA_CUT_LIBRARY}
+      Out: ""
+      RuleId: "remove_CUDA_CUT_LIBRARY"
+
+# No SYCL equivalent currently exists for CUDA_npp_LIBRARY and hence is removed in the migrated CMake.
+- Rule: CUDA_npp_LIBRARY_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_npp_LIBRARY
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: \${CUDA_npp_LIBRARY}
+      Out: ""
+      RuleId: "remove_CUDA_npp_LIBRARY"
+
+# No SYCL equivalent currently exists for CUDA_nppc_LIBRARY and hence is removed in the migrated CMake.
+- Rule: CUDA_nppc_LIBRARY_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_nppc_LIBRARY
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: \${CUDA_nppc_LIBRARY}
+      Out: ""
+      RuleId: "remove_CUDA_nppc_LIBRARY"
+
+# No SYCL equivalent currently exists for CUDA_nppi_LIBRARY and hence is removed in the migrated CMake.
+- Rule: CUDA_nppi_LIBRARY_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_nppi_LIBRARY
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: \${CUDA_nppi_LIBRARY}
+      Out: ""
+      RuleId: "remove_CUDA_nppi_LIBRARY"
+
+# No SYCL equivalent currently exists for CUDA_nppial_LIBRARY and hence is removed in the migrated CMake.
+- Rule: CUDA_nppial_LIBRARY_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_nppial_LIBRARY
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: \${CUDA_nppial_LIBRARY}
+      Out: ""
+      RuleId: "remove_CUDA_nppial_LIBRARY"
+
+# No SYCL equivalent currently exists for CUDA_nppicc_LIBRARY and hence is removed in the migrated CMake.
+- Rule: CUDA_nppicc_LIBRARY_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_nppicc_LIBRARY
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: \${CUDA_nppicc_LIBRARY}
+      Out: ""
+      RuleId: "remove_CUDA_nppicc_LIBRARY"
+
+# No SYCL equivalent currently exists for CUDA_nppicom_LIBRARY and hence is removed in the migrated CMake.
+- Rule: CUDA_nppicom_LIBRARY_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_nppicom_LIBRARY
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: \${CUDA_nppicom_LIBRARY}
+      Out: ""
+      RuleId: "remove_CUDA_nppicom_LIBRARY"
+
+# No SYCL equivalent currently exists for CUDA_nppidei_LIBRARY and hence is removed in the migrated CMake.
+- Rule: CUDA_nppidei_LIBRARY_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_nppidei_LIBRARY
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: \${CUDA_nppidei_LIBRARY}
+      Out: ""
+      RuleId: "remove_CUDA_nppidei_LIBRARY"
+
+# No SYCL equivalent currently exists for CUDA_nppif_LIBRARY and hence is removed in the migrated CMake.
+- Rule: CUDA_nppif_LIBRARY_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_nppif_LIBRARY
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: \${CUDA_nppif_LIBRARY}
+      Out: ""
+      RuleId: "remove_CUDA_nppif_LIBRARY"
+
+# No SYCL equivalent currently exists for CUDA_nppig_LIBRARY and hence is removed in the migrated CMake.
+- Rule: CUDA_nppig_LIBRARY_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_nppig_LIBRARY
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: \${CUDA_nppig_LIBRARY}
+      Out: ""
+      RuleId: "remove_CUDA_nppig_LIBRARY"
+
+# No SYCL equivalent currently exists for CUDA_nppim_LIBRARY and hence is removed in the migrated CMake.
+- Rule: CUDA_nppim_LIBRARY_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_nppim_LIBRARY
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: \${CUDA_nppim_LIBRARY}
+      Out: ""
+      RuleId: "remove_CUDA_nppim_LIBRARY"
+
+# No SYCL equivalent currently exists for CUDA_nppist_LIBRARY and hence is removed in the migrated CMake.
+- Rule: CUDA_nppist_LIBRARY_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_nppist_LIBRARY
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: \${CUDA_nppist_LIBRARY}
+      Out: ""
+      RuleId: "remove_CUDA_nppist_LIBRARY"
+
+# No SYCL equivalent currently exists for CUDA_nppsu_LIBRARY and hence is removed in the migrated CMake.
+- Rule: CUDA_nppisu_LIBRARY_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_nppisu_LIBRARY
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: \${CUDA_nppisu_LIBRARY}
+      Out: ""
+      RuleId: "remove_CUDA_nppisu_LIBRARY"
+
+# No SYCL equivalent currently exists for CUDA_nppitc_LIBRARY and hence is removed in the migrated CMake.
+- Rule: CUDA_nppitc_LIBRARY_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_nppitc_LIBRARY
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: \${CUDA_nppitc_LIBRARY}
+      Out: ""
+      RuleId: "remove_CUDA_nppitc_LIBRARY"
+
+# No SYCL equivalent currently exists for CUDA_npps_LIBRARY and hence is removed in the migrated CMake.
+- Rule: CUDA_npps_LIBRARY_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_npps_LIBRARY
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: \${CUDA_npps_LIBRARY}
+      Out: ""
+      RuleId: "remove_CUDA_npps_LIBRARY"
+
+# No SYCL equivalent currently exists for CUDA_nvcuvenc_LIBRARY and hence is removed in the migrated CMake.
+- Rule: CUDA_nvcuvenc_LIBRARY_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_nvcuvenc_LIBRARY
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: \${CUDA_nvcuvenc_LIBRARY}
+      Out: ""
+      RuleId: "remove_CUDA_nvcuvenc_LIBRARY"
+
+# No SYCL equivalent currently exists for CUDA_nvcuvid_LIBRARY and hence is removed in the migrated CMake.
+- Rule: CUDA_nvcuvid_LIBRARY_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_nvcuvid_LIBRARY
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: \${CUDA_nvcuvid_LIBRARY}
+      Out: ""
+      RuleId: "remove_CUDA_nvcuvid_LIBRARY"
+
+# No SYCL equivalent currently exists for CUDA_nvToolsExt_LIBRARY and hence is removed in the migrated CMake.
+- Rule: CUDA_nvToolsExt_LIBRARY_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_nvToolsExt_LIBRARY
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: \${CUDA_nvToolsExt_LIBRARY}
+      Out: ""
+      RuleId: "remove_CUDA_nvToolsExt_LIBRARY"
 
 - Rule: rule_cuda_compile_with_opts
   Kind: CMakeRule
@@ -375,21 +765,6 @@
   MatchMode: Partial
   In: cuda_compile_cubin(${device} ${value} OPTIONS ${opts})
   Out: dpct_helper_compile_sycl_code(${device} ${value})
-
-# CUDA_cudadevrt_LIBRARY is cmake cuda reverved list variable, should be removed in SYCL
-- Rule: rule_target_link_libraries_CUDA_cudadevrt_LIBRARY
-  Kind: CMakeRule
-  Priority: Fallback
-  CmakeSyntax: CUDA_cudadevrt_LIBRARY_target_link_libraries
-  In: ${prefix}link_libraries(${CULibraries})
-  Out: ${prefix}link_libraries(${CULibraries})
-  Subrules:
-    CULibraries:
-      In: |
-        \${CUDA_cudadevrt_LIBRARY}
-      Out: ""
-      MatchMode: Full
-      RuleId: "remove_cuda_reserved_variable_CUDA_cudadevrt_LIBRARY"
 
 - Rule: rule_target_link_libraries_cuda
   Kind: CMakeRule
@@ -800,6 +1175,906 @@
       In: CUDA::cublasLt_static
       Out: |
         \${DNN_LIB}
+
+- Rule: cufft_rule
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: cufft
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::cufft
+      Out: |
+        \${MKL_LIB}
+      RuleId: "replace_cufft_with_MKL"
+
+- Rule: cufftw_rule
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: cufftw
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::cufftw
+      Out: |
+        \${MKL_LIB}
+      RuleId: "replace_cufftw_with_MKL"
+
+- Rule: cufft_static_rule
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: cufft_static
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::cufft_static
+      Out: |
+        \${MKL_LIB}
+      RuleId: "replace_cufft_static_with_MKL"
+
+- Rule: cufft_static_nocallback_rule
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: cufft_static_nocallback
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::cufft_static_nocallback
+      Out: |
+        \${MKL_LIB}
+      RuleId: "replace_cufft_static_nocallback_with_MKL"
+
+- Rule: cufftw_static_rule
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: cufftw_static
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::cufftw_static
+      Out: |
+        \${MKL_LIB}
+      RuleId: "replace_cufftw_static_with_MKL"
+
+- Rule: curand_rule
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: curand
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::curand
+      Out: |
+        \${MKL_LIB}
+      RuleId: "replace_curand_with_MKL"
+
+- Rule: curand_static_rule
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: curand_static
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::curand_static
+      Out: |
+        \${MKL_LIB}
+      RuleId: "replace_curand_static_with_MKL"
+
+- Rule: cusolver_rule
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: cusolver
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::cusolver
+      Out: |
+        \${MKL_LIB}
+      RuleId: "replace_cusolver_with_MKL"
+
+- Rule: cusolver_static_rule
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: cusolver_static
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::cusolver_static
+      Out: |
+        \${MKL_LIB}
+      RuleId: "replace_cusolver_static_with_MKL"
+
+- Rule: cusparse_rule
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: cusparse
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::cusparse
+      Out: |
+        \${MKL_LIB}
+      RuleId: "replace_cusparse_with_MKL"
+
+- Rule: cusparse_static_rule
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: cusparse_static
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::cusparse_static
+      Out: |
+        \${MKL_LIB}
+      RuleId: "replace_cusparse_static_with_MKL"
+
+# No SYCL equivalent exists for cudla currently and hence is removed in migrate CMake
+- Rule: cudla_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: cudla
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::cudla
+      Out: ""
+      RuleId: "remove_cudla"
+
+# No SYCL equivalent exists for cuFile currently and hence is removed in migrate CMake
+- Rule: cuFile_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: cuFile
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::cuFile
+      Out: ""
+      RuleId: "remove_cuFile"
+
+# No SYCL equivalent exists for cuFile_static currently and hence is removed in migrate CMake
+- Rule: cuFile_static_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: cuFile_static
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::cuFile_static
+      Out: ""
+      RuleId: "remove_cuFile_static"
+
+# No SYCL equivalent exists for cuFile_rdma currently and hence is removed in migrate CMake
+- Rule: cuFile_rdma_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: cuFile_rdma
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::cuFile_rdma
+      Out: ""
+      RuleId: "remove_cuFile_rdma"
+
+# No SYCL equivalent exists for cuFile_rdma_static currently and hence is removed in migrate CMake
+- Rule: cuFile_rdma_static_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: cuFile_rdma_static
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::cuFile_rdma_static
+      Out: ""
+      RuleId: "remove_cuFile_rdma_static"
+
+# No SYCL equivalent exists for cupti currently and hence is removed in migrate CMake
+- Rule: cupti_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: cupti
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::cupti
+      Out: ""
+      RuleId: "remove_cupti"
+
+# No SYCL equivalent exists for cupti_static currently and hence is removed in migrate CMake
+- Rule: cupti_static_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: cupti_static
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::cupti_static
+      Out: ""
+      RuleId: "remove_cupti_static"
+
+# No SYCL equivalent exists for nvperf_host currently and hence is removed in migrate CMake
+- Rule: nvperf_host_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nvperf_host
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nvperf_host
+      Out: ""
+      RuleId: "remove_nvperf_host"
+
+# No SYCL equivalent exists for nvperf_host_static currently and hence is removed in migrate CMake
+- Rule: nvperf_host_static_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nvperf_host_static
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nvperf_host_static
+      Out: ""
+      RuleId: "remove_nvperf_host_static"
+
+# No SYCL equivalent exists for nvperf_target currently and hence is removed in migrate CMake
+- Rule: nvperf_target_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nvperf_target
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nvperf_target
+      Out: ""
+      RuleId: "remove_nvperf_target"
+
+# No SYCL equivalent exists for pcsamplingutil currently and hence is removed in migrate CMake
+- Rule: pcsamplingutil_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: pcsamplingutil
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::pcsamplingutil
+      Out: ""
+      RuleId: "remove_pcsamplingutil"
+
+# No SYCL equivalent exists for nppc currently and hence is removed in migrate CMake
+- Rule: nppc_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nppc
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nppc
+      Out: ""
+      RuleId: "remove_nppc"
+
+# No SYCL equivalent exists for nppc_static currently and hence is removed in migrate CMake
+- Rule: nppc_static_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nppc_static
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nppc_static
+      Out: ""
+      RuleId: "remove_nppc_static"
+
+# No SYCL equivalent exists for nppial currently and hence is removed in migrate CMake
+- Rule: nppial_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nppial
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nppial
+      Out: ""
+      RuleId: "remove_nppial"
+
+# No SYCL equivalent exists for nppial_static currently and hence is removed in migrate CMake
+- Rule: nppial_static_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nppial_static
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nppial_static
+      Out: ""
+      RuleId: "remove_nppial_static"
+
+# No SYCL equivalent exists for nppicc currently and hence is removed in migrate CMake
+- Rule: nppicc_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nppicc
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nppicc
+      Out: ""
+      RuleId: "remove_nppicc"
+
+# No SYCL equivalent exists for nppicc_static currently and hence is removed in migrate CMake
+- Rule: nppicc_static_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nppicc_static
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nppicc_static
+      Out: ""
+      RuleId: "remove_nppicc_static"
+
+# No SYCL equivalent exists for nppicom currently and hence is removed in migrate CMake
+- Rule: nppicom_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nppicom
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nppicom
+      Out: ""
+      RuleId: "remove_nppicom"
+
+# No SYCL equivalent exists for nppicom_static currently and hence is removed in migrate CMake
+- Rule: nppicom_static_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nppicom_static
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nppicom_static
+      Out: ""
+      RuleId: "remove_nppicom_static"
+
+# No SYCL equivalent exists for nppidei currently and hence is removed in migrate CMake
+- Rule: nppidei_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nppidei
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nppidei
+      Out: ""
+      RuleId: "remove_nppidei"
+
+# No SYCL equivalent exists for nppidei_static currently and hence is removed in migrate CMake
+- Rule: nppidei_static_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nppidei_static
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nppidei_static
+      Out: ""
+      RuleId: "remove_nppidei_static"
+
+# No SYCL equivalent exists for nppif currently and hence is removed in migrate CMake
+- Rule: nppif_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nppif
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nppif
+      Out: ""
+      RuleId: "remove_nppif"
+
+# No SYCL equivalent exists for nppif_static currently and hence is removed in migrate CMake
+- Rule: nppif_static_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nppif_static
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nppif_static
+      Out: ""
+      RuleId: "remove_nppif_static"
+
+# No SYCL equivalent exists for nppig currently and hence is removed in migrate CMake
+- Rule: nppig_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nppig
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nppig
+      Out: ""
+      RuleId: "remove_nppig"
+
+# No SYCL equivalent exists for nppig_static currently and hence is removed in migrate CMake
+- Rule: nppig_static_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nppig_static
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nppig_static
+      Out: ""
+      RuleId: "remove_nppig_static"
+
+# No SYCL equivalent exists for nppim currently and hence is removed in migrate CMake
+- Rule: nppim_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nppim
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nppim
+      Out: ""
+      RuleId: "remove_nppim"
+
+# No SYCL equivalent exists for nppim_static currently and hence is removed in migrate CMake
+- Rule: nppim_static_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nppim_static
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nppim_static
+      Out: ""
+      RuleId: "remove_nppim_static"
+
+# No SYCL equivalent exists for nppist currently and hence is removed in migrate CMake
+- Rule: nppist_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nppist
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nppist
+      Out: ""
+      RuleId: "remove_nppist"
+
+# No SYCL equivalent exists for nppist_static currently and hence is removed in migrate CMake
+- Rule: nppist_static_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nppist_static
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nppist_static
+      Out: ""
+      RuleId: "remove_nppist_static"
+
+# No SYCL equivalent exists for nppisu currently and hence is removed in migrate CMake
+- Rule: nppisu_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nppisu
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nppisu
+      Out: ""
+      RuleId: "remove_nppisu"
+
+# No SYCL equivalent exists for nppisu_static currently and hence is removed in migrate CMake
+- Rule: nppisu_static_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nppisu_static
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nppisu_static
+      Out: ""
+      RuleId: "remove_nppisu_static"
+
+# No SYCL equivalent exists for nppitc currently and hence is removed in migrate CMake
+- Rule: nppitc_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nppitc
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nppitc
+      Out: ""
+      RuleId: "remove_nppitc"
+
+# No SYCL equivalent exists for nppitc_static currently and hence is removed in migrate CMake
+- Rule: nppitc_static_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nppitc_static
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nppitc_static
+      Out: ""
+      RuleId: "remove_nppitc_static"
+
+# No SYCL equivalent exists for npps currently and hence is removed in migrate CMake
+- Rule: npps_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: npps
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::npps
+      Out: ""
+      RuleId: "remove_npps"
+
+# No SYCL equivalent exists for npps_static currently and hence is removed in migrate CMake
+- Rule: npps_static_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: npps_static
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::npps_static
+      Out: ""
+      RuleId: "remove_npps_static"
+
+# No SYCL equivalent exists for nvblas currently and hence is removed in migrate CMake
+- Rule: nvblas_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nvblas
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nvblas
+      Out: ""
+      RuleId: "remove_nvblas"
+
+# No SYCL equivalent exists for nvgraph currently and hence is removed in migrate CMake
+- Rule: nvgraph_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nvgraph
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nvgraph
+      Out: ""
+      RuleId: "remove_nvgraph"
+
+# No SYCL equivalent exists for nvgraph_static currently and hence is removed in migrate CMake
+- Rule: nvgraph_static_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nvgraph_static
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nvgraph_static
+      Out: ""
+      RuleId: "remove_nvgraph_static"
+
+# No SYCL equivalent exists for nvjpeg currently and hence is removed in migrate CMake
+- Rule: nvjpeg_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nvjpeg
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nvjpeg
+      Out: ""
+      RuleId: "remove_nvjpeg"
+
+# No SYCL equivalent exists for nvjpeg_static currently and hence is removed in migrate CMake
+- Rule: nvjpeg_static_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nvjpeg_static
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nvjpeg_static
+      Out: ""
+      RuleId: "remove_nvjpeg_static"
+
+# No SYCL equivalent exists for nvptxcompiler_static currently and hence is removed in migrate CMake
+- Rule: nvptxcompiler_static_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nvptxcompiler_static
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nvptxcompiler_static
+      Out: ""
+      RuleId: "remove_nvptxcompiler_static"
+
+# No SYCL equivalent exists for nvrtc_builtins currently and hence is removed in migrate CMake
+- Rule: nvrtc_builtins_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nvrtc_builtins
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nvrtc_builtins
+      Out: ""
+      RuleId: "remove_nvrtc_builtins"
+
+# No SYCL equivalent exists for nvrtc_static currently and hence is removed in migrate CMake
+- Rule: nvrtc_static_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nvrtc_static
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nvrtc_static
+      Out: ""
+      RuleId: "remove_nvrtc_static"
+
+# No SYCL equivalent exists for nvrtc_builtins_static currently and hence is removed in migrate CMake
+- Rule: nvrtc_builtins_static_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nvrtc_builtins_static
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nvrtc_builtins_static
+      Out: ""
+      RuleId: "remove_nvrtc_builtins_static"
+
+# No SYCL equivalent exists for nvJitLink currently and hence is removed in migrate CMake
+- Rule: nvJitLink_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nvJitLink
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nvJitLink
+      Out: ""
+      RuleId: "remove_nvJitLink"
+
+# No SYCL equivalent exists for nvJitLink_static currently and hence is removed in migrate CMake
+- Rule: nvJitLink_static_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nvJitLink_static
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nvJitLink_static
+      Out: ""
+      RuleId: "remove_nvJitLink_static"
+
+# No SYCL equivalent exists for nvml currently and hence is removed in migrate CMake
+- Rule: nvml_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nvml
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nvml
+      Out: ""
+      RuleId: "remove_nvml"
+
+# No SYCL equivalent exists for nvtx3 currently and hence is removed in migrate CMake
+- Rule: nvtx3_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nvtx3
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::nvtx3
+      Out: ""
+      RuleId: "remove_nvtx3"
+
+# No SYCL equivalent exists for OpenCL currently and hence is removed in migrate CMake
+- Rule: OpenCL_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: OpenCL
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA::OpenCL
+      Out: ""
+      RuleId: "remove_OpenCL"
 
 - Rule: rule_set_property_cuda_standard
   Kind: CMakeRule

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -202,6 +202,7 @@
       MatchMode: Full
       In: \${CUDA_LIBRARIES}
       Out: ""
+      RuleId: "remove_CUDA_LIBRARIES"
 
 # ${CUDA_cudart_static_LIBRARY} is cmake reserved variable for static version of the CUDA runtime library.
 # SYCL runtime is auto-loaded when "-fsycl" flag is specified, so this variable is removed in the migrated CMake.
@@ -217,8 +218,9 @@
       MatchMode: Full
       In: \${CUDA_cudart_static_LIBRARY}
       Out: ""
+      RuleId: "remove_CUDA_cudart_static_LIBRARY"
 
-# ${CUDA_cudart_static_LIBRARY} is cmake reserved variable for CUDA device runtime library.
+# ${CUDA_cudadevrt_LIBRARY} is cmake reserved variable for CUDA device runtime library.
 # SYCL runtime is auto-loaded when "-fsycl" flag is specified, so this variable is removed in the migrated CMake.
 - Rule: CUDA_cudadevrt_LIBRARY_removed
   Kind: CMakeRule
@@ -232,6 +234,7 @@
       MatchMode: Full
       In: \${CUDA_cudadevrt_LIBRARY}
       Out: ""
+      RuleId: "remove_CUDA_cudadevrt_LIBRARY"
 
 - Rule: CUDA_CUFFT_LIBRARIES_rule
   Kind: CMakeRule
@@ -307,7 +310,6 @@
       Out: |
         \${MKL_LIB}
       RuleId: "replace_CUDA_cusparse_LIBRARY_with_MKL"
-
 
 - Rule: CUDA_cupti_LIBRARY_removed
   Kind: CMakeRule
@@ -805,51 +807,6 @@
         \${MKL_LIB}
       MatchMode: Full
       RuleId: "replace_-lcublas_with_qmkl"
-
-- Rule: rule_target_link_libraries_CUDA_CUBLAS_LIBRARIES
-  Kind: CMakeRule
-  Priority: Fallback
-  CmakeSyntax: CUDA_CUBLAS_LIBRARIES_target_link_libraries
-  In: ${prefix}link_libraries(${CUDALibraries})
-  Out: ${prefix}link_libraries(${CUDALibraries})
-  Subrules:
-    CUDALibraries:
-      In: |
-        \${CUDA_CUBLAS_LIBRARIES}
-      Out: |
-        \${MKL_LIB}
-      MatchMode: Full
-      RuleId: "replace_CUDA_CUBLAS_LIBRARIES_with_MKL"
-
-- Rule: rule_target_link_libraries_CUDA_CUFFT_LIBRARIES
-  Kind: CMakeRule
-  Priority: Fallback
-  CmakeSyntax: CUDA_CUFFT_LIBRARIES_target_link_libraries
-  In: ${prefix}link_libraries(${CUDALibraries})
-  Out: ${prefix}link_libraries(${CUDALibraries})
-  Subrules:
-    CUDALibraries:
-      In: |
-        \${CUDA_CUFFT_LIBRARIES}
-      Out: |
-        \${MKL_LIB}
-      MatchMode: Full
-      RuleId: "replace_CUDA_CUFFT_LIBRARIES_with_MKL"
-
-- Rule: rule_target_link_libraries_CUDA_cusparse_LIBRARY
-  Kind: CMakeRule
-  Priority: Fallback
-  CmakeSyntax: CUDA_cusparse_LIBRARY_target_link_libraries
-  In: ${prefix}link_libraries(${CUDALibraries})
-  Out: ${prefix}link_libraries(${CUDALibraries})
-  Subrules:
-    CUDALibraries:
-      In: |
-        \${CUDA_cusparse_LIBRARY}
-      Out: |
-        \${MKL_LIB}
-      MatchMode: Full
-      RuleId: "replace_CUDA_cusparse_LIBRARY_with_MKL"
 
 - Rule: rule_target_link_libraries_cudnn
   Kind: CMakeRule


### PR DESCRIPTION
Added migration support for following CMake CUDA library variables and targets: 


- CUDA_CUFFT_LIBRARIES {MKL}
- CUDA_CUBLAS_LIBRARIES {MKL}
- CUDA_curand_LIBRARY {MKL}
- CUDA_cusolver_LIBRARY {MKL}
- CUDA_cusparse_LIBRARY {MKL}
----
- CUDA_LIBRARIES {NA}
- CUDA_cudart_static_LIBRARY {NA}
- CUDA_cudadevrt_LIBRARY {NA}
- CUDA_cupti_LIBRARY {NA}
- CUDA_CUT_LIBRARY {NA}
- CUDA_npp_LIBRARY {NA}
- CUDA_nppc_LIBRARY {NA}
- CUDA_nppi_LIBRARY {NA}
- CUDA_nppial_LIBRARY {NA}
- CUDA_nppicc_LIBRARY {NA}
- CUDA_nppicom_LIBRARY {NA}
- CUDA_nppidei_LIBRARY {NA}
- CUDA_nppif_LIBRARY {NA}
- CUDA_nppig_LIBRARY {NA}
- CUDA_nppim_LIBRARY {NA}
- CUDA_nppist_LIBRARY {NA}
- CUDA_nppisu_LIBRARY {NA}
- CUDA_nppitc_LIBRARY {NA}
- CUDA_npps_LIBRARY {NA}
- CUDA_nvcuvenc_LIBRARY {NA}
- CUDA_nvcuvid_LIBRARY {NA}
- CUDA_nvToolsExt_LIBRARY {NA}
----
- CUDA::cufft {MKL}
- CUDA::cufftw {MKL}
- CUDA::cufft_static {MKL}
- CUDA::cufft_static_nocallback {MKL}
- CUDA::cufftw_static {MKL}
- CUDA::curand {MKL}
- CUDA::curand_static {MKL}
- CUDA::cusolver {MKL}
- CUDA::cusolver_static {MKL}
- CUDA::cusparse {MKL}
- CUDA::cusparse_static {MKL}
----
- CUDA::cudla {NA}
- CUDA::cuFile {NA}
- CUDA::cuFile_static {NA}
- CUDA::cuFile_rdma {NA}
- CUDA::cuFile_rdma_static {NA}
- CUDA::cupti {NA}
- CUDA::cupti_static {NA}
- CUDA::nvperf_host {NA}
- CUDA::nvperf_host_static {NA}
- CUDA::nvperf_target {NA}
- CUDA::pcsamplingutil {NA}
- CUDA::nppc {NA}
- CUDA::nppc_static {NA}
- CUDA::nppial {NA}
- CUDA::nppial_static {NA}
- CUDA::nppicc {NA}
- CUDA::nppicc_static {NA}
- CUDA::nppicom {NA}
- CUDA::nppicom_static {NA}
- CUDA::nppidei {NA}
- CUDA::nppidei_static {NA}
- CUDA::nppif {NA}
- CUDA::nppif_static {NA}
- CUDA::nppig {NA}
- CUDA::nppig_static {NA}
- CUDA::nppim {NA}
- CUDA::nppim_static {NA}
- CUDA::nppist {NA}
- CUDA::nppist_static {NA}
- CUDA::nppisu {NA}
- CUDA::nppisu_static {NA}
- CUDA::nppitc {NA}
- CUDA::nppitc_static {NA}
- CUDA::npps {NA}
- CUDA::npps_static {NA}
- CUDA::nvblas {NA}
- CUDA::nvgraph {NA}
- CUDA::nvgraph_static {NA}
- CUDA::nvjpeg {NA}
- CUDA::nvjpeg_static {NA}
- CUDA::nvptxcompiler_static {NA}
- CUDA::nvrtc_builtins {NA}
- CUDA::nvrtc_static starting {NA}
- CUDA::nvrtc_builtins_static {NA}
- CUDA::nvJitLink starting {NA}
- CUDA::nvJitLink_static {NA}
- CUDA::nvml {NA}
- CUDA::nvtx3 {NA}
- CUDA::OpenCL {NA}
----

Note: SYCL target is displayed inside {} against each CMake CUDA syntax