### PR TITLE
[SYCLomatic] Update memory order with sycl::memory_order::seq_cst or sycl::memory_order::acq_rel on condition of the target platform

### DIFF
--- a/clang/runtime/dpct-rt/include/dpct/atomic.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/atomic.hpp
@@ -58,13 +58,13 @@ inline T atomic_fetch_add(T *addr, T operand,
   case sycl::memory_order::acq_rel:
     return atomic_fetch_add<T, addressSpace, sycl::memory_order::acq_rel,
                             sycl::memory_scope::device>(addr, operand);
-  case sycl::memory_order::seq_cst:
-    return atomic_fetch_add<T, addressSpace, sycl::memory_order::seq_cst,
+  case sycl::memory_order::acq_rel:
+    return atomic_fetch_add<T, addressSpace, sycl::memory_order::acq_rel,
                             sycl::memory_scope::device>(addr, operand);
   default:
     assert(false && "Invalid memory_order for atomics. Valid memory_order for "
                     "atomics are: sycl::memory_order::relaxed, "
-                    "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
+                    "sycl::memory_order::acq_rel, sycl::memory_order::acq_rel!");
   }
 }
 
@@ -121,13 +121,13 @@ inline T atomic_fetch_sub(T *addr, T operand,
   case sycl::memory_order::acq_rel:
     return atomic_fetch_sub<T, addressSpace, sycl::memory_order::acq_rel,
                             sycl::memory_scope::device>(addr, operand);
-  case sycl::memory_order::seq_cst:
-    return atomic_fetch_sub<T, addressSpace, sycl::memory_order::seq_cst,
+  case sycl::memory_order::acq_rel:
+    return atomic_fetch_sub<T, addressSpace, sycl::memory_order::acq_rel,
                             sycl::memory_scope::device>(addr, operand);
   default:
     assert(false && "Invalid memory_order for atomics. Valid memory_order for "
                     "atomics are: sycl::memory_order::relaxed, "
-                    "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
+                    "sycl::memory_order::acq_rel, sycl::memory_order::acq_rel!");
   }
 }
 
@@ -184,13 +184,13 @@ inline T atomic_fetch_and(T *addr, T operand,
   case sycl::memory_order::acq_rel:
     return atomic_fetch_and<T, addressSpace, sycl::memory_order::acq_rel,
                             sycl::memory_scope::device>(addr, operand);
-  case sycl::memory_order::seq_cst:
-    return atomic_fetch_and<T, addressSpace, sycl::memory_order::seq_cst,
+  case sycl::memory_order::acq_rel:
+    return atomic_fetch_and<T, addressSpace, sycl::memory_order::acq_rel,
                             sycl::memory_scope::device>(addr, operand);
   default:
     assert(false && "Invalid memory_order for atomics. Valid memory_order for "
                     "atomics are: sycl::memory_order::relaxed, "
-                    "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
+                    "sycl::memory_order::acq_rel, sycl::memory_order::acq_rel!");
   }
 }
 
@@ -247,13 +247,13 @@ inline T atomic_fetch_or(T *addr, T operand,
   case sycl::memory_order::acq_rel:
     return atomic_fetch_or<T, addressSpace, sycl::memory_order::acq_rel,
                            sycl::memory_scope::device>(addr, operand);
-  case sycl::memory_order::seq_cst:
-    return atomic_fetch_or<T, addressSpace, sycl::memory_order::seq_cst,
+  case sycl::memory_order::acq_rel:
+    return atomic_fetch_or<T, addressSpace, sycl::memory_order::acq_rel,
                            sycl::memory_scope::device>(addr, operand);
   default:
     assert(false && "Invalid memory_order for atomics. Valid memory_order for "
                     "atomics are: sycl::memory_order::relaxed, "
-                    "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
+                    "sycl::memory_order::acq_rel, sycl::memory_order::acq_rel!");
   }
 }
 
