### PR TITLE
[SYCLomatic] [NFC] Fix the no override warning when the destructive function is virtual.

### DIFF
--- a/clang/runtime/dpct-rt/include/dpct/image.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/image.hpp
@@ -777,7 +777,7 @@ public:
                               IsImageArray>::accessor_t;
 
   image_wrapper() { set_channel(image_channel::create<T>()); }
-  ~image_wrapper() { detach(); }
+  ~image_wrapper() override { detach(); }
 
   /// Get image accessor.
   accessor_t get_access(sycl::handler &cgh, sycl::queue &q = get_default_queue()) {


### PR DESCRIPTION
…n is virtual.