### PR TITLE
[SYCLomatic] Fix the out-of-bound access in dpct::device_vector::reserve()

### DIFF
--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/vector.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/vector.h
@@ -438,7 +438,7 @@ public:
       // copy content (old buffer to new buffer)
       if (capacity() > 0) {
         device_allocator_traits<Allocator>::uninitialized_device_copy_n(
-            _alloc, begin(), n, tmp);
+            _alloc, begin(), _size, tmp);
         alloc_traits::deallocate(_alloc, _storage, _capacity);
       }
       _storage = tmp;


### PR DESCRIPTION
Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>