@@ -310,13 +310,13 @@ inline T atomic_fetch_xor(T *addr, T operand,
   case sycl::memory_order::acq_rel:
     return atomic_fetch_xor<T, addressSpace, sycl::memory_order::acq_rel,
                             sycl::memory_scope::device>(addr, operand);
-  case sycl::memory_order::seq_cst:
-    return atomic_fetch_xor<T, addressSpace, sycl::memory_order::seq_cst,
+  case sycl::memory_order::acq_rel:
+    return atomic_fetch_xor<T, addressSpace, sycl::memory_order::acq_rel,
                             sycl::memory_scope::device>(addr, operand);
   default:
     assert(false && "Invalid memory_order for atomics. Valid memory_order for "
                     "atomics are: sycl::memory_order::relaxed, "
-                    "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
+                    "sycl::memory_order::acq_rel, sycl::memory_order::acq_rel!");
   }
 }
 
@@ -373,13 +373,13 @@ inline T atomic_fetch_min(T *addr, T operand,
   case sycl::memory_order::acq_rel:
     return atomic_fetch_min<T, addressSpace, sycl::memory_order::acq_rel,
                             sycl::memory_scope::device>(addr, operand);
-  case sycl::memory_order::seq_cst:
-    return atomic_fetch_min<T, addressSpace, sycl::memory_order::seq_cst,
+  case sycl::memory_order::acq_rel:
+    return atomic_fetch_min<T, addressSpace, sycl::memory_order::acq_rel,
                             sycl::memory_scope::device>(addr, operand);
   default:
     assert(false && "Invalid memory_order for atomics. Valid memory_order for "
                     "atomics are: sycl::memory_order::relaxed, "
-                    "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
+                    "sycl::memory_order::acq_rel, sycl::memory_order::acq_rel!");
   }
 }
 
@@ -436,13 +436,13 @@ inline T atomic_fetch_max(T *addr, T operand,
   case sycl::memory_order::acq_rel:
     return atomic_fetch_max<T, addressSpace, sycl::memory_order::acq_rel,
                             sycl::memory_scope::device>(addr, operand);
-  case sycl::memory_order::seq_cst:
-    return atomic_fetch_max<T, addressSpace, sycl::memory_order::seq_cst,
+  case sycl::memory_order::acq_rel:
+    return atomic_fetch_max<T, addressSpace, sycl::memory_order::acq_rel,
                             sycl::memory_scope::device>(addr, operand);
   default:
     assert(false && "Invalid memory_order for atomics. Valid memory_order for "
                     "atomics are: sycl::memory_order::relaxed, "
-                    "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
+                    "sycl::memory_order::acq_rel, sycl::memory_order::acq_rel!");
   }
 }
 
@@ -528,14 +528,14 @@ atomic_fetch_compare_inc(unsigned int *addr, unsigned int operand,
     return atomic_fetch_compare_inc<addressSpace, sycl::memory_order::acq_rel,
                                     sycl::memory_scope::device>(addr,
                                                                    operand);
-  case sycl::memory_order::seq_cst:
-    return atomic_fetch_compare_inc<addressSpace, sycl::memory_order::seq_cst,
+  case sycl::memory_order::acq_rel:
+    return atomic_fetch_compare_inc<addressSpace, sycl::memory_order::acq_rel,
                                     sycl::memory_scope::device>(addr,
                                                                    operand);
   default:
     assert(false && "Invalid memory_order for atomics. Valid memory_order for "
                     "atomics are: sycl::memory_order::relaxed, "
-                    "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
+                    "sycl::memory_order::acq_rel, sycl::memory_order::acq_rel!");
   }
 }
 
@@ -582,13 +582,13 @@ inline T atomic_exchange(T *addr, T operand,
   case sycl::memory_order::acq_rel:
     return atomic_exchange<T, addressSpace, sycl::memory_order::acq_rel,
                            sycl::memory_scope::device>(addr, operand);
-  case sycl::memory_order::seq_cst:
-    return atomic_exchange<T, addressSpace, sycl::memory_order::seq_cst,
+  case sycl::memory_order::acq_rel:
+    return atomic_exchange<T, addressSpace, sycl::memory_order::acq_rel,
                            sycl::memory_scope::device>(addr, operand);
   default:
     assert(false && "Invalid memory_order for atomics. Valid memory_order for "
                     "atomics are: sycl::memory_order::relaxed, "
-                    "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
+                    "sycl::memory_order::acq_rel, sycl::memory_order::acq_rel!");
   }
 }
 
