### PR TITLE
[SYCLomatic] Fix compile error of auto-generated Makefile for macros defined for string directedly used in printf() and std::cout()

### DIFF
--- a/clang/lib/DPCT/GenMakefile.cpp
+++ b/clang/lib/DPCT/GenMakefile.cpp
@@ -286,14 +286,14 @@ static void getCompileInfo(
         IsSystemInclude = true;
       } else if (llvm::StringRef(Option).starts_with("-D")) {
         // Parse macros defined.
-        bool NeedSigleQuote = false;
+        bool NeedSingleQuote = false;
         std::size_t Len = Option.length() - strlen("-D");
         std::size_t Pos = Option.find("=");
         if (Pos != std::string::npos) {
           std::string Value = Option.substr(Pos + 1, Option.length() - Pos);
           if (Value.size() >= 2 && Value.front() == '"' &&
               Value.back() == '"') {
-            NeedSigleQuote = true;
+            NeedSingleQuote = true;
           }
 
           Len = Pos - strlen("-D");
@@ -305,7 +305,7 @@ static void getCompileInfo(
           continue;
         }
 
-        if (NeedSigleQuote) {
+        if (NeedSingleQuote) {
           // For macros like -DMSG="message", will migrated to '-DMSG="message"'
           // in auto-generated Makefile.
           NewOptions += "\'" + Option + "\' ";

--- a/clang/lib/DPCT/GenMakefile.cpp
+++ b/clang/lib/DPCT/GenMakefile.cpp
@@ -309,6 +309,8 @@ static void getCompileInfo(
           // For macros like -DMSG="message", will migrated to '-DMSG="message"'
           // in auto-generated Makefile.
           NewOptions += "\'" + Option + "\' ";
+        } else {
+          NewOptions += Option + " ";
         }
       } else if (llvm::StringRef(Option).starts_with("-std=")) {
 

--- a/clang/lib/DPCT/GenMakefile.cpp
+++ b/clang/lib/DPCT/GenMakefile.cpp
@@ -306,7 +306,7 @@ static void getCompileInfo(
         }
 
         if (NeedSingleQuote) {
-          // For macros like -DMSG="message", will migrated to '-DMSG="message"'
+          // For macros like -DMSG="message", will be migrated to '-DMSG="message"'
           // in auto-generated Makefile.
           NewOptions += "\'" + Option + "\' ";
         } else {

--- a/clang/test/dpct/compilation_database/parse_double_quoted_str/test.cu
+++ b/clang/test/dpct/compilation_database/parse_double_quoted_str/test.cu
@@ -1,9 +1,11 @@
 // RUN: cd %T
 // RUN: cat %S/compile_commands.json > %T/compile_commands.json
 // RUN: cat %s > %T/test.cu
-// RUN: dpct --format-range=none -in-root=%T  -out-root=%T/out -p ./ --format-range=none --cuda-include-path="%cuda-path/include"
+// RUN: dpct --format-range=none -in-root=%T  -out-root=%T/out -p ./ --format-range=none --cuda-include-path="%cuda-path/include" -gen-build-script
 // RUN: FileCheck %s --match-full-lines --input-file %T/out/test.dp.cpp
 // RUN: %if build_lit %{icpx -DNAMD="\"3.0b3\"" -c -fsycl %T/out/test.dp.cpp -o %T/out/test.dp.o %}
+// RUN: cd %T/out
+// RUN: %if build_lit %{make -f Makefile.dpct %}
 
 // CHECK:  #include <sycl/sycl.hpp>
 // CHECK-NEXT: #include <dpct/dpct.hpp>
@@ -12,5 +14,6 @@
 #include <iostream>
 int main() {
   std::cout << NAMD;
+  printf(NAMD);
   return 0;
 }


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>