### PR TITLE
[SYCLomatic][CMake] Enable migration of CMake reserved CUDA-specific variable "CUDA_NVCC_EXECUTABLE"

### DIFF
--- a/clang/test/dpct/cmake_migration/case_001/expected.txt
+++ b/clang/test/dpct/cmake_migration/case_001/expected.txt
@@ -53,3 +53,6 @@ if(FOO_OPENMP)
         endif()
     endif()
 endif()
+
+if(SYCL_COMPILER_EXECUTABLE)
+endif()

--- a/clang/test/dpct/cmake_migration/case_001/input.cmake
+++ b/clang/test/dpct/cmake_migration/case_001/input.cmake
@@ -43,3 +43,6 @@ if(FOO_OPENMP)
         endif()
     endif()
 endif()
+
+if(CUDA_NVCC_EXECUTABLE)
+endif()

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -2619,3 +2619,15 @@
       MatchMode: Full
       In: --expt-relaxed-constexpr
       Out: ""
+
+- Rule: rule_CUDA_NVCC_EXECUTABLE
+  Kind: CMakeRule
+  Priority: Fallback
+  CmakeSyntax: CUDA_NVCC_EXECUTABLE
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CUDA_NVCC_EXECUTABLE
+      Out: SYCL_COMPILER_EXECUTABLE

--- a/clang/tools/dpct/cmake/dpct.cmake
+++ b/clang/tools/dpct/cmake/dpct.cmake
@@ -126,3 +126,6 @@ set(SYCL_TOOLKIT_INCLUDE "${SYCL_INCLUDE_DIR}")
 set(SYCLToolkit_LIBRARY_DIR "${SYCL_INCLUDE_DIR}/../lib")
 set(SYCL_HOST_COMPILER "icpx")
 set(SYCL_HOST_FLAGS "")
+
+# 'SYCL_COMPILER_EXECUTABLE' is used to specify the path to the SYCL Compiler (icpx).
+set(SYCL_COMPILER_EXECUTABLE "${SYCL_INCLUDE_DIR}/../bin/icpx")


### PR DESCRIPTION
 Signed-off-by: chenwei.sun <chenwei.sun@intel.com>
