### PR TITLE
[SYCLomatic] [CMake] Promote C++ standard from C++17 to C++20 in the migrated CMake script when Experimental extension "device_global" depending on C++20 is used to migrate code project

### DIFF
--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -481,6 +481,21 @@ static void loadMainSrcFileInfo(clang::tooling::UnifiedPath OutRoot) {
   for (auto &Entry : PreTU->MainSourceFilesDigest) {
     MainSrcFilesHasCudaSyntex.insert(Entry.first);
   }
+
+  // Currently, when "--use-experimental-features=device_global" and
+  // "--use-experimental-features=all" are specified, the migrated code should
+  // be compiled with C++20 or later.
+  auto Iter = PreTU->OptionMap.find("ExperimentalFlag");
+  if (Iter != PreTU->OptionMap.end()) {
+    if (Iter->second.Specified) {
+      const std::string Value = Iter->second.Value;
+      unsigned int UValue = std::stoul(Value);
+      if (UValue & (1 << static_cast<unsigned>(
+                        ExperimentalFeatures::Exp_DeviceGlobal))) {
+        LANG_Cplusplus_20_Used = true;
+      }
+    }
+  }
 }
 
 int runDPCT(int argc, const char **argv) {

--- a/clang/lib/DPCT/PatternRewriter.cpp
+++ b/clang/lib/DPCT/PatternRewriter.cpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 std::set<std::string> MainSrcFilesHasCudaSyntex;
+bool LANG_Cplusplus_20_Used = false;
 
 struct SpacingElement {};
 
@@ -428,6 +429,15 @@ updateExtentionName(const std::string &Input, size_t Next,
   }
 }
 
