### PR TITLE
[SYCLomatic] Skip lit test for thrust::detail::enable_if and thrust::detail::is_same when using CUDA-12.6 header files as they are dropped in thrust of CUDA-12.6

### DIFF
--- a/clang/test/dpct/thrust_detail_namespace.cu
+++ b/clang/test/dpct/thrust_detail_namespace.cu
@@ -1,6 +1,6 @@
 // UNSUPPORTED: system-windows
-// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-11.0, cuda-11.1, cuda-11.2, cuda-11.3
-// UNSUPPORTED: v8.0, v9.0, v9.1, v9.2, v10.0, v11.0, v11.1, v11.2, v11.3
+// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-11.0, cuda-11.1, cuda-11.2, cuda-11.3, cuda-12.6
+// UNSUPPORTED: v8.0, v9.0, v9.1, v9.2, v10.0, v11.0, v11.1, v11.2, v11.3, v12.6
 // RUN: dpct --sycl-named-lambda --format-range=none --usm-level=none -out-root %T/thrust_detail_namespace -in-root=%S %s --cuda-include-path="%cuda-path/include" -- -x cuda --cuda-host-only -std=c++17 -fsized-deallocation
 // RUN: FileCheck --input-file %T/thrust_detail_namespace/thrust_detail_namespace.dp.cpp --match-full-lines %s
 // RUN: %if build_lit %{icpx -c -fsycl -DBUILD_TEST  %T/thrust_detail_namespace/thrust_detail_namespace.dp.cpp -o %T/thrust_detail_namespace/thrust_detail_namespace.dp.o %}

--- a/clang/test/dpct/thrust_detail_namespace.cu
+++ b/clang/test/dpct/thrust_detail_namespace.cu
@@ -1,6 +1,6 @@
 // UNSUPPORTED: system-windows
-// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-11.0, cuda-11.1, cuda-11.2, cuda-11.3, cuda-12.6
-// UNSUPPORTED: v8.0, v9.0, v9.1, v9.2, v10.0, v11.0, v11.1, v11.2, v11.3, v12.6
+// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-11.0, cuda-11.1, cuda-11.2, cuda-11.3
+// UNSUPPORTED: v8.0, v9.0, v9.1, v9.2, v10.0, v11.0, v11.1, v11.2, v11.3
 // RUN: dpct --sycl-named-lambda --format-range=none --usm-level=none -out-root %T/thrust_detail_namespace -in-root=%S %s --cuda-include-path="%cuda-path/include" -- -x cuda --cuda-host-only -std=c++17 -fsized-deallocation
 // RUN: FileCheck --input-file %T/thrust_detail_namespace/thrust_detail_namespace.dp.cpp --match-full-lines %s
 // RUN: %if build_lit %{icpx -c -fsycl -DBUILD_TEST  %T/thrust_detail_namespace/thrust_detail_namespace.dp.cpp -o %T/thrust_detail_namespace/thrust_detail_namespace.dp.o %}
@@ -11,29 +11,6 @@
 #include <thrust/detail/allocator/allocator_traits.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/device_vector.h>
-
-
-// CHECK:template <typename T>
-// CHECK-NEXT:typename std::enable_if<std::is_integral<T>::value, void>::type
-// CHECK-NEXT:print_info(T value) {
-// CHECK-NEXT:  std::cout << "Integral value: " << value << std::endl;
-// CHECK-NEXT:}
-template <typename T>
-typename thrust::detail::enable_if<std::is_integral<T>::value, void>::type
-print_info(T value) {
-  std::cout << "Integral value: " << value << std::endl;
-}
-
-// CHECK:template <typename T>
-// CHECK-NEXT:typename std::enable_if<std::is_floating_point<T>::value, void>::type
-// CHECK-NEXT:print_info(T value) {
-// CHECK-NEXT:  std::cout << "Floating-point value: " << value << std::endl;
-// CHECK-NEXT:}
-template <typename T>
-typename thrust::detail::enable_if<std::is_floating_point<T>::value, void>::type
-print_info(T value) {
-  std::cout << "Floating-point value: " << value << std::endl;
-}
 
 // CHECK:template <typename T>
 // CHECK-NEXT:struct is_integer {
