### PR TITLE
[SYCLomatic] Fix for ambiguous operations in device_vector

### DIFF
--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/memory.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/memory.h
@@ -79,64 +79,7 @@ template <typename T> struct device_reference {
     return *this;
   };
   pointer operator&() const { return pointer(&value); };
-  device_reference &operator++() {
-    ++value;
-    return *this;
-  };
-  device_reference &operator--() {
-    --value;
-    return *this;
-  };
-  device_reference operator++(int) {
-    device_reference ref(*this);
-    ++(*this);
-    return ref;
-  };
-  device_reference operator--(int) {
-    device_reference ref(*this);
-    --(*this);
-    return ref;
-  };
-  device_reference &operator+=(const T &input) {
-    value += input;
-    return *this;
-  };
-  device_reference &operator-=(const T &input) {
-    value -= input;
-    return *this;
-  };
-  device_reference &operator*=(const T &input) {
-    value *= input;
-    return *this;
-  };
-  device_reference &operator/=(const T &input) {
-    value /= input;
-    return *this;
-  };
-  device_reference &operator%=(const T &input) {
-    value %= input;
-    return *this;
-  };
-  device_reference &operator&=(const T &input) {
-    value &= input;
-    return *this;
-  };
-  device_reference &operator|=(const T &input) {
-    value |= input;
-    return *this;
-  };
-  device_reference &operator^=(const T &input) {
-    value ^= input;
-    return *this;
-  };
-  device_reference &operator<<=(const T &input) {
-    value <<= input;
-    return *this;
-  };
-  device_reference &operator>>=(const T &input) {
-    value >>= input;
-    return *this;
-  };
+
   operator T &() { return value; }
   operator const T &() const { return value; }
   void swap(device_reference &input) {


### PR DESCRIPTION
After conversion operator was added to a normal reference #1538, many provided operators became ambiguous with the operators of the converted type.
This removes those ambiguous operators, in favor of converting to the base reference type and using the operators there.  

We can convert back to back to `device_reference<T>` from a `T&` already.
