### PR TITLE
[SYCLomatic][UX] Improved dpct --help info

### DIFF
--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -2569,7 +2569,8 @@ public:
       showDiagMsg = true;
       break;
     default:
-      showDiagMsg = false;    }
+      showDiagMsg = false;
+    }
 
     if (showDiagMsg) {
       for (const auto &I : GlobalParser->MoreHelp)

--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -2561,16 +2561,15 @@ public:
 #ifdef SYCLomatic_CUSTOMIZATION
     bool showDiagMsg = false;
 
-    switch(helpCatEnum) {
-      case HelpCategory::HC_Advanced:
-      case HelpCategory::HC_Basic:
-      case HelpCategory::HC_BuildScript:
-      case HelpCategory::HC_CodeGen:
-        showDiagMsg = true;
-        break;
-      default:
-        showDiagMsg = false;
-    }
+    switch (helpCatEnum) {
+    case HelpCategory::HC_Advanced:
+    case HelpCategory::HC_Basic:
+    case HelpCategory::HC_BuildScript:
+    case HelpCategory::HC_CodeGen:
+      showDiagMsg = true;
+      break;
+    default:
+      showDiagMsg = false;    }
 
     if (showDiagMsg) {
       for (const auto &I : GlobalParser->MoreHelp)


### PR DESCRIPTION
Added the following behavior to dpct --help options

- Options string now reflects the selected label (except for default & examples)
- Restricted showcasing diagnostic message for only relevant options