### PR TITLE
[SYCLomatic] Support migration of cudaDeviceProp::regsPerBlock.

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -3255,6 +3255,9 @@ void DeviceInfoVarRule::runRule(const MatchFinder::MatchResult &Result) {
     emplaceTransformation(
         new ReplaceToken(ME->getBeginLoc(), ME->getEndLoc(), std::move(Repl)));
     return;
+  } else if (MemberName == "regsPerBlock") {
+    report(ME->getBeginLoc(), Diagnostics::UNCOMPATIBLE_DEVICE_PROP, false,
+           MemberName, "get_max_register_size_per_work_group");
   }
 
   if (MemberName == "sharedMemPerBlock" ||

--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -3206,12 +3206,6 @@ void DeviceInfoVarRule::runRule(const MatchFinder::MatchResult &Result) {
       EA.applyAllSubExprRepl();
       return;
   }
-  // unmigrated properties
-  if (MemberName == "regsPerBlock") {
-    report(ME->getBeginLoc(), Diagnostics::UNMIGRATED_DEVICE_PROP, false,
-           MemberName);
-    return;
-  }
 
   // not functionally compatible properties
   if (MemberName == "deviceOverlap" || MemberName == "concurrentKernels") {

--- a/clang/lib/DPCT/MapNames.cpp
+++ b/clang/lib/DPCT/MapNames.cpp
@@ -4051,6 +4051,7 @@ const MapNames::MapTy DeviceInfoVarRule::PropNamesMap{
     {"maxTexture1D", "image1d_max"},
     {"maxTexture2D", "image2d_max"},
     {"maxTexture3D", "image3d_max"},
+    {"regsPerBlock", "max_register_size_per_work_group"},
     // ...
 };
 

--- a/clang/runtime/dpct-rt/include/dpct/device.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/device.hpp
@@ -386,9 +386,16 @@ work groups is not supported."
   prop.set_max_nd_range_size(max_nd_range_size);
 #endif
 
-  // Estimates max register size per work group, feel free to update the value
-  // according to device properties.
-  prop.set_max_register_size_per_work_group(65536);
+#ifdef SYCL_EXT_CODEPLAY_MAX_REGISTERS_PER_WORK_GROUP_QUERY
+  if (dev.get_backend() == sycl::backend::ext_oneapi_cuda)
+    prop.set_max_register_size_per_work_group(
+        dev.get_info<sycl::ext::codeplay::experimental::info::device::
+                         max_registers_per_work_group>());
+  else
+#endif
+    // Estimates max register size per work group, feel free to update the value
+    // according to device properties.
+    prop.set_max_register_size_per_work_group(65536);
 
   prop.set_global_mem_cache_size(
       dev.get_info<sycl::info::device::global_mem_cache_size>());

--- a/clang/test/dpct/device001.cu
+++ b/clang/test/dpct/device001.cu
@@ -250,10 +250,7 @@ void test3() {
   //CHECK-NEXT:*/
   //CHECK-NEXT:size_t a3 = deviceProp.get_global_mem_size();
   size_t a3 = deviceProp.totalConstMem;
-  //CHECK:/*
-  //CHECK-NEXT:DPCT1090:{{[0-9]+}}: SYCL does not support the device property that would be functionally compatible with regsPerBlock. It was not migrated. You need to rewrite the code.
-  //CHECK-NEXT:*/
-  //CHECK-NEXT:int a4 = deviceProp.regsPerBlock;
+  //CHECK:int a4 = deviceProp.get_max_register_size_per_work_group();
   int a4 = deviceProp.regsPerBlock;
   //CHECK:/*
   //CHECK-NEXT:DPCT1051:{{[0-9]+}}: SYCL does not support a device property functionally compatible with textureAlignment. It was migrated to dpct::get_current_device().get_info<sycl::info::device::mem_base_addr_align>(). You may need to adjust the value of dpct::get_current_device().get_info<sycl::info::device::mem_base_addr_align>() for the specific device.

--- a/clang/test/dpct/device001.cu
+++ b/clang/test/dpct/device001.cu
@@ -250,6 +250,9 @@ void test3() {
   //CHECK-NEXT:*/
   //CHECK-NEXT:size_t a3 = deviceProp.get_global_mem_size();
   size_t a3 = deviceProp.totalConstMem;
+  //CHECK:/*
+  //CHECK-NEXT:DPCT1051:{{[0-9]+}}: SYCL does not support a device property functionally compatible with regsPerBlock. It was migrated to get_max_register_size_per_work_group. You may need to adjust the value of get_max_register_size_per_work_group for the specific device.
+  //CHECK-NEXT:*/
   //CHECK:int a4 = deviceProp.get_max_register_size_per_work_group();
   int a4 = deviceProp.regsPerBlock;
   //CHECK:/*


### PR DESCRIPTION
Signed-off-by: Tang, Jiajun jiajun.tang@intel.com