### PR TITLE
[SYCLomatic] Fix migration of cub::BlockReduce::Reduce

### DIFF
--- a/clang/lib/DPCT/CUBAPIMigration.cpp
+++ b/clang/lib/DPCT/CUBAPIMigration.cpp
@@ -1160,8 +1160,10 @@ void CubRule::processBlockLevelMemberCall(const CXXMemberCallExpr *BlockMC) {
     ExprAnalysis InEA(InData);
     bool IsPartialReduce = false;
     unsigned ValidItemParamIdx = 0;
-    if (FuncName == "Reduce" && NumArgs == 2) {
+    if (FuncName == "Reduce") {
       OpRepl = getOpRepl(FuncArgs[1]);
+      IsPartialReduce = NumArgs == 3;
+      ValidItemParamIdx = 2;
     } else if (FuncName == "Sum") {
       OpRepl = getOpRepl(nullptr);
       IsPartialReduce = NumArgs == 2;

--- a/clang/test/dpct/cub/blocklevel/blockreduce.cu
+++ b/clang/test/dpct/cub/blocklevel/blockreduce.cu
@@ -94,6 +94,29 @@ __global__ void ReduceSumValid(int *data, int valid_items) {
   data[threadid] = output;
 }
 
+// CHECK: void ReduceReduceValid(int *data, int valid_items,
+// CHECK-NEXT:  const sycl::nd_item<3> &item_ct1) {
+// CHECK-EMPTY:
+// CHECK-NEXT:  int threadid = item_ct1.get_local_id(2);
+// CHECK-EMPTY:
+// CHECK-NEXT:  int input = data[threadid];
+// CHECK-NEXT:  int output = 0;
+// CHECK-NEXT:  output = sycl::reduce_over_group(item_ct1.get_group(), (item_ct1.get_group().get_local_linear_id() < valid_items) ? input : sycl::known_identity_v<sycl::plus<>, int>, sycl::plus<>());
+// CHECK-NEXT:  data[threadid] = output;
+// CHECK-NEXT:}
+__global__ void ReduceReduceValid(int *data, int valid_items) {
+  typedef cub::BlockReduce<int, 4> BlockReduce;
+
+  __shared__ typename BlockReduce::TempStorage temp1;
+
+  int threadid = threadIdx.x;
+
+  int input = data[threadid];
+  int output = 0;
+  output = BlockReduce(temp1).Sum(input, valid_items);
+  data[threadid] = output;
+}
+
 //CHECK: void ReduceKernel_Max(int* data,
 //CHECK-NEXT:  const sycl::nd_item<3> &item_ct1) {
 //CHECK-EMPTY:
@@ -176,6 +199,16 @@ int main() {
   // CHECK-NEXT:          ReduceSumValid(dev_data, 8, item_ct1);
   // CHECK-NEXT:        });
   ReduceSumValid<<<GridSize, BlockSize>>>(dev_data, 8);
+  cudaDeviceSynchronize();
+  verify_data(dev_data, TotalThread);
+
+  init_data(dev_data, TotalThread);
+  // CHECK:  q_ct1.parallel_for(
+  // CHECK-NEXT:        sycl::nd_range<3>(GridSize * BlockSize, BlockSize),
+  // CHECK-NEXT:        [=](sycl::nd_item<3> item_ct1) {
+  // CHECK-NEXT:          ReduceReduceValid(dev_data, 8, item_ct1);
+  // CHECK-NEXT:        });
+  ReduceReduceValid<<<GridSize, BlockSize>>>(dev_data, 8);
   cudaDeviceSynchronize();
   verify_data(dev_data, TotalThread);
 


### PR DESCRIPTION
E2E test: https://github.com/oneapi-src/SYCLomatic-test/pull/711