### PR TITLE
[SYCLomatic][CMake] Fix bug issue that library cuda is  not removed when it is used in CMake list command

### DIFF
--- a/clang/test/dpct/cmake_migration/case_020/expected.txt
+++ b/clang/test/dpct/cmake_migration/case_020/expected.txt
@@ -1,3 +1,4 @@
 set(SOURCES foo.dp.cpp ${CMAKE_SOURCE_DIR}/foo/bar.dp.cpp)
 list(APPEND SOURCES foo.dp.cpp)
 list(append my_libs )
+list(APPEND FOO_LIBRARIES )

--- a/clang/test/dpct/cmake_migration/case_020/input.cmake
+++ b/clang/test/dpct/cmake_migration/case_020/input.cmake
@@ -1,3 +1,4 @@
 set(SOURCES foo.cu ${CMAKE_SOURCE_DIR}/foo/bar.cu)
 list(APPEND SOURCES foo.dp.cpp)
 list(append my_libs ${CUDA_LIBRARIES})
+list(APPEND FOO_LIBRARIES cuda)

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -2258,3 +2258,17 @@
       Out: IntelSYCL_FOUND
       MatchMode: Full
       RuleId: "replace_cuda_toolkit_found_with_intel_sycl_found"
+
+- Rule: rule_lib_cuda_removed
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: lib_cuda
+  In: list${empty}(${value})
+  Out: list${empty}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: cuda
+      Out: ""
+      RuleId: "remove_lib_cuda"


### PR DESCRIPTION
 Signed-off-by: chenwei.sun <chenwei.sun@intel.com>
