### PR TITLE
Add clang version while printing dpct version

### DIFF
--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -472,7 +472,7 @@ std::string printCTVersion() {
     if (!Revision.empty()) {
       OS << Revision;
     }
-    OS << ').';
+    OS << ").";
   } 
   
   OS << " Clang parser: (" << CLANG_VERSION_MAJOR 

--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -473,9 +473,9 @@ std::string printCTVersion() {
       OS << Revision;
     }
     OS << ").";
-  } 
-  
-  OS << " Clang parser: (" << CLANG_VERSION_MAJOR << "." << CLANG_VERSION_MINOR 
+  }
+
+  OS << " Clang parser: (" << CLANG_VERSION_MAJOR << "." << CLANG_VERSION_MINOR
      << "." << CLANG_VERSION_PATCHLEVEL << ")\n";
 
   return OS.str();

--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -464,8 +464,7 @@ std::string printCTVersion() {
   llvm::raw_string_ostream OS(buf);
 
   OS << "\n"
-     << TOOL_NAME << " version " << DPCT_VERSION_MAJOR << "."
-     << DPCT_VERSION_MINOR << "." << DPCT_VERSION_PATCH << "."
+     << TOOL_NAME << " version " << getDpctVersionStr() << "."
      << " Codebase:";
   std::string Revision = getClangRevision();
   if (!Revision.empty()) {
@@ -473,8 +472,9 @@ std::string printCTVersion() {
     if (!Revision.empty()) {
       OS << Revision;
     }
-    OS << ')';
-  }
+    OS << ').';
+  } 
+  OS << " Clang parser: (" << ")"; 
   OS << "\n";
   return OS.str();
 }

--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -475,8 +475,7 @@ std::string printCTVersion() {
     OS << ").";
   } 
   
-  OS << " Clang parser: (" << CLANG_VERSION_MAJOR 
-     << "." << CLANG_VERSION_MINOR 
+  OS << " Clang parser: (" << CLANG_VERSION_MAJOR << "." << CLANG_VERSION_MINOR 
      << "." << CLANG_VERSION_PATCHLEVEL << ")\n";
 
   return OS.str();

--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -474,8 +474,11 @@ std::string printCTVersion() {
     }
     OS << ').';
   } 
-  OS << " Clang parser: (" << ")"; 
-  OS << "\n";
+  
+  OS << " Clang parser: (" << CLANG_VERSION_MAJOR 
+     << "." << CLANG_VERSION_MINOR 
+     << "." << CLANG_VERSION_PATCHLEVEL << ")\n";
+
   return OS.str();
 }
 


### PR DESCRIPTION
* Add clang version string
* Use existing helper `getDpctVersionStr` to avoid code duplication