### PR TITLE
[SYCLomatic] Fix issue with migration of redefined CUDA type

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -2244,12 +2244,25 @@ void TypeInDeclRule::runRule(const MatchFinder::MatchResult &Result) {
     }
     return;
   }
-  if (auto TL = getNodeAsType<TypeLoc>(Result, "cudaTypeDef")) {
-    if (const auto *ND = getNamedDecl(TL->getTypePtr())) {
-      auto Loc = ND->getBeginLoc();
-      if (DpctGlobalInfo::isInAnalysisScope(Loc))
-        return;
+  if (const auto *TL = getNodeAsType<TypeLoc>(Result, "cudaTypeDef")) {
+    if(const auto *TypePtr = TL->getTypePtr()) {
+      if (isTypeInAnalysisScope(TypePtr)) {
+        if (const auto *const ET = dyn_cast<ElaboratedType>(TypePtr))
+          TypePtr = ET->getNamedType().getTypePtr();
+
+        // The definition of the type is in current files for analysis and
+        // neither they are typedefed. We donot want to migarte such types.
+        if (TypePtr->getTypeClass() != clang::Type::Typedef)
+          return;
+
+        // When a CUDA type is redefined in the files under analysis we
+        // want to migrate them.
+        const auto *TT = dyn_cast<TypedefType>(TypePtr);
+        if(!isRedeclIsInCUDAHeader(TT))
+          return;
+      }
     }
+
     // if TL is the T in
     // template<typename T> void foo(T a);
     if (TL->getType()->getTypeClass() == clang::Type::SubstTemplateTypeParm ||

--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -2245,7 +2245,7 @@ void TypeInDeclRule::runRule(const MatchFinder::MatchResult &Result) {
     return;
   }
   if (const auto *TL = getNodeAsType<TypeLoc>(Result, "cudaTypeDef")) {
-    if(const auto *TypePtr = TL->getTypePtr()) {
+    if (const auto *TypePtr = TL->getTypePtr()) {
       if (isTypeInAnalysisScope(TypePtr)) {
         if (const auto *const ET = dyn_cast<ElaboratedType>(TypePtr))
           TypePtr = ET->getNamedType().getTypePtr();
@@ -2258,7 +2258,7 @@ void TypeInDeclRule::runRule(const MatchFinder::MatchResult &Result) {
         // When a CUDA type is redefined in the files under analysis we
         // want to migrate them.
         const auto *TT = dyn_cast<TypedefType>(TypePtr);
-        if(!isRedeclIsInCUDAHeader(TT))
+        if (!isRedeclInCUDAHeader(TT))
           return;
       }
     }

--- a/clang/lib/DPCT/CallExprRewriterCommon.h
+++ b/clang/lib/DPCT/CallExprRewriterCommon.h
@@ -792,14 +792,9 @@ inline std::function<std::string(const CallExpr *C)> getDerefedType(size_t Idx) 
     while (const auto *ET = dyn_cast<ElaboratedType>(DerefQT)) {
       DerefQT = ET->getNamedType();
       if (const auto *TDT = dyn_cast<TypedefType>(DerefQT)) {
-        auto *TDecl = TDT->getDecl();
-        const auto Redecls = TDecl->redecls();
-        auto IsDeclInCudaHeader = [](const TypedefNameDecl * D) {
-          return dpct::DpctGlobalInfo::isInCudaPath(D->getLocation());
-        };
-        if (std::any_of(Redecls.begin(), Redecls.end(), IsDeclInCudaHeader))
+        if (isRedeclIsInCUDAHeader(TDT))
           break;
-        DerefQT = TDecl->getUnderlyingType();
+        DerefQT = TDT->getDecl()->getUnderlyingType();
       }
     }
     std::string TypeStr = DpctGlobalInfo::getReplacedTypeName(DerefQT);

--- a/clang/lib/DPCT/CallExprRewriterCommon.h
+++ b/clang/lib/DPCT/CallExprRewriterCommon.h
@@ -793,7 +793,7 @@ inline std::function<std::string(const CallExpr *C)> getDerefedType(size_t Idx) 
     while (const auto *ET = dyn_cast<ElaboratedType>(DerefQT)) {
       DerefQT = ET->getNamedType();
       if (const auto *TDT = dyn_cast<TypedefType>(DerefQT)) {
-        if (isRedeclIsInCUDAHeader(TDT))
+        if (isRedeclInCUDAHeader(TDT))
           break;
         DerefQT = TDT->getDecl()->getUnderlyingType();
       }

--- a/clang/lib/DPCT/Utility.cpp
+++ b/clang/lib/DPCT/Utility.cpp
@@ -3289,10 +3289,10 @@ bool isTypeInAnalysisScope(const clang::Type *TypePtr) {
 
 /// This function returns true if any of the redeclartions of typedef is in CUDA
 /// header
-bool isRedeclIsInCUDAHeader(const clang::TypedefType *T) {
+bool isRedeclInCUDAHeader(const clang::TypedefType *T) {
   const auto *TND = T->getDecl();
   const auto Redecls = TND->redecls();
-  auto IsDeclInCudaHeader = [](const TypedefNameDecl * D) {
+  auto IsDeclInCudaHeader = [](const TypedefNameDecl *D) {
     return dpct::DpctGlobalInfo::isInCudaPath(D->getLocation());
   };
   return std::any_of(Redecls.begin(), Redecls.end(), IsDeclInCudaHeader);

--- a/clang/lib/DPCT/Utility.cpp
+++ b/clang/lib/DPCT/Utility.cpp
@@ -3276,6 +3276,7 @@ const NamedDecl *getNamedDecl(const clang::Type *TypePtr) {
   }
   return ND;
 }
+
 bool isTypeInAnalysisScope(const clang::Type *TypePtr) {
   bool IsInAnalysisScope = false;
   if (const auto *ND = getNamedDecl(TypePtr)) {
@@ -3284,6 +3285,17 @@ bool isTypeInAnalysisScope(const clang::Type *TypePtr) {
       IsInAnalysisScope = true;
   }
   return IsInAnalysisScope;
+}
+
+/// This function returns true if any of the redeclartions of typedef is in CUDA
+/// header
+bool isRedeclIsInCUDAHeader(const clang::TypedefType *T) {
+  const auto *TND = T->getDecl();
+  const auto Redecls = TND->redecls();
+  auto IsDeclInCudaHeader = [](const TypedefNameDecl * D) {
+    return dpct::DpctGlobalInfo::isInCudaPath(D->getLocation());
+  };
+  return std::any_of(Redecls.begin(), Redecls.end(), IsDeclInCudaHeader);
 }
 
 /// This function will find all assignments to the DRE of \p HandleDecl in

--- a/clang/lib/DPCT/Utility.h
+++ b/clang/lib/DPCT/Utility.h
@@ -517,7 +517,7 @@ void checkIsPrivateVar(const clang::Expr *Expr, LocalVarAddrSpaceEnum &Result);
 bool isModifiedRef(const clang::DeclRefExpr *DRE);
 bool isDefaultStream(const clang::Expr *StreamArg);
 const clang::NamedDecl *getNamedDecl(const clang::Type *TypePtr);
-bool isRedeclIsInCUDAHeader(const clang::TypedefType *T);
+bool isRedeclInCUDAHeader(const clang::TypedefType *T);
 bool isTypeInAnalysisScope(const clang::Type *TypePtr);
 void findAssignments(const clang::DeclaratorDecl *HandleDecl,
                      const clang::CompoundStmt *CS,

--- a/clang/lib/DPCT/Utility.h
+++ b/clang/lib/DPCT/Utility.h
@@ -517,6 +517,7 @@ void checkIsPrivateVar(const clang::Expr *Expr, LocalVarAddrSpaceEnum &Result);
 bool isModifiedRef(const clang::DeclRefExpr *DRE);
 bool isDefaultStream(const clang::Expr *StreamArg);
 const clang::NamedDecl *getNamedDecl(const clang::Type *TypePtr);
+bool isRedeclIsInCUDAHeader(const clang::TypedefType *T);
 bool isTypeInAnalysisScope(const clang::Type *TypePtr);
 void findAssignments(const clang::DeclaratorDecl *HandleDecl,
                      const clang::CompoundStmt *CS,


### PR DESCRIPTION
If the CUDA type is redefined in the source-under analysis it wasn't getting migrated. This PR fixes the issue. In the below example the first use of `CUdeviceptr` gets migrated but the next one doesn't.
```
#include <cuda.h>
void foo(CUdeviceptr ptr) { ; }
typedef unsigned long long CUdeviceptr;
void bar(CUdeviceptr ptr) { ; }                                                                                                                                                                                                                                                                                       
```
Note: This is compilable by `nvcc` only in the case when the underlying type of `CUdeviceptr` is same as defined in CUDA headers.

Signed off by: [Deepak Raj H R](deepak.raj.h.r@intel.com)