### PR TITLE
[SYCLomatic] Refine migration of cuTexRefSetArray with bindless image.

### DIFF
--- a/clang/lib/DPCT/APINamesTexture.inc
+++ b/clang/lib/DPCT/APINamesTexture.inc
@@ -203,9 +203,13 @@ ASSIGNABLE_FACTORY(DELETER_FACTORY_ENTRY("cuArrayDestroy", ARG(0)))
 ENTRY_UNSUPPORTED("cuTexObjectGetResourceViewDesc", Diagnostics::API_NOT_MIGRATED)
 FEATURE_REQUEST_FACTORY(
     HelperFeatureEnum::device_ext,
-        ASSIGNABLE_FACTORY(MEMBER_CALL_FACTORY_ENTRY(
+    ASSIGNABLE_FACTORY(CONDITIONAL_FACTORY_ENTRY(
+        UseExtBindlessImages,
+        MEMBER_CALL_FACTORY_ENTRY("cuTexRefSetArray", ARG(0), true, "attach",
+                                  ARG(1)),
+        MEMBER_CALL_FACTORY_ENTRY(
             "cuTexRefSetArray", ARG(0), true, "attach",
-            CALL(MapNames::getDpctNamespace() + "image_data", ARG(1)))))
+            CALL(MapNames::getDpctNamespace() + "image_data", ARG(1))))))
 
 FEATURE_REQUEST_FACTORY(
     HelperFeatureEnum::device_ext,

--- a/clang/lib/DPCT/MapNames.cpp
+++ b/clang/lib/DPCT/MapNames.cpp
@@ -466,7 +466,10 @@ void MapNames::setExplicitNamespaceMap() {
        std::make_shared<TypeNameRule>(getDpctNamespace() + "image_data_type",
                                       HelperFeatureEnum::device_ext)},
       {"CUtexref", std::make_shared<TypeNameRule>(
-                       getDpctNamespace() + "image_wrapper_base_p",
+                       DpctGlobalInfo::useExtBindlessImages()
+                           ? getDpctNamespace() +
+                                 "experimental::bindless_image_wrapper_base_p"
+                           : getDpctNamespace() + "image_wrapper_base_p",
                        HelperFeatureEnum::device_ext)},
       {"cudaDeviceAttr", std::make_shared<TypeNameRule>("int")},
       {"__nv_bfloat16", std::make_shared<TypeNameRule>(

--- a/clang/runtime/dpct-rt/include/dpct/bindless_images.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/bindless_images.hpp
@@ -461,19 +461,14 @@ static inline sampling_info get_sampling_info(
   return detail::get_img_info_map(handle).second;
 }
 
-/// The wrapper class of bindless image.
-template <class T, int dimensions> class bindless_image_wrapper {
+/// The base class of different template specialization bindless_image_wrapper
+/// class.
+class bindless_image_wrapper_base {
 public:
-  /// Create bindless image wrapper according to template argument \p T.
-  bindless_image_wrapper() : _channel(image_channel::create<T>()) {
-    // Make sure that singleton class dev_mgr will destruct later than this.
-    dev_mgr::instance();
-  }
-
   /// Destroy bindless image wrapper.
-  ~bindless_image_wrapper() {
+  virtual ~bindless_image_wrapper_base() {
     destroy_bindless_image(_img, get_default_queue());
-  }
+  };
 
   /// Attach linear data to bindless image.
   /// \param [in] data The linear data used to create bindless image.
@@ -506,6 +501,28 @@ public:
   /// \param [in] q The queue where the image creation be executed.
   void attach(void *data, size_t size, sycl::queue q = get_default_queue()) {
     attach(data, size, _channel, q);
+  }
+
+  /// Attach device_ptr data to bindless image.
+  void attach(const sycl::ext::oneapi::experimental::image_descriptor *desc,
+              device_ptr ptr, size_t pitch,
+              sycl::queue q = get_default_queue()) {
+    detach(q);
+    auto samp = sycl::ext::oneapi::experimental::bindless_image_sampler(
+        _addressing_mode, _coordinate_normalization_mode, _filtering_mode);
+#ifdef DPCT_USM_LEVEL_NONE
+    auto mem = new image_mem_wrapper(desc);
+    _img = sycl::ext::oneapi::experimental::create_image(mem->get_handle(),
+                                                         samp, *desc, q);
+    detail::get_img_mem_map(_img) = mem;
+    q.ext_oneapi_copy(get_buffer(ptr).get_host_access().get_pointer(),
+                      mem->get_handle(), mem->get_desc());
+    q.wait_and_throw();
+#else
+    _img = sycl::ext::oneapi::experimental::create_image(ptr, pitch, samp,
+                                                         *desc, q);
+    detail::get_img_mem_map(_img) = nullptr;
+#endif
   }
 
   /// Attach 2D data to bindless image.
@@ -606,6 +623,16 @@ public:
     return _channel.get_channel_data_type();
   }
 
+  /// Set channel num of bindless image.
+  /// \param [in] filtering_mode The channel num used to set.
+  void set_channel_num(unsigned num) { return _channel.set_channel_num(num); }
+
+  /// Set channel type of bindless image.
+  /// \param [in] filtering_mode The channel type used to set.
+  void set_channel_type(sycl::image_channel_type type) {
+    return _channel.set_channel_type(type);
+  }
+
   /// Set addressing mode of bindless image.
   /// \param [in] addressing_mode The addressing mode used to set.
   void set(sycl::addressing_mode addressing_mode) {
@@ -620,6 +647,14 @@ public:
   /// mode used to set.
   void set(sycl::coordinate_normalization_mode coordinate_normalization_mode) {
     _coordinate_normalization_mode = coordinate_normalization_mode;
+  }
+  /// Set coordinate normalization mode of bindless image.
+  /// \param [in] is_normalized Determine whether the coordinate should be
+  /// normalized.
+  void set_coordinate_normalization_mode(int is_normalized) {
+    _coordinate_normalization_mode =
+        is_normalized ? sycl::coordinate_normalization_mode::normalized
+                      : sycl::coordinate_normalization_mode::unnormalized;
   }
   /// Get coordinate normalization mode of bindless image.
   /// \returns The coordinate normalization mode of bindless image.
@@ -650,6 +685,18 @@ private:
       sycl::coordinate_normalization_mode::unnormalized;
   sycl::filtering_mode _filtering_mode = sycl::filtering_mode::nearest;
   sycl::ext::oneapi::experimental::sampled_image_handle _img{0};
+};
+
+/// The wrapper class of bindless image.
+template <class T, int dimensions>
+class bindless_image_wrapper : public bindless_image_wrapper_base {
+public:
+  /// Create bindless image wrapper according to template argument \p T.
+  bindless_image_wrapper() {
+    set_channel(image_channel::create<T>());
+    // Make sure that singleton class dev_mgr will destruct later than this.
+    dev_mgr::instance();
+  }
 };
 
 /// Asynchronously copies from the image memory to memory specified by a
@@ -842,6 +889,7 @@ static inline void dpct_memcpy(image_mem_wrapper *dest, size_t w_offset_dest,
 }
 
 using image_mem_wrapper_ptr = image_mem_wrapper *;
+using bindless_image_wrapper_base_p = bindless_image_wrapper_base *;
 
 #endif
 

--- a/clang/runtime/dpct-rt/include/dpct/bindless_images.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/bindless_images.hpp
@@ -466,9 +466,9 @@ static inline sampling_info get_sampling_info(
 class bindless_image_wrapper_base {
 public:
   /// Destroy bindless image wrapper.
-  virtual ~bindless_image_wrapper_base() {
+  ~bindless_image_wrapper_base() {
     destroy_bindless_image(_img, get_default_queue());
-  };
+  }
 
   /// Attach linear data to bindless image.
   /// \param [in] data The linear data used to create bindless image.

--- a/clang/test/dpct/texture/texture_reference_bindless_image.cu
+++ b/clang/test/dpct/texture/texture_reference_bindless_image.cu
@@ -29,6 +29,50 @@ __global__ void kernel() {
   tex3DLod(tex3, 1.0f, 2.0f, 3.0f, 4.0f);
 }
 
+void driverTextureReferenceManagement() {
+  // CHECK: sycl::addressing_mode am;
+  CUaddress_mode am;
+  // CHECK: dpct::experimental::bindless_image_wrapper_base_p r;
+  CUtexref r;
+  int i = 1;
+  // CHECK: sycl::filtering_mode fm;
+  CUfilter_mode fm;
+  unsigned int u;
+  size_t s1 = 1, s2 = 1;
+  // CHECK: dpct::device_ptr d;
+  CUdeviceptr d;
+  // CHECK: sycl::ext::oneapi::experimental::image_descriptor D;
+  CUDA_ARRAY_DESCRIPTOR D;
+  // CHECK: dpct::experimental::image_mem_wrapper_ptr a;
+  CUarray a;
+  // CHECK: sycl::image_channel_type f;
+  CUarray_format f;
+  // CHECK: am = r->get_addressing_mode();
+  cuTexRefGetAddressMode(&am, r, i);
+  // CHECK: fm = r->get_filtering_mode();
+  cuTexRefGetFilterMode(&fm, r);
+  // CHECK: u = r->is_coordinate_normalized() << 1;
+  cuTexRefGetFlags(&u, r);
+  // CHECK: r->attach(d, s2);
+  cuTexRefSetAddress(&s1, r, d, s2);
+  // CHECK: r->attach(&D, d, s1);
+  cuTexRefSetAddress2D(r, &D, d, s1);
+  // CHECK: r->set(am);
+  cuTexRefSetAddressMode(r, i, am);
+  // CHECK: r->attach(a);
+  cuTexRefSetArray(r, a, u);
+  // CHECK: r->set(fm);
+  cuTexRefSetFilterMode(r, fm);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1074:{{.*}}: The SYCL Image class does not support some of the flags used in the original code. Unsupported flags were ignored. Data read from SYCL Image could not be normalized as specified in the original code.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: r->set_coordinate_normalization_mode(u & 0x02);
+  cuTexRefSetFlags(r, u);
+  // CHECK: r->set_channel_type(f);
+  // CHECK-NEXT: r->set_channel_num(i);
+  cuTexRefSetFormat(r, f, i);
+}
+
 int main() {
   int i;
   // CHECK: tex2.set(sycl::addressing_mode::repeat);


### PR DESCRIPTION
Signed-off-by: Tang, Jiajun jiajun.tang@intel.com