### PR TITLE
[SYCLomatic][CMake]Add test for try_compile and try_run

### DIFF
--- a/clang/test/dpct/cmake_migration/case_056/expected.txt
+++ b/clang/test/dpct/cmake_migration/case_056/expected.txt
@@ -1,0 +1,3 @@
+try_run(bin result "${ENV_VAR}/cmake/src.dp.cpp" COMPILE_DEFINITIONS "-I/path/to/include" COMPILE_OUTPUT_VARIABLE out) 
+
+try_compile(HAVE_PROCESSOR_NUMBER ${CMAKE_BINARY_DIR} "${CMAKE_SOURCE_DIR}/dirA/FileA.dp.cpp")

--- a/clang/test/dpct/cmake_migration/case_056/input.cmake
+++ b/clang/test/dpct/cmake_migration/case_056/input.cmake
@@ -1,0 +1,3 @@
+try_run(bin result "${ENV_VAR}/cmake/src.cu" COMPILE_DEFINITIONS "-I/path/to/include" COMPILE_OUTPUT_VARIABLE out) 
+
+try_compile(HAVE_PROCESSOR_NUMBER ${CMAKE_BINARY_DIR} "${CMAKE_SOURCE_DIR}/dirA/FileA.cu")

--- a/clang/test/dpct/cmake_migration/case_056/try_compile_n_try_run.cpp
+++ b/clang/test/dpct/cmake_migration/case_056/try_compile_n_try_run.cpp
@@ -1,0 +1,10 @@
+// RUN: rm -rf %T && mkdir -p %T
+// RUN: cd %T
+// RUN: cp %S/input.cmake ./input.cmake
+// RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
+// RUN: echo "begin" > %T/diff.txt
+// RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
+// RUN: echo "end" >> %T/diff.txt
+
+// CHECK: begin
+// CHECK-NEXT: end


### PR DESCRIPTION
Migration of CUDA source files in `try_compile` and `try_run` is already supported in DPCT. This PR adds test.