### PR TITLE
[DOC] Migration Workflow Stage 1,4,5,Find More changes

### DIFF
--- a/docs/dev_guide/migration/migration-workflow.rst
+++ b/docs/dev_guide/migration/migration-workflow.rst
@@ -16,6 +16,9 @@ stages:
 * `Stage 3: Review the Migrated Code`_. Review and manually convert any unmigrated code.
 * `Stage 4: Build and Validate the New  SYCL Code Base`_. Build your project with the
   migrated code.
+* `Stage 5: Validate the New SYCL Application`_. Validate your new SYCL application to
+  check for correct functionality after migration.
+
 
 This document describes the steps in each stage with general recommendations and
 optional steps.
@@ -85,6 +88,23 @@ in the migration results:
 
 For detailed information about dialect differences between Clang and nvcc, refer to llvm.org's
 `Compiling CUDA with clang <https://www.llvm.org/docs/CompileCudaWithLLVM.html>`_ page.
+
+Run CodePin to Capture Application Signature
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+CodePin is feature that helps reduce the effort of debugging inconsistencies in
+runtime behavior. CodePin generates reports from the CUDA and SYCL programs
+that, when compared, can help identify the source of divergent runtime behavior.
+
+Enable the CodePin tool during the migration in order to capture the project
+signature.
+
+This signature will be used later for validation after migration.
+
+Enable CodePin with the ``–enable-codepin`` option.
+
+For detailed information about debugging using the CodePin tool, refer to
+`Debug Migrated Code Runtime Behavior <https://www.intel.com/content/www/us/en/docs/dpcpp-compatibility-tool/developer-guide-reference/2024-1/debug-with-codepin.html>`_.
 
 Configure the Tool
 ******************
@@ -285,11 +305,10 @@ your CUDA source.
    `contribute to the SYCLomatic project <https://github.com/oneapi-src/SYCLomatic/blob/SYCLomatic/CONTRIBUTING.md>`_.
    This helps prioritize which CUDA APIs will be supported in future releases.
 
-Stage 4: Build and Validate the New SYCL Code Base
---------------------------------------------------
+Stage 4: Build the New SYCL Code Base
+-------------------------------------
 
-After you have completed any manual migration steps, build your converted code
-and validate your new code base.
+After you have completed any manual migration steps, build your converted code.
 
 Install New SYCL Code Base Dependencies
 ***************************************
@@ -354,6 +373,35 @@ in the Codeplay plugin documentation:
 * `Install the oneAPI for AMD GPUs plugin <https://developer.codeplay.com/products/oneapi/amd/guides/>`_ from Codeplay.
 * `Install the oneAPI for NVIDIA GPUs plugin <https://developer.codeplay.com/products/oneapi/nvidia/guides/>`_ from Codeplay.
 
+Stage 5: Validate the New SYCL Application
+------------------------------------------
+
+After you have built your converted code, validate your new SYCL application to
+check for correct functionality after migration.
+
+Use a Debugger to Validate Migrated Code
+****************************************
+
+After you have successfully compiled your new SYCL application, run the app in
+debug mode using a debugger such as 
+`Intel Distribution for GDB <https://www.intel.com/content/www/us/en/developer/tools/oneapi/distribution-for-gdb.html>`_ to verify that your application runs
+as expected after migration.
+
+Learn more about `Debugging with Intel Distribution for GDB <https://www.intel.com/content/www/us/en/docs/distribution-for-gdb/tutorial-debugging-dpcpp-linux/2024-1/overview.html>`_. 
+
+Use CodePIN to Validate Migrated Code
+*************************************
+
+Use the CodePIN signature (captured in Stage 1) to validate your migrated code.
+
+If the CodePin feature has been enabled during the migration time,
+project signature will be logged during the execution time.
+
+The signature contains the data value of each execution checkpoint, which can be verified manually or with an auto-analysis tool.
+
+For detailed information about debugging using the CodePin tool, refer to
+`Debug Migrated Code Runtime Behavior <https://www.intel.com/content/www/us/en/docs/dpcpp-compatibility-tool/developer-guide-reference/2024-1/debug-with-codepin.html>`_.
+
 Optimize Your Code
 ------------------
 
@@ -403,3 +451,8 @@ Find More
      - Forum to get assistance when migrating your CUDA code to SYCL.
    * - `Intel® oneAPI Math Kernel Library Link Line Advisor <https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl-link-line-advisor.html>`_
      - Intel® oneAPI Math Kernel Library tool to help determine how to include oneMKL libraries for your specific use case.
+   * - `Tutorial: Debugging with Intel® Distribution for GDB* <https://www.intel.com/content/www/us/en/docs/distribution-for-gdb/tutorial-debugging-dpcpp-linux/2024-1/overview.html>`_
+     - This tutorial describes the basic scenarios of debugging applications using Intel® Distribution for GDB*.
+   * - `Intel® VTune™ Profiler Tutorials <https://www.intel.com/content/www/us/en/developer/articles/training/vtune-profiler-tutorials.html>`_
+     - Tutorials demonstrating an end-to-end workflow using Intel® VTune™ Profiler
+     that you can ultimately apply to your own applications. 


### PR DESCRIPTION
Migration workflow stage 5 changes, adding Stage 5 link to Overview, adding step 5.1 (Use a debugger), adding VTune and Intel Distribution for GDB tutorial links to Find More section per Migration Workflow Outline, incorporating Andy Huang's comments from https://github.com/oneapi-src/SYCLomatic/pull/2031 to Stage 1 and Stage 4 sections about CodePin signature. I cancelled/closed PR https://github.com/oneapi-src/SYCLomatic/pull/2031 and made those changes part of this PR.