### PR TITLE
[SYCLomatic][CMake] Refine migration rules for link_libraries() and target_link_libraries() to avoid target names in target_link_libraries touched

### DIFF
--- a/clang/test/dpct/cmake_migration/case_004/expected.txt
+++ b/clang/test/dpct/cmake_migration/case_004/expected.txt
@@ -15,11 +15,8 @@ target_link_libraries(${target} PRIVATE
          
          )
                      
-target_link_libraries(${PROJECT_NAME}
-   
-   
-)
-target_link_libraries(nlm_cuda  ${OpenCV_LIBS} stdc++ stdc++fs)
+target_link_libraries(${PROJECT_NAME} )
+target_link_libraries(nlm_cuda ${OpenCV_LIBS} stdc++ stdc++fs)
 target_link_libraries(cublas-cudnn-test ${MKL_LIB} ${DNN_LIB})
 
-target_link_libraries(tsne  ${MKL_LIB} ${MKL_LIB} ${MKL_LIB})
+target_link_libraries(tsne ${MKL_LIB} ${MKL_LIB} ${MKL_LIB})

--- a/clang/test/dpct/cmake_migration/case_032/expected.txt
+++ b/clang/test/dpct/cmake_migration/case_032/expected.txt
@@ -41,9 +41,7 @@ set(LIBS ${LIBS}
     
 )
 