@@ -67,23 +44,6 @@ struct is_integer<long> {
 template <std::size_t Len, std::size_t Align>
 void test_aligned_storage_instantiation() {
   typedef thrust::detail::integral_constant<bool, false> ValidAlign;
-}
-
-// CHECK:template <typename T, typename U>
-// CHECK-NEXT:void checkTypes() {
-// CHECK-NEXT:  if (std::is_same<T, U>::value) {
-// CHECK-NEXT:    std::cout << "Types T and U are the same." << std::endl;
-// CHECK-NEXT:  } else {
-// CHECK-NEXT:    std::cout << "Types T and U are different." << std::endl;
-// CHECK-NEXT:  }
-// CHECK-NEXT:}
-template <typename T, typename U>
-void checkTypes() {
-  if (thrust::detail::is_same<T, U>::value) {
-    std::cout << "Types T and U are the same." << std::endl;
-  } else {
-    std::cout << "Types T and U are different." << std::endl;
-  }
 }
 
 // CHECK:template <class ExampleVector, typename NewType, typename new_alloc> struct vector_like {

--- a/clang/test/dpct/thrust_detail_namespace_drop_12_6.cu
+++ b/clang/test/dpct/thrust_detail_namespace_drop_12_6.cu
@@ -1,0 +1,55 @@
+// UNSUPPORTED: system-windows
+// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-11.0, cuda-11.1, cuda-11.2, cuda-11.3, cuda-12.6
+// UNSUPPORTED: v8.0, v9.0, v9.1, v9.2, v10.0, v11.0, v11.1, v11.2, v11.3, v12.6
+// RUN: dpct --sycl-named-lambda --format-range=none --usm-level=none -out-root %T/thrust_detail_namespace_drop_12_6 -in-root=%S %s --cuda-include-path="%cuda-path/include" -- -x cuda --cuda-host-only -std=c++17 -fsized-deallocation
+// RUN: FileCheck --input-file %T/thrust_detail_namespace_drop_12_6/thrust_detail_namespace_drop_12_6.dp.cpp --match-full-lines %s
+// RUN: %if build_lit %{icpx -c -fsycl -DBUILD_TEST  %T/thrust_detail_namespace_drop_12_6/thrust_detail_namespace_drop_12_6.dp.cpp -o %T/thrust_detail_namespace_drop_12_6/thrust_detail_namespace_drop_12_6.dp.o %}
+
+#ifndef BUILD_TEST
+#include <iostream>
+#include <thrust/detail/type_traits.h>
+#include <thrust/detail/allocator/allocator_traits.h>
+#include <thrust/iterator/iterator_traits.h>
+#include <thrust/device_vector.h>
+
+
+// CHECK:template <typename T>
+// CHECK-NEXT:typename std::enable_if<std::is_integral<T>::value, void>::type
+// CHECK-NEXT:print_info(T value) {
+// CHECK-NEXT:  std::cout << "Integral value: " << value << std::endl;
+// CHECK-NEXT:}
+template <typename T>
+typename thrust::detail::enable_if<std::is_integral<T>::value, void>::type
+print_info(T value) {
+  std::cout << "Integral value: " << value << std::endl;
+}
+
+// CHECK:template <typename T>
+// CHECK-NEXT:typename std::enable_if<std::is_floating_point<T>::value, void>::type
+// CHECK-NEXT:print_info(T value) {
+// CHECK-NEXT:  std::cout << "Floating-point value: " << value << std::endl;
+// CHECK-NEXT:}
+template <typename T>
+typename thrust::detail::enable_if<std::is_floating_point<T>::value, void>::type
+print_info(T value) {
+  std::cout << "Floating-point value: " << value << std::endl;
+}
+
+// CHECK:template <typename T, typename U>
+// CHECK-NEXT:void checkTypes() {
+// CHECK-NEXT:  if (std::is_same<T, U>::value) {
+// CHECK-NEXT:    std::cout << "Types T and U are the same." << std::endl;
+// CHECK-NEXT:  } else {
+// CHECK-NEXT:    std::cout << "Types T and U are different." << std::endl;
+// CHECK-NEXT:  }
+// CHECK-NEXT:}
+template <typename T, typename U>
+void checkTypes() {
+  if (thrust::detail::is_same<T, U>::value) {
+    std::cout << "Types T and U are the same." << std::endl;
+  } else {
+    std::cout << "Types T and U are different." << std::endl;
+  }
+}
+
+#endif


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>