### PR TITLE
[SYCLomatic] Fix enum `CU_TR_*` migarion when found as `DeclRefExpr`

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -13146,7 +13146,8 @@ void TextureRule::registerMatcher(MatchFinder &MF) {
           to(enumConstantDecl(hasType(enumDecl(hasAnyName(
               "cudaTextureAddressMode", "cudaTextureFilterMode",
               "cudaChannelFormatKind", "cudaResourceType",
-              "CUarray_format_enum", "CUaddress_mode", "CUfilter_mode"))))))
+              "CUarray_format_enum", "CUaddress_mode_enum",
+              "CUfilter_mode_enum"))))))
           .bind("texEnum"),
       this);
 

--- a/clang/test/dpct/texture_driver.cu
+++ b/clang/test/dpct/texture_driver.cu
@@ -224,3 +224,30 @@ void test_texref() {
   CUDA_ARRAY_DESCRIPTOR desc;
   cuTexRefSetAddress2D(tex, &desc, dptr, b);
 }
+
+// CHECK: sycl::addressing_mode AddrMode[] = {
+// CHECK-NEXT:     sycl::addressing_mode::repeat, sycl::addressing_mode::clamp_to_edge,
+// CHECK-NEXT:     sycl::addressing_mode::clamp};
+CUaddress_mode AddrMode[] =
+{
+  CU_TR_ADDRESS_MODE_WRAP,
+  CU_TR_ADDRESS_MODE_CLAMP,
+  CU_TR_ADDRESS_MODE_BORDER
+};
+
+// CHECK: sycl::filtering_mode FltMode[] = {
+// CHECK-NEXT:     sycl::filtering_mode::nearest, sycl::filtering_mode::linear};
+CUfilter_mode FltMode[] =
+{
+  CU_TR_FILTER_MODE_POINT,
+  CU_TR_FILTER_MODE_LINEAR
+};
+
+// CHECK: void TestAssignment(sycl::addressing_mode a) {
+// CHECK-NEXT:   if (a == sycl::addressing_mode::repeat);
+// CHECK-NEXT:   if (a == sycl::addressing_mode::clamp_to_edge);
+// CHECK-NEXT: }
+void TestAssignment(CUaddress_mode a) {
+  if (a == CU_TR_ADDRESS_MODE_WRAP);
+  if (a == CU_TR_ADDRESS_MODE_CLAMP);
+}


### PR DESCRIPTION
When the `CU_TR_ADDRESS_MODE_WRAP` and `CU_TR_FILTER_MODE_POINT` are not migrated due to mismatch in enum name. This PR fixes it.

Signed off by: [Deepak Raj H R](deepak.raj.h.r@intel.com)