### PR TITLE
[SYCLomatic] Fix intercept-build crash issue when parsing option "-arch all|native|all-major" and "--gpu-architecture all|native|all-major"

### DIFF
--- a/clang/test/dpct/dpct-intercept-build/Makefile
+++ b/clang/test/dpct/dpct-intercept-build/Makefile
@@ -8,7 +8,7 @@ $(program): main.cpp test
 
 
 test: 
-	$(CC) -c kernels/test.cu -o test.o 
+	$(CC) -c kernels/test.cu -o test.o -arch=all -arch=native -arch=all-major --gpu-architecture=all --gpu-architecture=native --gpu-architecture=all-major
 
 clean:
 	rm -rf *.o all compile_commands.json

--- a/clang/tools/scan-build-py/lib/libscanbuild/compilation.py
+++ b/clang/tools/scan-build-py/lib/libscanbuild/compilation.py
@@ -295,7 +295,8 @@ def parse_args(args, directory='.'):
                 new_flag += arg_next
             elif arg == '--gpu-architecture' or arg == '-arch':
                 arg_next = next(args)
-                if arg_next == "all": # Skip option "-arch all" and "--gpu-architecture all"
+                # Skip option "-arch all|native|all-major" and "--gpu-architecture all|native|all-major"
+                if arg_next == "all" or arg_next == "native" or arg_next == "all-major":
                     continue
                 arg_next = gpu_virtual_arch_to_arch(arg_next)
                 # clang cuda parser does not support CUDA gpu architecture: sm_13
@@ -447,7 +448,8 @@ def parse_args(args, directory='.'):
             #split by '=' and strip whitespace
             result = [x.strip() for x in arg.split('=')]
 
-            if result[1] == 'all': # Skip option "-arch=all" and "--gpu-architecture=all"
+            # Skip option "-arch all|native|all-major" and "--gpu-architecture all|native|all-major"
+            if result[1] == "all" or result[1] == "native" or result[1] == "all-major":
                 continue
 
             new_opt = MAP_FLAGS[result[0]] + gpu_virtual_arch_to_arch(result[1])


### PR DESCRIPTION
 Signed-off-by: chenwei.sun <chenwei.sun@intel.com>
