### PR TITLE
[SYCLomatic] Fix the crash issue during migrating device operator overloading functions defined in a struct type when assert is enabled 

### DIFF
--- a/clang/lib/DPCT/GroupFunctionAnalyzer.cpp
+++ b/clang/lib/DPCT/GroupFunctionAnalyzer.cpp
@@ -85,7 +85,8 @@ void GroupFunctionCallInControlFlowAnalyzer::PostVisit(CallExpr *) {}
 bool GroupFunctionCallInControlFlowAnalyzer::isSyncThreadsCallExpr(
     const CallExpr *CE) const {
   const auto *FD = CE->getDirectCallee();
-  return FD && FD->getName() == "__syncthreads" &&
+
+  return FD && !isa<CXXMethodDecl>(FD) && FD->getName() == "__syncthreads" &&
          (FD->hasAttr<CUDADeviceAttr>() || FD->hasAttr<CUDAGlobalAttr>());
 }
 

--- a/clang/test/dpct/overload_unary_operator.cu
+++ b/clang/test/dpct/overload_unary_operator.cu
@@ -33,3 +33,13 @@ static __device__ uint2 operator^(const uint2 a, const uint2 b) {
 __device__ uint2 chi(const uint2 a, const uint2 b, const uint2 c) {
     return a ^ (~b) & c;
 };
+
+// The code piece below is used to test the assert that `Name.isIdentifier() &&
+// "Name is not a simple identifier"' when assert is enabled to build
+// SYCLomatic.
+template <typename T, int m> struct array {
+  __host__ __device__ bool operator==(const array &other) const { return true; }
+  __host__ __device__ bool operator!=(const array &other) const {
+    return !operator==(other);
+  }
+};


### PR DESCRIPTION
 Signed-off-by: chenwei.sun <chenwei.sun@intel.com>