### PR TITLE
[SYCLomatic] Refine the migration of 8 asm instruction to address compiler breaking change of sycl math APIs

### DIFF
--- a/clang/lib/DPCT/AsmMigration.cpp
+++ b/clang/lib/DPCT/AsmMigration.cpp
@@ -1491,12 +1491,7 @@ protected:
     if (tryEmitStmt(Op, Inst->getInputOperand(0)))
       return SYCLGenError();
 
-    std::string TypeString;
-    if (tryEmitType(TypeString, Inst->getType(0)))
-      return SYCLGenError();
-
-    std::string ReplaceString =
-        MapNames::getClNamespace() + MathFn.str() + "<" + TypeString + ">(";
+    std::string ReplaceString = MapNames::getClNamespace() + MathFn.str() + '(';
     if (Inst->getOpcode() == asmtok::op_ex2)
       ReplaceString += "2, ";
     ReplaceString += Op + ")";
@@ -1541,15 +1536,13 @@ protected:
     if (emitStmt(Inst->getOutputOperand()))
       return SYCLGenError();
     OS() << " = ";
-    std::string Op[3], TypeString;
+    std::string Op[3];
     for (int i = 0; i < 3; ++i)
       if (tryEmitStmt(Op[i], Inst->getInputOperand(i)))
         return SYCLGenError();
-    if (tryEmitType(TypeString, Inst->getType(0)))
-      return SYCLGenError();
 
-    OS() << MapNames::getClNamespace() << "abs_diff<" << TypeString << ">("
-         << Op[0] << ", " << Op[1] << ") + " << Op[2];
+    OS() << MapNames::getClNamespace() << "abs_diff(" << Op[0] << ", " << Op[1]
+         << ") + " << Op[2];
     endstmt();
     return SYCLGenSuccess();
   }

--- a/clang/test/dpct/asm/cos.cu
+++ b/clang/test/dpct/asm/cos.cu
@@ -11,10 +11,10 @@
 __global__ void cos() {
   float f32;
 
-  // CHECK: f32 = sycl::cos<float>(1.0f);
+  // CHECK: f32 = sycl::cos(1.0f);
   asm("cos.approx.f32 %0, %1;" : "=f"(f32) : "f"(1.0f));
   
-  // CHECK: f32 = sycl::cos<float>(1.0f);
+  // CHECK: f32 = sycl::cos(1.0f);
   asm("cos.approx.ftz.f32 %0, %1;" : "=f"(f32) : "f"(1.0f));
 }
 

--- a/clang/test/dpct/asm/ex2.cu
+++ b/clang/test/dpct/asm/ex2.cu
@@ -10,10 +10,10 @@
 
 __global__ void ex2() {
   float f32;
-  // CHECK: f32 = sycl::pow<float>(2, 3.4f);
+  // CHECK: f32 = sycl::pow(2, 3.4f);
   asm("ex2.approx.f32 %0, %1;" : "=f"(f32) : "f"(3.4f));
   
-  // CHECK: f32 = sycl::pow<float>(2, 3.4f);
+  // CHECK: f32 = sycl::pow(2, 3.4f);
   asm("ex2.approx.ftz.f32 %0, %1;" : "=f"(f32) : "f"(3.4f));
 }
 

--- a/clang/test/dpct/asm/lg2.cu
+++ b/clang/test/dpct/asm/lg2.cu
@@ -10,10 +10,10 @@
 
 __global__ void lg2() {
   float f32;
-  // CHECK: f32 = sycl::log2<float>(1.0f);
+  // CHECK: f32 = sycl::log2(1.0f);
   asm("lg2.approx.f32 %0, %1;" : "=f"(f32) : "f"(1.0f));
   
-  // CHECK: f32 = sycl::log2<float>(1.0f);
+  // CHECK: f32 = sycl::log2(1.0f);
   asm("lg2.approx.ftz.f32 %0, %1;" : "=f"(f32) : "f"(1.0f));
 }
 

--- a/clang/test/dpct/asm/rsqrt.cu
+++ b/clang/test/dpct/asm/rsqrt.cu
@@ -12,13 +12,13 @@ __global__ void rsqrt() {
   float f32;
   double f64;
 
-  // CHECK: f32 = sycl::rsqrt<float>(1.0f);
+  // CHECK: f32 = sycl::rsqrt(1.0f);
   asm("rsqrt.approx.f32 %0, %1;" : "=f"(f32) : "f"(1.0f));
 
-  // CHECK: f32 = sycl::rsqrt<float>(1.0f);
+  // CHECK: f32 = sycl::rsqrt(1.0f);
   asm("rsqrt.approx.ftz.f32 %0, %1;" : "=f"(f32) : "f"(1.0f));
 
-  // CHECK: f64 = sycl::rsqrt<double>(1.0);
+  // CHECK: f64 = sycl::rsqrt(1.0);
   asm("rsqrt.approx.f64 %0, %1;" : "=d"(f64) : "d"(1.0));
 }
 // clang-format on

