### PR TITLE
[NFC][SYCLomatic] Update template rank_keys call in dpct/group_utils.hpp

### DIFF
--- a/clang/runtime/dpct-rt/include/dpct/group_utils.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/group_utils.hpp
@@ -388,7 +388,8 @@ public:
 
       int ranks[VALUES_PER_THREAD];
       detail::radix_rank<RADIX_BITS, DESCENDING>(_local_memory)
-          .template rank_keys(item, unsigned_keys, ranks, i, pass_bits);
+          .template rank_keys<Item, VALUES_PER_THREAD>(item, unsigned_keys,
+                                                       ranks, i, pass_bits);
 
       item.barrier(sycl::access::fence_space::local_space);
 


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/80801 requires a template argument list after an identifier prefixed by the template keyword.

Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>