### PR TITLE
[NFC][SYCLomatic] Cleanup build warnings

### DIFF
--- a/clang/lib/DPCT/Diagnostics.cpp
+++ b/clang/lib/DPCT/Diagnostics.cpp
@@ -94,7 +94,7 @@ void initWarningIDs() {
         reportInvalidWarningID(ID);
       return Value;
     };
-    int Begin = ParseNumber();
+    auto Begin = ParseNumber();
 
     if (*Cur == '\0') {
       WarningIDs.insert(Begin);

--- a/clang/lib/Lex/InitHeaderSearch.cpp
+++ b/clang/lib/Lex/InitHeaderSearch.cpp
@@ -521,10 +521,10 @@ void InitHeaderSearch::Realize(const LangOptions &Lang) {
   // keep one /usr/include in last position to WA include_next issue
   // eg. cmath using "include_next math.h"
   for (auto &Entry : SearchList) {
-    if (Entry.Lookup.getName().equals("/usr/include")) {
-       SearchList.push_back(Entry);
+    if (Entry.Lookup.getName() == "/usr/include") {
+      SearchList.push_back(Entry);
       break;
-     }
+    }
   }
 #endif // SYCLomatic_CUSTOMIZATION
 

--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -2410,40 +2410,26 @@ protected:
     switch (reqCatEnumVal) {
     case HelpCategory::HC_All:
       return cl::getDPCTCategory();
-      break;
     case HelpCategory::HC_Basic:
       return cl::getDPCTBasicCategory();
-      break;
     case HelpCategory::HC_Advanced:
       return cl::getDPCTAdvancedCategory();
-      break;
     case HelpCategory::HC_CodeGen:
       return cl::getDPCTCodeGenCategory();
-      break;
     case HelpCategory::HC_ReportGen:
       return cl::getDPCTReportGenCategory();
-      break;
     case HelpCategory::HC_BuildScript:
       return cl::getDPCTBuildScriptCategory();
-      break;
     case HelpCategory::HC_QueryAPI:
       return cl::getDPCTQueryAPICategory();
-      break;
     case HelpCategory::HC_Warnings:
       return cl::getDPCTWarningsCategory();
-      break;
     case HelpCategory::HC_HelpInfo:
       return cl::getDPCTHelpInfoCategory();
-      break;
     case HelpCategory::HC_InterceptBuild:
       return cl::getDPCTInterceptBuildCategory();
-      break;
     case HelpCategory::HC_Examples:
       return cl::getDPCTExamplesCategory();
-      break;
-    default:
-      return cl::getDPCTCategory();
-      break;
     }
   }
 #endif // SYCLomatic_CUSTOMIZATION


### PR DESCRIPTION
```
clang/lib/Lex/InitHeaderSearch.cpp:524:53: warning: ‘bool llvm::StringRef::equals(llvm::StringRef) const’ is deprecated: Use == instead [-Wdeprecated-declarations]
  524 |     if (Entry.Lookup.getName().equals("/usr/include")) {
      |                                                     ^

clang/lib/DPCT/Diagnostics.cpp:105:33: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
  105 |       if (*Cur == '\0' && Begin < End) {
      |                           ~~~~~~^~~~~

llvm/lib/Support/CommandLine.cpp:2444:5: warning: default label in switch which covers all enumeration values [-Wcovered-switch-default]
    default:
    ^
```