### PR TITLE
[SYCLomatic] Adding comments to mark USM_NONE functionality relying on UB

### DIFF
--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/memory.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/memory.h
@@ -221,22 +221,25 @@ public:
   device_pointer_base(const device_pointer_base &in)
       : buffer(in.buffer), idx(in.idx) {}
   pointer get() const {
-    //This code returns a pointer data within to a sycl buffer accessor which is leaving scope. This relies on undefined
-    // behavior and may not provide a valid pointer to data inside that buffer.
+    // This code returns a pointer data within to a sycl buffer accessor which
+    // is leaving scope. This relies on undefined behavior and may not provide
+    // a valid pointer to data inside that buffer.
     auto res =
         (const_cast<device_pointer_base *>(this)->buffer.get_host_access())
             .get_pointer();
     return res + idx;
   }
   operator ValueType *() {
-    //This code returns a pointer to data within a sycl buffer accessor which is leaving scope. This relies on undefined
-    // behavior and may not provide a valid pointer to data inside that buffer.
+    // This code returns a pointer to data within a sycl buffer accessor which
+    // is leaving scope. This relies on undefined behavior and may not provide
+    // a valid pointer to data inside that buffer.
     auto res = (buffer.get_host_access()).get_pointer();
     return res + idx;
   }
   operator ValueType *() const {
-    //This code returns a pointer to data within a sycl buffer accessor which is leaving scope. This relies on undefined
-    // behavior and may not provide a valid pointer to data inside that buffer.
+    // This code returns a pointer to data within a sycl buffer accessor which
+    // is leaving scope. This relies on undefined behavior and may not provide
+    // a valid pointer to data inside that buffer.
     auto res =
         (const_cast<device_pointer_base *>(this)->buffer.get_host_access())
             .get_pointer();
@@ -1000,8 +1003,9 @@ device_pointer<T> get_device_pointer(const device_pointer<T> &ptr) {
 }
 
 template <typename T> T *get_raw_pointer(const device_pointer<T> &ptr) {
-  //This code returns a pointer to data within a sycl buffer accessor which has left scope. This relies on undefined
-  // behavior and may not provide a valid pointer to data inside that buffer.
+  // This code returns a pointer to data within a sycl buffer accessor which has
+  // left scope. This relies on undefined behavior and may not provide a valid
+  // pointer to data inside that buffer.
   return ptr.get();
 }
 
@@ -1010,14 +1014,10 @@ template <typename Pointer> Pointer get_raw_pointer(const Pointer &ptr) {
 }
 
 template <typename T> const T &get_raw_reference(const device_reference<T> &ref) {
-  //This code returns a reference to data insde a sycl buffer accessor which has left scope. This relies on undefined
-  // behavior and may not provide a valid pointer to data inside that buffer.
   return ref.value;
 }
 
 template <typename T> T &get_raw_reference(device_reference<T> &ref) {
-  //This code returns a reference to data insde a sycl buffer accessor which has left scope. This relies on undefined
-  // behavior and may not provide a valid pointer to data inside that buffer.
   return ref.value;
 }
 

--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/memory.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/memory.h
@@ -221,16 +221,22 @@ public:
   device_pointer_base(const device_pointer_base &in)
       : buffer(in.buffer), idx(in.idx) {}
   pointer get() const {
+    //This code returns a pointer data within to a sycl buffer accessor which is leaving scope. This relies on undefined
+    // behavior and may not provide a valid pointer to data inside that buffer.
     auto res =
         (const_cast<device_pointer_base *>(this)->buffer.get_host_access())
             .get_pointer();
     return res + idx;
   }
   operator ValueType *() {
+    //This code returns a pointer to data within a sycl buffer accessor which is leaving scope. This relies on undefined
+    // behavior and may not provide a valid pointer to data inside that buffer.
     auto res = (buffer.get_host_access()).get_pointer();
     return res + idx;
   }
   operator ValueType *() const {
+    //This code returns a pointer to data within a sycl buffer accessor which is leaving scope. This relies on undefined
+    // behavior and may not provide a valid pointer to data inside that buffer.
     auto res =
         (const_cast<device_pointer_base *>(this)->buffer.get_host_access())
             .get_pointer();
@@ -994,6 +1000,8 @@ device_pointer<T> get_device_pointer(const device_pointer<T> &ptr) {
 }
 
 template <typename T> T *get_raw_pointer(const device_pointer<T> &ptr) {
+  //This code returns a pointer to data within a sycl buffer accessor which has left scope. This relies on undefined
+  // behavior and may not provide a valid pointer to data inside that buffer.
   return ptr.get();
 }
 
@@ -1002,10 +1010,14 @@ template <typename Pointer> Pointer get_raw_pointer(const Pointer &ptr) {
 }
 
 template <typename T> const T &get_raw_reference(const device_reference<T> &ref) {
+  //This code returns a reference to data insde a sycl buffer accessor which has left scope. This relies on undefined
+  // behavior and may not provide a valid pointer to data inside that buffer.
   return ref.value;
 }
 
 template <typename T> T &get_raw_reference(device_reference<T> &ref) {
+  //This code returns a reference to data insde a sycl buffer accessor which has left scope. This relies on undefined
+  // behavior and may not provide a valid pointer to data inside that buffer.
   return ref.value;
 }
 

--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/vector.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/vector.h
@@ -785,12 +785,16 @@ public:
   const_iterator end() const { return device_iterator<T>(get_buffer(), _size); }
   const_iterator cend() const { return end(); }
   T *real_begin() {
+    //This code returns a pointer to a data within sycl buffer accessor which is leaving scope. This relies on undefined
+    // behavior and may not provide a valid pointer to data inside that buffer.
     return (detail::mem_mgr::instance()
                 .translate_ptr(_storage)
                 .buffer.get_host_access())
         .get_pointer();
   }
   const T *real_begin() const {
+    //This code returns a pointer to a data within sycl buffer accessor which is leaving scope. This relies on undefined
+    // behavior and may not provide a valid pointer to data inside that buffer.
     return const_cast<device_vector *>(this)
         ->detail::mem_mgr::instance()
         .translate_ptr(_storage)

--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/vector.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/vector.h
@@ -785,7 +785,8 @@ public:
   const_iterator end() const { return device_iterator<T>(get_buffer(), _size); }
   const_iterator cend() const { return end(); }
   T *real_begin() {
-    //This code returns a pointer to a data within sycl buffer accessor which is leaving scope. This relies on undefined
+    // This code returns a pointer to a data within sycl buffer accessor which
+    // is leaving scope. This relies on undefined
     // behavior and may not provide a valid pointer to data inside that buffer.
     return (detail::mem_mgr::instance()
                 .translate_ptr(_storage)
@@ -793,7 +794,8 @@ public:
         .get_pointer();
   }
   const T *real_begin() const {
-    //This code returns a pointer to a data within sycl buffer accessor which is leaving scope. This relies on undefined
+    // This code returns a pointer to a data within sycl buffer accessor which
+    // is leaving scope. This relies on undefined
     // behavior and may not provide a valid pointer to data inside that buffer.
     return const_cast<device_vector *>(this)
         ->detail::mem_mgr::instance()


### PR DESCRIPTION
Alternative to #1617 for code relying on undefined behavior within `DPCT_USM_LEVEL_NONE`.

Adding comments to signify that this functionality may not provide valid pointers / references.