### PR TITLE
[SYCLomatic] Add support for casting `dpct::kernel_function` to `uint64_t` (`CUfuntion`)

### DIFF
--- a/clang/runtime/dpct-rt/include/dpct/kernel.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/kernel.hpp
@@ -401,7 +401,7 @@ public:
     ptr(q, range, a, args, extra);
   }
 
-  operator uint64_t() const { return (uint64_t)this; }
+  explicit operator uint64_t() const { return (uint64_t)this; }
 
 private:
   dpct::kernel_functor ptr;

--- a/clang/runtime/dpct-rt/include/dpct/kernel.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/kernel.hpp
@@ -9,6 +9,7 @@
 #ifndef __DPCT_KERNEL_HPP__
 #define __DPCT_KERNEL_HPP__
 
+#include <cstdint>
 #include <sycl/sycl.hpp>
 #ifdef _WIN32
 #include <unordered_set>
@@ -399,6 +400,8 @@ public:
                   unsigned int a, void **args, void **extra) {
     ptr(q, range, a, args, extra);
   }
+
+  operator uint64_t() const { return (uint64_t)this; }
 
 private:
   dpct::kernel_functor ptr;

--- a/clang/test/dpct/kernel-function-typecast.cu
+++ b/clang/test/dpct/kernel-function-typecast.cu
@@ -12,7 +12,10 @@ u64 foo(CUfunction cuFunc, CUmodule cuMod) {
   // CHECK: cuFunc = dpct::get_kernel_function(cuMod, "kfoo");
   cuModuleGetFunction(&cuFunc, cuMod, "kfoo");
   u64 function = (u64)cuFunc;
-  u64 functionTwo = cuFunc;
 
   return function;
+}
+
+void createNew(u64 function) {
+  CUfunction cuFunc = function;
 }

--- a/clang/test/dpct/kernel-function-typecast.cu
+++ b/clang/test/dpct/kernel-function-typecast.cu
@@ -1,0 +1,13 @@
+// RUN: dpct -out-root %T/kernel-function-typecast %s --cuda-include-path="%cuda-path/include"
+// RUN: FileCheck --match-full-lines --input-file %T/kernel-function-typecast/kernel-function-typecast.dp.cpp %s
+// RUN: %if build_lit %{icpx -c -fsycl %T/kernel-function-typecast/kernel-function-typecast.dp.cpp -o %T/kernel-function-typecast/kernel-function-typecast.dp.o %}
+
+#include <cstdint>
+#include <cuda.h>
+
+typedef uint64_t u64;
+u64 foo(CUfunction cuFunc, CUmodule cuMod) {
+  cuModuleGetFunction(&cuFunc, cuMod, "kfoo");
+  u64 function = (u64)cuFunc;
+  return function;
+}

--- a/clang/test/dpct/kernel-function-typecast.cu
+++ b/clang/test/dpct/kernel-function-typecast.cu
@@ -16,6 +16,3 @@ u64 foo(CUfunction cuFunc, CUmodule cuMod) {
   return function;
 }
 
-void createNew(u64 function) {
-  CUfunction cuFunc = function;
-}

--- a/clang/test/dpct/kernel-function-typecast.cu
+++ b/clang/test/dpct/kernel-function-typecast.cu
@@ -6,8 +6,13 @@
 #include <cuda.h>
 
 typedef uint64_t u64;
+
+// CHECK: u64 foo(dpct::kernel_function cuFunc, dpct::kernel_library cuMod) {
 u64 foo(CUfunction cuFunc, CUmodule cuMod) {
+  // CHECK: cuFunc = dpct::get_kernel_function(cuMod, "kfoo");
   cuModuleGetFunction(&cuFunc, cuMod, "kfoo");
   u64 function = (u64)cuFunc;
+  u64 functionTwo = cuFunc;
+
   return function;
 }


### PR DESCRIPTION
A variable of type `CUfunction` attribute can be assigned to another one of type `uint64_t`. The `CUfuntion` is migrated to `dpct::kernel_function` this will break such an assignment.

Sample CUDA code
```
CUfuntion func;
uint64_t funcAddr;
funcAddr = func;
```
nvcc will be able to compile this code. But `icpx` fails to compile the code migrated by DPCT. See below.

```
dpct::kernel_function func;
uint64_t funcAddr;
funcAdd = func; // This assignment will result in a error.
```

The reason is `CUfunction` is a pointer to a structure. And assignment of a pointer to `uint64_t` is semantically valid.

DPCT migrates `CUfunction` to `dpct::kernel_function` which is a class variable encapsulating a function pointer. Any assignment to `uint64_t` is semantically invalid.

This PR fixes this issue by adding the ability to typecast `kernel_funciton` object to `uint64_t`. 