### PR TITLE
[SYCLomatic] Support migration of cub::DeviceSpmv::CsrMV

### DIFF
--- a/clang/lib/DPCT/APINames_CUB.inc
+++ b/clang/lib/DPCT/APINames_CUB.inc
@@ -167,7 +167,7 @@ ENTRY_MEMBER_FUNCTION(cub::DeviceSelect, cub::DeviceSelect, Flagged, Flagged, tr
 ENTRY_MEMBER_FUNCTION(cub::DeviceSelect, cub::DeviceSelect, If, If, true, NO_FLAG, P4, "Successful: DPCT1026/DPCT1027")
 ENTRY_MEMBER_FUNCTION(cub::DeviceSelect, cub::DeviceSelect, Unique, Unique, true, NO_FLAG, P4, "Successful: DPCT1026/DPCT1027")
 ENTRY_MEMBER_FUNCTION(cub::DeviceSelect, cub::DeviceSelect, UniqueByKey, UniqueByKey, true, NO_FLAG, P4, "Successful: DPCT1026/DPCT1027")
-ENTRY_MEMBER_FUNCTION(cub::DeviceSpmv, cub::DeviceSpmv, CsrMV, CsrMV, false, NO_FLAG, P4, "Comment")
+ENTRY_MEMBER_FUNCTION(cub::DeviceSpmv, cub::DeviceSpmv, CsrMV, CsrMV, true, NO_FLAG, P4, "Successful: DPCT1026/DPCT1027")
 ENTRY_MEMBER_FUNCTION(cub::DeviceSegmentedRadixSort, cub::DeviceSegmentedRadixSort, SortPairs, SortPairs, true, NO_FLAG, P4, "Successful: DPCT1026/DPCT1027")
 ENTRY_MEMBER_FUNCTION(cub::DeviceSegmentedRadixSort, cub::DeviceSegmentedRadixSort, SortPairsDescending, SortPairsDescending, true, NO_FLAG, P4, "Successful: DPCT1026/DPCT1027")
 ENTRY_MEMBER_FUNCTION(cub::DeviceSegmentedRadixSort, cub::DeviceSegmentedRadixSort, SortKeys, SortKeys, true, NO_FLAG, P4, "Successful: DPCT1026/DPCT1027")

--- a/clang/lib/DPCT/CMakeLists.txt
+++ b/clang/lib/DPCT/CMakeLists.txt
@@ -117,6 +117,7 @@ add_clang_library(DPCT
   Rewriters/CUB/RewriterDeviceSelect.cpp
   Rewriters/CUB/RewriterUtilityFunctions.cpp
   Rewriters/CUB/RewriterDevicePartition.cpp
+  Rewriters/CUB/RewriterDeviceSpmv.cpp
   Rewriters/Math/CallExprRewriterMath.cpp
   Rewriters/Math/RewriterSTDFunctions.cpp
   Rewriters/Math/RewriterHalfArithmeticFunctions.cpp

--- a/clang/lib/DPCT/CUBAPIMigration.cpp
+++ b/clang/lib/DPCT/CUBAPIMigration.cpp
@@ -67,14 +67,14 @@ auto isDeviceFuncCallExpr = []() {
         "If", "StableSortKeys", "StableSortKeysDescending", "StableSortPairs",
         "StableSortPairsDescending", "NonTrivialRuns", "HistogramEven",
         "MultiHistogramEven", "HistogramRange", "MultiHistogramRange",
-        "SortKeysCopy", "StableSortKeys");
+        "SortKeysCopy", "StableSortKeys", "CsrMV");
   };
   auto hasDeviceRecordName = []() {
     return hasAnyName("DeviceSegmentedReduce", "DeviceReduce", "DeviceScan",
                       "DeviceSelect", "DeviceRunLengthEncode",
                       "DeviceRadixSort", "DeviceSegmentedRadixSort",
                       "DeviceSegmentedSort", "DeviceHistogram",
-                      "DeviceMergeSort", "DevicePartition");
+                      "DeviceMergeSort", "DevicePartition", "DeviceSpmv");
   };
   return callExpr(callee(functionDecl(allOf(
       hasDeviceFuncName(),

--- a/clang/lib/DPCT/InclusionHeaders.cpp
+++ b/clang/lib/DPCT/InclusionHeaders.cpp
@@ -236,8 +236,8 @@ void IncludesCallbacks::InclusionDirective(
       break;
     case DpctInclusionInfo::IF_MarkInserted:
       setHeadersAsInserted(FileInfo, Info.Headers);
+      break;
     case DpctInclusionInfo::IF_DoNothing:
-    default:
       break;
     }
     return;
@@ -278,8 +278,6 @@ void DpctInclusionHeadersMap::registInclusionHeaderEntry(
   case MatchMode::Mode_Startwith:
     Info = &InclusionStartWithMap.emplace_back(Filename).Info;
     break;
-  default:
-    return;
   }
   Info->RuleGroup = Group;
   Info->ProcessFlag = Flag;

--- a/clang/lib/DPCT/Rewriters/CUB/CallExprRewriterCUB.cpp
+++ b/clang/lib/DPCT/Rewriters/CUB/CallExprRewriterCUB.cpp
@@ -23,6 +23,7 @@ void CallExprRewriterFactoryBase::initRewriterMapCUB() {
   RewriterMap->merge(createDeviceHistgramRewriterMap());
   RewriterMap->merge(createUtilityFunctionsRewriterMap());
   RewriterMap->merge(createDevicePartitionRewriterMap());
+  RewriterMap->merge(createDeviceSpmvRewriterMap());
 }
 
 void CallExprRewriterFactoryBase::initMethodRewriterMapCUB() {

--- a/clang/lib/DPCT/Rewriters/CUB/CallExprRewriterCUB.h
+++ b/clang/lib/DPCT/Rewriters/CUB/CallExprRewriterCUB.h
@@ -82,6 +82,8 @@ RewriterMap createDeviceMergeSortRewriterMap();
 RewriterMap createClassMethodsRewriterMap();
 RewriterMap createUtilityFunctionsRewriterMap();
 RewriterMap createDevicePartitionRewriterMap();
+RewriterMap createDeviceSpmvRewriterMap();
+
 } // namespace clang::dpct
 
 #endif // CLANG_DPCT_CALL_EXPR_REWRITER_CUB_H

--- a/clang/lib/DPCT/Rewriters/CUB/RewriterDeviceSpmv.cpp
+++ b/clang/lib/DPCT/Rewriters/CUB/RewriterDeviceSpmv.cpp
@@ -1,4 +1,4 @@
-//===--------------- RewriterDeviceSelect.cpp -----------------------------===//
+//===--------------- RewriterDeviceSpmv.cpp -------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/clang/lib/DPCT/Rewriters/CUB/RewriterDeviceSpmv.cpp
+++ b/clang/lib/DPCT/Rewriters/CUB/RewriterDeviceSpmv.cpp
@@ -1,0 +1,37 @@
+//===--------------- RewriterDeviceSelect.cpp -----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CallExprRewriterCUB.h"
+#include "CallExprRewriterCommon.h"
+#include "MapNames.h"
+
+using namespace clang::dpct;
+
+RewriterMap dpct::createDeviceSpmvRewriterMap() {
+  return RewriterMap{
+      // cub::DeviceSpmv::CsrMV
+      CONDITIONAL_FACTORY_ENTRY(
+          CheckCubRedundantFunctionCall(),
+          REMOVE_API_FACTORY_ENTRY("cub::DeviceSpmv::CsrMV"),
+          HEADER_INSERT_FACTORY(
+              HeaderType::HT_DPCT_SPBLAS_Utils,
+              REMOVE_CUB_TEMP_STORAGE_FACTORY(CONDITIONAL_FACTORY_ENTRY(
+                  makeCheckAnd(CheckArgCount(11, std::greater_equal<>(),
+                                             /* IncludeDefaultArg */ false),
+                               makeCheckNot(CheckArgIsDefaultCudaStream(10))),
+                  CALL_FACTORY_ENTRY(
+                      "cub::DeviceSpmv::CsrMV",
+                      CALL(MapNames::getDpctNamespace() + "sparse::csrmv",
+                           STREAM(10), ARG(2), ARG(3), ARG(4), ARG(5), ARG(6),
+                           ARG(7), ARG(8))),
+                  CALL_FACTORY_ENTRY(
+                      "cub::DeviceSpmv::CsrMV",
+                      CALL(MapNames::getDpctNamespace() + "sparse::csrmv",
+                           QUEUESTR, ARG(2), ARG(3), ARG(4), ARG(5), ARG(6),
+                           ARG(7), ARG(8)))))))};
+}

--- a/clang/runtime/dpct-rt/include/dpct/sparse_utils.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/sparse_utils.hpp
@@ -163,6 +163,30 @@ void csrmv(sycl::queue &queue, oneapi::mkl::transpose trans, int num_rows,
                           row_ptr, col_ind, x, beta, y);
 }
 
+/// Computes a CSR format sparse matrix-dense vector product. y = A * x
+///
+/// \param [in] queue The queue where the routine should be executed. It must
+/// have the in_order property when using the USM mode.
+/// \param [in] num_rows Number of rows of the matrix A.
+/// \param [in] num_cols Number of columns of the matrix A.
+/// \param [in] values An array containing the non-zero elements of the matrix A.
+/// \param [in] row_offsets An array of length \p num_rows + 1.
+/// \param [in] column_indices An array containing the column indices in index-based numbering.
+/// \param [in] x Data of the vector x.
+/// \param [in, out] y Data of the vector y.
+template <typename T>
+void csrmv(sycl::queue &queue, const T *values, const int *row_offsets,
+           const int *column_indices, const T *vector_x, T *vector_y,
+           int num_rows, int num_cols) {
+  T alpha{1}, beta{0};
+  auto matrix_info = std::make_shared<dpct::sparse::matrix_info>();
+  matrix_info->set_index_base(oneapi::mkl::index_base::zero);
+  matrix_info->set_matrix_type(dpct::sparse::matrix_info::matrix_type::ge);
+  detail::csrmv_impl<T>()(queue, oneapi::mkl::transpose::nontrans, num_rows,
+                          num_cols, &alpha, matrix_info, values, row_offsets,
+                          column_indices, vector_x, &beta, vector_y);
+}
+
 /// Computes a CSR format sparse matrix-dense vector product.
 /// y = alpha * op(A) * x + beta * y
 /// \param [in] queue The queue where the routine should be executed. It must

--- a/clang/runtime/dpct-rt/include/dpct/sparse_utils.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/sparse_utils.hpp
@@ -167,13 +167,14 @@ void csrmv(sycl::queue &queue, oneapi::mkl::transpose trans, int num_rows,
 ///
 /// \param [in] queue The queue where the routine should be executed. It must
 /// have the in_order property when using the USM mode.
+/// \param [in] values An array containing the non-zero elements of the matrix.
+/// \param [in] row_offsets An array of length \p num_rows + 1.
+/// \param [in] column_indices An array containing the column indices in
+/// index-based numbering.
+/// \param [in] vector_x Data of the vector x.
+/// \param [in, out] vector_y Data of the vector y.
 /// \param [in] num_rows Number of rows of the matrix A.
 /// \param [in] num_cols Number of columns of the matrix A.
-/// \param [in] values An array containing the non-zero elements of the matrix A.
-/// \param [in] row_offsets An array of length \p num_rows + 1.
-/// \param [in] column_indices An array containing the column indices in index-based numbering.
-/// \param [in] x Data of the vector x.
-/// \param [in, out] y Data of the vector y.
 template <typename T>
 void csrmv(sycl::queue &queue, const T *values, const int *row_offsets,
            const int *column_indices, const T *vector_x, T *vector_y,

--- a/clang/test/dpct/cub/devicelevel/device_spmv.cu
+++ b/clang/test/dpct/cub/devicelevel/device_spmv.cu
@@ -1,0 +1,69 @@
+// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2
+// UNSUPPORTED: v8.0, v9.0, v9.1, v9.2, v10.0, v10.1, v10.2
+// RUN: dpct --format-range=none -in-root %S -out-root %T/devicelevel/device_spmv %S/device_spmv.cu --cuda-include-path="%cuda-path/include" -- -std=c++14 -x cuda --cuda-host-only
+// RUN: FileCheck --input-file %T/devicelevel/device_spmv/device_spmv.dp.cpp --match-full-lines %s
+// RUN: %if build_lit %{icpx -c -fsycl %T/devicelevel/device_spmv/device_spmv.dp.cpp -o %T/devicelevel/device_spmv/device_spmv.dp.o %}
+
+// CHECK: #include <oneapi/dpl/execution>
+// CHECK: #include <oneapi/dpl/algorithm>
+// CHECK: #include <dpct/sparse_utils.hpp>
+
+#include <cub/cub.cuh>
+#include <initializer_list>
+
+template <class T> T *init(std::initializer_list<T> L) {
+  T *Ptr = nullptr;
+  cudaMallocManaged(&Ptr, sizeof(T) * L.size());
+  std::copy(L.begin(), L.end(), Ptr);
+  return Ptr;
+}
+
+int main() {
+  int num_rows = 9;
+  int num_cols = 9;
+  int num_nonzeros = 24;
+  float *d_values = init<float>(
+      {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1});
+
+  int *d_column_indices = init(
+      {1, 3, 0, 2, 4, 1, 5, 0, 4, 6, 1, 3, 5, 7, 2, 4, 8, 3, 7, 4, 6, 8, 5, 7});
+
+  int *d_row_offsets = init({0, 2, 5, 7, 10, 14, 17, 19, 22, 24});
+
+  float *d_vector_x = init<float>({1, 1, 1, 1, 1, 1, 1, 1, 1});
+  float *d_vector_y = init<float>({0, 1, 0, 0, 0, 0, 0, 0, 0});
+
+  void *d_temp_storage = NULL;
+  size_t temp_storage_bytes = 0;
+  // CHECK: DPCT1026:{{.*}} The call to cub::DeviceSpmv::CsrMV was removed because this functionality is redundant in SYCL.
+  cub::DeviceSpmv::CsrMV(d_temp_storage, temp_storage_bytes, d_values,
+                         d_row_offsets, d_column_indices, d_vector_x,
+                         d_vector_y, num_rows, num_cols, num_nonzeros);
+
+  cudaMalloc(&d_temp_storage, temp_storage_bytes);
+  // CHECK: dpct::sparse::csrmv(q_ct1, d_values, d_row_offsets, d_column_indices, d_vector_x, d_vector_y, num_rows, num_cols);
+  cub::DeviceSpmv::CsrMV(d_temp_storage, temp_storage_bytes, d_values,
+                         d_row_offsets, d_column_indices, d_vector_x,
+                         d_vector_y, num_rows, num_cols, num_nonzeros);
+  cudaDeviceSynchronize();
+  for (int i = 0; i < 9; ++i) {
+    printf("%.2f%c", d_vector_y[i], (i == 8 ? '\n' : ' '));
+  }
+
+  cudaStream_t S;
+  cudaStreamCreate(&S);
+  d_temp_storage = NULL;
+  temp_storage_bytes = 0;
+  // CHECK: DPCT1026:{{.*}} The call to cub::DeviceSpmv::CsrMV was removed because this functionality is redundant in SYCL.
+  cub::DeviceSpmv::CsrMV(d_temp_storage, temp_storage_bytes, d_values,
+                         d_row_offsets, d_column_indices, d_vector_x,
+                         d_vector_y, num_rows, num_cols, num_nonzeros, S);
+
+  cudaMalloc(&d_temp_storage, temp_storage_bytes);
+  // CHECK: dpct::sparse::csrmv(*S, d_values, d_row_offsets, d_column_indices, d_vector_x, d_vector_y, num_rows, num_cols);
+  cub::DeviceSpmv::CsrMV(d_temp_storage, temp_storage_bytes, d_values,
+                         d_row_offsets, d_column_indices, d_vector_x,
+                         d_vector_y, num_rows, num_cols, num_nonzeros, S);
+  cudaDeviceSynchronize();
+  return 0;
+}


### PR DESCRIPTION
E2E test https://github.com/oneapi-src/SYCLomatic-test/pull/721.