--- a/clang/test/dpct/asm/sad.cu
+++ b/clang/test/dpct/asm/sad.cu
@@ -16,22 +16,22 @@ __global__ void sad() {
   int64_t i64;
   uint64_t u64;
 
-  // CHECK: i16 = sycl::abs_diff<int16_t>(i16, i16) + i16;
+  // CHECK: i16 = sycl::abs_diff(i16, i16) + i16;
   asm("sad.s16 %0, %1, %2, %3;" : "=h"(i16) : "h"(i16), "h"(i16), "h"(i16));
   
-  // CHECK: u16 = sycl::abs_diff<uint16_t>(u16, u16) + u16;
+  // CHECK: u16 = sycl::abs_diff(u16, u16) + u16;
   asm("sad.u16 %0, %1, %2, %3;" : "=h"(u16) : "h"(u16), "h"(u16), "h"(u16));
   
-  // CHECK: i32 = sycl::abs_diff<int32_t>(i32, i32) + i32;
+  // CHECK: i32 = sycl::abs_diff(i32, i32) + i32;
   asm("sad.s32 %0, %1, %2, %3;" : "=r"(i32) : "r"(i32), "r"(i32), "r"(i32));
   
-  // CHECK: u32 = sycl::abs_diff<uint32_t>(u32, u32) + u32;
+  // CHECK: u32 = sycl::abs_diff(u32, u32) + u32;
   asm("sad.u32 %0, %1, %2, %3;" : "=r"(u32) : "r"(u32), "r"(u32), "r"(u32));
   
-  // CHECK: i64 = sycl::abs_diff<int64_t>(i64, i64) + i64;
+  // CHECK: i64 = sycl::abs_diff(i64, i64) + i64;
   asm("sad.s64 %0, %1, %2, %3;" : "=l"(i64) : "l"(i64), "l"(i64), "l"(i64));
   
-  // CHECK: u64 = sycl::abs_diff<uint64_t>(u64, u64) + u64;
+  // CHECK: u64 = sycl::abs_diff(u64, u64) + u64;
   asm("sad.u64 %0, %1, %2, %3;" : "=l"(u64) : "l"(u64), "l"(u64), "l"(u64));
 }
 

--- a/clang/test/dpct/asm/sin.cu
+++ b/clang/test/dpct/asm/sin.cu
@@ -11,10 +11,10 @@
 __global__ void sin() {
   float f32;
 
-  // CHECK: f32 = sycl::sin<float>(1.0f);
+  // CHECK: f32 = sycl::sin(1.0f);
   asm("sin.approx.f32 %0, %1;" : "=f"(f32) : "f"(1.0f));
   
-  // CHECK: f32 = sycl::sin<float>(1.0f);
+  // CHECK: f32 = sycl::sin(1.0f);
   asm("sin.approx.ftz.f32 %0, %1;" : "=f"(f32) : "f"(1.0f));
 }
 

--- a/clang/test/dpct/asm/sqrt.cu
+++ b/clang/test/dpct/asm/sqrt.cu
@@ -11,56 +11,56 @@
 // CHECK: void sqrt() {
 // CHECK-NEXT:   float f32;
 // CHECK-NEXT:   double f64;
-// CHECK-NEXT:   f32 = sycl::sqrt<float>(1.0f);
-// CHECK-NEXT:   f32 = sycl::sqrt<float>(1.0f);
+// CHECK-NEXT:   f32 = sycl::sqrt(1.0f);
+// CHECK-NEXT:   f32 = sycl::sqrt(1.0f);
 // CHECK-NEXT:   /*
 // CHECK-NEXT:   DPCT1013:{{.*}}: The rounding mode could not be specified and the generated code may have different accuracy than the original code. Verify the correctness. SYCL math built-in function rounding mode is aligned with OpenCL C 1.2 standard.
 // CHECK-NEXT:   */
-// CHECK-NEXT:   f32 = sycl::sqrt<float>(1.0f);
+// CHECK-NEXT:   f32 = sycl::sqrt(1.0f);
 // CHECK-NEXT:   /*
 // CHECK-NEXT:   DPCT1013:{{.*}}: The rounding mode could not be specified and the generated code may have different accuracy than the original code. Verify the correctness. SYCL math built-in function rounding mode is aligned with OpenCL C 1.2 standard.
 // CHECK-NEXT:   */
-// CHECK-NEXT:   f32 = sycl::sqrt<float>(1.0f);
+// CHECK-NEXT:   f32 = sycl::sqrt(1.0f);
 // CHECK-NEXT:   /*
 // CHECK-NEXT:   DPCT1013:{{.*}}: The rounding mode could not be specified and the generated code may have different accuracy than the original code. Verify the correctness. SYCL math built-in function rounding mode is aligned with OpenCL C 1.2 standard.
 // CHECK-NEXT:   */
-// CHECK-NEXT:   f32 = sycl::sqrt<float>(1.0f);
+// CHECK-NEXT:   f32 = sycl::sqrt(1.0f);
 // CHECK-NEXT:   /*
 // CHECK-NEXT:   DPCT1013:{{.*}}: The rounding mode could not be specified and the generated code may have different accuracy than the original code. Verify the correctness. SYCL math built-in function rounding mode is aligned with OpenCL C 1.2 standard.
 // CHECK-NEXT:   */
