### PR TITLE
[SYCLomatic] [stable_]partition performance improvement

### DIFF
--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/algorithm.h
@@ -19,6 +19,35 @@
 
 namespace dpct {
 
+namespace internal {
+// This function is ported from oneDPL with the check for an FPGA policy
+// removed. This function should be used to wrap a provided policy when multiple
+// oneDPL calls are made to ensure unique kernel names.
+template <template <typename> class NewKernelName, typename Policy>
+auto make_wrapped_policy(Policy &&policy)
+    -> decltype(oneapi::dpl::execution::make_device_policy<
+                NewKernelName<typename ::std::decay_t<Policy>::kernel_name>>(
+        ::std::forward<Policy>(policy))) {
+  return oneapi::dpl::execution::make_device_policy<
+      NewKernelName<typename ::std::decay_t<Policy>::kernel_name>>(
+      ::std::forward<Policy>(policy));
+}
+
+template <typename Name> class partition_call1;
+
+template <typename Name> class partition_call2;
+
+template <typename Name> class copy_before_partition;
+
+template <typename Name> class reverse_partition;
+
+template <typename Name> class copy_call1;
+
+template <typename Name> class copy_call2;
+
+}; // namespace internal
+
+
 template <typename Policy, typename Iter1, typename Iter2, typename Pred,
           typename T>
 void replace_if(Policy &&policy, Iter1 first, Iter1 last, Iter2 mask, Pred p,
@@ -937,18 +966,28 @@ stable_partition(Policy &&policy, Iter1 first, Iter1 last, Iter2 mask, Pred p) {
                        std::random_access_iterator_tag>::value,
       "Iterators passed to algorithms must be random-access iterators.");
   typedef typename std::decay<Policy>::type policy_type;
-  internal::__buffer<typename std::iterator_traits<Iter1>::value_type> _tmp(
-      std::distance(first, last));
+  auto _partition_call1 =
+      internal::make_wrapped_policy<internal::partition_call1>(policy);
+  auto _copy_call1 =
+      internal::make_wrapped_policy<internal::copy_call1>(policy);
+  auto _copy_call2 =
+      internal::make_wrapped_policy<internal::copy_call2>(policy);
 
-  std::copy(policy, mask, mask + std::distance(first, last), _tmp.get());
+  auto _n = std::distance(first, last);
+  internal::__buffer<typename std::iterator_traits<Iter1>::value_type> _tmp(_n);
 
-  auto ret_val =
-      std::stable_partition(std::forward<Policy>(policy),
-                            oneapi::dpl::make_zip_iterator(first, _tmp.get()),
-                            oneapi::dpl::make_zip_iterator(
-                                last, _tmp.get() + std::distance(first, last)),
-                            internal::predicate_key_fun<Pred>(p));
-  return std::get<0>(ret_val.base());
+  auto _tmp_first = _tmp.get();
+  auto _tmp_last = _tmp_first + _n;
+  auto _tmp_last_rev = std::reverse_iterator(_tmp_last);
+
+  auto _end_pair = stable_partition_copy(std::move(_partition_call1), first, last, mask, _tmp_first
+                                         _tmp_last_rev, p);
+  auto _first_n = std::distance(_tmp_first, std::get<0>(_end_pair));
+  std::copy(std::move(_copy_call1), _tmp_first, std::get<0>(_end_pair), first);
+  std::copy(std::move(_copy_call2), _tmp_last_rev, std::get<1>(_end_pair),
+            first + _first_n);
+
+  return first + _first_n;
 }
 
 template <typename Policy, typename Iter1, typename Iter2, typename Pred>
@@ -978,7 +1017,41 @@ stable_partition(Policy &&policy, Iter1 first, Iter1 last, Iter2 mask, Pred p) {
 }
 
 template <typename Policy, typename Iter1, typename Iter2, typename Pred>
-internal::enable_if_execution_policy<Policy, Iter1>
+typename std::enable_if<internal::is_hetero_execution_policy<
+                            typename std::decay<Policy>::type>::value,
+                        Iter1>::type
+partition(Policy &&policy, Iter1 first, Iter1 last, Iter2 mask, Pred p) {
+  static_assert(
+      std::is_same<typename std::iterator_traits<Iter1>::iterator_category,
+                   std::random_access_iterator_tag>::value &&
+          std::is_same<typename std::iterator_traits<Iter2>::iterator_category,
+                       std::random_access_iterator_tag>::value,
+      "Iterators passed to algorithms must be random-access iterators.");
+  typedef typename std::decay<Policy>::type policy_type;
+  auto _partition_call1 =
+      internal::make_wrapped_policy<internal::partition_call1>(policy);
+  auto _copy_call1 =
+      internal::make_wrapped_policy<internal::copy_call1>(policy);
+
+  auto _n = std::distance(first, last);
+  internal::__buffer<typename std::iterator_traits<Iter1>::value_type> _tmp(_n);
+
+  auto _tmp_first = _tmp.get();
+  auto _tmp_last = _tmp_first + _n;
+  auto _tmp_last_rev = std::reverse_iterator(_tmp_last);
+
+  auto _end_pair = stable_partition_copy(std::move(_partition_call1), first, last, mask, _tmp_first,
+                                         _tmp_last_rev, p);
+  auto _first_n = std::distance(_tmp_first, std::get<0>(_end_pair));
+  std::copy(std::move(_copy_call1), _tmp_first, _tmp_last, first);
+
+  return first + _first_n;
+}
+
+template <typename Policy, typename Iter1, typename Iter2, typename Pred>
+typename std::enable_if<!internal::is_hetero_execution_policy<
+                            typename std::decay<Policy>::type>::value,
+                        Iter1>::type
 partition(Policy &&policy, Iter1 first, Iter1 last, Iter2 mask, Pred p) {
   static_assert(
       std::is_same<typename std::iterator_traits<Iter1>::iterator_category,
@@ -2410,30 +2483,6 @@ void nontrivial_run_length_encode(ExecutionPolicy &&policy,
   auto ret_dist = ::std::distance(zipped_out_beg, zipped_out_vals_end);
   ::std::fill(policy, num_runs, num_runs + 1, ret_dist);
 }
-
-namespace internal {
-// This function is ported from oneDPL with the check for an FPGA policy
-// removed. This function should be used to wrap a provided policy when multiple
-// oneDPL calls are made to ensure unique kernel names.
-template <template <typename> class NewKernelName, typename Policy>
-auto make_wrapped_policy(Policy &&policy)
-    -> decltype(oneapi::dpl::execution::make_device_policy<
-                NewKernelName<typename ::std::decay_t<Policy>::kernel_name>>(
-        ::std::forward<Policy>(policy))) {
-  return oneapi::dpl::execution::make_device_policy<
-      NewKernelName<typename ::std::decay_t<Policy>::kernel_name>>(
-      ::std::forward<Policy>(policy));
-}
-
-template <typename Name> class partition_call1;
-
-template <typename Name> class partition_call2;
-
-template <typename Name> class copy_before_partition;
-
-template <typename Name> class reverse_partition;
-
-}; // namespace internal
 
 template <typename ExecutionPolicy, typename InputIterator,
           typename OutputIterator, typename CountIterator,

--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/algorithm.h
@@ -980,8 +980,9 @@ stable_partition(Policy &&policy, Iter1 first, Iter1 last, Iter2 mask, Pred p) {
   auto _tmp_last = _tmp_first + _n;
   auto _tmp_last_rev = std::reverse_iterator(_tmp_last);
 
-  auto _end_pair = stable_partition_copy(std::move(_partition_call1), first, last, mask, _tmp_first
-                                         _tmp_last_rev, p);
+  auto _end_pair = stable_partition_copy(std::move(_partition_call1), first,
+                                         last, mask, _tmp_first, _tmp_last_rev,
+                                         p);
   auto _first_n = std::distance(_tmp_first, std::get<0>(_end_pair));
   std::copy(std::move(_copy_call1), _tmp_first, std::get<0>(_end_pair), first);
   std::copy(std::move(_copy_call2), _tmp_last_rev, std::get<1>(_end_pair),

--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/algorithm.h
@@ -970,8 +970,8 @@ stable_partition(Policy &&policy, Iter1 first, Iter1 last, Iter2 mask, Pred p) {
       internal::make_wrapped_policy<internal::partition_call1>(policy);
   auto _copy_call1 =
       internal::make_wrapped_policy<internal::copy_call1>(policy);
-  auto _copy_call2 =
-      internal::make_wrapped_policy<internal::copy_call2>(policy);
+  auto _copy_call2 = internal::make_wrapped_policy<internal::copy_call2>(
+      std::forward<Policy>(policy));
 
   auto _n = std::distance(first, last);
   internal::__buffer<typename std::iterator_traits<Iter1>::value_type> _tmp(_n);
@@ -980,9 +980,9 @@ stable_partition(Policy &&policy, Iter1 first, Iter1 last, Iter2 mask, Pred p) {
   auto _tmp_last = _tmp_first + _n;
   auto _tmp_last_rev = std::reverse_iterator(_tmp_last);
 
-  auto _end_pair = stable_partition_copy(std::move(_partition_call1), first,
-                                         last, mask, _tmp_first, _tmp_last_rev,
-                                         p);
+  auto _end_pair =
+      stable_partition_copy(std::move(_partition_call1), first, last, mask,
+                            _tmp_first, _tmp_last_rev, p);
   auto _first_n = std::distance(_tmp_first, std::get<0>(_end_pair));
   std::copy(std::move(_copy_call1), _tmp_first, std::get<0>(_end_pair), first);
   std::copy(std::move(_copy_call2), _tmp_last_rev, std::get<1>(_end_pair),
@@ -1028,11 +1028,10 @@ partition(Policy &&policy, Iter1 first, Iter1 last, Iter2 mask, Pred p) {
           std::is_same<typename std::iterator_traits<Iter2>::iterator_category,
                        std::random_access_iterator_tag>::value,
       "Iterators passed to algorithms must be random-access iterators.");
-  typedef typename std::decay<Policy>::type policy_type;
   auto _partition_call1 =
       internal::make_wrapped_policy<internal::partition_call1>(policy);
-  auto _copy_call1 =
-      internal::make_wrapped_policy<internal::copy_call1>(policy);
+  auto _copy_call1 = internal::make_wrapped_policy<internal::copy_call1>(
+      std::forward<Policy>(policy));
 
   auto _n = std::distance(first, last);
   internal::__buffer<typename std::iterator_traits<Iter1>::value_type> _tmp(_n);
@@ -1041,8 +1040,9 @@ partition(Policy &&policy, Iter1 first, Iter1 last, Iter2 mask, Pred p) {
   auto _tmp_last = _tmp_first + _n;
   auto _tmp_last_rev = std::reverse_iterator(_tmp_last);
 
-  auto _end_pair = stable_partition_copy(std::move(_partition_call1), first, last, mask, _tmp_first,
-                                         _tmp_last_rev, p);
+  auto _end_pair =
+      stable_partition_copy(std::move(_partition_call1), first, last, mask,
+                            _tmp_first, _tmp_last_rev, p);
   auto _first_n = std::distance(_tmp_first, std::get<0>(_end_pair));
   std::copy(std::move(_copy_call1), _tmp_first, _tmp_last, first);
 

--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/algorithm.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/algorithm.h
@@ -983,12 +983,12 @@ stable_partition(Policy &&policy, Iter1 first, Iter1 last, Iter2 mask, Pred p) {
   auto _end_pair =
       stable_partition_copy(std::move(_partition_call1), first, last, mask,
                             _tmp_first, _tmp_last_rev, p);
-  auto _first_n = std::distance(_tmp_first, std::get<0>(_end_pair));
-  std::copy(std::move(_copy_call1), _tmp_first, std::get<0>(_end_pair), first);
+  auto _first_part_end = std::copy(std::move(_copy_call1), _tmp_first,
+                                   std::get<0>(_end_pair), first);
   std::copy(std::move(_copy_call2), _tmp_last_rev, std::get<1>(_end_pair),
-            first + _first_n);
+            _first_part_end);
 
-  return first + _first_n;
+  return _first_part_end;
 }
 
 template <typename Policy, typename Iter1, typename Iter2, typename Pred>


### PR DESCRIPTION
Performance improvement for in-place `partition` and `stable_partition`.  

This allows us to avoid the extra copy of the mask, and reduce the number of kernels.  We rely internally upon `[stable_]partition_copy` now instead of `stable_partition` which internally does a partion_copy followed by a copy.  This allows us to avoid writing to the mask list without allocating a tmp mask buffer and copying to it.  

The change for `partition` reverses the "false" list, so it breaks stability.  Stability is not required for this API though, and we can skip one copy kernel this way.

It would be possible to write a specialized sycl copy kernel which copies two different sequences into an output, but for now we just call copy twice.

Requires https://github.com/oneapi-src/SYCLomatic-test/pull/752 to be merged first for passing tests (relaxing stability requirement of `partition` test).
