### PR TITLE
[SYCLomatic] Fix template parameter deduce ambiguous error while using gcc 9.x to compile SYCLomatic code repo

### DIFF
--- a/clang/lib/DPCT/CallExprRewriterCommon.h
+++ b/clang/lib/DPCT/CallExprRewriterCommon.h
@@ -1235,7 +1235,8 @@ createMemberCallExprRewriterFactory(
 }
 
 template <bool HasExplicitTemplateArg, class BaseT, class... ArgsT>
-inline std::shared_ptr<CallExprRewriterFactoryBase>
+inline std::shared_ptr<std::enable_if_t<
+    !std::is_invocable_v<BaseT, const CallExpr *>, CallExprRewriterFactoryBase>>
 createMemberCallExprRewriterFactory(
     const std::string &SourceName, BaseT BaseCreator, bool IsArrow,
     std::string MemberName,


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>