### PR TITLE
[SYCLomatic] Fix the incorrect place of option "-shared"  and keep static library wrapped by "--push-state" and "--pop-state" in the linker command

### DIFF
--- a/clang/test/dpct/gen_build_script/Makefile.dpct.ref
+++ b/clang/test/dpct/gen_build_script/Makefile.dpct.ref
@@ -29,7 +29,7 @@
 // CHECK:$(TARGET_0_OBJ_1):$(TARGET_0_SRC_1)
 // CHECK:	$(CC) -fsycl -c ${TARGET_0_SRC_1} -o ${TARGET_0_OBJ_1} $(TARGET_0_FLAG_1)
 // CHECK:$(TARGET_1): $(OBJS_1)
-// CHECK:	$(CC) -fsycl -o -shared $@ $^ $(LIB) 
+// CHECK:	$(CC) bar.a -shared -fsycl -o $@ $^ $(LIB) 
 // CHECK:$(TARGET_0_OBJ_0):$(TARGET_0_SRC_0)
 // CHECK:	$(CC) -fsycl -c ${TARGET_0_SRC_0} -o ${TARGET_0_OBJ_0} $(TARGET_0_FLAG_0)
 // CHECK:$(TARGET_0_OBJ_1):$(TARGET_0_SRC_1)

--- a/clang/test/dpct/gen_build_script/foo.cu
+++ b/clang/test/dpct/gen_build_script/foo.cu
@@ -21,7 +21,7 @@
 // RUN: echo "        \"directory\": \"%T/build\"" >> compile_commands.json
 // RUN: echo "    }," >> compile_commands.json
 // RUN: echo "    {" >> compile_commands.json
-// RUN: echo "        \"command\": \"ld -shared objs/foo.cu.o objs/bar.cpp.dp.o -o libapp.so\"," >> compile_commands.json
+// RUN: echo "        \"command\": \"ld -shared objs/foo.cu.o objs/bar.cpp.dp.o --push-state --whole-archive bar.a --pop-state -o libapp.so\"," >> compile_commands.json
 // RUN: echo "        \"directory\": \"%T/build\"" >> compile_commands.json
 // RUN: echo "    }" >> compile_commands.json
 // RUN: echo "]" >> compile_commands.json


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>