### PR TITLE
[SYCLomatic][CMake] Refine migration rule for target_compile_options to process argument "$<$<COMPILE_LANGUAGE:CUDA,NVIDIA>"

### DIFF
--- a/clang/test/dpct/cmake_migration/case_022/expected.txt
+++ b/clang/test/dpct/cmake_migration/case_022/expected.txt
@@ -1,1 +1,9 @@
-target_compile_options(tiny-cuda-nn PUBLIC )
+target_compile_options(tiny-cuda-nn PUBLIC $<$<COMPILE_LANGUAGE:CXX>:${CMAKE_SYCL_FLAGS}>)
+
+target_compile_options(
+  foo
+  PRIVATE $<$<COMPILE_LANGUAGE:CXX>:
+          $<IF:$<CONFIG:RELEASE>,-w,-Wall -Wextra>
+          >)
+
+target_compile_options(foo PUBLIC $<$<COMPILE_LANGUAGE:CXX>: -Wno-unused-but-set-variable>)

--- a/clang/test/dpct/cmake_migration/case_022/input.cmake
+++ b/clang/test/dpct/cmake_migration/case_022/input.cmake
@@ -1,1 +1,9 @@
 target_compile_options(tiny-cuda-nn PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:${CUDA_NVCC_FLAGS}>)
+
+target_compile_options(
+  foo
+  PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:
+          $<IF:$<CONFIG:RELEASE>,-w,-Wall -Wextra>
+          >)
+
+target_compile_options(foo PUBLIC $<$<COMPILE_LANGUAGE:CUDA,NVIDIA>: -Wno-unused-but-set-variable>)

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -621,8 +621,8 @@
   Out: target_compile_options(${arg})
   Subrules:
     arg:
-      In: $<$<COMPILE_LANGUAGE:CUDA>:${flags}>
-      Out: ""
+      In: $<$<COMPILE_LANGUAGE:CUDA${rest}>:${flags}>
+      Out: $<$<COMPILE_LANGUAGE:CXX>:${flags}>
       RuleId: "target_compile_options_cuda_arg"
 
 - Rule: rule_CUDA_HAS_FP16


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>