### PR TITLE
[SYCLomatic] Fix bug that extention name for *.cpp file does not change when it is in MainSourceFiles.yaml

### DIFF
--- a/clang/lib/DPCT/PatternRewriter.cpp
+++ b/clang/lib/DPCT/PatternRewriter.cpp
@@ -10,6 +10,7 @@
 #include "Rules.h"
 #include "SaveNewFiles.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Path.h"
 #include <PatternRewriter.h>
 
 #include <optional>
@@ -396,13 +397,10 @@ updateExtentionName(const std::string &Input, size_t Next,
     for (; Pos > 0 && isIdentifiedChar(Input[Pos]); Pos--) {
     }
     Pos = Pos == 0 ? 0 : Pos + 1;
-    std::string FileName = Input.substr(Pos, Next + strlen(".cpp") - 1 - Pos);
-
-    std::string SyclFileName;
-    rewriteFileName(SyclFileName, FileName);
+    std::string FileName = Input.substr(Pos, Next + strlen(".cpp") - Pos);
     bool HasCudaSyntax = false;
     for (const auto &File : MainSrcFilesHasCudaSyntex) {
-      if (File.find(FileName) != std::string::npos) {
+      if (llvm::sys::path::filename(File) == FileName) {
         HasCudaSyntax = true;
       }
     }
@@ -511,7 +509,6 @@ static std::optional<MatchResult> findFullMatch(const MatchPattern &Pattern,
       }
 
       std::string ElementContents = Input.substr(Index, Next - Index);
-
       if (SrcFileType == SourceFileType::SFT_CMakeScript) {
         updateExtentionName(Input, Next, Result.Bindings);
       }

--- a/clang/test/dpct/cmake_migration/case_048/MainSourceFiles.yaml
+++ b/clang/test/dpct/cmake_migration/case_048/MainSourceFiles.yaml
@@ -1,0 +1,81 @@
+---
+MainSourceFile:  '/path/to/MainSrcFiles_placehold'
+Replacements:
+  - FilePath:        '/path/to/src/foo.cpp'
+    Offset:          0
+    Length:          0
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/path/to/src/baz.cpp'
+    Offset:          0
+    Length:          0
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  
+MainSourceFilesDigest:
+  - MainSourceFile:  '/path/to/src/foo.cpp'
+    Digest:          e2636fb8d174ac319083b0306294d3bd
+  - MainSourceFile:  '/path/to/src/baz.cpp'
+    Digest:          991d7e4825fc597205bf68f2eda27acd
+DpctVersion:     19.0.0
+MainHelperFileName: ''
+USMLevel:        ''
+FeatureMap:      {}
+CompileTargets:  {}
+OptionMap:
+  AnalysisScopePath:
+    Value:           '/path/to//target'
+    Specified:       false
+  AsyncHandler:
+    Value:           'false'
+    Specified:       false
+  BuildScript:
+    Value:           '1'
+    Specified:       true
+  CodePinEnabled:
+    Value:           'false'
+    Specified:       false
+  CommentsEnabled:
+    Value:           'false'
+    Specified:       false
+  CompilationsDir:
+    Value:           '/path/to/build'
+    Specified:       true
+  CtadEnabled:
+    Value:           'false'
+    Specified:       false
+  EnablepProfiling:
+    Value:           'true'
+    Specified:       true
+  ExperimentalFlag:
+    Value:           '6'
+    Specified:       true
+  ExplicitNamespace:
+    Value:           '20'
+    Specified:       false
+  ExtensionDDFlag:
+    Value:           '0'
+    Specified:       false
+  ExtensionDEFlag:
+    Value:           '4294967295'
+    Specified:       false
+  RuleFile:
+    Value:           ''
+    ValueVec:
+      - '/path/to/cmake_script_migration_rule.yaml'
+    Specified:       false
+  SyclNamedLambda:
+    Value:           'false'
+    Specified:       false
+  UsmLevel:
+    Value:           '1'
+    Specified:       false
+...

--- a/clang/test/dpct/cmake_migration/case_048/case_048_test_extension_name.cpp
+++ b/clang/test/dpct/cmake_migration/case_048/case_048_test_extension_name.cpp
@@ -1,0 +1,12 @@
+// RUN: rm -rf %T && mkdir -p %T
+// RUN: cd %T
+// RUN: mkdir -p out
+// RUN: cp %S/input.cmake ./input.cmake
+// RUN: cp %S/MainSourceFiles.yaml ./out/MainSourceFiles.yaml
+// RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
+// RUN: echo "begin" > %T/diff.txt
+// RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
+// RUN: echo "end" >> %T/diff.txt
+
+// CHECK: begin
+// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_048/expected.txt
+++ b/clang/test/dpct/cmake_migration/case_048/expected.txt
@@ -1,0 +1,6 @@
+add_library(target
+            foo.cpp.dp.cpp
+            foo.h
+            )
+            
+add_library(bar bar.cpp bar.h)

--- a/clang/test/dpct/cmake_migration/case_048/input.cmake
+++ b/clang/test/dpct/cmake_migration/case_048/input.cmake
@@ -1,0 +1,6 @@
+add_library(target
+            foo.cpp
+            foo.h
+            )
+            
+add_library(bar bar.cpp bar.h)


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>