### PR TITLE
[SYCLomatic][CMake] Enable migration of CUDA_NVCC_INCLUDE_DIRS and CUDA_NVCC_FLAGS

### DIFF
--- a/clang/test/dpct/cmake_migration/case_043/case_043_cuda_nvcc.cpp
+++ b/clang/test/dpct/cmake_migration/case_043/case_043_cuda_nvcc.cpp
@@ -1,0 +1,10 @@
+// RUN: rm -rf %T && mkdir -p %T
+// RUN: cd %T
+// RUN: cp %S/input.cmake ./input.cmake
+// RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
+// RUN: echo "begin" > %T/diff.txt
+// RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
+// RUN: echo "end" >> %T/diff.txt
+
+// CHECK: begin
+// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_043/expected.txt
+++ b/clang/test/dpct/cmake_migration/case_043/expected.txt
@@ -1,0 +1,9 @@
+include_directories(${SYCL_INCLUDE_DIR})
+
+target_include_directories(my_cuda_program PRIVATE ${SYCL_INCLUDE_DIR})
+
+list(APPEND CMAKE_SYCL_FLAGS ${ARCH_FLAGS})
+
+set(CMAKE_SYCL_FLAGS "${CMAKE_SYCL_FLAGS} ${COMPILE_FLAG}")
+
+set(CMAKE_SYCL_FLAGS "${CMAKE_SYCL_FLAGS} -std=c++17")

--- a/clang/test/dpct/cmake_migration/case_043/input.cmake
+++ b/clang/test/dpct/cmake_migration/case_043/input.cmake
@@ -1,0 +1,9 @@
+include_directories(${CUDA_NVCC_INCLUDE_DIRS})
+
+target_include_directories(my_cuda_program PRIVATE ${CUDA_NVCC_INCLUDE_DIRS})
+
+list(APPEND CUDA_NVCC_FLAGS ${ARCH_FLAGS})
+
+set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} ${COMPILE_FLAG}")
+
+set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -std=c++17")

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -864,6 +864,21 @@
         \${SYCL_INCLUDE_DIR}
       RuleId: "replace_CUDA_INCLUDE_DIRS_with_SYCL_INCLUDE_DIR"
 
+- Rule: rule_CUDA_NVCC_INCLUDE_DIRS
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_NVCC_INCLUDE_DIRS
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: \${CUDA_NVCC_INCLUDE_DIRS}
+      Out: |
+        \${SYCL_INCLUDE_DIR}
+      RuleId: "replace_CUDA_NVCC_INCLUDE_DIRS_with_SYCL_INCLUDE_DIR"
+
 - Rule: rule_cuda_add_cufft_to_target
   Kind: CMakeRule
   Priority: Fallback
@@ -958,6 +973,19 @@
     value:
       MatchMode: Full
       In: CMAKE_CUDA_FLAGS
+      Out: CMAKE_SYCL_FLAGS
+
+- Rule: rule_CUDA_NVCC_FLAGS
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: CUDA_NVCC_FLAGS
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA_NVCC_FLAGS
       Out: CMAKE_SYCL_FLAGS
 
 - Rule: rule_cudart_static_removed


### PR DESCRIPTION
Signed-off-by: Daiyaan Ahmed <daiyaan.ahmed@intel.com>