### PR TITLE
[NFC][SYCLomatic] Add a virtual destructor for clang::dpct::DpctOptionBase

### DIFF
--- a/clang/include/clang/DPCT/DpctOptions.h
+++ b/clang/include/clang/DPCT/DpctOptions.h
@@ -82,6 +82,7 @@ protected:
                  std::initializer_list<DpctActionKind>);
 
 public:
+  virtual ~DpctOptionBase() {}
   static void init();
   static void check();
 };

--- a/clang/include/clang/DPCT/DpctOptions.h
+++ b/clang/include/clang/DPCT/DpctOptions.h
@@ -82,7 +82,7 @@ protected:
                  std::initializer_list<DpctActionKind>);
 
 public:
-  virtual ~DpctOptionBase() {}
+  ~DpctOptionBase() = default;
   static void init();
   static void check();
 };
@@ -156,3 +156,4 @@ private:
 } // namespace clang
 
 #endif //!__DPCT_OPTIONS_H__
+


### PR DESCRIPTION
Avoid warning like the following:
```
SYCLomatic/clang/include/clang/DPCT/DpctOptions.h:41:7: warning: 'clang::dpct::DpctOptionBase' has virtual functions but non-virtual destructor [-Wnon-virtual-dtor]
class DpctOptionBase {
```