+static void updateCplusplusStandard(
+    std::unordered_map<std::string, std::string> &Bindings) {
+  if (LANG_Cplusplus_20_Used) {
+    Bindings["rewrite_cplusplus_version"] = "20";
+  } else {
+    Bindings["rewrite_cplusplus_version"] = "17";
+  }
+}
+
 static std::optional<MatchResult> findFullMatch(const MatchPattern &Pattern,
                                                 const std::string &Input,
                                                 const int Start) {
@@ -595,6 +605,11 @@ static std::optional<MatchResult> findMatch(const MatchPattern &Pattern,
         return {};
       }
       std::string ElementContents = Input.substr(Index, Next - Index);
+
+      if (SrcFileType == SourceFileType::SFT_CMakeScript) {
+        updateCplusplusStandard(Result.Bindings);
+      }
+
       Result.Bindings[Code.Name] = std::move(ElementContents);
       Index = Next;
       PatternIndex++;

--- a/clang/lib/DPCT/PatternRewriter.h
+++ b/clang/lib/DPCT/PatternRewriter.h
@@ -23,4 +23,5 @@ enum SourceFileType { SFT_CAndCXXSource, SFT_CMakeScript };
 void setFileTypeProcessed(enum SourceFileType FileType);
 
 extern std::set<std::string> MainSrcFilesHasCudaSyntex;
+extern bool LANG_Cplusplus_20_Used;
 #endif // DPCT_PATTERN_REWRITER_H

--- a/clang/test/dpct/cmake_migration/case_048/MainSourceFiles.yaml
+++ b/clang/test/dpct/cmake_migration/case_048/MainSourceFiles.yaml
@@ -58,7 +58,7 @@ OptionMap:
     Value:           'true'
     Specified:       true
   ExperimentalFlag:
-    Value:           '6'
+    Value:           '4096'
     Specified:       true
   ExplicitNamespace:
     Value:           '20'

--- a/clang/test/dpct/cmake_migration/case_048/expected.txt
+++ b/clang/test/dpct/cmake_migration/case_048/expected.txt
@@ -5,3 +5,9 @@ add_library(target
             )
             
 add_library(bar bar.cpp bar.h)
+
+target_compile_features(${TARGET} PUBLIC cxx_std_20)
+set(CMAKE_CXX_STANDARD 20)
+target_compile_features(culib PRIVATE cxx_std_20)
+set_target_properties(target_one PROPERTIES CXX_STANDARD 20)
+add_compile_options(-std=c++20)

--- a/clang/test/dpct/cmake_migration/case_048/input.cmake
+++ b/clang/test/dpct/cmake_migration/case_048/input.cmake
@@ -5,3 +5,9 @@ add_library(target
             )
             
 add_library(bar bar.cpp bar.h)
+
+target_compile_features(${TARGET} PUBLIC cxx_std_14)
+set(CMAKE_CXX_STANDARD 14)
+target_compile_features(culib PRIVATE cxx_std_14)
+set_target_properties(target_one PROPERTIES CXX_STANDARD 17)
+add_compile_options(-std=c++17)

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -109,8 +109,8 @@
   Kind: CMakeRule
   Priority: Fallback
   CmakeSyntax: cmake_cxx_standard
-  In: set${empty}(${empty}CMAKE_CXX_STANDARD ${version})
-  Out: set(CMAKE_CXX_STANDARD 17)
+  In: set${empty}(${empty}CMAKE_CXX_STANDARD ${cplusplus_version})
+  Out: set(CMAKE_CXX_STANDARD ${rewrite_cplusplus_version})
 
 - Rule: rule_cmake_cxx_compiler
   Kind: CMakeRule
@@ -648,8 +648,8 @@
   Out: target_compile_features(${value})
   Subrules:
     value:
-      In: cxx_std_${ver}
-      Out: cxx_std_17
+      In: cxx_std_${cplusplus_version}
+      Out: cxx_std_${rewrite_cplusplus_version}
       RuleId: "adjust_cxx_ver"
 
 # Current Yaml based rule hard-code to map "cuda_std_xx" to "cxx_std_17"
@@ -662,8 +662,8 @@
   Out: target_compile_features(${value})
   Subrules:
     value:
-      In: cuda_std_${ver}
-      Out: cxx_std_17
+      In: cuda_std_${cplusplus_version}
+      Out: cxx_std_${rewrite_cplusplus_version}
       RuleId: "adjust_cuda_ver"
 
 - Rule: rule_file_include_cuh_header_file
@@ -2046,22 +2046,22 @@
   Kind: CMakeRule
   Priority: Fallback
   CmakeSyntax: set_property_cuda_standard
-  In: set_property(${target} PROPERTY CUDA_STANDARD ${version})
-  Out: set_property(${target} PROPERTY CXX_STANDARD 17)
+  In: set_property(${target} PROPERTY CUDA_STANDARD ${cplusplus_version})
+  Out: set_property(${target} PROPERTY CXX_STANDARD ${rewrite_cplusplus_version})
 
 - Rule: rule_set_property_cxx_standard
   Kind: CMakeRule
   Priority: Fallback
   CmakeSyntax: set_property_cxx_standard
-  In: set_property(${target} PROPERTY CXX_STANDARD ${version})
-  Out: set_property(${target} PROPERTY CXX_STANDARD 17)
+  In: set_property(${target} PROPERTY CXX_STANDARD ${cplusplus_version})
+  Out: set_property(${target} PROPERTY CXX_STANDARD ${rewrite_cplusplus_version})
 
 - Rule: rule_set_cxx_target_properties
   Kind: CMakeRule
   Priority: Fallback
   CmakeSyntax: set_cxx_target_properties
-  In: set_target_properties(${targets} PROPERTIES CXX_STANDARD ${version})
-  Out: set_target_properties(${targets} PROPERTIES CXX_STANDARD 17)
+  In: set_target_properties(${targets} PROPERTIES CXX_STANDARD ${cplusplus_version})
+  Out: set_target_properties(${targets} PROPERTIES CXX_STANDARD ${rewrite_cplusplus_version})
 
 - Rule: rule_set_target_properties_cuda_standard
   Kind: CMakeRule
@@ -2071,16 +2071,15 @@
   Out: set_target_properties(${targets} PROPERTIES ${properties})
   Subrules:
     properties:
-      In: CUDA_STANDARD ${version} ${other_properties}
-      Out: CXX_STANDARD 17 ${other_properties}
-      MatchMode: Full
+      In: CUDA_STANDARD ${cplusplus_version} ${other_properties}
+      Out: CXX_STANDARD ${rewrite_cplusplus_version} ${other_properties}
 
 - Rule: rule_set_target_properties_cuda_standard-only
   Kind: CMakeRule
   Priority: Fallback
   CmakeSyntax: set_target_properties_cuda_standard-only
-  In: set_target_properties(${targets} PROPERTIES${properties}CUDA_STANDARD ${version})
-  Out: set_target_properties(${targets} PROPERTIES${properties}CXX_STANDARD 17)
+  In: set_target_properties(${targets} PROPERTIES${properties}CUDA_STANDARD ${cplusplus_version})
+  Out: set_target_properties(${targets} PROPERTIES${properties}CXX_STANDARD ${rewrite_cplusplus_version})
 
 - Rule: rule_set_cmake_cuda_required
   Kind: CMakeRule
@@ -2154,8 +2153,8 @@
   Out: ${func_name}(${value})
   Subrules:
     value:
-      In:  -std=c++${version}
-      Out: -std=c++17
+      In:  -std=c++${cplusplus_version}
+      Out: -std=c++${rewrite_cplusplus_version}
 
 # to handle the case like "list(APPEND PMEMD_NVCC_FLAGS --std c++11)"
 - Rule: rule_user_defined_variable_format_2
@@ -2167,8 +2166,8 @@
   Out: ${func_name}(${arg0} --std ${value})
   Subrules:
     value:
-      In:  c++${version}
-      Out: c++17
+      In:  c++${cplusplus_version}
+      Out: c++${rewrite_cplusplus_version}
 
 - Rule: rule_add_link_options
   Kind: CMakeRule


### PR DESCRIPTION
 Signed-off-by: chenwei.sun <chenwei.sun@intel.com>