### PR TITLE
[SYCLomatic] Support SYCLCompat for CUB

### DIFF
--- a/clang/lib/DPCT/APINamesTemplateType.inc
+++ b/clang/lib/DPCT/APINamesTemplateType.inc
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// clang-format off
-
 TYPE_REWRITE_ENTRY(
     "cuda::atomic",
         TYPE_CONDITIONAL_FACTORY(
@@ -110,42 +108,62 @@ TYPE_REWRITE_ENTRY("cub::ArgMin",
                     HEADER_INSERTION_FACTORY(
                            HeaderType::HT_DPCT_DPL_Utils,
                    TYPE_FACTORY(STR(MapNames::getLibraryHelperNamespace() + "argmin"))))
+// cub::BlockRadixSort
 TYPE_REWRITE_ENTRY(
     "cub::BlockRadixSort",
-    HEADER_INSERTION_FACTORY(HeaderType::HT_DPCT_GROUP_Utils,
-                             TYPE_FACTORY(STR(MapNames::getDpctNamespace() +
-                                              "group::group_radix_sort"),
-                                          TEMPLATE_ARG(0), TEMPLATE_ARG(2))))
+    TYPE_CONDITIONAL_FACTORY(
+        UseSYCLCompat(),
+        WARNING_FACTORY(Diagnostics::UNSUPPORT_SYCLCOMPAT, TYPESTR),
+        HEADER_INSERTION_FACTORY(
+            HeaderType::HT_DPCT_GROUP_Utils,
+            TYPE_FACTORY(STR(MapNames::getLibraryHelperNamespace() +
+                             "group::group_radix_sort"),
+                         TEMPLATE_ARG(0), TEMPLATE_ARG(2)))))
+
+// cub::BlockExchange
 TYPE_REWRITE_ENTRY(
     "cub::BlockExchange",
-    HEADER_INSERTION_FACTORY(HeaderType::HT_DPCT_GROUP_Utils,
-                             TYPE_FACTORY(STR(MapNames::getDpctNamespace() +
-                                              "group::exchange"),
-                                          TEMPLATE_ARG(0), TEMPLATE_ARG(2))))
-TYPE_REWRITE_ENTRY("cub::BlockLoad",
-                   HEADER_INSERTION_FACTORY(
-                       HeaderType::HT_DPCT_GROUP_Utils,
-                       TYPE_CONDITIONAL_FACTORY(
-                           CheckTemplateArgCount(4),
-                           TYPE_FACTORY(STR(MapNames::getDpctNamespace() +
-                                            "group::group_load"),
-                                        TEMPLATE_ARG(0), TEMPLATE_ARG(2),
-                                        TEMPLATE_ARG(3)),
-                           TYPE_FACTORY(STR(MapNames::getDpctNamespace() +
-                                            "group::group_load"),
-                                        TEMPLATE_ARG(0), TEMPLATE_ARG(2)))))
-TYPE_REWRITE_ENTRY("cub::BlockStore",
-                   HEADER_INSERTION_FACTORY(
-                       HeaderType::HT_DPCT_GROUP_Utils,
-                       TYPE_CONDITIONAL_FACTORY(
-                           CheckTemplateArgCount(4),
-                           TYPE_FACTORY(STR(MapNames::getDpctNamespace() +
-                                            "group::group_store"),
-                                        TEMPLATE_ARG(0), TEMPLATE_ARG(2),
-                                        TEMPLATE_ARG(3)),
-                           TYPE_FACTORY(STR(MapNames::getDpctNamespace() +
-                                            "group::group_store"),
-                                        TEMPLATE_ARG(0), TEMPLATE_ARG(2)))))
+    TYPE_CONDITIONAL_FACTORY(
+        UseSYCLCompat(),
+        WARNING_FACTORY(Diagnostics::UNSUPPORT_SYCLCOMPAT, TYPESTR),
+        HEADER_INSERTION_FACTORY(
+            HeaderType::HT_DPCT_GROUP_Utils,
+            TYPE_FACTORY(STR(MapNames::getLibraryHelperNamespace() +
+                             "group::exchange"),
+                         TEMPLATE_ARG(0), TEMPLATE_ARG(2)))))
+// cub::BlockLoad
+TYPE_REWRITE_ENTRY(
+    "cub::BlockLoad",
+    TYPE_CONDITIONAL_FACTORY(
+        UseSYCLCompat(),
+        WARNING_FACTORY(Diagnostics::UNSUPPORT_SYCLCOMPAT, TYPESTR),
+        HEADER_INSERTION_FACTORY(
+            HeaderType::HT_DPCT_GROUP_Utils,
+            TYPE_CONDITIONAL_FACTORY(
+                CheckTemplateArgCount(4),
+                TYPE_FACTORY(STR(MapNames::getLibraryHelperNamespace() +
+                                 "group::group_load"),
+                             TEMPLATE_ARG(0), TEMPLATE_ARG(2), TEMPLATE_ARG(3)),
+                TYPE_FACTORY(STR(MapNames::getLibraryHelperNamespace() +
+                                 "group::group_load"),
+                             TEMPLATE_ARG(0), TEMPLATE_ARG(2))))))
+// cub::BlockStore
+TYPE_REWRITE_ENTRY(
+    "cub::BlockStore",
+    TYPE_CONDITIONAL_FACTORY(
+        UseSYCLCompat(),
+        WARNING_FACTORY(Diagnostics::UNSUPPORT_SYCLCOMPAT, TYPESTR),
+        HEADER_INSERTION_FACTORY(
+            HeaderType::HT_DPCT_GROUP_Utils,
+            TYPE_CONDITIONAL_FACTORY(
+                CheckTemplateArgCount(4),
+                TYPE_FACTORY(STR(MapNames::getLibraryHelperNamespace() +
+                                 "group::group_store"),
+                             TEMPLATE_ARG(0), TEMPLATE_ARG(2), TEMPLATE_ARG(3)),
+                TYPE_FACTORY(STR(MapNames::getLibraryHelperNamespace() +
+                                 "group::group_store"),
+                             TEMPLATE_ARG(0), TEMPLATE_ARG(2))))))
+
 FEATURE_REQUEST_FACTORY(
     HelperFeatureEnum::device_ext,
     TYPE_REWRITE_ENTRY("thrust::system::cuda::experimental::pinned_allocator",

--- a/clang/lib/DPCT/CUBAPIMigration.cpp
+++ b/clang/lib/DPCT/CUBAPIMigration.cpp
@@ -92,6 +92,17 @@ REGISTER_RULE(CubMemberCallRule, PassKind::PK_Analysis)
 REGISTER_RULE(CubDeviceLevelRule, PassKind::PK_Analysis)
 REGISTER_RULE(CubIntrinsicRule, PassKind::PK_Analysis)
 
+#define REPORT_UNSUPPORT_SYCLCOMPACT(S)                                        \
+  if (DpctGlobalInfo::useSYCLCompat()) {                                       \
+    std::string PrettyStmt;                                                    \
+    llvm::raw_string_ostream OS(PrettyStmt);                                   \
+    S->printPretty(OS, /*Helper=*/nullptr,                                     \
+                   DpctGlobalInfo::getContext().getPrintingPolicy());          \
+    report(S->getBeginLoc(), Diagnostics::UNSUPPORT_SYCLCOMPAT,                \
+           /*UseTextBegin=*/false, PrettyStmt);                                \
+    return;                                                                    \
+  }
+
 void CubTypeRule::registerMatcher(ast_matchers::MatchFinder &MF) {
   auto TargetTypeName = [&]() {
     return hasAnyName(

--- a/clang/lib/DPCT/CallExprRewriterCommon.h
+++ b/clang/lib/DPCT/CallExprRewriterCommon.h
@@ -1712,6 +1712,10 @@ inline auto UseNonUniformGroups = [](const CallExpr *C) -> bool {
   return DpctGlobalInfo::useExpNonUniformGroups();
 };
 
+inline auto UseSYCLCompat = [](const CallExpr *C) -> bool {
+  return DpctGlobalInfo::useSYCLCompat();
+};
+
 class CheckDerefedTypeBeforeCast {
   unsigned Idx;
   std::string TypeName;

--- a/clang/lib/DPCT/Rewriters/CUB/RewriterClassMethods.cpp
+++ b/clang/lib/DPCT/Rewriters/CUB/RewriterClassMethods.cpp
@@ -71,167 +71,232 @@ RewriterMap dpct::createClassMethodsRewriterMap() {
                                    MEMBER_CALL(MemberExprBase(), false,
                                                LITERAL("create_normalize")))))
       // cub::BlockRadixSort.Sort
-      HEADER_INSERT_FACTORY(
-          HeaderType::HT_DPCT_GROUP_Utils,
-          CASE_FACTORY_ENTRY(
-              CASE(
-                  makeCheckAnd(
-                      makeCheckAnd(CheckArgCount(3, std::equal_to<>(),
+      CONDITIONAL_FACTORY_ENTRY(
+          UseSYCLCompat,
+          UNSUPPORT_FACTORY_ENTRY("cub::BlockRadixSort.Sort",
+                                  Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                  LITERAL("cub::BlockRadixSort.Sort")),
+          HEADER_INSERT_FACTORY(
+              HeaderType::HT_DPCT_GROUP_Utils,
+              CASE_FACTORY_ENTRY(
+                  CASE(makeCheckAnd(
+                           makeCheckAnd(
+                               CheckArgCount(3, std::equal_to<>(),
+                                             /*IncludeDefaultArg=*/false),
+                               CheckParamType(1, "int", /*isStrict=*/true)),
+                           CheckParamType(2, "int", /*isStrict=*/true)),
+                       MEMBER_CALL_FACTORY_ENTRY(
+                           "cub::BlockRadixSort.Sort", MemberExprBase(), false,
+                           "sort", NDITEM, ARG(0), ARG(1), ARG(2))),
+                  CASE(
+                      makeCheckAnd(CheckArgCount(2, std::equal_to<>(),
                                                  /*IncludeDefaultArg=*/false),
                                    CheckParamType(1, "int", /*isStrict=*/true)),
-                      CheckParamType(2, "int", /*isStrict=*/true)),
-                  MEMBER_CALL_FACTORY_ENTRY("cub::BlockRadixSort.Sort",
-                                            MemberExprBase(), false, "sort",
-                                            NDITEM, ARG(0), ARG(1), ARG(2))),
-              CASE(makeCheckAnd(CheckArgCount(2, std::equal_to<>(),
-                                              /*IncludeDefaultArg=*/false),
-                                CheckParamType(1, "int", /*isStrict=*/true)),
-                   MEMBER_CALL_FACTORY_ENTRY("cub::BlockRadixSort.Sort",
-                                             MemberExprBase(), false, "sort",
-                                             NDITEM, ARG(0), ARG(1))),
-              CASE(CheckArgCount(1, std::equal_to<>(),
-                                 /*IncludeDefaultArg=*/false),
-                   MEMBER_CALL_FACTORY_ENTRY("cub::BlockRadixSort.Sort",
-                                             MemberExprBase(), false, "sort",
-                                             NDITEM, ARG(0))),
-              OTHERWISE(UNSUPPORT_FACTORY_ENTRY("cub::BlockRadixSort.Sort",
-                                                Diagnostics::API_NOT_MIGRATED,
-                                                printCallExprPretty()))))
+                      MEMBER_CALL_FACTORY_ENTRY("cub::BlockRadixSort.Sort",
+                                                MemberExprBase(), false, "sort",
+                                                NDITEM, ARG(0), ARG(1))),
+                  CASE(CheckArgCount(1, std::equal_to<>(),
+                                     /*IncludeDefaultArg=*/false),
+                       MEMBER_CALL_FACTORY_ENTRY("cub::BlockRadixSort.Sort",
+                                                 MemberExprBase(), false,
+                                                 "sort", NDITEM, ARG(0))),
+                  OTHERWISE(UNSUPPORT_FACTORY_ENTRY(
+                      "cub::BlockRadixSort.Sort", Diagnostics::API_NOT_MIGRATED,
+                      printCallExprPretty())))))
       // cub::BlockRadixSort.SortDescending
-      HEADER_INSERT_FACTORY(
-          HeaderType::HT_DPCT_GROUP_Utils,
-          CASE_FACTORY_ENTRY(
-              CASE(
-                  makeCheckAnd(
-                      makeCheckAnd(CheckArgCount(3, std::equal_to<>(),
+      CONDITIONAL_FACTORY_ENTRY(
+          UseSYCLCompat,
+          UNSUPPORT_FACTORY_ENTRY(
+              "cub::BlockRadixSort.SortDescending",
+              Diagnostics::UNSUPPORT_SYCLCOMPAT,
+              LITERAL("cub::BlockRadixSort.SortDescending")),
+          HEADER_INSERT_FACTORY(
+              HeaderType::HT_DPCT_GROUP_Utils,
+              CASE_FACTORY_ENTRY(
+                  CASE(makeCheckAnd(
+                           makeCheckAnd(
+                               CheckArgCount(3, std::equal_to<>(),
+                                             /*IncludeDefaultArg=*/false),
+                               CheckParamType(1, "int", /*isStrict=*/true)),
+                           CheckParamType(2, "int", /*isStrict=*/true)),
+                       MEMBER_CALL_FACTORY_ENTRY(
+                           "cub::BlockRadixSort.SortDescending",
+                           MemberExprBase(), false, "sort_descending", NDITEM,
+                           ARG(0), ARG(1), ARG(2))),
+                  CASE(
+                      makeCheckAnd(CheckArgCount(2, std::equal_to<>(),
                                                  /*IncludeDefaultArg=*/false),
                                    CheckParamType(1, "int", /*isStrict=*/true)),
-                      CheckParamType(2, "int", /*isStrict=*/true)),
-                  MEMBER_CALL_FACTORY_ENTRY(
-                      "cub::BlockRadixSort.SortDescending", MemberExprBase(),
-                      false, "sort_descending", NDITEM, ARG(0), ARG(1),
-                      ARG(2))),
-              CASE(makeCheckAnd(CheckArgCount(2, std::equal_to<>(),
-                                              /*IncludeDefaultArg=*/false),
-                                CheckParamType(1, "int", /*isStrict=*/true)),
-                   MEMBER_CALL_FACTORY_ENTRY(
-                       "cub::BlockRadixSort.SortDescending", MemberExprBase(),
-                       false, "sort_descending", NDITEM, ARG(0), ARG(1))),
-              CASE(CheckArgCount(1, std::equal_to<>(),
-                                 /*IncludeDefaultArg=*/false),
-                   MEMBER_CALL_FACTORY_ENTRY(
-                       "cub::BlockRadixSort.SortDescending", MemberExprBase(),
-                       false, "sort_descending", NDITEM, ARG(0))),
-              OTHERWISE(UNSUPPORT_FACTORY_ENTRY(
-                  "cub::BlockRadixSort.SortDescending",
-                  Diagnostics::API_NOT_MIGRATED, printCallExprPretty()))))
+                      MEMBER_CALL_FACTORY_ENTRY(
+                          "cub::BlockRadixSort.SortDescending",
+                          MemberExprBase(), false, "sort_descending", NDITEM,
+                          ARG(0), ARG(1))),
+                  CASE(CheckArgCount(1, std::equal_to<>(),
+                                     /*IncludeDefaultArg=*/false),
+                       MEMBER_CALL_FACTORY_ENTRY(
+                           "cub::BlockRadixSort.SortDescending",
+                           MemberExprBase(), false, "sort_descending", NDITEM,
+                           ARG(0))),
+                  OTHERWISE(UNSUPPORT_FACTORY_ENTRY(
+                      "cub::BlockRadixSort.SortDescending",
+                      Diagnostics::API_NOT_MIGRATED, printCallExprPretty())))))
       // cub::BlockRadixSort.SortBlockedToStriped
-      HEADER_INSERT_FACTORY(
-          HeaderType::HT_DPCT_GROUP_Utils,
-          CASE_FACTORY_ENTRY(
-              CASE(
-                  makeCheckAnd(
-                      makeCheckAnd(CheckArgCount(3, std::equal_to<>(),
+      CONDITIONAL_FACTORY_ENTRY(
+          UseSYCLCompat,
+          UNSUPPORT_FACTORY_ENTRY(
+              "cub::BlockRadixSort.SortBlockedToStriped",
+              Diagnostics::UNSUPPORT_SYCLCOMPAT,
+              LITERAL("cub::BlockRadixSort.SortBlockedToStriped")),
+          HEADER_INSERT_FACTORY(
+              HeaderType::HT_DPCT_GROUP_Utils,
+              CASE_FACTORY_ENTRY(
+                  CASE(makeCheckAnd(
+                           makeCheckAnd(
+                               CheckArgCount(3, std::equal_to<>(),
+                                             /*IncludeDefaultArg=*/false),
+                               CheckParamType(1, "int", /*isStrict=*/true)),
+                           CheckParamType(2, "int", /*isStrict=*/true)),
+                       MEMBER_CALL_FACTORY_ENTRY(
+                           "cub::BlockRadixSort.SortBlockedToStriped",
+                           MemberExprBase(), false, "sort_blocked_to_striped",
+                           NDITEM, ARG(0), ARG(1), ARG(2))),
+                  CASE(
+                      makeCheckAnd(CheckArgCount(2, std::equal_to<>(),
                                                  /*IncludeDefaultArg=*/false),
                                    CheckParamType(1, "int", /*isStrict=*/true)),
-                      CheckParamType(2, "int", /*isStrict=*/true)),
-                  MEMBER_CALL_FACTORY_ENTRY(
+                      MEMBER_CALL_FACTORY_ENTRY(
+                          "cub::BlockRadixSort.SortBlockedToStriped",
+                          MemberExprBase(), false, "sort_blocked_to_striped",
+                          NDITEM, ARG(0), ARG(1))),
+                  CASE(CheckArgCount(1, std::equal_to<>(),
+                                     /*IncludeDefaultArg=*/false),
+                       MEMBER_CALL_FACTORY_ENTRY(
+                           "cub::BlockRadixSort.SortBlockedToStriped",
+                           MemberExprBase(), false, "sort_blocked_to_striped",
+                           NDITEM, ARG(0))),
+                  OTHERWISE(UNSUPPORT_FACTORY_ENTRY(
                       "cub::BlockRadixSort.SortBlockedToStriped",
-                      MemberExprBase(), false, "sort_blocked_to_striped",
-                      NDITEM, ARG(0), ARG(1), ARG(2))),
-              CASE(makeCheckAnd(CheckArgCount(2, std::equal_to<>(),
-                                              /*IncludeDefaultArg=*/false),
-                                CheckParamType(1, "int", /*isStrict=*/true)),
-                   MEMBER_CALL_FACTORY_ENTRY(
-                       "cub::BlockRadixSort.SortBlockedToStriped",
-                       MemberExprBase(), false, "sort_blocked_to_striped",
-                       NDITEM, ARG(0), ARG(1))),
-              CASE(CheckArgCount(1, std::equal_to<>(),
-                                 /*IncludeDefaultArg=*/false),
-                   MEMBER_CALL_FACTORY_ENTRY(
-                       "cub::BlockRadixSort.SortBlockedToStriped",
-                       MemberExprBase(), false, "sort_blocked_to_striped",
-                       NDITEM, ARG(0))),
-              OTHERWISE(UNSUPPORT_FACTORY_ENTRY(
-                  "cub::BlockRadixSort.SortBlockedToStriped",
-                  Diagnostics::API_NOT_MIGRATED, printCallExprPretty()))))
+                      Diagnostics::API_NOT_MIGRATED, printCallExprPretty())))))
       // cub::BlockRadixSort.SortDescendingBlockedToStriped
-      HEADER_INSERT_FACTORY(
-          HeaderType::HT_DPCT_GROUP_Utils,
-          CASE_FACTORY_ENTRY(
-              CASE(
-                  makeCheckAnd(
-                      makeCheckAnd(CheckArgCount(3, std::equal_to<>(),
+      CONDITIONAL_FACTORY_ENTRY(
+          UseSYCLCompat,
+          UNSUPPORT_FACTORY_ENTRY(
+              "cub::BlockRadixSort.SortDescendingBlockedToStriped",
+              Diagnostics::UNSUPPORT_SYCLCOMPAT,
+              LITERAL("cub::BlockRadixSort.SortDescendingBlockedToStriped")),
+          HEADER_INSERT_FACTORY(
+              HeaderType::HT_DPCT_GROUP_Utils,
+              CASE_FACTORY_ENTRY(
+                  CASE(makeCheckAnd(
+                           makeCheckAnd(
+                               CheckArgCount(3, std::equal_to<>(),
+                                             /*IncludeDefaultArg=*/false),
+                               CheckParamType(1, "int", /*isStrict=*/true)),
+                           CheckParamType(2, "int", /*isStrict=*/true)),
+                       MEMBER_CALL_FACTORY_ENTRY(
+                           "cub::BlockRadixSort.SortDescendingBlockedToStriped",
+                           MemberExprBase(), false,
+                           "sort_descending_blocked_to_striped", NDITEM, ARG(0),
+                           ARG(1), ARG(2))),
+                  CASE(
+                      makeCheckAnd(CheckArgCount(2, std::equal_to<>(),
                                                  /*IncludeDefaultArg=*/false),
                                    CheckParamType(1, "int", /*isStrict=*/true)),
-                      CheckParamType(2, "int", /*isStrict=*/true)),
-                  MEMBER_CALL_FACTORY_ENTRY(
+                      MEMBER_CALL_FACTORY_ENTRY(
+                          "cub::BlockRadixSort.SortDescendingBlockedToStriped",
+                          MemberExprBase(), false,
+                          "sort_descending_blocked_to_striped", NDITEM, ARG(0),
+                          ARG(1))),
+                  CASE(CheckArgCount(1, std::equal_to<>(),
+                                     /*IncludeDefaultArg=*/false),
+                       MEMBER_CALL_FACTORY_ENTRY(
+                           "cub::BlockRadixSort.SortDescendingBlockedToStriped",
+                           MemberExprBase(), false,
+                           "sort_descending_blocked_to_striped", NDITEM,
+                           ARG(0))),
+                  OTHERWISE(UNSUPPORT_FACTORY_ENTRY(
                       "cub::BlockRadixSort.SortDescendingBlockedToStriped",
-                      MemberExprBase(), false,
-                      "sort_descending_blocked_to_striped", NDITEM, ARG(0),
-                      ARG(1), ARG(2))),
-              CASE(makeCheckAnd(CheckArgCount(2, std::equal_to<>(),
-                                              /*IncludeDefaultArg=*/false),
-                                CheckParamType(1, "int", /*isStrict=*/true)),
-                   MEMBER_CALL_FACTORY_ENTRY(
-                       "cub::BlockRadixSort.SortDescendingBlockedToStriped",
-                       MemberExprBase(), false,
-                       "sort_descending_blocked_to_striped", NDITEM, ARG(0),
-                       ARG(1))),
-              CASE(CheckArgCount(1, std::equal_to<>(),
-                                 /*IncludeDefaultArg=*/false),
-                   MEMBER_CALL_FACTORY_ENTRY(
-                       "cub::BlockRadixSort.SortDescendingBlockedToStriped",
-                       MemberExprBase(), false,
-                       "sort_descending_blocked_to_striped", NDITEM, ARG(0))),
-              OTHERWISE(UNSUPPORT_FACTORY_ENTRY(
-                  "cub::BlockRadixSort.SortDescendingBlockedToStriped",
-                  Diagnostics::API_NOT_MIGRATED, printCallExprPretty()))))
+                      Diagnostics::API_NOT_MIGRATED, printCallExprPretty())))))
       // cub::BlockExchange.BlockedToStriped
-      HEADER_INSERT_FACTORY(HeaderType::HT_DPCT_GROUP_Utils,
-                            MEMBER_CALL_FACTORY_ENTRY(
-                                "cub::BlockExchange.BlockedToStriped",
-                                MemberExprBase(), false, "blocked_to_striped",
-                                NDITEM, ARG(0), ARG(1)))
+      CONDITIONAL_FACTORY_ENTRY(
+          UseSYCLCompat,
+          UNSUPPORT_FACTORY_ENTRY(
+              "cub::BlockExchange.BlockedToStriped",
+              Diagnostics::UNSUPPORT_SYCLCOMPAT,
+              LITERAL("cub::BlockExchange.BlockedToStriped")),
+          HEADER_INSERT_FACTORY(
+              HeaderType::HT_DPCT_GROUP_Utils,
+              MEMBER_CALL_FACTORY_ENTRY(
+                  "cub::BlockExchange.BlockedToStriped", MemberExprBase(),
+                  false, "blocked_to_striped", NDITEM, ARG(0), ARG(1))))
       // cub::BlockExchange.StripedToBlocked
-      HEADER_INSERT_FACTORY(HeaderType::HT_DPCT_GROUP_Utils,
-                            MEMBER_CALL_FACTORY_ENTRY(
-                                "cub::BlockExchange.StripedToBlocked",
-                                MemberExprBase(), false, "striped_to_blocked",
-                                NDITEM, ARG(0), ARG(1)))
+      CONDITIONAL_FACTORY_ENTRY(
+          UseSYCLCompat,
+          UNSUPPORT_FACTORY_ENTRY(
+              "cub::BlockExchange.StripedToBlocked",
+              Diagnostics::UNSUPPORT_SYCLCOMPAT,
+              LITERAL("cub::BlockExchange.StripedToBlocked")),
+          HEADER_INSERT_FACTORY(
+              HeaderType::HT_DPCT_GROUP_Utils,
+              MEMBER_CALL_FACTORY_ENTRY(
+                  "cub::BlockExchange.StripedToBlocked", MemberExprBase(),
+                  false, "striped_to_blocked", NDITEM, ARG(0), ARG(1))))
       // cub::BlockExchange.ScatterToBlocked
-      HEADER_INSERT_FACTORY(HeaderType::HT_DPCT_GROUP_Utils,
-                            MEMBER_CALL_FACTORY_ENTRY(
-                                "cub::BlockExchange.ScatterToBlocked",
-                                MemberExprBase(), false, "scatter_to_blocked",
-                                NDITEM, ARG(0), ARG(1)))
+      CONDITIONAL_FACTORY_ENTRY(
+          UseSYCLCompat,
+          UNSUPPORT_FACTORY_ENTRY(
+              "cub::BlockExchange.ScatterToBlocked",
+              Diagnostics::UNSUPPORT_SYCLCOMPAT,
+              LITERAL("cub::BlockExchange.ScatterToBlocked")),
+          HEADER_INSERT_FACTORY(
+              HeaderType::HT_DPCT_GROUP_Utils,
+              MEMBER_CALL_FACTORY_ENTRY(
+                  "cub::BlockExchange.ScatterToBlocked", MemberExprBase(),
+                  false, "scatter_to_blocked", NDITEM, ARG(0), ARG(1))))
       // cub::BlockExchange.ScatterToStriped
-      HEADER_INSERT_FACTORY(HeaderType::HT_DPCT_GROUP_Utils,
-                            MEMBER_CALL_FACTORY_ENTRY(
-                                "cub::BlockExchange.ScatterToStriped",
-                                MemberExprBase(), false, "scatter_to_striped",
-                                NDITEM, ARG(0), ARG(1)))
-      // cub::BlockLoad::Load
-      HEADER_INSERT_FACTORY(
-          HeaderType::HT_DPCT_GROUP_Utils,
-          CONDITIONAL_FACTORY_ENTRY(
-              makeCheckAnd(CheckArgCount(2), CheckCUBEnumTemplateArg(3)),
-              MEMBER_CALL_FACTORY_ENTRY("cub::BlockLoad.Load", MemberExprBase(),
-                                        false, "load", NDITEM, ARG(0), ARG(1)),
-              UNSUPPORT_FACTORY_ENTRY("cub::BlockLoad.Load",
-                                      Diagnostics::API_NOT_MIGRATED,
-                                      printCallExprPretty())))
-      // cub::BlockStore::Store
-      HEADER_INSERT_FACTORY(
-          HeaderType::HT_DPCT_GROUP_Utils,
-          CONDITIONAL_FACTORY_ENTRY(
-              makeCheckAnd(CheckArgCount(2), CheckCUBEnumTemplateArg(3)),
-              MEMBER_CALL_FACTORY_ENTRY("cub::BlockStore.Store",
-                                        MemberExprBase(), false, "store",
-                                        NDITEM, ARG(0), ARG(1)),
-              UNSUPPORT_FACTORY_ENTRY("cub::BlockStore.Store",
-                                      Diagnostics::API_NOT_MIGRATED,
-                                      printCallExprPretty())))
+      CONDITIONAL_FACTORY_ENTRY(
+          UseSYCLCompat,
+          UNSUPPORT_FACTORY_ENTRY(
+              "cub::BlockExchange.ScatterToStriped",
+              Diagnostics::UNSUPPORT_SYCLCOMPAT,
+              LITERAL("cub::BlockExchange.ScatterToStriped")),
+          HEADER_INSERT_FACTORY(
+              HeaderType::HT_DPCT_GROUP_Utils,
+              MEMBER_CALL_FACTORY_ENTRY(
+                  "cub::BlockExchange.ScatterToStriped", MemberExprBase(),
+                  false, "scatter_to_striped", NDITEM, ARG(0), ARG(1))))
+      // cub::BlockLoad.Load
+      CONDITIONAL_FACTORY_ENTRY(
+          UseSYCLCompat,
+          UNSUPPORT_FACTORY_ENTRY("cub::BlockLoad.Load",
+                                  Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                  LITERAL("cub::BlockLoad::Load")),
+          HEADER_INSERT_FACTORY(
+              HeaderType::HT_DPCT_GROUP_Utils,
+              CONDITIONAL_FACTORY_ENTRY(
+                  makeCheckAnd(CheckArgCount(2), CheckCUBEnumTemplateArg(3)),
+                  MEMBER_CALL_FACTORY_ENTRY("cub::BlockLoad.Load",
+                                            MemberExprBase(), false, "load",
+                                            NDITEM, ARG(0), ARG(1)),
+                  UNSUPPORT_FACTORY_ENTRY("cub::BlockLoad.Load",
+                                          Diagnostics::API_NOT_MIGRATED,
+                                          printCallExprPretty()))))
+      // cub::BlockStore.Store
+      CONDITIONAL_FACTORY_ENTRY(
+          UseSYCLCompat,
+          UNSUPPORT_FACTORY_ENTRY("cub::BlockStore.Store",
+                                  Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                  LITERAL("cub::BlockStore::Store")),
+          HEADER_INSERT_FACTORY(
+              HeaderType::HT_DPCT_GROUP_Utils,
+              CONDITIONAL_FACTORY_ENTRY(
+                  makeCheckAnd(CheckArgCount(2), CheckCUBEnumTemplateArg(3)),
+                  MEMBER_CALL_FACTORY_ENTRY("cub::BlockStore.Store",
+                                            MemberExprBase(), false, "store",
+                                            NDITEM, ARG(0), ARG(1)),
+                  UNSUPPORT_FACTORY_ENTRY("cub::BlockStore.Store",
+                                          Diagnostics::API_NOT_MIGRATED,
+                                          printCallExprPretty()))))
 
   };
 }

--- a/clang/lib/DPCT/Rewriters/CUB/RewriterUtilityFunctions.cpp
+++ b/clang/lib/DPCT/Rewriters/CUB/RewriterUtilityFunctions.cpp
@@ -125,11 +125,19 @@ RewriterMap dpct::createUtilityFunctionsRewriterMap() {
           CALL(MapNames::getDpctNamespace() + "dev_mgr::instance"), false,
           "current_device_id")
       // cub::PtxVersion
-      ASSIGN_FACTORY_ENTRY("cub::PtxVersion", ARG(0),
-                           LITERAL("DPCT_COMPATIBILITY_TEMP"))
+      CONDITIONAL_FACTORY_ENTRY(
+          UseSYCLCompat,
+          ASSIGN_FACTORY_ENTRY("cub::PtxVersion", ARG(0),
+                               LITERAL("SYCLCOMPAT_COMPATIBILITY_TEMP")),
+          ASSIGN_FACTORY_ENTRY("cub::PtxVersion", ARG(0),
+                               LITERAL("DPCT_COMPATIBILITY_TEMP")))
       // cub::PtxVersionUncached
-      ASSIGN_FACTORY_ENTRY("cub::PtxVersionUncached", ARG(0),
-                           LITERAL("DPCT_COMPATIBILITY_TEMP"))
+      CONDITIONAL_FACTORY_ENTRY(
+          UseSYCLCompat,
+          ASSIGN_FACTORY_ENTRY("cub::PtxVersionUncached", ARG(0),
+                               LITERAL("SYCLCOMPAT_COMPATIBILITY_TEMP")),
+          ASSIGN_FACTORY_ENTRY("cub::PtxVersionUncached", ARG(0),
+                               LITERAL("DPCT_COMPATIBILITY_TEMP")))
       // cub::SmVersion
       ASSIGN_FACTORY_ENTRY(
           "cub::SmVersion", ARG(0),
@@ -158,72 +166,103 @@ RewriterMap dpct::createUtilityFunctionsRewriterMap() {
       MEMBER_CALL_FACTORY_ENTRY("cub::RowMajorTid", NDITEM, /*IsArrow=*/false,
                                 "get_local_linear_id")
       // cub::LoadDirectBlocked
-      HEADER_INSERT_FACTORY(
-          HeaderType::HT_DPCT_GROUP_Utils,
-          CALL_FACTORY_ENTRY(
-              "cub::LoadDirectBlocked",
-              CALL(PRETTY_TEMPLATED_CALLEE(MapNames::getDpctNamespace() +
-                                               "group::load_direct_blocked",
-                                           0, 1, 2),
-                   NDITEM, ARG(1), ARG(2))))
+      CONDITIONAL_FACTORY_ENTRY(
+          UseSYCLCompat,
+          UNSUPPORT_FACTORY_ENTRY("cub::LoadDirectBlocked",
+                                  Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                  LITERAL("cub::LoadDirectBlocked")),
+          HEADER_INSERT_FACTORY(
+              HeaderType::HT_DPCT_GROUP_Utils,
+              CALL_FACTORY_ENTRY(
+                  "cub::LoadDirectBlocked",
+                  CALL(PRETTY_TEMPLATED_CALLEE(MapNames::getDpctNamespace() +
+                                                   "group::load_direct_blocked",
+                                               0, 1, 2),
+                       NDITEM, ARG(1), ARG(2)))))
       // cub::LoadDirectStriped
-      HEADER_INSERT_FACTORY(
-          HeaderType::HT_DPCT_GROUP_Utils,
-          CALL_FACTORY_ENTRY(
-              "cub::LoadDirectStriped",
-              CALL(PRETTY_TEMPLATED_CALLEE(MapNames::getDpctNamespace() +
-                                               "group::load_direct_striped",
-                                           1, 2, 3),
-                   NDITEM, ARG(1), ARG(2))))
-
+      CONDITIONAL_FACTORY_ENTRY(
+          UseSYCLCompat,
+          UNSUPPORT_FACTORY_ENTRY("cub::LoadDirectStriped",
+                                  Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                  LITERAL("cub::LoadDirectStriped")),
+          HEADER_INSERT_FACTORY(
+              HeaderType::HT_DPCT_GROUP_Utils,
+              CALL_FACTORY_ENTRY(
+                  "cub::LoadDirectStriped",
+                  CALL(PRETTY_TEMPLATED_CALLEE(MapNames::getDpctNamespace() +
+                                                   "group::load_direct_striped",
+                                               1, 2, 3),
+                       NDITEM, ARG(1), ARG(2)))))
       // cub::StoreDirectBlocked
-      HEADER_INSERT_FACTORY(
-          HeaderType::HT_DPCT_GROUP_Utils,
-          CALL_FACTORY_ENTRY(
-              "cub::StoreDirectBlocked",
-              CALL(PRETTY_TEMPLATED_CALLEE(MapNames::getDpctNamespace() +
-                                               "group::store_direct_blocked",
-                                           0, 1, 2),
-                   NDITEM, ARG(1), ARG(2))))
+      CONDITIONAL_FACTORY_ENTRY(
+          UseSYCLCompat,
+          UNSUPPORT_FACTORY_ENTRY("cub::StoreDirectBlocked",
+                                  Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                  LITERAL("cub::StoreDirectBlocked")),
+          HEADER_INSERT_FACTORY(
+              HeaderType::HT_DPCT_GROUP_Utils,
+              CALL_FACTORY_ENTRY("cub::StoreDirectBlocked",
+                                 CALL(PRETTY_TEMPLATED_CALLEE(
+                                          MapNames::getDpctNamespace() +
+                                              "group::store_direct_blocked",
+                                          0, 1, 2),
+                                      NDITEM, ARG(1), ARG(2)))))
       // cub::StoreDirectStriped
-      HEADER_INSERT_FACTORY(
-          HeaderType::HT_DPCT_GROUP_Utils,
-          CALL_FACTORY_ENTRY(
-              "cub::StoreDirectStriped",
-              CALL(PRETTY_TEMPLATED_CALLEE(MapNames::getDpctNamespace() +
-                                               "group::store_direct_striped",
-                                           1, 2, 3),
-                   NDITEM, ARG(1), ARG(2))))
+      CONDITIONAL_FACTORY_ENTRY(
+          UseSYCLCompat,
+          UNSUPPORT_FACTORY_ENTRY("cub::StoreDirectStriped",
+                                  Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                  LITERAL("cub::StoreDirectStriped")),
+          HEADER_INSERT_FACTORY(
+              HeaderType::HT_DPCT_GROUP_Utils,
+              CALL_FACTORY_ENTRY("cub::StoreDirectStriped",
+                                 CALL(PRETTY_TEMPLATED_CALLEE(
+                                          MapNames::getDpctNamespace() +
+                                              "group::store_direct_striped",
+                                          1, 2, 3),
+                                      NDITEM, ARG(1), ARG(2)))))
       // cub::ShuffleDown
-      SUBGROUPSIZE_FACTORY(
-          UINT_MAX,
-          MapNames::getDpctNamespace() + "experimental::shift_sub_group_left",
-          CONDITIONAL_FACTORY_ENTRY(
-              UseNonUniformGroups,
-              CALL_FACTORY_ENTRY(
-                  "cub::ShuffleDown",
-                  CALL(
-                      TEMPLATED_CALLEE(MapNames::getDpctNamespace() +
-                                           "experimental::shift_sub_group_left",
-                                       0, 1),
-                      SUBGROUP, ARG(0), ARG(1), ARG(2), ARG(3))),
-              UNSUPPORT_FACTORY_ENTRY("cub::ShuffleDown",
-                                      Diagnostics::API_NOT_MIGRATED,
-                                      LITERAL("cub::ShuffleDown"))))
+      CONDITIONAL_FACTORY_ENTRY(
+          UseSYCLCompat,
+          UNSUPPORT_FACTORY_ENTRY("cub::ShuffleDown",
+                                  Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                  LITERAL("cub::ShuffleDown")),
+          SUBGROUPSIZE_FACTORY(
+              UINT_MAX,
+              MapNames::getDpctNamespace() +
+                  "experimental::shift_sub_group_left",
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseNonUniformGroups,
+                  CALL_FACTORY_ENTRY(
+                      "cub::ShuffleDown",
+                      CALL(TEMPLATED_CALLEE(
+                               MapNames::getDpctNamespace() +
+                                   "experimental::shift_sub_group_left",
+                               0, 1),
+                           SUBGROUP, ARG(0), ARG(1), ARG(2), ARG(3))),
+                  UNSUPPORT_FACTORY_ENTRY("cub::ShuffleDown",
+                                          Diagnostics::API_NOT_MIGRATED,
+                                          LITERAL("cub::ShuffleDown")))))
       // cub::ShuffleUp
-      SUBGROUPSIZE_FACTORY(
-          UINT_MAX,
-          MapNames::getDpctNamespace() + "experimental::shift_sub_group_right",
-          CONDITIONAL_FACTORY_ENTRY(
-              UseNonUniformGroups,
-              CALL_FACTORY_ENTRY(
-                  "cub::ShuffleUp",
-                  CALL(TEMPLATED_CALLEE(
-                           MapNames::getDpctNamespace() +
-                               "experimental::shift_sub_group_right",
-                           0, 1),
-                       SUBGROUP, ARG(0), ARG(1), ARG(2), ARG(3))),
-              UNSUPPORT_FACTORY_ENTRY("cub::ShuffleUp",
-                                      Diagnostics::API_NOT_MIGRATED,
-                                      LITERAL("cub::ShuffleUp"))))};
+      CONDITIONAL_FACTORY_ENTRY(
+          UseSYCLCompat,
+          UNSUPPORT_FACTORY_ENTRY("cub::ShuffleUp",
+                                  Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                  LITERAL("cub::ShuffleUp")),
+          SUBGROUPSIZE_FACTORY(
+              UINT_MAX,
+              MapNames::getDpctNamespace() +
+                  "experimental::shift_sub_group_right",
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseNonUniformGroups,
+                  CALL_FACTORY_ENTRY(
+                      "cub::ShuffleUp",
+                      CALL(TEMPLATED_CALLEE(
+                               MapNames::getDpctNamespace() +
+                                   "experimental::shift_sub_group_right",
+                               0, 1),
+                           SUBGROUP, ARG(0), ARG(1), ARG(2), ARG(3))),
+                  UNSUPPORT_FACTORY_ENTRY("cub::ShuffleUp",
+                                          Diagnostics::API_NOT_MIGRATED,
+                                          LITERAL("cub::ShuffleUp")))))};
 }

--- a/clang/lib/DPCT/TypeLocRewriters.cpp
+++ b/clang/lib/DPCT/TypeLocRewriters.cpp
@@ -12,6 +12,9 @@
 
 namespace clang {
 namespace dpct {
+inline auto UseSYCLCompat() {
+  return [](const TypeLoc) -> bool { return DpctGlobalInfo::useSYCLCompat(); };
+}
 
 TemplateArgumentInfo getTemplateArg(const TypeLoc &TL, unsigned Idx) {
   if (auto TSTL = TL.getAs<TemplateSpecializationTypeLoc>()) {

--- a/clang/runtime/dpct-rt/include/dpct/compat_service.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/compat_service.hpp
@@ -21,6 +21,7 @@ namespace ns = ::dpct;
 template <typename T> using DataType = ::dpct::DataType<T>;
 using memcpy_direction = ::dpct::memcpy_direction;
 template <class... Args> using kernel_name = dpct_kernel_name<Args...>;
+using byte_t = ::dpct::byte_t;
 #else
 namespace ns = ::syclcompat;
 template <typename T> using DataType = ::syclcompat::detail::DataType<T>;
@@ -29,6 +30,7 @@ template <class... Args> using kernel_name = syclcompat_kernel_name<Args...>;
 #ifndef __dpct_inline__
 #define __dpct_inline__ __syclcompat_inline__
 #endif
+using byte_t = ::syclcompat::byte_t;
 #endif
 
 using ns::get_current_device;

--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/dpcpp_extensions.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/dpcpp_extensions.h
@@ -9,14 +9,12 @@
 #ifndef __DPCT_DPCPP_EXTENSIONS_H__
 #define __DPCT_DPCPP_EXTENSIONS_H__
 
-#include <sycl/sycl.hpp>
 #include <stdexcept>
 
 #ifdef SYCL_EXT_ONEAPI_USER_DEFINED_REDUCTIONS
 #include <sycl/ext/oneapi/experimental/user_defined_reductions.hpp>
 #endif
 
-#include "../dpct.hpp"
 #include "functional.h"
 
 namespace dpct {

--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/functional.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/functional.h
@@ -20,7 +20,6 @@
 #include <tuple>
 #include <utility>
 
-#include "../dpct.hpp"
 #define _DPCT_GCC_VERSION                                                      \
   (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 

--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/vector.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/vector.h
@@ -13,15 +13,11 @@
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/memory>
 
-#include <sycl/sycl.hpp>
-
 #include "memory.h"
 
 #include <algorithm>
 #include <iterator>
 #include <vector>
-
-#include "../device.hpp"
 
 namespace dpct {
 
@@ -78,8 +74,9 @@ template <typename _Allocator> struct device_allocator_traits {
       }
     } else {
       ::std::uninitialized_value_construct_n(
-          oneapi::dpl::execution::make_device_policy(get_default_queue()), p,
-          n);
+          oneapi::dpl::execution::make_device_policy(
+              ::dpct::cs::get_default_queue()),
+          p, n);
     }
   }
 
@@ -92,9 +89,9 @@ template <typename _Allocator> struct device_allocator_traits {
         ::std::allocator_traits<_Allocator>::construct(alloc, first + i, value);
       }
     } else {
-      ::std::uninitialized_fill_n(
-          oneapi::dpl::execution::make_device_policy(get_default_queue()),
-          first, n, value);
+      ::std::uninitialized_fill_n(oneapi::dpl::execution::make_device_policy(
+                                      ::dpct::cs::get_default_queue()),
+                                  first, n, value);
     }
   }
 
@@ -116,9 +113,9 @@ template <typename _Allocator> struct device_allocator_traits {
                                       Iter1>::value_type>::value) {
       __uninitialized_custom_copy_n(alloc, first, n, d_first);
     } else {
-      ::std::uninitialized_copy_n(
-          oneapi::dpl::execution::make_device_policy(get_default_queue()),
-          first, n, d_first);
+      ::std::uninitialized_copy_n(oneapi::dpl::execution::make_device_policy(
+                                      ::dpct::cs::get_default_queue()),
+                                  first, n, d_first);
     }
   }
 
@@ -143,9 +140,9 @@ template <typename _Allocator> struct device_allocator_traits {
         ::std::allocator_traits<_Allocator>::destroy(alloc, p + i);
       }
     } else {
-      ::std::destroy_n(
-          oneapi::dpl::execution::make_device_policy(get_default_queue()), p,
-          n);
+      ::std::destroy_n(oneapi::dpl::execution::make_device_policy(
+                           ::dpct::cs::get_default_queue()),
+                       p, n);
     }
   }
 };
@@ -221,18 +218,18 @@ private:
     if (other.size() <= _size) {
       // if incoming elements fit within existing elements, copy then destroy
       // excess
-      ::std::copy(
-          oneapi::dpl::execution::make_device_policy(get_default_queue()),
-          other.begin(), other.end(), begin());
+      ::std::copy(oneapi::dpl::execution::make_device_policy(
+                      ::dpct::cs::get_default_queue()),
+                  other.begin(), other.end(), begin());
       resize(other.size());
     } else if (other.size() < _capacity) {
       // if incoming elements don't fit within existing elements but do fit
       // within total capacity
       // copy elements that fit, then use uninitialized copy to ge the rest
       // and adjust size
-      std::copy_n(
-          oneapi::dpl::execution::make_device_policy(get_default_queue()),
-          other.begin(), _size, begin());
+      std::copy_n(oneapi::dpl::execution::make_device_policy(
+                      ::dpct::cs::get_default_queue()),
+                  other.begin(), _size, begin());
       device_allocator_traits<Allocator>::uninitialized_device_copy_n(
           _alloc, other.begin() + _size, other.size() - _size,
           _storage + _size);
@@ -252,12 +249,14 @@ private:
 public:
   template <typename OtherA> operator ::std::vector<T, OtherA>() const {
     auto __tmp = ::std::vector<T, OtherA>(this->size());
-    ::std::copy(oneapi::dpl::execution::make_device_policy(get_default_queue()),
+    ::std::copy(oneapi::dpl::execution::make_device_policy(
+                    ::dpct::cs::get_default_queue()),
                 this->begin(), this->end(), __tmp.begin());
     return __tmp;
   }
 
-  device_vector(const Allocator &alloc = Allocator(get_default_queue()))
+  device_vector(
+      const Allocator &alloc = Allocator(::dpct::cs::get_default_queue()))
       : _alloc(alloc), _size(0), _capacity(_min_capacity()) {
     _set_capacity_and_alloc();
   }
@@ -267,8 +266,8 @@ public:
     alloc_traits::deallocate(_alloc, _storage, _capacity);
   }
 
-  explicit device_vector(
-      size_type n, const Allocator &alloc = Allocator(get_default_queue()))
+  explicit device_vector(size_type n, const Allocator &alloc = Allocator(
+                                          ::dpct::cs::get_default_queue()))
       : _alloc(alloc), _size(n) {
     _set_capacity_and_alloc();
     _construct(n);
@@ -276,7 +275,7 @@ public:
 
   explicit device_vector(
       size_type n, const T &value,
-      const Allocator &alloc = Allocator(get_default_queue()))
+      const Allocator &alloc = Allocator(::dpct::cs::get_default_queue()))
       : _alloc(alloc), _size(n) {
     _set_capacity_and_alloc();
     _construct(n, value);
@@ -305,7 +304,7 @@ public:
       typename ::std::enable_if_t<
           dpct::internal::is_iterator<InputIterator>::value, InputIterator>
           last,
-      const Allocator &alloc = Allocator(get_default_queue()))
+      const Allocator &alloc = Allocator(::dpct::cs::get_default_queue()))
       : _alloc(alloc) {
     _size = ::std::distance(first, last);
     _set_capacity_and_alloc();
@@ -329,8 +328,9 @@ public:
   }
 
   template <typename OtherAllocator>
-  device_vector(const device_vector<T, OtherAllocator> &other,
-                const Allocator &alloc = Allocator(get_default_queue()))
+  device_vector(
+      const device_vector<T, OtherAllocator> &other,
+      const Allocator &alloc = Allocator(::dpct::cs::get_default_queue()))
       : _alloc(alloc) {
     _size = other.size();
     _capacity = other.capacity();
@@ -350,7 +350,8 @@ public:
   template <typename OtherAllocator>
   device_vector &operator=(const ::std::vector<T, OtherAllocator> &v) {
     resize(v.size());
-    ::std::copy(oneapi::dpl::execution::make_device_policy(get_default_queue()),
+    ::std::copy(oneapi::dpl::execution::make_device_policy(
+                    ::dpct::cs::get_default_queue()),
                 v.begin(), v.end(), begin());
     return *this;
   }
@@ -408,11 +409,12 @@ public:
       // swap all elements up to the minimum size between the two vectors
       size_type min_size = (::std::min)(size(), v.size());
       auto zip = oneapi::dpl::make_zip_iterator(begin(), v.begin());
-      ::std::for_each(
-          oneapi::dpl::execution::make_device_policy(get_default_queue()), zip,
-          zip + min_size, [](auto zip_ele) {
-            std::swap(::std::get<0>(zip_ele), ::std::get<1>(zip_ele));
-          });
+      ::std::for_each(oneapi::dpl::execution::make_device_policy(
+                          ::dpct::cs::get_default_queue()),
+                      zip, zip + min_size, [](auto zip_ele) {
+                        std::swap(::std::get<0>(zip_ele),
+                                  ::std::get<1>(zip_ele));
+                      });
       // then copy the elements beyond the end of the smaller list, and resize
       if (size() > v.size()) {
         v.reserve(capacity());
@@ -473,9 +475,9 @@ public:
       size_type tmp_capacity = (::std::max)(_size, _min_capacity());
       auto tmp = alloc_traits::allocate(_alloc, tmp_capacity);
       if (_size > 0) {
-        ::std::copy(
-            oneapi::dpl::execution::make_device_policy(get_default_queue()),
-            begin(), end(), tmp);
+        ::std::copy(oneapi::dpl::execution::make_device_policy(
+                        ::dpct::cs::get_default_queue()),
+                    begin(), end(), tmp);
       }
       alloc_traits::deallocate(_alloc, _storage, _capacity);
       _storage = tmp;
@@ -485,9 +487,9 @@ public:
   void assign(size_type n, const T &x) {
     resize(n);
     if (_size > 0) {
-      ::std::fill(
-          oneapi::dpl::execution::make_device_policy(get_default_queue()),
-          begin(), begin() + n, x);
+      ::std::fill(oneapi::dpl::execution::make_device_policy(
+                      ::dpct::cs::get_default_queue()),
+                  begin(), begin() + n, x);
     }
   }
   template <typename InputIterator>
@@ -525,16 +527,17 @@ public:
     if (m <= 0) {
       return end();
     } else if (n >= m) {
-      ::std::copy(
-          oneapi::dpl::execution::make_device_policy(get_default_queue()), last,
-          last + m, first);
+      ::std::copy(oneapi::dpl::execution::make_device_policy(
+                      ::dpct::cs::get_default_queue()),
+                  last, last + m, first);
     } else {
       auto tmp = alloc_traits::allocate(_alloc, m);
 
       device_allocator_traits<Allocator>::uninitialized_device_copy_n(
           _alloc, last, m, tmp);
 
-      std::copy(oneapi::dpl::execution::make_device_policy(get_default_queue()),
+      std::copy(oneapi::dpl::execution::make_device_policy(
+                    ::dpct::cs::get_default_queue()),
                 tmp, tmp + m, first);
       device_allocator_traits<Allocator>::destroy_n(_alloc, tmp, m);
       alloc_traits::deallocate(_alloc, tmp, m);
@@ -568,12 +571,12 @@ public:
       resize(size() + n);
       // resizing might invalidate position
       position = begin() + position.get_idx();
-      ::std::fill(
-          oneapi::dpl::execution::make_device_policy(get_default_queue()),
-          position, position + n, x);
-      ::std::copy(
-          oneapi::dpl::execution::make_device_policy(get_default_queue()), tmp,
-          tmp + m, position + n);
+      ::std::fill(oneapi::dpl::execution::make_device_policy(
+                      ::dpct::cs::get_default_queue()),
+                  position, position + n, x);
+      ::std::copy(oneapi::dpl::execution::make_device_policy(
+                      ::dpct::cs::get_default_queue()),
+                  tmp, tmp + m, position + n);
       device_allocator_traits<Allocator>::destroy_n(_alloc, tmp, m);
       alloc_traits::deallocate(_alloc, tmp, m);
     }
@@ -602,9 +605,9 @@ public:
       position = begin() + position.get_idx();
       // unsafe to call on device as we dont know the InputIterator type
       ::std::copy(first, last, position);
-      ::std::copy(
-          oneapi::dpl::execution::make_device_policy(get_default_queue()), tmp,
-          tmp + m, position + n);
+      ::std::copy(oneapi::dpl::execution::make_device_policy(
+                      ::dpct::cs::get_default_queue()),
+                  tmp, tmp + m, position + n);
       device_allocator_traits<Allocator>::destroy_n(_alloc, tmp, m);
       alloc_traits::deallocate(_alloc, tmp, m);
     }
@@ -681,7 +684,8 @@ public:
         _size(std::distance(first, last)) {
     auto buf = get_buffer();
     auto dst = oneapi::dpl::begin(buf);
-    std::copy(oneapi::dpl::execution::make_device_policy(get_default_queue()),
+    std::copy(oneapi::dpl::execution::make_device_policy(
+                  ::dpct::cs::get_default_queue()),
               first, last, dst);
   }
 
@@ -696,7 +700,8 @@ public:
     auto start = oneapi::dpl::begin(tmp_buf);
     auto end = oneapi::dpl::end(tmp_buf);
     auto dst = oneapi::dpl::begin(buf);
-    std::copy(oneapi::dpl::execution::make_device_policy(get_default_queue()),
+    std::copy(oneapi::dpl::execution::make_device_policy(
+                  ::dpct::cs::get_default_queue()),
               start, end, dst);
   }
 
@@ -716,7 +721,8 @@ public:
     auto start = oneapi::dpl::begin(tmp_buf);
     auto end = oneapi::dpl::end(tmp_buf);
     auto dst = oneapi::dpl::begin(buf);
-    std::copy(oneapi::dpl::execution::make_device_policy(get_default_queue()),
+    std::copy(oneapi::dpl::execution::make_device_policy(
+                  ::dpct::cs::get_default_queue()),
               start, end, dst);
   }
 
@@ -725,7 +731,8 @@ public:
       : _storage(alloc_store(v.size() * sizeof(T))), _size(v.size()) {
     auto buf = get_buffer();
     auto dst = oneapi::dpl::begin(buf);
-    std::copy(oneapi::dpl::execution::make_device_policy(get_default_queue()),
+    std::copy(oneapi::dpl::execution::make_device_policy(
+                  ::dpct::cs::get_default_queue()),
               v.real_begin(), v.real_begin() + v.size(), dst);
   }
 

--- a/clang/runtime/dpct-rt/include/dpct/dpl_utils.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_utils.hpp
@@ -16,6 +16,8 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/numeric>
 
+#include "compat_service.hpp"
+
 #include "dpl_extras/memory.h"
 #include "dpl_extras/algorithm.h"
 #include "dpl_extras/numeric.h"
@@ -23,7 +25,6 @@
 #include "dpl_extras/vector.h"
 #include "dpl_extras/dpcpp_extensions.h"
 
-#include "group_utils.hpp"
 // Only include iterator adaptor (and therefore boost) if necessary
 #ifdef ITERATOR_ADAPTOR_REQUIRED
 #include "dpl_extras/iterator_adaptor.h"


### PR DESCRIPTION
Depends on [[SYCLomatic] Add support to SYCLcompat](https://github.com/oneapi-src/SYCLomatic/pull/2122).
Depends on [[SYCLomatic] Using SYCL compat API in library related helper functions](https://github.com/oneapi-src/SYCLomatic/pull/2207).
