### PR TITLE
[SYCLomatic][CMake] Remove '-static-libstdc++' from target_link_options as '-static-libstdc++' is not supported together with '-fsycl' when using icpx compiler

### DIFF
--- a/clang/test/dpct/cmake_migration/case_041/expected.txt
+++ b/clang/test/dpct/cmake_migration/case_041/expected.txt
@@ -9,3 +9,16 @@ target_link_options(quda PUBLIC )
 target_link_options( quda PUBLIC )
 
 target_link_options(quda PUBLIC  )
+
+target_link_options(nvcv_util_compat PUBLIC
+    
+    -static-libgcc
+    -Wl,--wrap=__libc_start_main
+    -Wl,-u__cxa_thread_atexit_impl
+    ${linkcompat}
+    -Wl,--push-state,--no-as-needed
+    ${CMAKE_CURRENT_SOURCE_DIR}/stubs/libdl-2.17_stub.so
+    ${CMAKE_CURRENT_SOURCE_DIR}/stubs/librt-2.17_stub.so
+    ${CMAKE_CURRENT_SOURCE_DIR}/stubs/libpthread-2.17_stub.so
+    -Wl,--pop-state
+)

--- a/clang/test/dpct/cmake_migration/case_041/input.cmake
+++ b/clang/test/dpct/cmake_migration/case_041/input.cmake
@@ -9,3 +9,17 @@ target_link_options(quda PUBLIC $<$<CUDA_COMPILER_ID:Clang>: --cuda-path=${CUDAT
 target_link_options( quda PUBLIC $<$<CUDA_COMPILER_ID:Clang>: --cuda-path=${CUDAToolkit_TARGET_DIR}>)
 
 target_link_options(quda PUBLIC $<$<CUDA_COMPILER_ID:Clang>: --cuda-path=${CUDAToolkit_TARGET_DIR}> )
+
+target_link_options(nvcv_util_compat
+PUBLIC
+    -static-libstdc++
+    -static-libgcc
+    -Wl,--wrap=__libc_start_main
+    -Wl,-u__cxa_thread_atexit_impl
+    ${linkcompat}
+    -Wl,--push-state,--no-as-needed
+    ${CMAKE_CURRENT_SOURCE_DIR}/stubs/libdl-2.17_stub.so
+    ${CMAKE_CURRENT_SOURCE_DIR}/stubs/librt-2.17_stub.so
+    ${CMAKE_CURRENT_SOURCE_DIR}/stubs/libpthread-2.17_stub.so
+    -Wl,--pop-state
+)

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -2426,10 +2426,10 @@
       RuleId: "remove_target_link_options_cuda_arg"
 
 #'-static-libstdc++' is not supported together with '-fsycl' when using icpx compiler.
-- Rule: rule_libstdc++_target_link_options
+- Rule: rule_static_libstdc++_target_link_options
   Kind: CMakeRule
   Priority: Fallback
-  CmakeSyntax: libstdc++_target_link_options
+  CmakeSyntax: static_libstdc++_target_link_options
   In: target_link_options${empty}(${target} ${libs})
   Out: target_link_options(${target} ${libs})
   Subrules:

--- a/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/DpctOptRules/cmake_script_migration_rule.yaml
@@ -2425,6 +2425,19 @@
       Out: ""
       RuleId: "remove_target_link_options_cuda_arg"
 
+#'-static-libstdc++' is not supported together with '-fsycl' when using icpx compiler.
+- Rule: rule_libstdc++_target_link_options
+  Kind: CMakeRule
+  Priority: Fallback
+  CmakeSyntax: libstdc++_target_link_options
+  In: target_link_options${empty}(${target} ${libs})
+  Out: target_link_options(${target} ${libs})
+  Subrules:
+    libs:
+      In: -static-libstdc++
+      Out: ""
+      MatchMode: Full
+
 - Rule: rule_target_link_directories
   Kind: CMakeRule
   Priority: Fallback


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>