-target_link_libraries(${target}
-    
-    ${MKL_LIB}
+target_link_libraries(${target} ${MKL_LIB}
     ${MKL_LIB}
     
     
@@ -89,10 +87,7 @@ set(LIBS ${LIBS}
     
 )
 
-target_link_libraries(${target}
-    
-    
-    
+target_link_libraries(${target} 
     ${MKL_LIB}
     
     

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -733,8 +733,8 @@
   Kind: CMakeRule
   Priority: Fallback
   CmakeSyntax: cuda_target_link_libraries
-  In: ${prefix}link_libraries(${libs})
-  Out: ${prefix}link_libraries(${libs})
+  In: target_link_libraries(${target} ${libs})
+  Out: target_link_libraries(${target} ${libs})
   Subrules:
     libs:
       In: cuda
@@ -745,8 +745,8 @@
   Kind: CMakeRule
   Priority: Fallback
   CmakeSyntax: cublas_target_link_libraries
-  In: ${prefix}link_libraries(${libs})
-  Out: ${prefix}link_libraries(${libs})
+  In: target_link_libraries(${target} ${libs})
+  Out: target_link_libraries(${target} ${libs})
   Subrules:
     libs:
       In: cublas
@@ -759,8 +759,8 @@
   Kind: CMakeRule
   Priority: Fallback
   CmakeSyntax: libcublas_target_link_libraries
-  In: ${prefix}link_libraries(${libs})
-  Out: ${prefix}link_libraries(${libs})
+  In: target_link_libraries(${target} ${libs})
+  Out: target_link_libraries(${target} ${libs})
   Subrules:
     libs:
       In: -lcublas
@@ -773,8 +773,8 @@
   Kind: CMakeRule
   Priority: Fallback
   CmakeSyntax: cudnn_target_link_libraries
-  In: ${prefix}link_libraries(${libs})
-  Out: ${prefix}link_libraries(${libs})
+  In: target_link_libraries(${target} ${libs})
+  Out: target_link_libraries(${target} ${libs})
   Subrules:
     libs:
       In: "cudnn"
@@ -787,8 +787,8 @@
   Kind: CMakeRule
   Priority: Fallback
   CmakeSyntax: libnvinfer_target_link_libraries
-  In: ${prefix}link_libraries(${libs})
-  Out: ${prefix}link_libraries(${libs})
+  In: target_link_libraries(${target} ${libs})
+  Out: target_link_libraries(${target} ${libs})
   Subrules:
     libs:
       In: libnvinfer.so
@@ -800,8 +800,8 @@
   Kind: CMakeRule
   Priority: Fallback
   CmakeSyntax: libnvonnxparser_target_link_libraries
-  In: ${prefix}link_libraries(${libs})
-  Out: ${prefix}link_libraries(${libs})
+  In: target_link_libraries(${target} ${libs})
+  Out: target_link_libraries(${target} ${libs})
   Subrules:
     libs:
       In: libnvonnxparser.so
@@ -814,8 +814,102 @@
   Kind: CMakeRule
   Priority: Fallback
   CmakeSyntax: libstdc++_target_link_libraries
-  In: ${prefix}link_libraries(${libs})
-  Out: ${prefix}link_libraries(${libs})
+  In: target_link_libraries(${target} ${libs})
+  Out: target_link_libraries(${target} ${libs})
+  Subrules:
+    libs:
+      In: -static-libstdc++
+      Out: ""
+      MatchMode: Full
+      RuleId: "remove_-static-libstdc++"
+
+- Rule: rule_link_libraries_cuda
+  Kind: CMakeRule
+  Priority: Fallback
+  CmakeSyntax: link_libraries_cuda
+  In: link_libraries(${libs})
+  Out: link_libraries(${libs})
+  Subrules:
+    libs:
+      In: cuda
+      Out: ""
+      MatchMode: Full
+
+- Rule: rule_link_libraries_cublas
+  Kind: CMakeRule
+  Priority: Fallback
+  CmakeSyntax: link_libraries_cublas
+  In: link_libraries(${libs})
+  Out: link_libraries(${libs})
+  Subrules:
+    libs:
+      In: cublas
+      Out: |
+        \${MKL_LIB}
+      MatchMode: Full
+      RuleId: "replace_cublas_with_MKL_target"
+
+- Rule: rule_link_libraries_libcublas
+  Kind: CMakeRule
+  Priority: Fallback
+  CmakeSyntax: link_libraries_libcublas
+  In: link_libraries(${libs})
+  Out: link_libraries(${libs})
+  Subrules:
+    libs:
+      In: -lcublas
+      Out: |
+        \${MKL_LIB}
+      MatchMode: Full
+      RuleId: "replace_libcublas_with_qmkl"
+
+- Rule: rule_link_libraries_cudnn
+  Kind: CMakeRule
+  Priority: Fallback
+  CmakeSyntax: link_libraries_cudnn
+  In: link_libraries(${libs})
+  Out: link_libraries(${libs})
+  Subrules:
+    libs:
+      In: "cudnn"
+      Out: |
+        \${DNN_LIB}
+      MatchMode: Full
+      RuleId: "replace_cudnn_with_libdnn"
+
+- Rule: rule_link_libraries_libnvinfer
+  Kind: CMakeRule
+  Priority: Fallback
+  CmakeSyntax: link_libraries_libnvinfer
+  In: link_libraries(${libs})
+  Out: link_libraries(${libs})
+  Subrules:
+    libs:
+      In: libnvinfer.so
+      Out: ""
+      MatchMode: Full
+      RuleId: "remove_libnvinfer"
+
+- Rule: rule_link_libraries_libnvonnxparser
+  Kind: CMakeRule
+  Priority: Fallback
+  CmakeSyntax: link_libraries_libnvonnxparser
+  In: link_libraries(${libs})
+  Out: link_libraries(${libs})
+  Subrules:
+    libs:
+      In: libnvonnxparser.so
+      Out: ""
+      MatchMode: Full
+      RuleId: "remove_libnvonnxparser"
+
+# icpx: error: '-static-libstdc++' is not supported with '-fsycl', so removing here
+- Rule: rule_link_libraries_libstdc++
+  Kind: CMakeRule
+  Priority: Fallback
+  CmakeSyntax: link_libraries_libstdc++
+  In: link_libraries(${libs})
+  Out: link_libraries(${libs})
   Subrules:
     libs:
       In: -static-libstdc++


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>
