### PR TITLE
[SYCLomatic] Implement a simple option to apply all SYCL extensions/experimental features during migration

### DIFF
--- a/clang/include/clang/DPCT/DPCTOptions.inc
+++ b/clang/include/clang/DPCT/DPCTOptions.inc
@@ -338,27 +338,30 @@ DPCT_ENUM_OPTION(DPCT_OPT_TYPE(static llvm::cl::bits<DPCPPExtensionsDefaultEnabl
            DPCT_OPTION_VALUES(
              DPCT_OPT_ENUM("bfloat16",
                                      int(DPCPPExtensionsDefaultEnabled::ExtDE_BFloat16),
-                                     "Use the SYCL extensions for bfloat16.",
+                                     "Disable the SYCL extensions for bfloat16.",
                                      false),
              DPCT_OPT_ENUM("device_info",
                                      int(DPCPPExtensionsDefaultEnabled::ExtDE_DeviceInfo),
-                                     "Use the Intel extensions for device information, if supported by the compiler and the backend.",
+                                     "Disable the Intel extensions for device information, if supported by the compiler and the backend.",
                                      false),
              DPCT_OPT_ENUM("enqueued_barriers",
                                      int(DPCPPExtensionsDefaultEnabled::ExtDE_EnqueueBarrier),
-                                     "Use the enqueued barriers extension.",
+                                     "Disable the enqueued barriers extension.",
                                      false),
              DPCT_OPT_ENUM("peer_access",
                                      int(DPCPPExtensionsDefaultEnabled::ExtDE_PeerAccess),
-                                     "Use the peer access extension.",
+                                     "Disable the peer access extension.",
                                      false),
              DPCT_OPT_ENUM("assert",
                                      int(DPCPPExtensionsDefaultEnabled::ExtDE_Assert),
-                                     "Use the assert extension.", false),
+                                     "Disable the assert extension.", false),
              DPCT_OPT_ENUM("queue_empty",
                                      int(DPCPPExtensionsDefaultEnabled::ExtDE_QueueEmpty),
-                                     "Use the queue empty extension.",
-                                     false)
+                                     "Disable the queue empty extension.",
+                                     false),
+             DPCT_OPT_ENUM("all",
+                                     int(DPCPPExtensionsDefaultEnabled::ExtDE_All),
+                                     "Disable all extensions.", false)
            ),
            llvm::cl::desc("A comma-separated list of extensions not to be used in migrated code.\n"
            "By default, these extensions are used in migrated code.\n"
@@ -378,6 +381,10 @@ DPCT_ENUM_OPTION(DPCT_OPT_TYPE(static llvm::cl::bits<DPCPPExtensionsDefaultDisab
                                      int(DPCPPExtensionsDefaultDisabled::ExtDD_IntelDeviceMath),
                                      "Use sycl::ext::intel::math functions from the libdevice library (provided by Intel(R) oneAPI\n"
                                      "DPC++/C++ Compiler) to migrate functions which have no mapping in the SYCL standard.",
+                                     false),
+             DPCT_OPT_ENUM("all",
+                                     int(DPCPPExtensionsDefaultDisabled::ExtDD_All),
+                                     "Enable all DPC++ extensions.",
                                      false)
            ),
            llvm::cl::desc("A comma-separated list of extensions to be used in migrated code.\n"
@@ -423,6 +430,9 @@ DPCT_ENUM_OPTION(DPCT_OPT_TYPE(static llvm::cl::bits<ExperimentalFeatures>), Exp
         false),
              DPCT_OPT_ENUM("non-uniform-groups", int(ExperimentalFeatures::Exp_NonUniformGroups),
         "Experimental extension that allows use of non-uniform groups.\n",
+        false),
+            DPCT_OPT_ENUM("all", int(ExperimentalFeatures::Exp_All),
+        "Enable all experimental extensions.\n",
         false)
            ),
            llvm::cl::desc("Comma-separated list of experimental features to be used in migrated "

--- a/clang/include/clang/DPCT/DPCTOptions.inc
+++ b/clang/include/clang/DPCT/DPCTOptions.inc
@@ -361,7 +361,7 @@ DPCT_ENUM_OPTION(DPCT_OPT_TYPE(static llvm::cl::bits<DPCPPExtensionsDefaultEnabl
                                      false),
              DPCT_OPT_ENUM("all",
                                      int(DPCPPExtensionsDefaultEnabled::ExtDE_All),
-                                     "Disable all extensions.", false)
+                                     "Disable all extensions listed in this option.", false)
            ),
            llvm::cl::desc("A comma-separated list of extensions not to be used in migrated code.\n"
            "By default, these extensions are used in migrated code.\n"
@@ -384,7 +384,7 @@ DPCT_ENUM_OPTION(DPCT_OPT_TYPE(static llvm::cl::bits<DPCPPExtensionsDefaultDisab
                                      false),
              DPCT_OPT_ENUM("all",
                                      int(DPCPPExtensionsDefaultDisabled::ExtDD_All),
-                                     "Enable all DPC++ extensions.",
+                                     "Enable all DPC++ extensions listed in this option.",
                                      false)
            ),
            llvm::cl::desc("A comma-separated list of extensions to be used in migrated code.\n"
@@ -432,7 +432,7 @@ DPCT_ENUM_OPTION(DPCT_OPT_TYPE(static llvm::cl::bits<ExperimentalFeatures>), Exp
         "Experimental extension that allows use of non-uniform groups.\n",
         false),
             DPCT_OPT_ENUM("all", int(ExperimentalFeatures::Exp_All),
-        "Enable all experimental extensions.\n",
+        "Enable all experimental extensions listed in this option.\n",
         false)
            ),
            llvm::cl::desc("Comma-separated list of experimental features to be used in migrated "

--- a/clang/lib/DPCT/AnalysisInfo.h
+++ b/clang/lib/DPCT/AnalysisInfo.h
@@ -780,17 +780,40 @@ public:
   static bool getUsingExtensionDE(DPCPPExtensionsDefaultEnabled Ext) {
     return ExtensionDEFlag & (1 << static_cast<unsigned>(Ext));
   }
-  static void setExtensionDEFlag(unsigned Flag) { ExtensionDEFlag = Flag; }
+  static void setExtensionDEFlag(unsigned Flag) {
+    // The bits in Flag was reversed, so we need to check whether the ExtDE_All
+    // bit of Flag is 0. That means disable all default enabled extensions,
+    // otherwise disable the extensions represented by the 0 bit
+    if (Flag &
+        (1 << static_cast<unsigned>(DPCPPExtensionsDefaultEnabled::ExtDE_All)))
+      ExtensionDEFlag = Flag;
+    else
+      ExtensionDEFlag = 0;
+  }
   static unsigned getExtensionDEFlag() { return ExtensionDEFlag; }
   static bool getUsingExtensionDD(DPCPPExtensionsDefaultDisabled Ext) {
     return ExtensionDDFlag & (1 << static_cast<unsigned>(Ext));
   }
-  static void setExtensionDDFlag(unsigned Flag) { ExtensionDDFlag = Flag; }
+  static void setExtensionDDFlag(unsigned Flag) {
+    // If the ExtDD_All bit is 1, enable all default disabled extensions.
+    if (Flag &
+        (1 << static_cast<unsigned>(DPCPPExtensionsDefaultDisabled::ExtDD_All)))
+      ExtensionDDFlag = static_cast<unsigned>(-1);
+    else
+      ExtensionDDFlag = Flag;
+  }
   static unsigned getExtensionDDFlag() { return ExtensionDDFlag; }
   template <ExperimentalFeatures Exp> static bool getUsingExperimental() {
     return ExperimentalFlag & (1 << static_cast<unsigned>(Exp));
   }
-  static void setExperimentalFlag(unsigned Flag) { ExperimentalFlag = Flag; }
+  static void setExperimentalFlag(unsigned Flag) {
+    // If the ExtDD_All bit is 1, enable all default disabled experimental
+    // features.
+    if (Flag & (1 << static_cast<unsigned>(ExperimentalFeatures::Exp_All)))
+      ExperimentalFlag = static_cast<unsigned>(-1);
+    else
+      ExperimentalFlag = Flag;
+  }
   static unsigned getExperimentalFlag() { return ExperimentalFlag; }
   static bool getHelperFuncPreference(HelperFuncPreference HFP) {
     return HelperFuncPreferenceFlag & (1 << static_cast<unsigned>(HFP));

--- a/clang/lib/DPCT/ValidateArguments.h
+++ b/clang/lib/DPCT/ValidateArguments.h
@@ -66,12 +66,14 @@ enum class DPCPPExtensionsDefaultEnabled : unsigned int {
   ExtDE_PeerAccess,
   ExtDE_Assert,
   ExtDE_QueueEmpty,
-  ExtDE_DPCPPExtensionsDefaultEnabledEnumSize
+  ExtDE_DPCPPExtensionsDefaultEnabledEnumSize,
+  ExtDE_All
 };
 enum class DPCPPExtensionsDefaultDisabled : unsigned int {
   ExtDD_CCXXStandardLibrary = 0,
   ExtDD_IntelDeviceMath,
-  ExtDD_DPCPPExtensionsDefaultDisabledEnumSize
+  ExtDD_DPCPPExtensionsDefaultDisabledEnumSize,
+  ExtDD_All
 };
 enum class ExperimentalFeatures : unsigned int {
   Exp_NdRangeBarrier = 0, // Using nd_range_barrier.
@@ -87,7 +89,8 @@ enum class ExperimentalFeatures : unsigned int {
   Exp_BFloat16Math,
   Exp_BindlessImages,
   Exp_NonUniformGroups,
-  Exp_ExperimentalFeaturesEnumSize
+  Exp_ExperimentalFeaturesEnumSize,
+  Exp_All
 };
 enum class HelperFuncPreference : unsigned int { NoQueueDevice = 0 };
 enum class SYCLFileExtensionEnum { DP_CPP, SYCL_CPP, CPP };

--- a/clang/test/dpct/disable-all-extensions.cu
+++ b/clang/test/dpct/disable-all-extensions.cu
@@ -1,0 +1,438 @@
+// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.1, cuda-11.2, cuda-11.3, cuda-11.4, cuda-11.5
+// UNSUPPORTED: v8.0, v9.0, v9.1, v9.2, v10.0, v10.1, v10.2, v11.0, v11.1, v11.2, v11.3, v11.4, v11.5
+// RUN: dpct --format-range=none -usm-level=none -out-root %T/disable-all-extensions %s --cuda-include-path="%cuda-path/include" --no-dpcpp-extensions=all
+// RUN: FileCheck --input-file %T/disable-all-extensions/disable-all-extensions.dp.cpp --match-full-lines %s
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <functional>
+#include <list>
+#include <stdio.h>
+
+// bfloat16
+
+__global__ void f() {
+  // CHECK: __nv_bfloat16 bf16;
+  __nv_bfloat16 bf16;
+  // CHECK: __nv_bfloat162 bf162;
+  __nv_bfloat162 bf162;
+  float f;
+  float2 f2;
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1007:{{[0-9]+}}: Migration of __hadd_sat is not supported.
+  // CHECK-NEXT: */
+  bf16 = __hadd_sat(bf16, bf16);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1007:{{[0-9]+}}: Migration of __hfma_sat is not supported.
+  // CHECK-NEXT: */
+  bf16 = __hfma_sat(bf16, bf16, bf16);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1007:{{[0-9]+}}: Migration of __hmul_sat is not supported.
+  // CHECK-NEXT: */
+  bf16 = __hmul_sat(bf16, bf16);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1007:{{[0-9]+}}: Migration of __hsub_sat is not supported.
+  // CHECK-NEXT: */
+  bf16 = __hsub_sat(bf16, bf16);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1007:{{[0-9]+}}: Migration of __habs2 is not supported.
+  // CHECK-NEXT: */
+  bf162 = __habs2(bf162);
+  // CHECK: f2 = sycl::float2(bf162[0], bf162[1]);
+  f2 = __bfloat1622float2(bf162);
+  // CHECK: f = static_cast<float>(bf16);
+  f = __bfloat162float(bf16);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1007:{{[0-9]+}}: Migration of __float22bfloat162_rn is not supported.
+  // CHECK-NEXT: */
+  bf162 = __float22bfloat162_rn(f2);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1007:{{[0-9]+}}: Migration of __float2bfloat16 is not supported.
+  // CHECK-NEXT: */
+  bf16 = __float2bfloat16(f);
+}
+
+// device_info
+void device_info() {
+  cudaDeviceProp properties;
+  cudaGetDeviceProperties(&properties, 0);
+
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1090:{{[0-9]+}}: SYCL does not support the device property that would be functionally compatible with pciDeviceID. It was not migrated. You need to rewrite the code.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: const int id = properties.pciDeviceID;
+  const int id = properties.pciDeviceID;
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1090:{{[0-9]+}}: SYCL does not support the device property that would be functionally compatible with uuid. It was not migrated. You need to rewrite the code.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: const std::array<unsigned char, 16> uuid = properties.uuid;
+  const cudaUUID_t uuid = properties.uuid;
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1090:{{[0-9]+}}: SYCL does not support the device property that would be functionally compatible with pciDeviceID. It was not migrated. You need to rewrite the code.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: properties.pciDeviceID = id;
+  properties.pciDeviceID = id;
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1090:{{[0-9]+}}: SYCL does not support the device property that would be functionally compatible with uuid. It was not migrated. You need to rewrite the code.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: properties.uuid = uuid;
+  properties.uuid = uuid;
+}
+
+// enqueued_barriers
+
+#define N 1000
+
+#define CHECK(call)                                          \
+  {                                                          \
+    const cudaError_t error = call;                          \
+    if (error != cudaSuccess) {                              \
+      fprintf(stderr, "Error: %s:%d, ", __FILE__, __LINE__); \
+      fprintf(stderr, "code: %d, reason: %s\n", error,       \
+              cudaGetErrorString(error));                    \
+    }                                                        \
+  }
+
+__global__ void add(int *a, int *b) {
+  int i = blockIdx.x;
+  if (i < N) {
+    b[i] = 2 * a[i];
+  }
+}
+
+int enqueued_barriers() {
+  // CHECK: dpct::device_ext &dev_ct1 = dpct::get_current_device();
+  // CHECK-NEXT: sycl::queue &q_ct1 = dev_ct1.out_of_order_queue();
+  cudaStream_t stream;
+
+  int ha[N], hb[N];
+  cudaEvent_t start, stop;
+
+  int *da, *db;
+  float elapsedTime;
+
+  cudaMalloc((void **)&da, N * sizeof(int));
+  cudaMalloc((void **)&db, N * sizeof(int));
+
+  for (int i = 0; i < N; ++i) {
+    ha[i] = i;
+  }
+
+  cudaEventCreate(&start);
+  cudaEventCreate(&stop);
+
+  // CHECK:   dpct::get_current_device().queues_wait_and_throw();
+  // CHECK-NEXT:    *start = q_ct1.single_task([=](){});
+  // CHECK-NEXT:    dpct::get_current_device().queues_wait_and_throw();
+  cudaEventRecord(start, 0);
+
+  cudaMemcpyAsync(da, ha, N * sizeof(int), cudaMemcpyHostToDevice);
+  cudaMemcpyAsync(da, ha, N * sizeof(int), cudaMemcpyHostToDevice, 0);
+  cudaMemcpyAsync(da, ha, N * sizeof(int), cudaMemcpyHostToDevice, stream);
+
+  // CHECK:    dpct::get_current_device().queues_wait_and_throw();
+  // CHECK-NEXT:    *stop = q_ct1.single_task([=](){});
+  // CHECK-NEXT:    dpct::get_current_device().queues_wait_and_throw();
+  // CHECK-NEXT:     stop->wait_and_throw();
+  // CHECK-NEXT:    elapsedTime = (stop->get_profiling_info<sycl::info::event_profiling::command_end>() - start->get_profiling_info<sycl::info::event_profiling::command_start>()) / 1000000.0f;
+  cudaEventRecord(stop, 0);
+  cudaEventSynchronize(stop);
+  cudaEventElapsedTime(&elapsedTime, start, stop);
+
+  add<<<N, 1>>>(da, db);
+
+  // CHECK: dpct::async_dpct_memcpy(hb, db, N * sizeof(int), dpct::device_to_host);
+  cudaMemcpyAsync(hb, db, N * sizeof(int), cudaMemcpyDeviceToHost);
+
+  cudaDeviceSynchronize();
+
+  for (int i = 0; i < N; ++i) {
+    printf("%d\n", hb[i]);
+  }
+
+  cudaEventDestroy(start);
+  cudaEventDestroy(stop);
+
+  cudaFree(da);
+  cudaFree(db);
+
+  return 0;
+}
+
+// peer_access
+int peer_access() {
+  int r;
+  // CHECK:  /*
+  // CHECK:  DPCT1031:{{[0-9]+}}: Memory access across peer devices is an implementation-specific feature which may not be supported by some SYCL backends and compilers. The output parameter(s) are set to 0. You can migrate the code with peer access extension if you do not specify -no-dpcpp-extensions=peer_access.
+  // CHECK:  */
+  // CHECK:  r = 0;
+  cudaDeviceCanAccessPeer(&r, 0, 0);
+  // CHECK:  /*
+  // CHECK:  DPCT1026:{{[0-9]+}}: The call to cudaDeviceEnablePeerAccess was removed because SYCL currently does not support memory access across peer devices. You can migrate the code with peer access extension by not specifying -no-dpcpp-extensions=peer_access.
+  // CHECK:  */
+  cudaDeviceEnablePeerAccess(0, 0);
+  // CHECK:  /*
+  // CHECK:  DPCT1026:{{[0-9]+}}: The call to cudaDeviceDisablePeerAccess was removed because SYCL currently does not support memory access across peer devices. You can migrate the code with peer access extension by not specifying -no-dpcpp-extensions=peer_access.
+  // CHECK:  */
+  cudaDeviceDisablePeerAccess(0);
+
+  return 0;
+}
+
+__global__ void kernel() {
+  // CHECK:  /*
+  // CHECK:  DPCT1028:{{[0-9]+}}: The __trap was not migrated because assert extension is disabled. You can migrate the code with assert extension by not specifying --no-dpcpp-extensions=assert.
+  // CHECK:  */
+  // CHECK:  __trap();
+  __trap();
+}
+
+// queue_empty
+
+template <typename T>
+// CHECK: void my_error_checker(T ReturnValue, char const *const FuncName) {
+void my_error_checker(T ReturnValue, char const *const FuncName) {
+}
+
+#define MY_ERROR_CHECKER(CALL) my_error_checker((CALL), #CALL)
+
+__global__ void kernelFunc() {
+}
+
+// CHECK: void process(dpct::queue_ptr st, char *data, dpct::err0 status) {}
+void process(cudaStream_t st, char *data, cudaError_t status) {}
+
+template <typename T>
+// CHECK: void callback(dpct::queue_ptr st, dpct::err0 status, void *vp) {
+void callback(cudaStream_t st, cudaError_t status, void *vp) {
+  T *data = static_cast<T *>(vp);
+  process(st, data, status);
+}
+
+template <typename FloatN, typename Float>
+static void func() {
+  // CHECK: dpct::device_ext &dev_ct1 = dpct::get_current_device();
+  // CHECK: std::list<dpct::queue_ptr> streams;
+  std::list<cudaStream_t> streams;
+  for (auto Iter = streams.begin(); Iter != streams.end(); ++Iter)
+    // CHECK: *Iter = dev_ct1.create_queue();
+    cudaStreamCreate(&*Iter);
+  for (auto Iter = streams.begin(); Iter != streams.end(); ++Iter)
+    // CHECK: dev_ct1.destroy_queue(*Iter);
+    cudaStreamDestroy(*Iter);
+
+  // CHECK: dpct::queue_ptr s0, &s1 = s0;
+  // CHECK-NEXT: dpct::queue_ptr s2, *s3 = &s2;
+  // CHECK-NEXT: dpct::queue_ptr s4, s5;
+  // CHECK-EMPTY:
+  cudaStream_t s0, &s1 = s0;
+  cudaStream_t s2, *s3 = &s2;
+  cudaStream_t s4, s5;
+
+  // CHECK: if (1)
+  // CHECK-NEXT: s0 = dev_ct1.create_queue();
+  if (1)
+    cudaStreamCreate(&s0);
+
+  // CHECK: while (0)
+  // CHECK-NEXT: s0 = dev_ct1.create_queue();
+  while (0)
+    cudaStreamCreate(&s0);
+
+  // CHECK: do
+  // CHECK-NEXT: s0 = dev_ct1.create_queue();
+  // CHECK: while (0);
+  do
+    cudaStreamCreate(&s0);
+  while (0);
+
+  // CHECK: for (; 0;)
+  // CHECK-NEXT: s0 = dev_ct1.create_queue();
+  for (; 0;)
+    cudaStreamCreate(&s0);
+
+  // CHECK:   q_ct1.parallel_for(
+  // CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, 16) * sycl::range<3>(1, 1, 32), sycl::range<3>(1, 1, 32)),
+  // CHECK-NEXT:         [=](sycl::nd_item<3> item_ct1) {
+  // CHECK-NEXT:           kernelFunc();
+  // CHECK-NEXT:         });
+  kernelFunc<<<16, 32, 0>>>();
+
+  // CHECK: MY_ERROR_CHECKER(DPCT_CHECK_ERROR(s1 = dev_ct1.create_queue()));
+  MY_ERROR_CHECKER(cudaStreamCreate(&s1));
+
+  // CHECK:   s0->parallel_for(
+  // CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, 16) * sycl::range<3>(1, 1, 32), sycl::range<3>(1, 1, 32)),
+  // CHECK-NEXT:         [=](sycl::nd_item<3> item_ct1) {
+  // CHECK-NEXT:           kernelFunc();
+  // CHECK-NEXT:         });
+  kernelFunc<<<16, 32, 0, s0>>>();
+
+  // CHECK:   s1->parallel_for(
+  // CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, 16) * sycl::range<3>(1, 1, 32), sycl::range<3>(1, 1, 32)),
+  // CHECK-NEXT:         [=](sycl::nd_item<3> item_ct1) {
+  // CHECK-NEXT:           kernelFunc();
+  // CHECK-NEXT:         });
+  kernelFunc<<<16, 32, 0, s1>>>();
+
+  {
+    // CHECK: /*
+    // CHECK-NEXT: DPCT1025:{{[0-9]+}}: The SYCL queue is created ignoring the flag and priority options.
+    // CHECK-NEXT: */
+    // CHECK-NEXT: s2 = dev_ct1.create_queue();
+    cudaStreamCreateWithFlags(&s2, cudaStreamDefault);
+
+    // CHECK: /*
+    // CHECK-NEXT: DPCT1025:{{[0-9]+}}: The SYCL queue is created ignoring the flag and priority options.
+    // CHECK-NEXT: */
+    // CHECK-NEXT: MY_ERROR_CHECKER(DPCT_CHECK_ERROR(*(s3) = dev_ct1.create_queue()));
+    MY_ERROR_CHECKER(cudaStreamCreateWithFlags(s3, cudaStreamNonBlocking));
+
+    // CHECK:   s2->parallel_for(
+    // CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, 16) * sycl::range<3>(1, 1, 32), sycl::range<3>(1, 1, 32)),
+    // CHECK-NEXT:         [=](sycl::nd_item<3> item_ct1) {
+    // CHECK-NEXT:           kernelFunc();
+    // CHECK-NEXT:         });
+    kernelFunc<<<16, 32, 0, s2>>>();
+
+    // CHECK:   (*s3)->parallel_for(
+    // CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, 16) * sycl::range<3>(1, 1, 32), sycl::range<3>(1, 1, 32)),
+    // CHECK-NEXT:         [=](sycl::nd_item<3> item_ct1) {
+    // CHECK-NEXT:           kernelFunc();
+    // CHECK-NEXT:         });
+    kernelFunc<<<16, 32, 0, *s3>>>();
+
+    // CHECK: dev_ct1.destroy_queue(s2);
+    cudaStreamDestroy(s2);
+    // CHECK: MY_ERROR_CHECKER(DPCT_CHECK_ERROR(dev_ct1.destroy_queue(*s3)));
+    MY_ERROR_CHECKER(cudaStreamDestroy(*s3));
+  }
+
+  {
+    {
+      // CHECK: /*
+      // CHECK-NEXT: DPCT1025:{{[0-9]+}}: The SYCL queue is created ignoring the flag and priority options.
+      // CHECK-NEXT: */
+      // CHECK-NEXT: s4 = dev_ct1.create_queue();
+      cudaStreamCreateWithPriority(&s4, cudaStreamDefault, 2);
+
+      // CHECK: /*
+      // CHECK-NEXT: DPCT1025:{{[0-9]+}}: The SYCL queue is created ignoring the flag and priority options.
+      // CHECK-NEXT: */
+      // CHECK-NEXT: MY_ERROR_CHECKER(DPCT_CHECK_ERROR(s5 = dev_ct1.create_queue()));
+      MY_ERROR_CHECKER(cudaStreamCreateWithPriority(&s5, cudaStreamNonBlocking, 3));
+
+      // CHECK:   s4->parallel_for(
+      // CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, 16) * sycl::range<3>(1, 1, 32), sycl::range<3>(1, 1, 32)),
+      // CHECK-NEXT:         [=](sycl::nd_item<3> item_ct1) {
+      // CHECK-NEXT:           kernelFunc();
+      // CHECK-NEXT:         });
+      kernelFunc<<<16, 32, 0, s4>>>();
+      // CHECK:   s5->parallel_for(
+      // CHECK-NEXT:         sycl::nd_range<3>(sycl::range<3>(1, 1, 16) * sycl::range<3>(1, 1, 32), sycl::range<3>(1, 1, 32)),
+      // CHECK-NEXT:         [=](sycl::nd_item<3> item_ct1) {
+      // CHECK-NEXT:           kernelFunc();
+      // CHECK-NEXT:         });
+      kernelFunc<<<16, 32, 0, s5>>>();
+
+      // CHECK: dev_ct1.destroy_queue(s4);
+      cudaStreamDestroy(s4);
+      // CHECK: MY_ERROR_CHECKER(DPCT_CHECK_ERROR(dev_ct1.destroy_queue(s5)));
+      MY_ERROR_CHECKER(cudaStreamDestroy(s5));
+    }
+  }
+
+  int priority_low;
+  int priority_hi;
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1014:{{[0-9]+}}: The flag and priority options are not supported for SYCL queues. The output parameter(s) are set to 0.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: *(&priority_low) = 0, *(&priority_hi) = 0;
+  cudaDeviceGetStreamPriorityRange(&priority_low, &priority_hi);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1014:{{[0-9]+}}: The flag and priority options are not supported for SYCL queues. The output parameter(s) are set to 0.
+  // CHECK-NEXT: */
+  // CHECK: MY_ERROR_CHECKER(DPCT_CHECK_ERROR((*(&priority_low) = 0, *(&priority_hi) = 0)));
+  MY_ERROR_CHECKER(cudaDeviceGetStreamPriorityRange(&priority_low, &priority_hi));
+
+  int priority;
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1014:{{[0-9]+}}: The flag and priority options are not supported for SYCL queues. The output parameter(s) are set to 0.
+  // CHECK-NEXT: */
+  // CHECK: MY_ERROR_CHECKER(DPCT_CHECK_ERROR(*(&priority) = 0));
+  MY_ERROR_CHECKER(cudaStreamGetPriority(s0, &priority));
+
+  char str[256];
+
+  unsigned int flags = 0;
+  // CHECK: dpct::err0 status = DPCT_CHECK_ERROR(std::async([&]() { s0->wait(); callback<char *>(s0, 0, str); }));
+  // CHECK-NEXT: std::async([&]() { s1->wait(); callback<char *>(s1, 0, str); });
+  cudaError_t status = cudaStreamAddCallback(s0, callback<char *>, str, flags);
+  cudaStreamAddCallback(s1, callback<char *>, str, flags);
+
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1014:{{[0-9]+}}: The flag and priority options are not supported for SYCL queues. The output parameter(s) are set to 0.
+  // CHECK-NEXT: */
+  // CHECK: MY_ERROR_CHECKER(DPCT_CHECK_ERROR(*(&flags) = 0));
+  MY_ERROR_CHECKER(cudaStreamGetFlags(s0, &flags));
+
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1026:{{[0-9]+}}: The call to cudaStreamAttachMemAsync was removed because SYCL currently does not support associating USM with a specific queue.
+  // CHECK-NEXT: */
+  cudaStreamAttachMemAsync(s0, nullptr);
+
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1027:{{[0-9]+}}: The call to cudaStreamAttachMemAsync was replaced with 0 because SYCL currently does not support associating USM with a specific queue.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: MY_ERROR_CHECKER(0);
+  MY_ERROR_CHECKER(cudaStreamAttachMemAsync(s0, nullptr));
+
+  // CHECK: dpct::event_ptr e;
+  // CHECK-NEXT: e->wait();
+  cudaEvent_t e;
+  cudaStreamWaitEvent(s0, e, 0);
+
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1026:{{[0-9]+}}: The call to cudaStreamQuery was removed because SYCL currently does not support query operations on queues.
+  // CHECK-NEXT: */
+  cudaStreamQuery(s0);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1027:{{[0-9]+}}: The call to cudaStreamQuery was replaced with 0 because SYCL currently does not support query operations on queues.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: MY_ERROR_CHECKER(0);
+  MY_ERROR_CHECKER(cudaStreamQuery(s0));
+
+  // CHECK: MY_ERROR_CHECKER(DPCT_CHECK_ERROR(e->wait()));
+  MY_ERROR_CHECKER(cudaStreamWaitEvent(s0, e, 0));
+
+  // CHECK: s0->wait();
+  cudaStreamSynchronize(s0);
+  // CHECK: MY_ERROR_CHECKER(DPCT_CHECK_ERROR(s1->wait()));
+  // CHECK-EMPTY:
+  MY_ERROR_CHECKER(cudaStreamSynchronize(s1));
+
+  // CHECK: q_ct1.wait();
+  // CHECK: MY_ERROR_CHECKER(DPCT_CHECK_ERROR(q_ct1.wait()));
+  // CHECK-NEXT: q_ct1.wait();
+  // CHECK: MY_ERROR_CHECKER(DPCT_CHECK_ERROR(q_ct1.wait()));
+  // CHECK-NEXT: q_ct1.wait();
+  // CHECK: MY_ERROR_CHECKER(DPCT_CHECK_ERROR(q_ct1.wait()));
+  cudaStreamSynchronize(cudaStreamDefault);
+  MY_ERROR_CHECKER(cudaStreamSynchronize(cudaStreamDefault));
+  cudaStreamSynchronize(cudaStreamLegacy);
+  MY_ERROR_CHECKER(cudaStreamSynchronize(cudaStreamLegacy));
+  cudaStreamSynchronize(cudaStreamPerThread);
+  MY_ERROR_CHECKER(cudaStreamSynchronize(cudaStreamPerThread));
+
+  // CHECK: dev_ct1.destroy_queue(s0);
+  cudaStreamDestroy(s0);
+  // CHECK: MY_ERROR_CHECKER(DPCT_CHECK_ERROR(dev_ct1.destroy_queue(s1)));
+  MY_ERROR_CHECKER(cudaStreamDestroy(s1));
+}
+
+template <typename T>
+class S {
+  static const unsigned int MAX_NUM_PATHS = 8;
+  // CHECK: dpct::queue_ptr streams[MAX_NUM_PATHS];
+  cudaStream_t streams[MAX_NUM_PATHS];
+};

--- a/clang/test/dpct/enable-all-experimental-features.cu
+++ b/clang/test/dpct/enable-all-experimental-features.cu
@@ -1,0 +1,463 @@
+// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.1, cuda-11.2, cuda-11.3, cuda-11.4, cuda-11.5
+// UNSUPPORTED: v8.0, v9.0, v9.1, v9.2, v10.0, v10.1, v10.2, v11.0, v11.1, v11.2, v11.3, v11.4, v11.5
+// RUN: dpct --format-range=none -out-root %T/enable-all-experimental-features %s --cuda-include-path="%cuda-path/include" --use-experimental-features=all
+// RUN: FileCheck --input-file %T/enable-all-experimental-features/enable-all-experimental-features.dp.cpp --match-full-lines %s
+
+#include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>
+#include <cub/cub.cuh>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <iostream>
+#include <mma.h>
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/for_each.h>
+
+// free-function-queries
+
+namespace cg = cooperative_groups;
+
+// CHECK:void testThreadGroup(dpct::experimental::group_base<3> g) {
+__device__ void testThreadGroup(cg::thread_group g) {
+  // CHECK:  g.get_local_linear_id();
+  g.thread_rank();
+  // CHECK:  g.barrier();
+  g.sync();
+  // CHECK:  g.get_local_linear_range();
+  g.size();
+
+  auto block = cg::this_thread_block();
+  // CHECK: block.get_local_id();
+  block.thread_index();
+}
+
+__global__ void kernelFunc() {
+  auto block = cg::this_thread_block();
+  // CHECK: block.get_local_id();
+  block.thread_index();
+  // CHECK:  auto threadBlockGroup = sycl::ext::oneapi::experimental::this_group<3>();
+  auto threadBlockGroup = cg::this_thread_block();
+
+  // CHECK:  testThreadGroup(dpct::experimental::group(threadBlockGroup, item_ct1));
+  testThreadGroup(threadBlockGroup);
+  // CHECK:  dpct::experimental::logical_group tilePartition16 = dpct::experimental::logical_group(item_ct1, sycl::ext::oneapi::experimental::this_group<3>(), 16);
+  cg::thread_block_tile<16> tilePartition16 = cg::tiled_partition<16>(threadBlockGroup);
+  // CHECK:  testThreadGroup(dpct::experimental::group(tilePartition16, item_ct1));
+  testThreadGroup(tilePartition16);
+  // CHECK:  sycl::sub_group tilePartition32 = sycl::ext::oneapi::experimental::this_sub_group();
+  cg::thread_block_tile<32> tilePartition32 = cg::tiled_partition<32>(threadBlockGroup);
+  // CHECK:  testThreadGroup(dpct::experimental::group(tilePartition32, item_ct1));
+  testThreadGroup(tilePartition32);
+  // CHECK:  dpct::experimental::logical_group tilePartition16_1(dpct::experimental::logical_group(item_ct1, sycl::ext::oneapi::experimental::this_group<3>(), 16));
+  // CHECK:  sycl::sub_group tilePartition32_2(sycl::ext::oneapi::experimental::this_sub_group());
+  cg::thread_block_tile<16> tilePartition16_1(cg::tiled_partition<16>(threadBlockGroup));
+  cg::thread_block_tile<32> tilePartition32_2(cg::tiled_partition<32>(threadBlockGroup));
+}
+// local-memory-kernel-scope-allocation
+
+class TestObject {
+public:
+  // CHECK: static void run(int *in, int *out) {
+  // CHECK-NEXT:    /*
+  // CHECK-NEXT:    DPCT1115:{{[0-9]+}}: The sycl::ext::oneapi::group_local_memory_for_overwrite is used to allocate group-local memory at the none kernel functor scope of a work-group data parallel kernel. You may need to adjust the code.
+  // CHECK-NEXT:    */
+  // CHECK-NEXT:  auto &a0 = *sycl::ext::oneapi::group_local_memory_for_overwrite<int>(sycl::ext::oneapi::experimental::this_group<3>()); // the size of s is static
+  // CHECK-NEXT:  a0 = sycl::ext::oneapi::experimental::this_nd_item<3>().get_local_id(2);
+  __device__ static void run(int *in, int *out) {
+    __shared__ int a0; // the size of s is static
+    a0 = threadIdx.x;
+  }
+  __device__ void test() {}
+};
+
+// CHECK: void memberAcc() {
+// CHECK-NEXT: auto &s = *sycl::ext::oneapi::group_local_memory_for_overwrite<TestObject>(sycl::ext::oneapi::experimental::this_group<3>()); // the size of s is static
+// CHECK-NEXT: s.test();
+// CHECK-NEXT: }
+__global__ void memberAcc() {
+  __shared__ TestObject s; // the size of s is static
+  s.test();
+}
+
+// logical-group
+
+// CHECK:  #define test33(a) testThreadGroup(a)
+#define test33(a) testThreadGroup(a)
+#define test22(a) test33(a)
+#define test11(a) test22(a)
+// CHECK:  #define test44(a) testThreadGroup(a)
+#define test44(a) testThreadGroup(a)
+
+namespace cg = cooperative_groups;
+
+__global__ void kernelFunc1() {
+  auto block = cg::this_thread_block();
+  // CHECK: block.get_local_id();
+  block.thread_index();
+  // CHECK:  auto threadBlockGroup = sycl::ext::oneapi::experimental::this_group<3>();
+  auto threadBlockGroup = cg::this_thread_block();
+
+  testThreadGroup(threadBlockGroup);
+
+  cg::thread_block_tile<16> tilePartition16 = cg::tiled_partition<16>(threadBlockGroup);
+  testThreadGroup(tilePartition16);
+  cg::thread_block_tile<32> tilePartition32 = cg::tiled_partition<32>(threadBlockGroup);
+  testThreadGroup(tilePartition32);
+  cg::thread_block_tile<16> tilePartition16_1(cg::tiled_partition<16>(threadBlockGroup));
+  cg::thread_block_tile<32> tilePartition32_2(cg::tiled_partition<32>(threadBlockGroup));
+
+  test11(tilePartition16);
+  testThreadGroup(tilePartition16);
+  // CHECK:  test44(dpct::experimental::group(tilePartition16, sycl::ext::oneapi::experimental::this_nd_item<3>()));
+  // CHECK:  test11(dpct::experimental::group(tilePartition32, sycl::ext::oneapi::experimental::this_nd_item<3>()));
+  // CHECK:  test11(dpct::experimental::group(threadBlockGroup, sycl::ext::oneapi::experimental::this_nd_item<3>()));
+  test44(tilePartition16);
+  test11(tilePartition32);
+  test11(threadBlockGroup);
+}
+
+// nd_range_barrier
+
+// CHECK: void kernel(sycl::atomic_ref<unsigned int, sycl::memory_order::seq_cst, sycl::memory_scope::device, sycl::access::address_space::global_space> &sync_ct1) {
+// CHECK-NEXT:   dpct::experimental::nd_range_barrier(sycl::ext::oneapi::experimental::this_nd_item<3>(), sync_ct1);
+// CHECK-NEXT: }
+__global__ void kernel() {
+  cg::grid_group grid = cg::this_grid();
+  grid.sync();
+}
+
+#define DATA_NUM 100
+
+template <typename T = int>
+void init_data(T *data, int num) {
+  for (int i = 0; i < num; i++)
+    data[i] = i;
+}
+
+template <typename T = int>
+bool verify_data(T *data, T *expect, int num, int step = 1) {
+  for (int i = 0; i < num; i = i + step) {
+    if (data[i] != expect[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <typename T = int>
+void print_data(T *data, int num) {
+  for (int i = 0; i < num; i++) {
+    std::cout << data[i] << ", ";
+    if ((i + 1) % 32 == 0)
+      std::cout << std::endl;
+  }
+  std::cout << std::endl;
+}
+
+struct UserMin {
+  template <typename T>
+  __device__ __host__ __forceinline__
+      T
+      operator()(const T &a, const T &b) const {
+    return (b < a) ? b : a;
+  }
+};
+
+bool test_reduce_1() {
+  int num_segments = 10;
+  int *device_offsets;
+  int *device_in;
+  int *device_out;
+  UserMin min_op;
+  int initial_value = INT_MAX;
+  void *temp_storage = NULL;
+  size_t temp_storage_size = 0;
+  int expect[DATA_NUM] = {0, 10, 20, 30, 40, 50, 60, 70, 80, 90};
+
+  cudaMallocManaged(&device_offsets, (num_segments + 1) * sizeof(int));
+  cudaMallocManaged(&device_in, DATA_NUM * sizeof(int));
+  cudaMallocManaged(&device_out, num_segments * sizeof(int));
+  init_data(device_in, DATA_NUM);
+  for (int i = 0; i < num_segments + 1; i++) {
+    device_offsets[i] = i * 10;
+  }
+  cub::DeviceSegmentedReduce::Reduce(temp_storage, temp_storage_size, device_in, device_out, num_segments, device_offsets, device_offsets + 1, min_op, initial_value);
+
+  cudaMalloc(&temp_storage, temp_storage_size);
+
+  // CHECK: dpct::device::experimental::segmented_reduce<128>(q_ct1, device_in, device_out, num_segments, device_offsets, device_offsets + 1, min_op, initial_value);
+  cub::DeviceSegmentedReduce::Reduce(temp_storage, temp_storage_size, device_in, device_out, num_segments, device_offsets, device_offsets + 1, min_op, initial_value);
+
+  cudaDeviceSynchronize();
+
+  if (!verify_data(device_out, expect, num_segments)) {
+    std::cout << "Reduce"
+              << " verify failed" << std::endl;
+    std::cout << "expect:" << std::endl;
+    print_data<int>(expect, num_segments);
+    std::cout << "current result:" << std::endl;
+    print_data<int>(device_out, num_segments);
+    return false;
+  }
+  return true;
+}
+
+// masked-sub-group-operation
+
+__global__ void kernel1() {
+  unsigned mask;
+  int val;
+  int srcLane;
+  // CHECK: /*
+  // CHECK: DPCT1108:{{[0-9]+}}: '__shfl_sync' was migrated with the experimental feature masked sub_group function which may not be supported by all compilers or runtimes. You may need to adjust the code.
+  // CHECK: */
+  // CHECK: dpct::experimental::select_from_sub_group(mask, sycl::ext::oneapi::experimental::this_sub_group(), val, srcLane);
+  __shfl_sync(mask, val, srcLane);
+}
+
+// dpl-experimental-api
+
+int thrust1() {
+  // CHECK: dpct::device_vector<float> dVec(4);
+  thrust::device_vector<float> dVec(4);
+  // CHECK: auto loop_body = [=] (int ind) -> void {};
+  auto loop_body = [=] __device__ __host__(int ind) -> void {};
+
+  // CHECK: oneapi::dpl::experimental::for_each_async(oneapi::dpl::execution::make_device_policy(dpct::get_in_order_queue()), dVec.begin(), dVec.end(), loop_body);
+  thrust::for_each(thrust::cuda::par_nosync, dVec.begin(), dVec.end(), loop_body);
+  return 0;
+}
+
+// occupancy-calculation
+
+__global__ void k() {}
+
+int occupancy() {
+  int num_blocks;
+  int block_size = 128;
+  size_t dynamic_shared_memory_size = 0;
+  // CHECK: /*
+  // CHECK: DPCT1111:{{[0-9]+}}: Please verify the input arguments of "dpct::experimental::calculate_max_active_wg_per_xecore" base on the target function "k".
+  // CHECK: */
+  // CHECK: dpct::experimental::calculate_max_active_wg_per_xecore(&num_blocks, block_size, dynamic_shared_memory_size + dpct_placeholder /* total share local memory size */);
+  cudaOccupancyMaxActiveBlocksPerMultiprocessor(&num_blocks, k, block_size, dynamic_shared_memory_size);
+
+  CUfunction func;
+  // CHECK: /*
+  // CHECK: DPCT1111:{{[0-9]+}}: Please verify the input arguments of "dpct::experimental::calculate_max_active_wg_per_xecore" base on the target function "func".
+  // CHECK: */
+  // CHECK: dpct::experimental::calculate_max_active_wg_per_xecore(&num_blocks, block_size, dynamic_shared_memory_size + dpct_placeholder /* total share local memory size */);
+  cuOccupancyMaxActiveBlocksPerMultiprocessor(&num_blocks, func, block_size, dynamic_shared_memory_size);
+
+  int min_grid_size;
+  int block_size_limit;
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1111:{{[0-9]+}}: Please verify the input arguments of "dpct::experimental::calculate_max_potential_wg" base on the target function "k".
+  // CHECK-NEXT: */
+  // CHECK-NEXT:dpct::experimental::calculate_max_potential_wg(&min_grid_size, &block_size, 0, dpct_placeholder /* total share local memory size */);
+  cudaOccupancyMaxPotentialBlockSize(&min_grid_size, &block_size, k);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1111:{{[0-9]+}}: Please verify the input arguments of "dpct::experimental::calculate_max_potential_wg" base on the target function "k".
+  // CHECK-NEXT: */
+  // CHECK-NEXT:dpct::experimental::calculate_max_potential_wg(&min_grid_size, &block_size, 0, dynamic_shared_memory_size + dpct_placeholder /* total share local memory size */);
+  cudaOccupancyMaxPotentialBlockSize(&min_grid_size, &block_size, k, dynamic_shared_memory_size);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1111:{{[0-9]+}}: Please verify the input arguments of "dpct::experimental::calculate_max_potential_wg" base on the target function "k".
+  // CHECK-NEXT: */
+  // CHECK-NEXT:dpct::experimental::calculate_max_potential_wg(&min_grid_size, &block_size, block_size_limit, dynamic_shared_memory_size + dpct_placeholder /* total share local memory size */);
+  cudaOccupancyMaxPotentialBlockSize(&min_grid_size, &block_size, k, dynamic_shared_memory_size, block_size_limit);
+  return 0;
+}
+
+// matrix
+
+#define WARP_SIZE 32
+
+// MMA matrix tile dimensions.
+
+#define M 16
+#define N 16
+#define K 16
+
+#define WMMA_M 16
+#define WMMA_N 16
+#define WMMA_K 16
+
+#define M_TILES 16
+#define N_TILES 16
+#define K_TILES 16
+
+#define M_GLOBAL (M * M_TILES)
+#define N_GLOBAL (N * N_TILES)
+#define K_GLOBAL (K * K_TILES)
+
+#define WARP_SIZE 32
+#define WARPS_PER_BLOCK 8
+#define THREADS_PER_BLOCK (WARP_SIZE * WARPS_PER_BLOCK)
+
+#define BLOCK_ROW_WARPS 2
+#define BLOCK_COL_WARPS 4
+
+#define WARP_ROW_TILES 4
+#define WARP_COL_TILES 2
+
+#define BLOCK_ROW_TILES (WARP_ROW_TILES * BLOCK_ROW_WARPS)
+#define BLOCK_COL_TILES (WARP_COL_TILES * BLOCK_COL_WARPS)
+
+__host__ void init_host_matrices(half *a, half *b, float *c) {
+  for (int i = 0; i < M_GLOBAL; i++) {
+    for (int j = 0; j < K_GLOBAL; j++) {
+      a[i * K_GLOBAL + j] = (half)(rand() % 3);
+    }
+  }
+
+  for (int i = 0; i < N_GLOBAL; i++) {
+    for (int j = 0; j < K_GLOBAL; j++) {
+      b[i * K_GLOBAL + j] = (half)(rand() % 3);
+    }
+  }
+
+  for (int t = 0; t < M_GLOBAL * N_GLOBAL; t++) {
+    c[t] = static_cast<float>(rand() % 3);
+  }
+}
+
+__global__ void simple_wmma_gemm(half *a, half *b, float *c, float *d, int m_ld,
+                                 int n_ld, int k_ld, float alpha, float beta) {
+  // Leading dimensions. Packed with no transpositions.
+  int lda = k_ld;
+  int ldb = k_ld;
+  int ldc = n_ld;
+
+  // Tile using a 2D grid
+  int warpM = (blockIdx.x * blockDim.x + threadIdx.x) / warpSize;
+  int warpN = (blockIdx.y * blockDim.y + threadIdx.y);
+  // CHECK: sycl::ext::oneapi::experimental::matrix::layout ly = sycl::ext::oneapi::experimental::matrix::layout::row_major;
+  nvcuda::wmma::layout_t ly = nvcuda::wmma::mem_row_major;
+  // Declare the fragments
+  // CHECK: sycl::ext::oneapi::experimental::matrix::joint_matrix<sycl::sub_group, sycl::half, sycl::ext::oneapi::experimental::matrix::use::a, WMMA_M, WMMA_K, sycl::ext::oneapi::experimental::matrix::layout::row_major>
+  nvcuda::wmma::fragment<nvcuda::wmma::matrix_a, WMMA_M, WMMA_N, WMMA_K, half, nvcuda::wmma::row_major>
+      a_frag;
+  // CHECK: sycl::ext::oneapi::experimental::matrix::joint_matrix<sycl::sub_group, sycl::half, sycl::ext::oneapi::experimental::matrix::use::b, WMMA_N, WMMA_K, sycl::ext::oneapi::experimental::matrix::layout::col_major>
+  nvcuda::wmma::fragment<nvcuda::wmma::matrix_b, WMMA_M, WMMA_N, WMMA_K, half, nvcuda::wmma::col_major>
+      b_frag;
+  // CHECK: sycl::ext::oneapi::experimental::matrix::joint_matrix<sycl::sub_group, float, sycl::ext::oneapi::experimental::matrix::use::accumulator, WMMA_M, WMMA_N> acc_frag;
+  nvcuda::wmma::fragment<nvcuda::wmma::accumulator, WMMA_M, WMMA_N, WMMA_K, float> acc_frag;
+  // CHECK: sycl::ext::oneapi::experimental::matrix::joint_matrix<sycl::sub_group, float, sycl::ext::oneapi::experimental::matrix::use::accumulator, WMMA_M, WMMA_N> c_frag;
+  nvcuda::wmma::fragment<nvcuda::wmma::accumulator, WMMA_M, WMMA_N, WMMA_K, float> c_frag;
+  // CHECK: sycl::ext::oneapi::experimental::matrix::joint_matrix_fill(sycl::ext::oneapi::experimental::this_sub_group(), acc_frag, 0.0f);
+  nvcuda::wmma::fill_fragment(acc_frag, 0.0f);
+
+  // Loop over k
+  for (int i = 0; i < k_ld; i += WMMA_K) {
+    int aCol = i;
+    int aRow = warpM * WMMA_M;
+    int bCol = warpN * N;
+    int bRow = i;
+
+    // Bounds checking
+    if (aRow < m_ld && aCol < k_ld && bRow < k_ld && bCol < n_ld) {
+      // Load the inputs
+      // CHECK: sycl::ext::oneapi::experimental::matrix::joint_matrix_load(sycl::ext::oneapi::experimental::this_sub_group(), a_frag, sycl::address_space_cast<sycl::access::address_space::generic_space, sycl::access::decorated::no, const sycl::half>(a + aCol + aRow * lda), lda);
+      nvcuda::wmma::load_matrix_sync(a_frag, a + aCol + aRow * lda, lda);
+      // CHECK: sycl::ext::oneapi::experimental::matrix::joint_matrix_load(sycl::ext::oneapi::experimental::this_sub_group(), b_frag, sycl::address_space_cast<sycl::access::address_space::generic_space, sycl::access::decorated::no, const sycl::half>(b + bRow + bCol * ldb), ldb);
+      nvcuda::wmma::load_matrix_sync(b_frag, b + bRow + bCol * ldb, ldb);
+
+      // Perform the matrix multiplication
+      // CHECK: sycl::ext::oneapi::experimental::matrix::joint_matrix_mad(sycl::ext::oneapi::experimental::this_sub_group(), acc_frag, a_frag, b_frag, acc_frag);
+      nvcuda::wmma::mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+    }
+  }
+
+  // Load in the current value of c, scale it by beta, and add this our result
+  // scaled by alpha
+  int cCol = warpN * WMMA_N;
+  int cRow = warpM * WMMA_M;
+
+  if (cRow < m_ld && cCol < n_ld) {
+    // CHECK: sycl::ext::oneapi::experimental::matrix::joint_matrix_load(sycl::ext::oneapi::experimental::this_sub_group(), c_frag, sycl::address_space_cast<sycl::access::address_space::generic_space, sycl::access::decorated::no, const float>(c + cCol + cRow * ldc), ldc, sycl::ext::oneapi::experimental::matrix::layout::row_major);
+    nvcuda::wmma::load_matrix_sync(c_frag, c + cCol + cRow * ldc, ldc, nvcuda::wmma::mem_row_major);
+    // CHECK: sycl::ext::oneapi::experimental::matrix::joint_matrix_load(sycl::ext::oneapi::experimental::this_sub_group(), c_frag, sycl::address_space_cast<sycl::access::address_space::generic_space, sycl::access::decorated::no, const float>(c + cCol + cRow * ldc), ldc, ly);
+    nvcuda::wmma::load_matrix_sync(c_frag, c + cCol + cRow * ldc, ldc, ly);
+    // Store the output
+    // CHECK: sycl::ext::oneapi::experimental::matrix::joint_matrix_store(sycl::ext::oneapi::experimental::this_sub_group(), c_frag, sycl::address_space_cast<sycl::access::address_space::generic_space, sycl::access::decorated::no, float>(d + cCol + cRow * ldc), ldc, sycl::ext::oneapi::experimental::matrix::layout::col_major);
+    nvcuda::wmma::store_matrix_sync(d + cCol + cRow * ldc, c_frag, ldc, nvcuda::wmma::mem_col_major);
+  }
+}
+
+// bfloat16_math_functions
+
+__global__ void kernelFuncBfloat16Arithmetic() {
+  // CHECK: sycl::ext::oneapi::bfloat16 bf16, bf16_1, bf16_2, bf16_3;
+  __nv_bfloat16 bf16, bf16_1, bf16_2, bf16_3;
+  // CHECK: bf16 = sycl::ext::oneapi::experimental::fabs(bf16_1);
+  bf16 = __habs(bf16_1);
+  // CHECK: bf16 = bf16_1 + bf16_2;
+  bf16 = __hadd(bf16_1, bf16_2);
+  // CHECK: bf16 = bf16_1 + bf16_2;
+  bf16 = __hadd_rn(bf16_1, bf16_2);
+  // CHECK: bf16 = dpct::clamp<sycl::ext::oneapi::bfloat16>(bf16_1 + bf16_2, 0.f, 1.0f);
+  bf16 = __hadd_sat(bf16_1, bf16_2);
+  // CHECK: bf16 = bf16_1 / bf16_2;
+  bf16 = __hdiv(bf16_1, bf16_2);
+  // CHECK: bf16 = sycl::ext::oneapi::experimental::fma(bf16_1, bf16_2, bf16_3);
+  bf16 = __hfma(bf16_1, bf16_2, bf16_3);
+  // CHECK: bf16 = dpct::relu(sycl::ext::oneapi::experimental::fma(bf16_1, bf16_2, bf16_3));
+  bf16 = __hfma_relu(bf16_1, bf16_2, bf16_3);
+  // CHECK: bf16 = dpct::clamp<sycl::ext::oneapi::bfloat16>(sycl::ext::oneapi::experimental::fma(bf16_1, bf16_2, bf16_3), 0.f, 1.0f);
+  bf16 = __hfma_sat(bf16_1, bf16_2, bf16_3);
+  // CHECK: bf16 = bf16_1 * bf16_2;
+  bf16 = __hmul(bf16_1, bf16_2);
+  // CHECK: bf16 = bf16_1 * bf16_2;
+  bf16 = __hmul_rn(bf16_1, bf16_2);
+  // CHECK: bf16 = dpct::clamp<sycl::ext::oneapi::bfloat16>(bf16_1 * bf16_2, 0.f, 1.0f);
+  bf16 = __hmul_sat(bf16_1, bf16_2);
+  // CHECK: bf16 = -bf16_1;
+  bf16 = __hneg(bf16_1);
+  // CHECK: bf16 = bf16_1 - bf16_2;
+  bf16 = __hsub(bf16_1, bf16_2);
+  // CHECK: bf16 = bf16_1 - bf16_2;
+  bf16 = __hsub_rn(bf16_1, bf16_2);
+  // CHECK: bf16 = dpct::clamp<sycl::ext::oneapi::bfloat16>(bf16_1 - bf16_2, 0.f, 1.0f);
+  bf16 = __hsub_sat(bf16_1, bf16_2);
+}
+
+// bindless_images
+void driver() {
+  // CHECK: sycl::ext::oneapi::experimental::sampled_image_handle o;
+  CUtexObject o;
+  // CHECK: dpct::image_data R;
+  CUDA_RESOURCE_DESC R;
+  // CHECK: dpct::sampling_info T;
+  CUDA_TEXTURE_DESC T;
+  // CHECK: o = dpct::experimental::create_bindless_image(R, T);
+  cuTexObjectCreate(&o, &R, &T, NULL);
+  // CHECK: dpct::experimental::destroy_bindless_image(o, dpct::get_in_order_queue());
+  cuTexObjectDestroy(o);
+  // CHECK: R = dpct::experimental::get_data(o);
+  cuTexObjectGetResourceDesc(&R, o);
+  // CHECK: T = dpct::experimental::get_sampling_info(o);
+  cuTexObjectGetTextureDesc(&T, o);
+}
+
+// non-uniform-groups
+
+__device__ void bar(int *arr, int *brr) {
+  arr[threadIdx.x] = threadIdx.x + 10;
+  if (threadIdx.x % 2 == 0) {
+    for (int i = 0; i < 1000; ++i)
+      arr[threadIdx.x] += arr[threadIdx.x] - 1 * arr[threadIdx.x] - 3;
+    if (arr[threadIdx.x] < 0)
+      arr[threadIdx.x] = 0;
+  }
+
+  // CHECK: sycl::group_barrier(sycl::ext::oneapi::experimental::get_ballot_group(item_ct1.get_sub_group(), 0b1010101010 & (1 << item_ct1.get_local_linear_id())));
+  asm volatile("bar.warp.sync %0;" ::"r"(0b1010101010));
+  if (threadIdx.x == 1) {
+    for (int i = 0; i < 10; ++i) {
+      brr[i] = arr[i];
+    }
+  }
+}

--- a/clang/test/dpct/enable-all-extensions.cu
+++ b/clang/test/dpct/enable-all-extensions.cu
@@ -1,0 +1,238 @@
+// RUN: dpct --format-range=none -out-root %T/enable-all-extensions %s --cuda-include-path="%cuda-path/include" --use-dpcpp-extensions=all
+// RUN: FileCheck --input-file %T/enable-all-extensions/enable-all-extensions.dp.cpp --match-full-lines %s
+// RUN: %if build_lit %{icpx -c -fsycl %T/enable-all-extensions/enable-all-extensions.dp.cpp -o %T/enable-all-extensions/enable-all-extensions.dp.o %}
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+// c_cxx_standard_library
+
+__device__ void d() {
+  float f, f2;
+  double d, d2;
+  int i, i2;
+  long l, l2;
+  long long ll, ll2;
+
+  // CHECK: f = sycl::fabs(f2);
+  // CHECK-NEXT: d = sycl::fabs(d2);
+  // CHECK-NEXT: i = sycl::abs(i2);
+  // CHECK-NEXT: l = sycl::abs(l2);
+  // CHECK-NEXT: ll = sycl::abs(ll2);
+  // CHECK-NEXT: f = sycl::fabs(f2);
+  // CHECK-NEXT: d = sycl::fabs(d2);
+  // CHECK-NEXT: i = sycl::abs(i2);
+  // CHECK-NEXT: l = sycl::abs(l2);
+  // CHECK-NEXT: ll = sycl::abs(ll2);
+  f = abs(f2);
+  d = abs(d2);
+  i = abs(i2);
+  l = abs(l2);
+  ll = abs(ll2);
+  f = std::abs(f2);
+  d = std::abs(d2);
+  i = std::abs(i2);
+  l = std::abs(l2);
+  ll = std::abs(ll2);
+}
+
+void h() {
+  float f, f2;
+  double d, d2;
+  int i, i2;
+  long l, l2;
+  long long ll, ll2;
+
+  // CHECK: f = abs(f2);
+  // CHECK-NEXT: d = abs(d2);
+  // CHECK-NEXT: i = abs(i2);
+  // CHECK-NEXT: l = abs(l2);
+  // CHECK-NEXT: ll = abs(ll2);
+  // CHECK-NEXT: f = std::abs(f2);
+  // CHECK-NEXT: d = std::abs(d2);
+  // CHECK-NEXT: i = std::abs(i2);
+  // CHECK-NEXT: l = std::abs(l2);
+  // CHECK-NEXT: ll = std::abs(ll2);
+  f = abs(f2);
+  d = abs(d2);
+  i = abs(i2);
+  l = abs(l2);
+  ll = abs(ll2);
+  f = std::abs(f2);
+  d = std::abs(d2);
+  i = std::abs(i2);
+  l = std::abs(l2);
+  ll = std::abs(ll2);
+}
+
+void foo1() {
+  int n;
+  // CHECK: sycl::range<3> abc(1, 1, 1);
+  // CHECK-NEXT: abc[1] = std::min(std::max(512 / (unsigned int)abc[2], 1u), (unsigned int)n);
+  // CHECK-NEXT: abc[0] = std::min(std::max(512 / ((unsigned int)abc[2] * (unsigned int)abc[1]), 1u), (unsigned int)n);
+  dim3 abc;
+  abc.y = std::min(std::max(512 / abc.x, 1u), (unsigned int)n);
+  abc.z = std::min(std::max(512 / (abc.x * abc.y), 1u), (unsigned int)n);
+}
+
+// intel_device_math
+__global__ void kernelFuncHalfConversion() {
+  float f;
+  float2 f2;
+  half h;
+  half2 h2;
+  int i;
+  long long ll;
+  short s;
+  unsigned u;
+  unsigned long long ull;
+  unsigned short us;
+  // CHECK: h2 = sycl::half2(sycl::ext::intel::math::float2half_rn(f2[0]), sycl::ext::intel::math::float2half_rn(f2[1]));
+  h2 = __float22half2_rn(f2);
+  // CHECK: h = sycl::ext::intel::math::float2half_rn(f);
+  h = __float2half(f);
+  // CHECK: h2 = sycl::half2(sycl::ext::intel::math::float2half_rn(f));
+  h2 = __float2half2_rn(f);
+  // CHECK: h = sycl::ext::intel::math::float2half_rd(f);
+  h = __float2half_rd(f);
+  // sycl::ext::intel::math::float2half_rn(f);
+  __float2half_rn(f);
+  // CHECK: h = sycl::ext::intel::math::float2half_ru(f);
+  h = __float2half_ru(f);
+  // CHECK: h = sycl::ext::intel::math::float2half_rz(f);
+  h = __float2half_rz(f);
+  // CHECK: h2 = sycl::half2(sycl::ext::intel::math::float2half_rn(f), sycl::ext::intel::math::float2half_rn(f));
+  h2 = __floats2half2_rn(f, f);
+  // CHECK: f2 = sycl::float2(sycl::ext::intel::math::half2float(h2[0]), sycl::ext::intel::math::half2float(h2[1]));
+  f2 = __half22float2(h2);
+  // CHECK: f = sycl::ext::intel::math::half2float(h);
+  f = __half2float(h);
+  // CHECK: h2 = sycl::half2(h);
+  h2 = __half2half2(h);
+  // CHECK: i = sycl::ext::intel::math::half2int_rd(h);
+  i = __half2int_rd(h);
+  // CHECK: i = sycl::ext::intel::math::half2int_rn(h);
+  i = __half2int_rn(h);
+  // CHECK: i = sycl::ext::intel::math::half2int_ru(h);
+  i = __half2int_ru(h);
+  // CHECK: i = sycl::ext::intel::math::half2int_rz(h);
+  i = __half2int_rz(h);
+  // CHECK: ll = sycl::ext::intel::math::half2ll_rd(h);
+  ll = __half2ll_rd(h);
+  // CHECK: ll = sycl::ext::intel::math::half2ll_rn(h);
+  ll = __half2ll_rn(h);
+  // CHECK: ll = sycl::ext::intel::math::half2ll_ru(h);
+  ll = __half2ll_ru(h);
+  // CHECK: ll = sycl::ext::intel::math::half2ll_rz(h);
+  ll = __half2ll_rz(h);
+  // CHECK: s = sycl::ext::intel::math::half2short_rd(h);
+  s = __half2short_rd(h);
+  // CHECK: s = sycl::ext::intel::math::half2short_rn(h);
+  s = __half2short_rn(h);
+  // CHECK: s = sycl::ext::intel::math::half2short_ru(h);
+  s = __half2short_ru(h);
+  // CHECK: s = sycl::ext::intel::math::half2short_rz(h);
+  s = __half2short_rz(h);
+  // CHECK: u = sycl::ext::intel::math::half2uint_rd(h);
+  u = __half2uint_rd(h);
+  // CHECK: u = sycl::ext::intel::math::half2uint_rn(h);
+  u = __half2uint_rn(h);
+  // CHECK: u = sycl::ext::intel::math::half2uint_ru(h);
+  u = __half2uint_ru(h);
+  // CHECK: u = sycl::ext::intel::math::half2uint_rz(h);
+  u = __half2uint_rz(h);
+  // CHECK: ull = sycl::ext::intel::math::half2ull_rd(h);
+  ull = __half2ull_rd(h);
+  // CHECK: ull = sycl::ext::intel::math::half2ull_rn(h);
+  ull = __half2ull_rn(h);
+  // CHECK: ull = sycl::ext::intel::math::half2ull_ru(h);
+  ull = __half2ull_ru(h);
+  // CHECK: ull = sycl::ext::intel::math::half2ull_rz(h);
+  ull = __half2ull_rz(h);
+  // CHECK: us = sycl::ext::intel::math::half2ushort_rd(h);
+  us = __half2ushort_rd(h);
+  // CHECK: us = sycl::ext::intel::math::half2ushort_rn(h);
+  us = __half2ushort_rn(h);
+  // CHECK: us = sycl::ext::intel::math::half2ushort_ru(h);
+  us = __half2ushort_ru(h);
+  // CHECK: us = sycl::ext::intel::math::half2ushort_rz(h);
+  us = __half2ushort_rz(h);
+  // CHECK: s = sycl::bit_cast<short, sycl::half>(h);
+  s = __half_as_short(h);
+  // CHECK: us = sycl::bit_cast<unsigned short, sycl::half>(h);
+  us = __half_as_ushort(h);
+  // CHECK: h2 = sycl::half2(h, h);
+  h2 = __halves2half2(h, h);
+  // CHECK: f = h2[1];
+  f = __high2float(h2);
+  // CHECK: h = h2[1];
+  h = __high2half(h2);
+  // CHECK: h2 = sycl::half2(h2[1]);
+  h2 = __high2half2(h2);
+  // CHECK: h2 = sycl::half2(h2[1], h2[1]);
+  h2 = __highs2half2(h2, h2);
+  // CHECK: h = sycl::ext::intel::math::int2half_rd(i);
+  h = __int2half_rd(i);
+  // CHECK: h = sycl::ext::intel::math::int2half_rn(i);
+  h = __int2half_rn(i);
+  // CHECK: h = sycl::ext::intel::math::int2half_ru(i);
+  h = __int2half_ru(i);
+  // CHECK: h = sycl::ext::intel::math::int2half_rz(i);
+  h = __int2half_rz(i);
+  // CHECK: h = sycl::ext::intel::math::ll2half_rd(ll);
+  h = __ll2half_rd(ll);
+  // CHECK: h = sycl::ext::intel::math::ll2half_rn(ll);
+  h = __ll2half_rn(ll);
+  // CHECK: h = sycl::ext::intel::math::ll2half_ru(ll);
+  h = __ll2half_ru(ll);
+  // CHECK: h = sycl::ext::intel::math::ll2half_rz(ll);
+  h = __ll2half_rz(ll);
+  // CHECK: f = h2[0];
+  f = __low2float(h2);
+  // CHECK: f = (*(&h2))[0];
+  f = __low2float(*(&h2));
+  // CHECK: h = h2[0];
+  h = __low2half(h2);
+  // CHECK: h2 = sycl::half2(h2[0]);
+  h2 = __low2half2(h2);
+  // CHECK: h2 = sycl::half2(h2[1], h2[0]);
+  h2 = __lowhigh2highlow(h2);
+  // CHECK: h2 = sycl::half2(h2[0], h2[0]);
+  h2 = __lows2half2(h2, h2);
+  // CHECK: h = sycl::ext::intel::math::short2half_rd(s);
+  h = __short2half_rd(s);
+  // CHECK: h = sycl::ext::intel::math::short2half_rn(s);
+  h = __short2half_rn(s);
+  // CHECK: h = sycl::ext::intel::math::short2half_ru(s);
+  h = __short2half_ru(s);
+  // CHECK: h = sycl::ext::intel::math::short2half_rz(s);
+  h = __short2half_rz(s);
+  // CHECK: h = sycl::bit_cast<sycl::half, short>(s);
+  h = __short_as_half(s);
+  // CHECK: h = sycl::ext::intel::math::uint2half_rd(u);
+  h = __uint2half_rd(u);
+  // CHECK: h = sycl::ext::intel::math::uint2half_rn(u);
+  h = __uint2half_rn(u);
+  // CHECK: h = sycl::ext::intel::math::uint2half_ru(u);
+  h = __uint2half_ru(u);
+  // CHECK: h = sycl::ext::intel::math::uint2half_rz(u);
+  h = __uint2half_rz(u);
+  // CHECK: h = sycl::ext::intel::math::ull2half_rd(ull);
+  h = __ull2half_rd(ull);
+  // CHECK: h = sycl::ext::intel::math::ull2half_rn(ull);
+  h = __ull2half_rn(ull);
+  // CHECK: h = sycl::ext::intel::math::ull2half_ru(ull);
+  h = __ull2half_ru(ull);
+  // CHECK: h = sycl::ext::intel::math::ull2half_rz(ull);
+  h = __ull2half_rz(ull);
+  // CHECK: h = sycl::ext::intel::math::ushort2half_rd(us);
+  h = __ushort2half_rd(us);
+  // CHECK: h = sycl::ext::intel::math::ushort2half_rn(us);
+  h = __ushort2half_rn(us);
+  // CHECK: h = sycl::ext::intel::math::ushort2half_ru(us);
+  h = __ushort2half_ru(us);
+  // CHECK: h = sycl::ext::intel::math::ushort2half_rz(us);
+  h = __ushort2half_rz(us);
+  // CHECK: h = sycl::bit_cast<sycl::half, unsigned short>(us);
+  h = __ushort_as_half(us);
+}


### PR DESCRIPTION
Add 3 options:
- `--use-experimental-features=all`
- `--use-dpcpp-extensions=all`
- `--no-dpcpp-extensions=all`