@@ -695,7 +695,7 @@ template <typename T> struct IsValidAtomicType {
 
 template <typename T,
           sycl::memory_scope DefaultScope = sycl::memory_scope::system,
-          sycl::memory_order DefaultOrder = sycl::memory_order::seq_cst,
+          sycl::memory_order DefaultOrder = sycl::memory_order::acq_rel,
           sycl::access::address_space Space =
               sycl::access::address_space::generic_space>
 class atomic{

--- a/clang/runtime/dpct-rt/include/dpct/atomic.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/atomic.hpp
@@ -58,13 +58,13 @@ inline T atomic_fetch_add(T *addr, T operand,
   case sycl::memory_order::acq_rel:
     return atomic_fetch_add<T, addressSpace, sycl::memory_order::acq_rel,
                             sycl::memory_scope::device>(addr, operand);
-  case sycl::memory_order::acq_rel:
-    return atomic_fetch_add<T, addressSpace, sycl::memory_order::acq_rel,
+  case sycl::memory_order::seq_cst:
+    return atomic_fetch_add<T, addressSpace, sycl::memory_order::seq_cst,
                             sycl::memory_scope::device>(addr, operand);
   default:
     assert(false && "Invalid memory_order for atomics. Valid memory_order for "
                     "atomics are: sycl::memory_order::relaxed, "
-                    "sycl::memory_order::acq_rel, sycl::memory_order::acq_rel!");
+                    "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
   }
 }
 
@@ -121,13 +121,13 @@ inline T atomic_fetch_sub(T *addr, T operand,
   case sycl::memory_order::acq_rel:
     return atomic_fetch_sub<T, addressSpace, sycl::memory_order::acq_rel,
                             sycl::memory_scope::device>(addr, operand);
-  case sycl::memory_order::acq_rel:
-    return atomic_fetch_sub<T, addressSpace, sycl::memory_order::acq_rel,
+  case sycl::memory_order::seq_cst:
+    return atomic_fetch_sub<T, addressSpace, sycl::memory_order::seq_cst,
                             sycl::memory_scope::device>(addr, operand);
   default:
     assert(false && "Invalid memory_order for atomics. Valid memory_order for "
                     "atomics are: sycl::memory_order::relaxed, "
-                    "sycl::memory_order::acq_rel, sycl::memory_order::acq_rel!");
+                    "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
   }
 }
 
@@ -184,13 +184,13 @@ inline T atomic_fetch_and(T *addr, T operand,
   case sycl::memory_order::acq_rel:
     return atomic_fetch_and<T, addressSpace, sycl::memory_order::acq_rel,
                             sycl::memory_scope::device>(addr, operand);
-  case sycl::memory_order::acq_rel:
-    return atomic_fetch_and<T, addressSpace, sycl::memory_order::acq_rel,
+  case sycl::memory_order::seq_cst:
+    return atomic_fetch_and<T, addressSpace, sycl::memory_order::seq_cst,
                             sycl::memory_scope::device>(addr, operand);
   default:
     assert(false && "Invalid memory_order for atomics. Valid memory_order for "
                     "atomics are: sycl::memory_order::relaxed, "
-                    "sycl::memory_order::acq_rel, sycl::memory_order::acq_rel!");
+                    "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
   }
 }
 
@@ -247,13 +247,13 @@ inline T atomic_fetch_or(T *addr, T operand,
   case sycl::memory_order::acq_rel:
     return atomic_fetch_or<T, addressSpace, sycl::memory_order::acq_rel,
                            sycl::memory_scope::device>(addr, operand);
-  case sycl::memory_order::acq_rel:
-    return atomic_fetch_or<T, addressSpace, sycl::memory_order::acq_rel,
+  case sycl::memory_order::seq_cst:
+    return atomic_fetch_or<T, addressSpace, sycl::memory_order::seq_cst,
                            sycl::memory_scope::device>(addr, operand);
   default:
     assert(false && "Invalid memory_order for atomics. Valid memory_order for "
                     "atomics are: sycl::memory_order::relaxed, "
-                    "sycl::memory_order::acq_rel, sycl::memory_order::acq_rel!");
+                    "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
   }
 }
 
