### PR TITLE
[SYCLomatic][CMake] Remove CUDA specific option "-Xfatbin=" and "--expt-extended-lambda" from the migrated CMake script

### DIFF
--- a/clang/test/dpct/cmake_migration/case_022/expected.txt
+++ b/clang/test/dpct/cmake_migration/case_022/expected.txt
@@ -7,3 +7,4 @@ target_compile_options(
           >)
 
 target_compile_options(foo PUBLIC $<$<COMPILE_LANGUAGE:CXX>: -Wno-unused-but-set-variable>)
+target_compile_options(faiss_gpu PRIVATE $<$<COMPILE_LANGUAGE:CXX>:>)

--- a/clang/test/dpct/cmake_migration/case_022/input.cmake
+++ b/clang/test/dpct/cmake_migration/case_022/input.cmake
@@ -7,3 +7,4 @@ target_compile_options(
           >)
 
 target_compile_options(foo PUBLIC $<$<COMPILE_LANGUAGE:CUDA,NVIDIA>: -Wno-unused-but-set-variable>)
+target_compile_options(faiss_gpu PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Xfatbin=-compress-all --expt-extended-lambda --expt-relaxed-constexpr>)

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -2606,6 +2606,30 @@
       In: --expt-relaxed-constexpr
       Out: ""
 
+- Rule: rule_expt_extended_lambda_remove
+  Kind: CMakeRule
+  Priority: Fallback
+  CmakeSyntax: expt_extended_lambda_remove
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: --expt-extended-lambda
+      Out: ""
+
+- Rule: rule_expt_xfatbin_remove
+  Kind: CMakeRule
+  Priority: Fallback
+  CmakeSyntax: expt_xfatbin_remove
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In:  -Xfatbin=${value}
+      Out: ""
+
 - Rule: rule_CUDA_NVCC_EXECUTABLE
   Kind: CMakeRule
   Priority: Fallback


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>
