### PR TITLE
[SYCLomatic][CMake] Support migrated CUDA-related libraries without prefix "CUDA::" used in target_link_libraries

### DIFF
--- a/clang/test/dpct/cmake_migration/case_004/expected.txt
+++ b/clang/test/dpct/cmake_migration/case_004/expected.txt
@@ -20,3 +20,5 @@ target_link_libraries(nlm_cuda ${OpenCV_LIBS} stdc++ stdc++fs)
 target_link_libraries(cublas-cudnn-test ${MKL_LIB} ${DNN_LIB})
 
 target_link_libraries(tsne ${MKL_LIB} ${MKL_LIB} ${MKL_LIB})
+
+target_link_libraries(mdgx ${MKL_LIB} ${MKL_LIB} ${MKL_LIB}  -lccl  )

--- a/clang/test/dpct/cmake_migration/case_004/input.cmake
+++ b/clang/test/dpct/cmake_migration/case_004/input.cmake
@@ -23,3 +23,5 @@ target_link_libraries(nlm_cuda  ${OpenCV_LIBS} stdc++ stdc++fs)
 target_link_libraries(cublas-cudnn-test cublas cudnn)
 
 target_link_libraries(tsne  ${CUDA_CUBLAS_LIBRARIES} ${CUDA_CUFFT_LIBRARIES} ${CUDA_cusparse_LIBRARY})
+
+target_link_libraries(mdgx cufft cusparse curand cudadevrt nccl nvrtc nvidia-ml)

--- a/clang/test/dpct/cmake_migration/case_032/expected.txt
+++ b/clang/test/dpct/cmake_migration/case_032/expected.txt
@@ -87,8 +87,7 @@ set(LIBS ${LIBS}
     
 )
 
-target_link_libraries(${target} 
-    ${MKL_LIB}
+target_link_libraries(${target} ${MKL_LIB}
     
     
     ${MKL_LIB}

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -1172,6 +1172,100 @@
         \${MKL_LIB}
       RuleId: "replace_cufft_with_MKL"
 
+- Rule: rule_cufft_without_cuda_prefix
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: cufft_without_cuda_prefix
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: cufft
+      Out: |
+        \${MKL_LIB}
+
+- Rule: rule_cusparse_without_cuda_prefix
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: cusparse_without_cuda_prefix
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: cusparse
+      Out: |
+        \${MKL_LIB}
+
+- Rule: rule_curand_without_cuda_prefix
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: curand_without_cuda_prefix
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: curand
+      Out: |
+        \${MKL_LIB}
+
+- Rule: rule_cudadevrt_without_cuda_prefix
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: cudadevrt_without_cuda_prefix
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: cudadevrt
+      Out: ""
+
+- Rule: rule_nccl_without_cuda_prefix
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nccl_without_cuda_prefix
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: nccl
+      Out: -lccl
+
+- Rule: rule_nvrtc_without_cuda_prefix
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nvrtc_without_cuda_prefix
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: nvrtc
+      Out: ""
+
+- Rule: rule_nvidia_ml_without_cuda_prefix
+  Kind: CMakeRule
+  Priority: Fallback
+  MatchMode: Partial
+  CmakeSyntax: nvidia_ml_without_cuda_prefix
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: nvidia-ml
+      Out: ""
+
 - Rule: rule_cufftw
   Kind: CMakeRule
   Priority: Fallback

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -1177,10 +1177,10 @@
   Priority: Fallback
   MatchMode: Partial
   CmakeSyntax: cufft_without_cuda_prefix
-  In: ${func_name}(${value})
-  Out: ${func_name}(${value})
+  In: target_link_libraries${empty}(${target} ${libs})
+  Out: target_link_libraries(${target} ${libs})
   Subrules:
-    value:
+    libs:
       MatchMode: Full
       In: cufft
       Out: |
@@ -1191,10 +1191,10 @@
   Priority: Fallback
   MatchMode: Partial
   CmakeSyntax: cusparse_without_cuda_prefix
-  In: ${func_name}(${value})
-  Out: ${func_name}(${value})
+  In: target_link_libraries${empty}(${target} ${libs})
+  Out: target_link_libraries(${target} ${libs})
   Subrules:
-    value:
+    libs:
       MatchMode: Full
       In: cusparse
       Out: |
@@ -1205,10 +1205,10 @@
   Priority: Fallback
   MatchMode: Partial
   CmakeSyntax: curand_without_cuda_prefix
-  In: ${func_name}(${value})
-  Out: ${func_name}(${value})
+  In: target_link_libraries${empty}(${target} ${libs})
+  Out: target_link_libraries(${target} ${libs})
   Subrules:
-    value:
+    libs:
       MatchMode: Full
       In: curand
       Out: |
@@ -1219,10 +1219,10 @@
   Priority: Fallback
   MatchMode: Partial
   CmakeSyntax: cudadevrt_without_cuda_prefix
-  In: ${func_name}(${value})
-  Out: ${func_name}(${value})
+  In: target_link_libraries${empty}(${target} ${libs})
+  Out: target_link_libraries(${target} ${libs})
   Subrules:
-    value:
+    libs:
       MatchMode: Full
       In: cudadevrt
       Out: ""
@@ -1232,10 +1232,10 @@
   Priority: Fallback
   MatchMode: Partial
   CmakeSyntax: nccl_without_cuda_prefix
-  In: ${func_name}(${value})
-  Out: ${func_name}(${value})
+  In: target_link_libraries${empty}(${target} ${libs})
+  Out: target_link_libraries(${target} ${libs})
   Subrules:
-    value:
+    libs:
       MatchMode: Full
       In: nccl
       Out: -lccl
@@ -1245,10 +1245,10 @@
   Priority: Fallback
   MatchMode: Partial
   CmakeSyntax: nvrtc_without_cuda_prefix
-  In: ${func_name}(${value})
-  Out: ${func_name}(${value})
+  In: target_link_libraries${empty}(${target} ${libs})
+  Out: target_link_libraries(${target} ${libs})
   Subrules:
-    value:
+    libs:
       MatchMode: Full
       In: nvrtc
       Out: ""
@@ -1258,10 +1258,10 @@
   Priority: Fallback
   MatchMode: Partial
   CmakeSyntax: nvidia_ml_without_cuda_prefix
-  In: ${func_name}(${value})
-  Out: ${func_name}(${value})
+  In: target_link_libraries${empty}(${target} ${libs})
+  Out: target_link_libraries(${target} ${libs})
   Subrules:
-    value:
+    libs:
       MatchMode: Full
       In: nvidia-ml
       Out: ""

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -1253,11 +1253,11 @@
       In: nvrtc
       Out: ""
 
-- Rule: rule_nvidia_ml_without_cuda_prefix
+- Rule: rule_ml_without_cuda_prefix
   Kind: CMakeRule
   Priority: Fallback
   MatchMode: Partial
-  CmakeSyntax: nvidia_ml_without_cuda_prefix
+  CmakeSyntax: ml_without_cuda_prefix
   In: target_link_libraries${empty}(${target} ${libs})
   Out: target_link_libraries(${target} ${libs})
   Subrules:


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>
