### PR TITLE
[SYCLomatic] Clean build warning: ‘clang::dpct::CheckAnd<F, S>’ may not intend to support class template argument deduction

### DIFF
--- a/clang/lib/DPCT/APINamesMisc.inc
+++ b/clang/lib/DPCT/APINamesMisc.inc
@@ -89,7 +89,7 @@ CALL_FACTORY_ENTRY("__assertfail", CALL("assert", LITERAL("0")))
 CALL_FACTORY_ENTRY("__assert_fail", CALL("assert", LITERAL("0")))
 
 CONDITIONAL_FACTORY_ENTRY(
-    CheckAnd(UseSYCLCompat, checkIsUseNoQueueDevice()),
+    makeCheckAnd(UseSYCLCompat, checkIsUseNoQueueDevice()),
     UNSUPPORT_FACTORY_ENTRY("cudaGetDeviceProperties",
                             Diagnostics::UNSUPPORT_SYCLCOMPAT,
                             LITERAL("cudaGetDeviceProperties")),
@@ -109,7 +109,7 @@ CONDITIONAL_FACTORY_ENTRY(
                 false, "get_device_info", DEREF(0))))))
 
 CONDITIONAL_FACTORY_ENTRY(
-    CheckAnd(UseSYCLCompat, checkIsUseNoQueueDevice()),
+    makeCheckAnd(UseSYCLCompat, checkIsUseNoQueueDevice()),
     UNSUPPORT_FACTORY_ENTRY("cudaGetDeviceProperties_v2",
                             Diagnostics::UNSUPPORT_SYCLCOMPAT,
                             LITERAL("cudaGetDeviceProperties_v2")),


### PR DESCRIPTION
Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>