### PR TITLE
[SYCLomatic][CMake Script] Fix bug that CMake script is not migrated when default directory "dpct_output" exists

### DIFF
--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -1001,8 +1001,10 @@ int runDPCT(int argc, const char **argv) {
     Tool.setPrintErrorMessage(false);
   } else {
     IsUsingDefaultOutRoot = OutRoot.getPath().empty();
+    bool NeedCheckDirEmpty =
+        !(BuildScript == BuildScript::BS_Cmake) && !MigrateBuildScriptOnly;
     if (!DpctGlobalInfo::isAnalysisModeEnabled() && IsUsingDefaultOutRoot &&
-        !getDefaultOutRoot(OutRoot)) {
+        !getDefaultOutRoot(OutRoot, NeedCheckDirEmpty)) {
       ShowStatus(MigrationErrorInvalidInRootOrOutRoot);
       dpctExit(MigrationErrorInvalidInRootOrOutRoot, false);
     }

--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -1001,10 +1001,10 @@ int runDPCT(int argc, const char **argv) {
     Tool.setPrintErrorMessage(false);
   } else {
     IsUsingDefaultOutRoot = OutRoot.getPath().empty();
-    bool NeedCheckDirEmpty =
+    bool NeedCheckOutRootEmpty =
         !(BuildScript == BuildScript::BS_Cmake) && !MigrateBuildScriptOnly;
     if (!DpctGlobalInfo::isAnalysisModeEnabled() && IsUsingDefaultOutRoot &&
-        !getDefaultOutRoot(OutRoot, NeedCheckDirEmpty)) {
+        !getDefaultOutRoot(OutRoot, NeedCheckOutRootEmpty)) {
       ShowStatus(MigrationErrorInvalidInRootOrOutRoot);
       dpctExit(MigrationErrorInvalidInRootOrOutRoot, false);
     }

--- a/clang/lib/DPCT/ValidateArguments.cpp
+++ b/clang/lib/DPCT/ValidateArguments.cpp
@@ -24,7 +24,8 @@ namespace path = llvm::sys::path;
 namespace fs = llvm::sys::fs;
 
 // Set OutRoot to the current working directory.
-bool getDefaultOutRoot(clang::tooling::UnifiedPath &OutRootPar) {
+bool getDefaultOutRoot(clang::tooling::UnifiedPath &OutRootPar,
+                       bool NeedCheckDirEmpty) {
   SmallString<256> OutRoot;
   if (fs::current_path(OutRoot) != std::error_code()) {
     llvm::errs() << "Could not get current path.\n";
@@ -39,14 +40,14 @@ bool getDefaultOutRoot(clang::tooling::UnifiedPath &OutRootPar) {
       return false;
     }
     fs::directory_iterator End;
-    if (Iter != End) {
+    if (NeedCheckDirEmpty && Iter != End) {
       llvm::errs() << "dpct_output directory is not empty. Please use option"
                       " \"--out-root\" to set output directory.\n";
       return false;
-    } else {
-      clang::dpct::PrintMsg(
-          "The directory \"dpct_output\" is used as \"out-root\"\n");
     }
+    clang::dpct::PrintMsg(
+        "The directory \"dpct_output\" is used as \"out-root\"\n");
+
   } else {
     clang::dpct::createDirectories(OutRoot, false);
     clang::dpct::PrintMsg(

--- a/clang/lib/DPCT/ValidateArguments.cpp
+++ b/clang/lib/DPCT/ValidateArguments.cpp
@@ -25,7 +25,7 @@ namespace fs = llvm::sys::fs;
 
 // Set OutRoot to the current working directory.
 bool getDefaultOutRoot(clang::tooling::UnifiedPath &OutRootPar,
-                       bool NeedCheckDirEmpty) {
+                       bool NeedCheckOutRootEmpty) {
   SmallString<256> OutRoot;
   if (fs::current_path(OutRoot) != std::error_code()) {
     llvm::errs() << "Could not get current path.\n";
@@ -40,7 +40,7 @@ bool getDefaultOutRoot(clang::tooling::UnifiedPath &OutRootPar,
       return false;
     }
     fs::directory_iterator End;
-    if (NeedCheckDirEmpty && Iter != End) {
+    if (NeedCheckOutRootEmpty && Iter != End) {
       llvm::errs() << "dpct_output directory is not empty. Please use option"
                       " \"--out-root\" to set output directory.\n";
       return false;

--- a/clang/lib/DPCT/ValidateArguments.h
+++ b/clang/lib/DPCT/ValidateArguments.h
@@ -96,7 +96,8 @@ bool makeInRootCanonicalOrSetDefaults(
     clang::tooling::UnifiedPath &InRoot, const std::vector<std::string> SourceFiles);
 bool makeAnalysisScopeCanonicalOrSetDefaults(clang::tooling::UnifiedPath &AnalysisScope,
                                              const clang::tooling::UnifiedPath &InRoot);
-bool getDefaultOutRoot(clang::tooling::UnifiedPath &OutRootPar);
+bool getDefaultOutRoot(clang::tooling::UnifiedPath &OutRootPar,
+                       bool NeedCheckDirEmpty = true);
 /// Make sure files passed to tool are under the
 /// input root directory and have an extension.
 /// return value:

--- a/clang/lib/DPCT/ValidateArguments.h
+++ b/clang/lib/DPCT/ValidateArguments.h
@@ -97,7 +97,7 @@ bool makeInRootCanonicalOrSetDefaults(
 bool makeAnalysisScopeCanonicalOrSetDefaults(clang::tooling::UnifiedPath &AnalysisScope,
                                              const clang::tooling::UnifiedPath &InRoot);
 bool getDefaultOutRoot(clang::tooling::UnifiedPath &OutRootPar,
-                       bool NeedCheckDirEmpty = true);
+                       bool NeedCheckOutRootEmpty = true);
 /// Make sure files passed to tool are under the
 /// input root directory and have an extension.
 /// return value:

--- a/clang/test/dpct/cmake_migration/case_027/case_027_CMAKE_CUDA_COMPILER.cpp
+++ b/clang/test/dpct/cmake_migration/case_027/case_027_CMAKE_CUDA_COMPILER.cpp
@@ -6,5 +6,12 @@
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
 
+// RUN: dpct  ./input.cmake --migrate-build-script-only
+// RUN: rm dpct_output/input.cmake
+// RUN: dpct  ./input.cmake --migrate-build-script-only
+// RUN: echo "begin" > %T/diff.txt
+// RUN: diff --strip-trailing-cr %S/expected.txt %T/dpct_output/input.cmake >> %T/diff.txt
+// RUN: echo "end" >> %T/diff.txt
+
 // CHECK: begin
 // CHECK-NEXT: end


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>
