### PR TITLE
[SYCLomatic] Use std::int64_t type for integer parameters in new added helper functions in dpct::blas namespace

### DIFF
--- a/clang/runtime/dpct-rt/include/dpct/blas_utils.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/blas_utils.hpp
@@ -1595,10 +1595,11 @@ deduce_compute_mode(std::optional<compute_type> ct, math_mode mm,
 /// \param [in] ldc Leading dimension of C.
 /// \param [in] ct Compute type.
 inline void gemm(descriptor_ptr desc_ptr, oneapi::mkl::transpose a_trans,
-                 oneapi::mkl::transpose b_trans, int m, int n, int k,
-                 const void *alpha, const void *a, library_data_t a_type,
-                 int lda, const void *b, library_data_t b_type, int ldb,
-                 const void *beta, void *c, library_data_t c_type, int ldc,
+                 oneapi::mkl::transpose b_trans, std::int64_t m, std::int64_t n,
+                 std::int64_t k, const void *alpha, const void *a,
+                 library_data_t a_type, std::int64_t lda, const void *b,
+                 library_data_t b_type, std::int64_t ldb, const void *beta,
+                 void *c, library_data_t c_type, std::int64_t ldc,
                  std::variant<compute_type, library_data_t> ct) {
 #ifndef __INTEL_MKL__
   throw std::runtime_error("The oneAPI Math Kernel Library (oneMKL) Interfaces "
@@ -1751,12 +1752,12 @@ inline void gemm(descriptor_ptr desc_ptr, oneapi::mkl::transpose a_trans,
 /// \param [in] scaling_type Data type of the scaling factors.
 /// \param [in] ct Compute type.
 inline void gemm_batch(descriptor_ptr desc_ptr, oneapi::mkl::transpose a_trans,
-                       oneapi::mkl::transpose b_trans, int m, int n, int k,
-                       const void *alpha, const void *a[],
-                       library_data_t a_type, int lda, const void *b[],
-                       library_data_t b_type, int ldb, const void *beta,
-                       void *c[], library_data_t c_type, int ldc,
-                       int batch_size,
+                       oneapi::mkl::transpose b_trans, std::int64_t m,
+                       std::int64_t n, std::int64_t k, const void *alpha,
+                       const void *a[], library_data_t a_type, std::int64_t lda,
+                       const void *b[], library_data_t b_type, std::int64_t ldb,
+                       const void *beta, void *c[], library_data_t c_type,
+                       std::int64_t ldc, std::int64_t batch_size,
                        std::variant<compute_type, library_data_t> ct) {
 #ifdef DPCT_USM_LEVEL_NONE
   throw std::runtime_error("this API is unsupported when USM level is none");
@@ -1930,12 +1931,14 @@ inline void gemm_batch(descriptor_ptr desc_ptr, oneapi::mkl::transpose a_trans,
 /// \param [in] batch_size Specifies the number of matrix multiply operations to perform.
 /// \param [in] ct Compute type.
 inline void gemm_batch(descriptor_ptr desc_ptr, oneapi::mkl::transpose a_trans,
-                       oneapi::mkl::transpose b_trans, int m, int n, int k,
-                       const void *alpha, const void *a, library_data_t a_type,
-                       int lda, long long int stride_a, const void *b,
-                       library_data_t b_type, int ldb, long long int stride_b,
-                       const void *beta, void *c, library_data_t c_type,
-                       int ldc, long long int stride_c, int batch_size,
+                       oneapi::mkl::transpose b_trans, std::int64_t m,
+                       std::int64_t n, std::int64_t k, const void *alpha,
+                       const void *a, library_data_t a_type, std::int64_t lda,
+                       long long int stride_a, const void *b,
+                       library_data_t b_type, std::int64_t ldb,
+                       long long int stride_b, const void *beta, void *c,
+                       library_data_t c_type, std::int64_t ldc,
+                       long long int stride_c, std::int64_t batch_size,
                        std::variant<compute_type, library_data_t> ct) {
   sycl::queue q = desc_ptr->get_queue();
 #ifdef __INTEL_MKL__
@@ -2094,9 +2097,9 @@ inline void gemm_batch(descriptor_ptr desc_ptr, oneapi::mkl::transpose a_trans,
 /// \param [in] ldc Leading dimension of C.
 template <class T>
 inline void syrk(descriptor_ptr desc_ptr, oneapi::mkl::uplo uplo,
-                 oneapi::mkl::transpose trans, int n, int k, const T *alpha,
-                 const T *a, int lda, const T *b, int ldb, const T *beta, T *c,
-                 int ldc) {
+                 oneapi::mkl::transpose trans, std::int64_t n, std::int64_t k,
+                 const T *alpha, const T *a, std::int64_t lda, const T *b,
+                 std::int64_t ldb, const T *beta, T *c, std::int64_t ldc) {
   sycl::queue q = desc_ptr->get_queue();
 #ifdef __INTEL_MKL__
   auto cm = deduce_compute_mode<T>(std::nullopt, desc_ptr->get_math_mode());
@@ -2122,15 +2125,16 @@ inline void syrk(descriptor_ptr desc_ptr, oneapi::mkl::uplo uplo,
 /// \param [in] ldc Leading dimension of C.
 template <class T, class Tbeta>
 inline void herk(descriptor_ptr desc_ptr, oneapi::mkl::uplo uplo,
-                 oneapi::mkl::transpose trans, int n, int k, const T *alpha,
-                 const T *a, int lda, const T *b, int ldb, const Tbeta *beta,
-                 T *c, int ldc) {
+                 oneapi::mkl::transpose trans, std::int64_t n, std::int64_t k,
+                 const T *alpha, const T *a, std::int64_t lda, const T *b,
+                 std::int64_t ldb, const Tbeta *beta, T *c, std::int64_t ldc) {
   sycl::queue q = desc_ptr->get_queue();
 #ifdef __INTEL_MKL__
   auto cm = deduce_compute_mode<T>(std::nullopt, desc_ptr->get_math_mode());
 #endif
   dpct::detail::rk_impl<true, T, Tbeta>(q, uplo, trans, n, k, alpha, a, lda, b,
-                                        ldb, beta, c, ldc DPCT_COMPUTE_MODE_ARG);
+                                        ldb, beta, c,
+                                        ldc DPCT_COMPUTE_MODE_ARG);
 }
 
 /// This routine performs a group of trsm operations. Each trsm solves an
@@ -2154,10 +2158,11 @@ inline void herk(descriptor_ptr desc_ptr, oneapi::mkl::uplo uplo,
 inline void trsm_batch(descriptor_ptr desc_ptr, oneapi::mkl::side left_right,
                        oneapi::mkl::uplo upper_lower,
                        oneapi::mkl::transpose trans,
-                       oneapi::mkl::diag unit_diag, int m, int n,
-                       const void *alpha, const void **a, library_data_t a_type,
-                       int lda, void **b, library_data_t b_type, int ldb,
-                       int batch_size,
+                       oneapi::mkl::diag unit_diag, std::int64_t m,
+                       std::int64_t n, const void *alpha, const void **a,
+                       library_data_t a_type, std::int64_t lda, void **b,
+                       library_data_t b_type, std::int64_t ldb,
+                       std::int64_t batch_size,
                        std::variant<compute_type, library_data_t> ct) {
 #ifdef DPCT_USM_LEVEL_NONE
   throw std::runtime_error("this API is unsupported when USM level is none");
@@ -2231,8 +2236,9 @@ inline void trsm_batch(descriptor_ptr desc_ptr, oneapi::mkl::side left_right,
 template <class T>
 inline void trmm(descriptor_ptr desc_ptr, oneapi::mkl::side left_right,
                  oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
-                 oneapi::mkl::diag unit_diag, int m, int n, const T *alpha,
-                 const T *a, int lda, const T *b, int ldb, T *c, int ldc) {
+                 oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
+                 const T *alpha, const T *a, std::int64_t lda, const T *b,
+                 std::int64_t ldb, T *c, std::int64_t ldc) {
   using Ty = typename DataType<T>::T2;
   sycl::queue q = desc_ptr->get_queue();
 #ifdef __INTEL_MKL__


### PR DESCRIPTION
Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>