### PR TITLE
[SYCLomatic] Handle typedefs to `CUDA_RESOURCE_DESC`

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -13099,10 +13099,10 @@ void TextureRule::registerMatcher(MatchFinder &MF) {
                             "cudaTextureObject_t", "CUtexObject"))))))
                     .bind("texObj"),
                 this);
-  MF.addMatcher(memberExpr(hasObjectExpression(hasType(namedDecl(hasAnyName(
+  MF.addMatcher(memberExpr(hasObjectExpression(hasType(type(hasUnqualifiedDesugaredType(recordType(hasDeclaration(recordDecl(hasAnyName(
                                "cudaChannelFormatDesc", "cudaTextureDesc",
                                "cudaResourceDesc", "textureReference",
-                               "CUDA_RESOURCE_DESC", "CUDA_TEXTURE_DESC")))))
+                               "CUDA_RESOURCE_DESC_st", "CUDA_TEXTURE_DESC_st")))))))))
                     .bind("texMember"),
                 this);
   MF.addMatcher(
@@ -13420,7 +13420,7 @@ void TextureRule::runRule(const MatchFinder::MatchResult &Result) {
     if (DpctGlobalInfo::useSYCLCompat())
       return;
     auto BaseTy = DpctGlobalInfo::getUnqualifiedTypeName(
-        ME->getBase()->getType(), *Result.Context);
+        ME->getBase()->getType().getDesugaredType(*Result.Context), *Result.Context);
     auto MemberName = ME->getMemberNameInfo().getAsString();
     if (BaseTy == "cudaResourceDesc" || BaseTy == "CUDA_RESOURCE_DESC_st" ||
         BaseTy == "CUDA_RESOURCE_DESC") {

--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -13099,12 +13099,15 @@ void TextureRule::registerMatcher(MatchFinder &MF) {
                             "cudaTextureObject_t", "CUtexObject"))))))
                     .bind("texObj"),
                 this);
-  MF.addMatcher(memberExpr(hasObjectExpression(hasType(type(hasUnqualifiedDesugaredType(recordType(hasDeclaration(recordDecl(hasAnyName(
-                               "cudaChannelFormatDesc", "cudaTextureDesc",
-                               "cudaResourceDesc", "textureReference",
-                               "CUDA_RESOURCE_DESC_st", "CUDA_TEXTURE_DESC_st")))))))))
-                    .bind("texMember"),
-                this);
+  MF.addMatcher(
+      memberExpr(hasObjectExpression(hasType(
+          type(hasUnqualifiedDesugaredType(recordType(hasDeclaration(
+              recordDecl(hasAnyName(
+                  "cudaChannelFormatDesc", "cudaTextureDesc",
+                  "cudaResourceDesc", "textureReference",
+                  "CUDA_RESOURCE_DESC_st", "CUDA_TEXTURE_DESC_st"))))))))
+          ).bind("texMember"),
+    this);
   MF.addMatcher(
       typeLoc(
           loc(qualType(hasDeclaration(namedDecl(hasAnyName(

--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -13423,7 +13423,8 @@ void TextureRule::runRule(const MatchFinder::MatchResult &Result) {
     if (DpctGlobalInfo::useSYCLCompat())
       return;
     auto BaseTy = DpctGlobalInfo::getUnqualifiedTypeName(
-        ME->getBase()->getType().getDesugaredType(*Result.Context), *Result.Context);
+        ME->getBase()->getType().getDesugaredType(*Result.Context),
+        *Result.Context);
     auto MemberName = ME->getMemberNameInfo().getAsString();
     if (BaseTy == "cudaResourceDesc" || BaseTy == "CUDA_RESOURCE_DESC_st" ||
         BaseTy == "CUDA_RESOURCE_DESC") {

--- a/clang/test/dpct/texture_object_driver.cu
+++ b/clang/test/dpct/texture_object_driver.cu
@@ -244,3 +244,18 @@ void foo(){
   tex_tmp.flags = CU_TRSF_NORMALIZED_COORDINATES;
 }
 
+// CHECK: typedef dpct::image_data REDEF_CUDA_RESOURCE_DESC;
+// CHECK-NEXT: REDEF_CUDA_RESOURCE_DESC check_typedefed_cuda_type(dpct::image_matrix_p arr, dpct::image_data a) {
+// CHECK-NEXT:   REDEF_CUDA_RESOURCE_DESC rdesc;
+// CHECK-NEXT:   rdesc.set_data_type(dpct::image_data_type::matrix);
+// CHECK-NEXT:   rdesc.set_data_ptr(arr);
+// CHECK-NEXT:   return rdesc;
+// CHECK-NEXT: }
+typedef CUDA_RESOURCE_DESC REDEF_CUDA_RESOURCE_DESC;
+REDEF_CUDA_RESOURCE_DESC check_typedefed_cuda_type(CUarray arr, cudaResourceDesc a) {
+  REDEF_CUDA_RESOURCE_DESC rdesc;
+  rdesc.resType = CU_RESOURCE_TYPE_ARRAY;
+  rdesc.res.array.hArray = arr;
+  return rdesc;
+}
+#undef REDEF_CUDA_RESOURCE_DESC

--- a/clang/test/dpct/texture_object_driver.cu
+++ b/clang/test/dpct/texture_object_driver.cu
@@ -245,14 +245,14 @@ void foo(){
 }
 
 // CHECK: typedef dpct::image_data REDEF_CUDA_RESOURCE_DESC;
-// CHECK-NEXT: REDEF_CUDA_RESOURCE_DESC check_typedefed_cuda_type(dpct::image_matrix_p arr, dpct::image_data a) {
+// CHECK-NEXT: REDEF_CUDA_RESOURCE_DESC check_typedefed_cuda_type(dpct::image_matrix_p arr) {
 // CHECK-NEXT:   REDEF_CUDA_RESOURCE_DESC rdesc;
 // CHECK-NEXT:   rdesc.set_data_type(dpct::image_data_type::matrix);
 // CHECK-NEXT:   rdesc.set_data_ptr(arr);
 // CHECK-NEXT:   return rdesc;
 // CHECK-NEXT: }
 typedef CUDA_RESOURCE_DESC REDEF_CUDA_RESOURCE_DESC;
-REDEF_CUDA_RESOURCE_DESC check_typedefed_cuda_type(CUarray arr, cudaResourceDesc a) {
+REDEF_CUDA_RESOURCE_DESC check_typedefed_cuda_type(CUarray arr) {
   REDEF_CUDA_RESOURCE_DESC rdesc;
   rdesc.resType = CU_RESOURCE_TYPE_ARRAY;
   rdesc.res.array.hArray = arr;


### PR DESCRIPTION
Migration of `CUDA_RESOURCE_DESC` breaks if the struct is "typedef"ed by the user. See below.

The following code migrates as expected
```
#include <cuda.h>

CUDA_RESOURCE_DESC works(CUarray arr) {
  CUDA_RESOURCE_DESC rdesc;
  rdesc.resType = CU_RESOURCE_TYPE_ARRAY;
  rdesc.res.array.hArray = arr;
  return rdesc;
}
```
Whereas the code below doesn't migrate as intended.
```
typedef CUDA_RESOURCE_DESC ATYPE;
ATYPE donot_work(CUarray arr, cudaResourceDesc a) {
  ATYPE rdesc;
  rdesc.resType = CU_RESOURCE_TYPE_ARRAY;
  rdesc.res.array.hArray = arr;
  return rdesc;
}                                                                                                                                                                                                                                                                                
```
This PR fixes this issue.

Signed off by: [Deepak Raj H R](deepak.raj.h.r@intel.com)
