### PR TITLE
Remove unnecessary `std::is_partitioned` check in `dpct::partition_point`

### DIFF
--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/algorithm.h
@@ -213,10 +213,7 @@ Iter partition_point(Policy &&policy, Iter first, Iter last, Pred p) {
       std::is_same<typename std::iterator_traits<Iter>::iterator_category,
                    std::random_access_iterator_tag>::value,
       "Iterators passed to algorithms must be random-access iterators.");
-  if (std::is_partitioned(policy, first, last, p))
-    return std::find_if_not(std::forward<Policy>(policy), first, last, p);
-  else
-    return first;
+  return std::find_if_not(std::forward<Policy>(policy), first, last, p);
 }
 
 template <typename Policy, typename Iter1, typename Iter2, typename Iter3,


### PR DESCRIPTION
With regards to preconditions of the input for `std::partition_point`, [cppref](https://en.cppreference.com/w/cpp/algorithm/partition_point) states, "If the elements elem of [first, last) are not partitioned with respect to the expression bool(p(elem)), the behavior is undefined."

We currently check `std::is_partitioned` on the input buffer in `dpct::partition_point` which is unnecessary from both the C++ standard and for migration purposes. This check launches an additional kernel that performs a full pass over the buffer and hurts performance.

This PR removes this unnecessary check.