### PR TITLE
[NFC][SYCLomatic] Add virtual Ctor for OutputBuilder and clean build warnings

### DIFF
--- a/clang/lib/DPCT/AnalysisInfo.cpp
+++ b/clang/lib/DPCT/AnalysisInfo.cpp
@@ -1175,10 +1175,6 @@ void DpctGlobalInfo::setSYCLFileExtension(SYCLFileExtensionEnum Extension) {
     SYCLSourceExtension = ".cpp";
     SYCLHeaderExtension = ".hpp";
     break;
-  default:
-    SYCLSourceExtension = ".dp.cpp";
-    SYCLHeaderExtension = ".dp.hpp";
-    break;
   }
 }
 

--- a/clang/lib/DPCT/BarrierFenceSpaceAnalyzer.h
+++ b/clang/lib/DPCT/BarrierFenceSpaceAnalyzer.h
@@ -160,8 +160,6 @@ private:
 
   std::set<const Expr *> DeviceFunctionCallArgs;
 
-  bool IsDifferenceBetweenThreadIdxXAndIndexConstant = false;
-
   // This map contains pairs meet below pattern:
   // loop {
   //   ...

--- a/clang/lib/DPCT/Rules.cpp
+++ b/clang/lib/DPCT/Rules.cpp
@@ -20,6 +20,8 @@
 std::vector<clang::tooling::UnifiedPath> MetaRuleObject::RuleFiles;
 std::vector<std::shared_ptr<MetaRuleObject>> MetaRules;
 
+OutputBuilder::~OutputBuilder() {}
+
 template <class Functor>
 void reisterMigrationRule(const std::string &Name, Functor F) {
   class UserDefinedRuleFactory : public clang::dpct::MigrationRuleFactoryBase {

--- a/clang/lib/DPCT/Rules.h
+++ b/clang/lib/DPCT/Rules.h
@@ -351,7 +351,7 @@ public:
   std::string Str;
   std::vector<std::shared_ptr<OutputBuilder>> SubBuilders;
   void parse(std::string &);
-
+  virtual ~OutputBuilder();
 protected:
   // /OutStr is the string specified in rule's "Out" session
   virtual std::shared_ptr<OutputBuilder> consumeKeyword(std::string &OutStr,
@@ -362,7 +362,7 @@ protected:
   void consumeLParen(std::string &OutStr, size_t &Idx, std::string &&Keyword);
 };
 
-class TypeOutputBuilder : public OutputBuilder{
+class TypeOutputBuilder : public OutputBuilder {
 private:
   // /OutStr is the string specified in rule's "Out" session
   std::shared_ptr<OutputBuilder> consumeKeyword(std::string &OutStr,


### PR DESCRIPTION
Avoid warnings like the following:
```Console
SYCLomatic/clang/lib/DPCT/Rules.h:332:7: warning: 'OutputBuilder' has virtual functions but non-virtual destructor [-Wnon-virtual-dtor]
```
```
SYCLomatic/clang/lib/DPCT/BarrierFenceSpaceAnalyzer.h:163:8: warning: private field 'IsDifferenceBetweenThreadIdxXAndIndexConstant' is not used [-Wunused-private-field]
  bool IsDifferenceBetweenThreadIdxXAndIndexConstant = false;
       ^
1 warning generated.
```
```
SYCLomatic/clang/lib/DPCT/AnalysisInfo.cpp:1178:3: warning: default label in switch which covers all enumeration values [-Wcovered-switch-default]
  default:
  ^
1 warning generated.
```