### PR TITLE
[SYCLomatic] Removed example string for --help=<arg> option and added autocompletion support

### DIFF
--- a/clang/lib/DPCT/AutoComplete.cpp
+++ b/clang/lib/DPCT/AutoComplete.cpp
@@ -17,7 +17,9 @@ namespace dpct {
 
 static std::map<std::string, std::set<std::string>> DPCTOptionInfoMap = {
   // To avoid make llvm library depends on this file, hard code 2 options here.
-  {"help", {}},
+  {"help",
+     {"basic", "advanced", "code-gen", "report-gen", "build-script",
+      "query-api", "warnings", "help-info", "intercept-build", "examples"}},
   {"version", {}},
 #define DPCT_OPTIONS_IN_LLVM_SUPPORT
 #define DPCT_OPTIONS_IN_CLANG_TOOLING

--- a/clang/lib/DPCT/AutoComplete.cpp
+++ b/clang/lib/DPCT/AutoComplete.cpp
@@ -16,11 +16,12 @@ namespace clang {
 namespace dpct {
 
 static std::map<std::string, std::set<std::string>> DPCTOptionInfoMap = {
-  // To avoid make llvm library depends on this file, hard code 2 options here.
-  {"help",
+    // To avoid make llvm library depends on this file, hard code 2 options
+    // here.
+    {"help",
      {"basic", "advanced", "code-gen", "report-gen", "build-script",
       "query-api", "warnings", "help-info", "intercept-build", "examples"}},
-  {"version", {}},
+    {"version", {}},
 #define DPCT_OPTIONS_IN_LLVM_SUPPORT
 #define DPCT_OPTIONS_IN_CLANG_TOOLING
 #define DPCT_OPTIONS_IN_CLANG_DPCT

--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -103,14 +103,7 @@ void initWarningIDs();
 } // namespace clang
 
 // clang-format off
-#include "llvm/migration_cmd_examples.inc"
-const char *const CtHelpTrailMsg = 
-    "\n"
-    "<source0> ... Paths of input source files. These paths are looked up in "
-    "the compilation database.\n\n";
-
-std::string CtHelpMessageStr = std::string(CtHelpTrailMsg) + DPCTExamplesMsg + DiagRef;
-const char *const CtHelpMessage = CtHelpMessageStr.c_str();
+const char *const CtHelpMessage = DiagRef;
 
 const char *const CtHelpHint =
     "  Warning: Please specify file(s) to be migrated.\n"

--- a/clang/test/dpct/autocomplete.c
+++ b/clang/test/dpct/autocomplete.c
@@ -27,7 +27,7 @@
 // DASH-NEXT: --format-style=
 // DASH-NEXT: --gen-build-script
 // DASH-NEXT: --gen-helper-function
-// DASH-NEXT: --help
+// DASH-NEXT: --help=
 // DASH-NEXT: --helper-function-dir
 // DASH-NEXT: --helper-function-preference=
 // DASH-NEXT: --in-root

--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -2484,6 +2484,19 @@ public:
     outs() << "OPTIONS:\n";
     printOptions(Opts, MaxArgLen);
 
+#ifdef SYCLomatic_CUSTOMIZATION
+    const char *const CtHelpTrailMsg = 
+    "\n"
+    "<source0> ... Paths of input source files. These paths are looked up in "
+    "the compilation database.\n\n";
+
+    outs() << CtHelpTrailMsg;
+
+    if (helpCatEnum == HelpCategory::HC_All) {  
+      outs() << DPCTExamplesMsg;
+    }
+#endif // SYCLomatic_CUSTOMIZATION
+
     // Print any extra help the user has declared.
     for (const auto &I : GlobalParser->MoreHelp)
       outs() << I;

--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -2485,14 +2485,14 @@ public:
     printOptions(Opts, MaxArgLen);
 
 #ifdef SYCLomatic_CUSTOMIZATION
-    const char *const CtHelpTrailMsg = 
-    "\n"
-    "<source0> ... Paths of input source files. These paths are looked up in "
-    "the compilation database.\n\n";
+    const char *const CtHelpTrailMsg = "\n"
+                                       "<source0> ... Paths of input source "
+                                       "files. These paths are looked up in "
+                                       "the compilation database.\n\n";
 
     outs() << CtHelpTrailMsg;
 
-    if (helpCatEnum == HelpCategory::HC_All) {  
+    if (helpCatEnum == HelpCategory::HC_All) {
       outs() << DPCTExamplesMsg;
     }
 #endif // SYCLomatic_CUSTOMIZATION


### PR DESCRIPTION
This PR adds following functionality to **dpct --help** option

- Removed default example string for --help=<arg> option and 
- Added autocompletion support for --help args