@@ -310,13 +310,13 @@ inline T atomic_fetch_xor(T *addr, T operand,
   case sycl::memory_order::acq_rel:
     return atomic_fetch_xor<T, addressSpace, sycl::memory_order::acq_rel,
                             sycl::memory_scope::device>(addr, operand);
-  case sycl::memory_order::acq_rel:
-    return atomic_fetch_xor<T, addressSpace, sycl::memory_order::acq_rel,
+  case sycl::memory_order::seq_cst:
+    return atomic_fetch_xor<T, addressSpace, sycl::memory_order::seq_cst,
                             sycl::memory_scope::device>(addr, operand);
   default:
     assert(false && "Invalid memory_order for atomics. Valid memory_order for "
                     "atomics are: sycl::memory_order::relaxed, "
-                    "sycl::memory_order::acq_rel, sycl::memory_order::acq_rel!");
+                    "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
   }
 }
 
@@ -373,13 +373,13 @@ inline T atomic_fetch_min(T *addr, T operand,
   case sycl::memory_order::acq_rel:
     return atomic_fetch_min<T, addressSpace, sycl::memory_order::acq_rel,
                             sycl::memory_scope::device>(addr, operand);
-  case sycl::memory_order::acq_rel:
-    return atomic_fetch_min<T, addressSpace, sycl::memory_order::acq_rel,
+  case sycl::memory_order::seq_cst:
+    return atomic_fetch_min<T, addressSpace, sycl::memory_order::seq_cst,
                             sycl::memory_scope::device>(addr, operand);
   default:
     assert(false && "Invalid memory_order for atomics. Valid memory_order for "
                     "atomics are: sycl::memory_order::relaxed, "
-                    "sycl::memory_order::acq_rel, sycl::memory_order::acq_rel!");
+                    "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
   }
 }
 
@@ -436,13 +436,13 @@ inline T atomic_fetch_max(T *addr, T operand,
   case sycl::memory_order::acq_rel:
     return atomic_fetch_max<T, addressSpace, sycl::memory_order::acq_rel,
                             sycl::memory_scope::device>(addr, operand);
-  case sycl::memory_order::acq_rel:
-    return atomic_fetch_max<T, addressSpace, sycl::memory_order::acq_rel,
+  case sycl::memory_order::seq_cst:
+    return atomic_fetch_max<T, addressSpace, sycl::memory_order::seq_cst,
                             sycl::memory_scope::device>(addr, operand);
   default:
     assert(false && "Invalid memory_order for atomics. Valid memory_order for "
                     "atomics are: sycl::memory_order::relaxed, "
-                    "sycl::memory_order::acq_rel, sycl::memory_order::acq_rel!");
+                    "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
   }
 }
 
@@ -528,14 +528,14 @@ atomic_fetch_compare_inc(unsigned int *addr, unsigned int operand,
     return atomic_fetch_compare_inc<addressSpace, sycl::memory_order::acq_rel,
                                     sycl::memory_scope::device>(addr,
                                                                    operand);
-  case sycl::memory_order::acq_rel:
-    return atomic_fetch_compare_inc<addressSpace, sycl::memory_order::acq_rel,
+  case sycl::memory_order::seq_cst:
+    return atomic_fetch_compare_inc<addressSpace, sycl::memory_order::seq_cst,
                                     sycl::memory_scope::device>(addr,
                                                                    operand);
   default:
     assert(false && "Invalid memory_order for atomics. Valid memory_order for "
                     "atomics are: sycl::memory_order::relaxed, "
-                    "sycl::memory_order::acq_rel, sycl::memory_order::acq_rel!");
+                    "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
   }
 }
 
