### PR TITLE
[SYCLomatic][CMake] Enable migration of CMAKE_CUDA_COMPILER_ID and its value used in if statement

### DIFF
--- a/clang/test/dpct/cmake_migration/case_055/expected.txt
+++ b/clang/test/dpct/cmake_migration/case_055/expected.txt
@@ -14,3 +14,7 @@ list(APPEND CMAKE_SYCL_FLAGS "-fno-strict-aliasing")
 list(APPEND CMAKE_SYCL_FLAGS "")
 list(APPEND CMAKE_SYCL_FLAGS "")
 list(APPEND CMAKE_SYCL_FLAGS "")
+
+if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
+  message(FATAL_ERROR "Error msg.")
+endif()

--- a/clang/test/dpct/cmake_migration/case_055/input.cmake
+++ b/clang/test/dpct/cmake_migration/case_055/input.cmake
@@ -14,3 +14,7 @@ list(APPEND CMAKE_CUDA_FLAGS "-Xcompiler=-fno-strict-aliasing")
 list(APPEND CMAKE_CUDA_FLAGS "-Xcudafe=--diag_suppress=unrecognized_gcc_pragma")
 list(APPEND CMAKE_CUDA_FLAGS "--extended-lambda")
 list(APPEND CMAKE_CUDA_FLAGS "--expt-relaxed-constexpr")
+
+if (NOT CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")
+  message(FATAL_ERROR "Error msg.")
+endif()

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -2677,3 +2677,27 @@
       MatchMode: Full
       In: OpenMP::OpenMP_CXX
       Out: ""
+
+- Rule: rule_cmake_cuda_compiler_id
+  Kind: CMakeRule
+  Priority: Fallback
+  CmakeSyntax: cmake_cuda_compiler_id
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: CMAKE_CUDA_COMPILER_ID
+      Out: CMAKE_CXX_COMPILER_ID
+
+- Rule: rule_cmake_cuda_compiler_id_value
+  Kind: CMakeRule
+  Priority: Fallback
+  CmakeSyntax: cmake_cuda_compiler_id_value
+  In: if${empty}(${value})
+  Out: if${empty}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: NVIDIA
+      Out: IntelLLVM


### PR DESCRIPTION
 Signed-off-by: chenwei.sun <chenwei.sun@intel.com>