### PR TITLE
[SYCLomatic] Introduce `dpct::argmax` and `dpct::argmin` functors

### DIFF
--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/functional.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/functional.h
@@ -58,6 +58,40 @@ template <typename _Op> struct mark_functor_const {
   }
 };
 
+// Forward declare key_value_pair to avoid creating cyclic dependency between
+// iterators.h and functional.h.
+template <typename _KeyTp, typename _ValueTp> class key_value_pair;
+
+// Returns the smaller of two key_value_pair objects based on their value
+// member. If value elements compare equal, then the pair with the lower key is
+// returned.
+struct argmin {
+  template <typename _ValueTp, typename _KeyTp>
+  key_value_pair<_KeyTp, _ValueTp>
+  operator()(const key_value_pair<_KeyTp, _ValueTp> &lhs,
+             const key_value_pair<_KeyTp, _ValueTp> &rhs) const {
+    return (lhs.value < rhs.value) ||
+                   (lhs.value == rhs.value && lhs.key < rhs.key)
+               ? lhs
+               : rhs;
+  }
+};
+
+// Returns the larger of two key_value_pair objects based on their value member.
+// If value elements compare equal, then the pair with the lower key is
+// returned.
+struct argmax {
+  template <typename _ValueTp, typename _KeyTp>
+  key_value_pair<_KeyTp, _ValueTp>
+  operator()(const key_value_pair<_KeyTp, _ValueTp> &lhs,
+             const key_value_pair<_KeyTp, _ValueTp> &rhs) const {
+    return (lhs.value > rhs.value) ||
+                   (lhs.value == rhs.value && lhs.key < rhs.key)
+               ? lhs
+               : rhs;
+  }
+};
+
 namespace internal {
 
 template <class _ExecPolicy, class _T>


### PR DESCRIPTION
This PR introduces `dpct::argmax` and `dpct::argmin` functors for determining the arg max / arg min of two `dpct::key_value_pair` types.

These functors have the following behavior:

`dpct::argmin`

- If the two `key_value_pair` objects have different values, then return a copy of the `key_value_pair` with the lower value.
- If the two `key_value_pair` objects the same values, then return a copy of the `key_value_pair` with the lower key.

`dpct::argmax`

- If the two `key_value_pair` objects have different values, then return a copy of the `key_value_pair` with the greater value.
- If the two `key_value_pair` objects the same values, then return a copy of the `key_value_pair` with the **lower** key.

The corresponding test PR is https://github.com/oneapi-src/SYCLomatic-test/pull/724