### PR TITLE
[SYCLomatic] Ignore oneapi::mkl::rng::mrg32k3a_mode argument for non-GPU devices

### DIFF
--- a/clang/runtime/dpct-rt/include/dpct/rng_utils.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/rng_utils.hpp
@@ -530,6 +530,8 @@ private:
                                        const random_mode mode) {
 #ifdef __INTEL_MKL__
     if constexpr (std::is_same_v<engine_t, oneapi::mkl::rng::mrg32k3a>) {
+      // oneapi::mkl::rng::mrg32k3a_mode is only supported for GPU device. For
+      // other devices, this argument will be ignored.
       if (queue->get_device().is_gpu()) {
         switch (mode) {
         case random_mode::best:
@@ -543,11 +545,6 @@ private:
                           oneapi::mkl::rng::mrg32k3a_mode::optimal_v);
         }
       }
-#ifndef NDEBUG
-      std::cout << "oneapi::mkl::rng::mrg32k3a_mode is not supported for "
-                << queue->get_device().get_info<sycl::info::device::name>()
-                << ". This argument will be ignored." << std::endl;
-#endif
     }
     return std::is_same_v<engine_t, oneapi::mkl::rng::sobol>
                ? engine_t(*queue, dimensions)

--- a/clang/runtime/dpct-rt/include/dpct/rng_utils.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/rng_utils.hpp
@@ -543,7 +543,7 @@ private:
                           oneapi::mkl::rng::mrg32k3a_mode::optimal_v);
         }
       }
-      std::cout << "oneapi::mkl::rng::mrg32k3a_mode does not support on "
+      std::cout << "oneapi::mkl::rng::mrg32k3a_mode is not supported for "
                 << queue->get_device().get_info<sycl::info::device::name>()
                 << ". This argument will be ignored." << std::endl;
     }

--- a/clang/runtime/dpct-rt/include/dpct/rng_utils.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/rng_utils.hpp
@@ -530,7 +530,7 @@ private:
                                        const random_mode mode) {
 #ifdef __INTEL_MKL__
     if constexpr (std::is_same_v<engine_t, oneapi::mkl::rng::mrg32k3a>) {
-      if (queue->is_gpu()) {
+      if (queue->get_device().is_gpu()) {
         switch (mode) {
         case random_mode::best:
           return engine_t(*queue, seed,

--- a/clang/runtime/dpct-rt/include/dpct/rng_utils.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/rng_utils.hpp
@@ -530,17 +530,22 @@ private:
                                        const random_mode mode) {
 #ifdef __INTEL_MKL__
     if constexpr (std::is_same_v<engine_t, oneapi::mkl::rng::mrg32k3a>) {
-      switch (mode) {
-      case random_mode::best:
-        return engine_t(*queue, seed,
-                        oneapi::mkl::rng::mrg32k3a_mode::custom{81920});
-      case random_mode::legacy:
-        return engine_t(*queue, seed,
-                        oneapi::mkl::rng::mrg32k3a_mode::custom{4096});
-      case random_mode::optimal:
-        return engine_t(*queue, seed,
-                        oneapi::mkl::rng::mrg32k3a_mode::optimal_v);
+      if (queue->is_gpu()) {
+        switch (mode) {
+        case random_mode::best:
+          return engine_t(*queue, seed,
+                          oneapi::mkl::rng::mrg32k3a_mode::custom{81920});
+        case random_mode::legacy:
+          return engine_t(*queue, seed,
+                          oneapi::mkl::rng::mrg32k3a_mode::custom{4096});
+        case random_mode::optimal:
+          return engine_t(*queue, seed,
+                          oneapi::mkl::rng::mrg32k3a_mode::optimal_v);
+        }
       }
+      std::cout << "oneapi::mkl::rng::mrg32k3a_mode does not support on "
+                << queue->get_device().get_info<sycl::info::device::name>()
+                << ". This argument will be ignored." << std::endl;
     }
     return std::is_same_v<engine_t, oneapi::mkl::rng::sobol>
                ? engine_t(*queue, dimensions)

--- a/clang/runtime/dpct-rt/include/dpct/rng_utils.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/rng_utils.hpp
@@ -543,9 +543,11 @@ private:
                           oneapi::mkl::rng::mrg32k3a_mode::optimal_v);
         }
       }
+#ifndef NDEBUG
       std::cout << "oneapi::mkl::rng::mrg32k3a_mode is not supported for "
                 << queue->get_device().get_info<sycl::info::device::name>()
                 << ". This argument will be ignored." << std::endl;
+#endif
     }
     return std::is_same_v<engine_t, oneapi::mkl::rng::sobol>
                ? engine_t(*queue, dimensions)


### PR DESCRIPTION
Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>