### PR TITLE
[DOC] Fixing broken links for 2024.2

### DIFF
--- a/docs/_include_files/cross_ref_links_gsg.rst
+++ b/docs/_include_files/cross_ref_links_gsg.rst
@@ -23,6 +23,6 @@ For a complete list of command-line options, refer to the :ref:`cmd_opt_ref`.
 
 .. _refer-dpct1003:
 
-Look up the :ref:`dpct1003` warning in the Diagnostic Reference.
+Look up the :ref:`DPCT1003` warning in the Diagnostic Reference.
 
 .. _refer-dpct1003-end:

--- a/docs/dev_guide/reference/diagnostic_ref/dpct1110.rst
+++ b/docs/dev_guide/reference/diagnostic_ref/dpct1110.rst
@@ -26,7 +26,7 @@ local variable size in a device function exceeds 128 bytes, some variables may b
 stored in local or global memory, potentially leading to reduced performance when
 frequently accessed. To address this issue, you can either decrease the sub-group
 size to make more registers available for each work-item, or follow the recommendations
-in the `Registerization and Avoid Register Spills <https://www.intel.com/content/www/us/en/docs/oneapi/optimization-guide-gpu/current/registerization-and-avoiding-register-spills.html>`_ section of the oneAPI GPU
+in the `Optimizing Register Spills <https://www.intel.com/content/www/us/en/docs/oneapi/optimization-guide-gpu/2024-1/optimizing-register-spills.html>`_ section of the oneAPI GPU
 Optimization Guide. For other hardware, please consult with your hardware vendor
 to get configuration information.
 


### PR DESCRIPTION
 Fixing broken links in Get Started Guide overview page + a broken link to GPU Opt Guide in DPCT1110. This PR needs merged by 6/6.