### PR TITLE
[SYCLomatic] return device_pointer from data()

### DIFF
--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/vector.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/vector.h
@@ -159,8 +159,8 @@ public:
   using reference = device_reference<T>;
   using const_reference = const reference;
   using value_type = T;
-  using pointer = T *;
-  using const_pointer = const T *;
+  using pointer = device_pointer<T>;
+  using const_pointer = const device_pointer<T>;
   using difference_type =
       typename ::std::iterator_traits<iterator>::difference_type;
   using size_type = ::std::size_t;
@@ -171,7 +171,7 @@ private:
   Allocator _alloc;
   size_type _size;
   size_type _capacity;
-  pointer _storage;
+  T* _storage;
 
   size_type _min_capacity() const { return size_type(1); }
 
@@ -462,8 +462,8 @@ public:
   reference front() { return *begin(); }
   const_reference back(void) const { return *(end() - 1); }
   reference back(void) { return *(end() - 1); }
-  pointer data(void) { return _storage; }
-  const_pointer data(void) const { return _storage; }
+  pointer data(void) { return pointer(_storage); }
+  const_pointer data(void) const { return pointer(_storage); }
   void shrink_to_fit(void) {
     if (_size != capacity() && capacity() > _min_capacity()) {
       size_type tmp_capacity = ::std::max(_size, _min_capacity());
@@ -622,8 +622,8 @@ public:
   using reference = device_reference<T>;
   using const_reference = const reference;
   using value_type = T;
-  using pointer = T *;
-  using const_pointer = const T *;
+  using pointer = device_pointer<T>;
+  using const_pointer = const device_pointer<T>;
   using difference_type =
       typename std::iterator_traits<iterator>::difference_type;
   using size_type = std::size_t;
@@ -850,9 +850,9 @@ public:
   reference front() { return *begin(); }
   const_reference back(void) const { return *(end() - 1); }
   reference back(void) { return *(end() - 1); }
-  pointer data(void) { return reinterpret_cast<pointer>(_storage); }
+  pointer data(void) { return pointer(reinterpret_cast<T*>(_storage)); }
   const_pointer data(void) const {
-    return reinterpret_cast<const_pointer>(_storage);
+    return const_pointer(reinterpret_cast<const_pointer>(_storage));
   }
   void shrink_to_fit(void) {
     if (_size != capacity()) {

--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/vector.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/vector.h
@@ -852,7 +852,7 @@ public:
   reference back(void) { return *(end() - 1); }
   pointer data(void) { return pointer(reinterpret_cast<T *>(_storage)); }
   const_pointer data(void) const {
-    return const_pointer(reinterpret_cast<const_pointer>(_storage));
+    return const_pointer(reinterpret_cast<T *>(_storage));
   }
   void shrink_to_fit(void) {
     if (_size != capacity()) {

--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/vector.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/vector.h
@@ -171,7 +171,7 @@ private:
   Allocator _alloc;
   size_type _size;
   size_type _capacity;
-  T* _storage;
+  T *_storage;
 
   size_type _min_capacity() const { return size_type(1); }
 
@@ -850,7 +850,7 @@ public:
   reference front() { return *begin(); }
   const_reference back(void) const { return *(end() - 1); }
   reference back(void) { return *(end() - 1); }
-  pointer data(void) { return pointer(reinterpret_cast<T*>(_storage)); }
+  pointer data(void) { return pointer(reinterpret_cast<T *>(_storage)); }
   const_pointer data(void) const {
     return const_pointer(reinterpret_cast<const_pointer>(_storage));
   }

--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/vector.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/vector.h
@@ -463,7 +463,7 @@ public:
   const_reference back(void) const { return *(end() - 1); }
   reference back(void) { return *(end() - 1); }
   pointer data(void) { return pointer(_storage); }
-  const_pointer data(void) const { return pointer(_storage); }
+  const_pointer data(void) const { return const_pointer(_storage); }
   void shrink_to_fit(void) {
     if (_size != capacity() && capacity() > _min_capacity()) {
       size_type tmp_capacity = ::std::max(_size, _min_capacity());

--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/vector.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/vector.h
@@ -160,7 +160,7 @@ public:
   using const_reference = const reference;
   using value_type = T;
   using pointer = device_pointer<T>;
-  using const_pointer = const device_pointer<T>;
+  using const_pointer = device_pointer<const T>;
   using difference_type =
       typename ::std::iterator_traits<iterator>::difference_type;
   using size_type = ::std::size_t;
@@ -623,7 +623,7 @@ public:
   using const_reference = const reference;
   using value_type = T;
   using pointer = device_pointer<T>;
-  using const_pointer = const device_pointer<T>;
+  using const_pointer = device_pointer<const T>;
   using difference_type =
       typename std::iterator_traits<iterator>::difference_type;
   using size_type = std::size_t;
@@ -852,7 +852,7 @@ public:
   reference back(void) { return *(end() - 1); }
   pointer data(void) { return pointer(reinterpret_cast<T *>(_storage)); }
   const_pointer data(void) const {
-    return const_pointer(reinterpret_cast<T *>(_storage));
+    return const_pointer(reinterpret_cast<const T *>(_storage));
   }
   void shrink_to_fit(void) {
     if (_size != capacity()) {


### PR DESCRIPTION
Fix for data() function return and `pointer` typedef for `device_vector` to use `device_pointer`

I don't know the motivation for originally using `T*` rather than `device_pointer<T>`.  This passes the tests for vector.  It seems that this should be a reasonable change. 