### PR TITLE
[SYCLomatoc][UX][NFC] Updated the Diagnostic Reference URL for SYCLomatic community build

### DIFF
--- a/clang/lib/DPCT/SaveNewFiles.h
+++ b/clang/lib/DPCT/SaveNewFiles.h
@@ -18,8 +18,7 @@ using ReplTy = std::map<std::string, clang::tooling::Replacements>;
 #define DiagRef                                                                \
   "See Diagnostics Reference to resolve warnings and complete the "            \
   "migration:\n"                                                               \
-  "https://www.intel.com/content/www/us/en/docs/dpcpp-compatibility-tool/"     \
-  "developer-guide-reference/current/diagnostics-reference.html\n"
+  "https://oneapi-src.github.io/SYCLomatic/dev_guide/reference.html\n"
 
 namespace llvm {
 class StringRef;

--- a/clang/lib/DPCT/SaveNewFiles.h
+++ b/clang/lib/DPCT/SaveNewFiles.h
@@ -18,7 +18,8 @@ using ReplTy = std::map<std::string, clang::tooling::Replacements>;
 #define DiagRef                                                                \
   "See Diagnostics Reference to resolve warnings and complete the "            \
   "migration:\n"                                                               \
-  "https://oneapi-src.github.io/SYCLomatic/dev_guide/reference.html\n"
+  "https://oneapi-src.github.io/SYCLomatic/dev_guide/reference/"               \
+  "diagnostics-reference.html\n"
 
 namespace llvm {
 class StringRef;


### PR DESCRIPTION
Changed the diagnostic reference URL for the community build from 
https://www.intel.com/content/www/us/en/docs/dpcpp-compatibility-tool/developer-guide-reference/current/diagnostics-reference.html
to
https://oneapi-src.github.io/SYCLomatic/dev_guide/reference.html