@@ -582,13 +582,13 @@ inline T atomic_exchange(T *addr, T operand,
   case sycl::memory_order::acq_rel:
     return atomic_exchange<T, addressSpace, sycl::memory_order::acq_rel,
                            sycl::memory_scope::device>(addr, operand);
-  case sycl::memory_order::acq_rel:
-    return atomic_exchange<T, addressSpace, sycl::memory_order::acq_rel,
+  case sycl::memory_order::seq_cst:
+    return atomic_exchange<T, addressSpace, sycl::memory_order::seq_cst,
                            sycl::memory_scope::device>(addr, operand);
   default:
     assert(false && "Invalid memory_order for atomics. Valid memory_order for "
                     "atomics are: sycl::memory_order::relaxed, "
-                    "sycl::memory_order::acq_rel, sycl::memory_order::acq_rel!");
+                    "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
   }
 }
 
@@ -695,10 +695,14 @@ template <typename T> struct IsValidAtomicType {
 
 template <typename T,
           sycl::memory_scope DefaultScope = sycl::memory_scope::system,
+#ifdef __AMDGPU__
           sycl::memory_order DefaultOrder = sycl::memory_order::acq_rel,
+#else
+          sycl::memory_order DefaultOrder = sycl::memory_order::seq_cst,
+#endif
           sycl::access::address_space Space =
               sycl::access::address_space::generic_space>
-class atomic{
+class atomic {
   static_assert(
     detail::IsValidAtomicType<T>::value,
     "Invalid atomic type.  Valid types are int, unsigned int, long, "

--- a/clang/runtime/dpct-rt/include/dpct/util.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/util.hpp
@@ -629,7 +629,7 @@ template <int dimensions = 3>
 inline void
 nd_range_barrier(const sycl::nd_item<dimensions> &item,
                  sycl::atomic_ref<
-                     unsigned int, sycl::memory_order::seq_cst,
+                     unsigned int, sycl::memory_order::acq_rel,
                      sycl::memory_scope::device,
                      sycl::access::address_space::global_space> &counter) {
 
@@ -669,7 +669,7 @@ template <>
 inline void
 nd_range_barrier(const sycl::nd_item<1> &item,
                  sycl::atomic_ref<
-                     unsigned int, sycl::memory_order::seq_cst,
+                     unsigned int, sycl::memory_order::acq_rel,
                      sycl::memory_scope::device,
                      sycl::access::address_space::global_space> &counter) {
   unsigned int num_groups = item.get_group_range(0);

--- a/clang/runtime/dpct-rt/include/dpct/util.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/util.hpp
@@ -626,10 +626,14 @@ namespace experimental {
 /// Note: Please make sure that all the work items of all work groups within
 /// a SYCL kernel can be scheduled actively at the same time on a device.
 template <int dimensions = 3>
-inline void
-nd_range_barrier(const sycl::nd_item<dimensions> &item,
-                 sycl::atomic_ref<
-                     unsigned int, sycl::memory_order::acq_rel,
+inline void nd_range_barrier(
+    const sycl::nd_item<dimensions> &item,
+    sycl::atomic_ref<unsigned int,
+#ifdef __AMDGPU__
+                     sycl::memory_order::acq_rel,
+#else
+                     sycl::memory_order::seq_cst,
+#endif
                      sycl::memory_scope::device,
                      sycl::access::address_space::global_space> &counter) {
 
@@ -666,10 +670,14 @@ nd_range_barrier(const sycl::nd_item<dimensions> &item,
 /// Note: Please make sure that all the work items of all work groups within
 /// a SYCL kernel can be scheduled actively at the same time on a device.
 template <>
-inline void
-nd_range_barrier(const sycl::nd_item<1> &item,
-                 sycl::atomic_ref<
-                     unsigned int, sycl::memory_order::acq_rel,
+inline void nd_range_barrier(
+    const sycl::nd_item<1> &item,
+    sycl::atomic_ref<unsigned int,
+#ifdef __AMDGPU__
+                     sycl::memory_order::acq_rel,
+#else
+                     sycl::memory_order::seq_cst,
+#endif
                      sycl::memory_scope::device,
                      sycl::access::address_space::global_space> &counter) {
   unsigned int num_groups = item.get_group_range(0);


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>