-// CHECK-NEXT:   f32 = sycl::sqrt<float>(1.0f);
+// CHECK-NEXT:   f32 = sycl::sqrt(1.0f);
 // CHECK-NEXT:   /*
 // CHECK-NEXT:   DPCT1013:{{.*}}: The rounding mode could not be specified and the generated code may have different accuracy than the original code. Verify the correctness. SYCL math built-in function rounding mode is aligned with OpenCL C 1.2 standard.
 // CHECK-NEXT:   */
-// CHECK-NEXT:   f32 = sycl::sqrt<float>(1.0f);
+// CHECK-NEXT:   f32 = sycl::sqrt(1.0f);
 // CHECK-NEXT:   /*
 // CHECK-NEXT:   DPCT1013:{{.*}}: The rounding mode could not be specified and the generated code may have different accuracy than the original code. Verify the correctness. SYCL math built-in function rounding mode is aligned with OpenCL C 1.2 standard.
 // CHECK-NEXT:   */
-// CHECK-NEXT:   f32 = sycl::sqrt<float>(1.0f);
+// CHECK-NEXT:   f32 = sycl::sqrt(1.0f);
 // CHECK-NEXT:   /*
 // CHECK-NEXT:   DPCT1013:{{.*}}: The rounding mode could not be specified and the generated code may have different accuracy than the original code. Verify the correctness. SYCL math built-in function rounding mode is aligned with OpenCL C 1.2 standard.
 // CHECK-NEXT:   */
-// CHECK-NEXT:   f32 = sycl::sqrt<float>(1.0f);
+// CHECK-NEXT:   f32 = sycl::sqrt(1.0f);
 // CHECK-NEXT:   /*
 // CHECK-NEXT:   DPCT1013:{{.*}}: The rounding mode could not be specified and the generated code may have different accuracy than the original code. Verify the correctness. SYCL math built-in function rounding mode is aligned with OpenCL C 1.2 standard.
 // CHECK-NEXT:   */
-// CHECK-NEXT:   f32 = sycl::sqrt<float>(1.0f);
+// CHECK-NEXT:   f32 = sycl::sqrt(1.0f);
 // CHECK-NEXT:   /*
 // CHECK-NEXT:   DPCT1013:{{.*}}: The rounding mode could not be specified and the generated code may have different accuracy than the original code. Verify the correctness. SYCL math built-in function rounding mode is aligned with OpenCL C 1.2 standard.
 // CHECK-NEXT:   */
-// CHECK-NEXT:   f64 = sycl::sqrt<double>(1.0);
+// CHECK-NEXT:   f64 = sycl::sqrt(1.0);
 // CHECK-NEXT:   /*
 // CHECK-NEXT:   DPCT1013:{{.*}}: The rounding mode could not be specified and the generated code may have different accuracy than the original code. Verify the correctness. SYCL math built-in function rounding mode is aligned with OpenCL C 1.2 standard.
 // CHECK-NEXT:   */
-// CHECK-NEXT:   f64 = sycl::sqrt<double>(1.0);
+// CHECK-NEXT:   f64 = sycl::sqrt(1.0);
 // CHECK-NEXT:   /*
 // CHECK-NEXT:   DPCT1013:{{.*}}: The rounding mode could not be specified and the generated code may have different accuracy than the original code. Verify the correctness. SYCL math built-in function rounding mode is aligned with OpenCL C 1.2 standard.
 // CHECK-NEXT:   */
-// CHECK-NEXT:   f64 = sycl::sqrt<double>(1.0);
+// CHECK-NEXT:   f64 = sycl::sqrt(1.0);
 // CHECK-NEXT:   /*
 // CHECK-NEXT:   DPCT1013:{{.*}}: The rounding mode could not be specified and the generated code may have different accuracy than the original code. Verify the correctness. SYCL math built-in function rounding mode is aligned with OpenCL C 1.2 standard.
 // CHECK-NEXT:   */
-// CHECK-NEXT:   f64 = sycl::sqrt<double>(1.0);
+// CHECK-NEXT:   f64 = sycl::sqrt(1.0);
 // CHECK-NEXT: }
 __global__ void sqrt() {
   float f32;

--- a/clang/test/dpct/asm/tanh.cu
+++ b/clang/test/dpct/asm/tanh.cu
@@ -11,7 +11,7 @@
 __global__ void tanh() {
   float f32;
 
-  // CHECK: f32 = sycl::tanh<float>(1.0f);
+  // CHECK: f32 = sycl::tanh(1.0f);
   asm("tanh.approx.f32 %0, %1;" : "=f"(f32) : "f"(1.0f));
 }
 


### PR DESCRIPTION
Refine the migration of cos, sin, tanh, ex2, lg2, sqrt, rsqrt, sad. The latest SYCL compiler disallow call math API with explicit template argument.