### PR TITLE
[SYCLomatic] Define __dpct_inline__ as an alias of  __syclcompat_inline__ when using syclcompat headers

### DIFF
--- a/clang/runtime/dpct-rt/include/dpct/compat_service.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/compat_service.hpp
@@ -26,6 +26,7 @@ namespace ns = ::syclcompat;
 template <typename T> using DataType = ::syclcompat::detail::DataType<T>;
 using memcpy_direction = ::syclcompat::experimental::memcpy_direction;
 template <class... Args> using kernel_name = syclcompat_kernel_name<Args...>;
+#define __dpct_inline__ __syclcompat_inline__
 #endif
 
 using ns::get_current_device;

--- a/clang/runtime/dpct-rt/include/dpct/compat_service.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/compat_service.hpp
@@ -26,7 +26,9 @@ namespace ns = ::syclcompat;
 template <typename T> using DataType = ::syclcompat::detail::DataType<T>;
 using memcpy_direction = ::syclcompat::experimental::memcpy_direction;
 template <class... Args> using kernel_name = syclcompat_kernel_name<Args...>;
+#ifndef __dpct_inline__
 #define __dpct_inline__ __syclcompat_inline__
+#endif
 #endif
 
 using ns::get_current_device;


### PR DESCRIPTION
Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>