### PR TITLE
[SYCLomatic] Use `sycl::ext::oneapi::this_work_item::get_sub_group` instead of `sycl::ext::oneapi::experimental::this_sub_group`

### DIFF
--- a/clang/runtime/dpct-rt/include/dpct/math.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/math.hpp
@@ -2182,13 +2182,15 @@ class joint_matrix {
 public:
   joint_matrix() : matrix() {}
   joint_matrix(joint_matrix &other) {
-    syclex::matrix::joint_matrix_copy(syclex::this_sub_group(), other.get(),
-                                      matrix);
+    syclex::matrix::joint_matrix_copy(
+        sycl::ext::oneapi::this_work_item::get_sub_group(), other.get(),
+        matrix);
   }
   joint_matrix &operator=(joint_matrix &other) {
     if (this != &other) {
-      syclex::matrix::joint_matrix_copy(syclex::this_sub_group(), other.get(),
-                                        matrix);
+      syclex::matrix::joint_matrix_copy(
+          sycl::ext::oneapi::this_work_item::get_sub_group(), other.get(),
+          matrix);
     }
     return *this;
   }


### PR DESCRIPTION
`sycl::ext::oneapi::experimental::this_sub_group` was deprecated. This PR clean the build warning in help function:
```
clang/runtime/dpct-rt/include/dpct/math.hpp:2185:47: warning: 'this_sub_group' is deprecated: use sycl::ext::oneapi::this_work_item::get_sub_group() instead [-Wdeprecated-declarations]
2185 |     syclex::matrix::joint_matrix_copy(syclex::this_sub_group(), other.get(),
     |                                               ^
```