### PR TITLE
[SYCLomatic][CMake] Remove openMP compiler specific option "OpenMP::OpenMP_CXX" in the migrated CMake script

### DIFF
--- a/clang/test/dpct/cmake_migration/case_008/expected.txt
+++ b/clang/test/dpct/cmake_migration/case_008/expected.txt
@@ -25,3 +25,12 @@ find_package(oneDPL REQUIRED)
 #find_package  (  MPI REQUIRED )
 #find_package ( OpenMP)
 #find_package  (  OpenMP REQUIRED)
+
+target_link_libraries(foo PRIVATE )
+
+target_link_libraries(foo PRIVATE
+faiss_avx512
+Python::Module
+Python::NumPy
+  
+)

--- a/clang/test/dpct/cmake_migration/case_008/input.cmake
+++ b/clang/test/dpct/cmake_migration/case_008/input.cmake
@@ -21,3 +21,12 @@ find_package( MPI  )
 find_package(  MPI REQUIRED )
 FIND_PACKAGE( OpenMP)
 FIND_PACKAGE(  OpenMP REQUIRED)
+
+target_link_libraries(foo PRIVATE OpenMP::OpenMP_CXX)
+
+target_link_libraries(foo PRIVATE
+faiss_avx512
+Python::Module
+Python::NumPy
+  OpenMP::OpenMP_CXX
+)

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -2639,3 +2639,17 @@
   In: cmake_cuda_architectures_all${empty}(${arg})
   Out: ""
 
+
+# oneAPI DPC++/C++ Compiler supports OpenMP* C++ pragmas that comply with OpenMP C++ API,
+# So the option "OpenMP::OpenMP_CXX" that is specific to openMP compiler (like mpicc) should be removed.
+- Rule: rule_openmp_cxx_remove
+  Kind: CMakeRule
+  Priority: Fallback
+  CmakeSyntax: openmp_cxx_remove
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: OpenMP::OpenMP_CXX
+      Out: ""


### PR DESCRIPTION
 Signed-off-by: chenwei.sun <chenwei.sun@intel.com>