### PR TITLE
[SYCLomatic][CMake] Fix incorrect migration of cpp extension name when the cpp source file is specified parent path in the CMakeLists.txt file

### DIFF
--- a/clang/lib/DPCT/PatternRewriter.cpp
+++ b/clang/lib/DPCT/PatternRewriter.cpp
@@ -415,7 +415,6 @@ updateExtentionName(const std::string &Input, size_t Next,
     std::string SrcFile = Input.substr(Pos, Next + strlen(".cpp") - Pos);
 
     SmallString<512> _SrcFile(SrcFile);
-    llvm::sys::path::remove_dots(_SrcFile, /* remove_dot_dot= */ true);
     llvm::sys::path::replace_path_prefix(_SrcFile, "${CMAKE_SOURCE_DIR}/", "");
     SrcFile = _SrcFile.c_str();
 

--- a/clang/lib/DPCT/PatternRewriter.cpp
+++ b/clang/lib/DPCT/PatternRewriter.cpp
@@ -436,9 +436,20 @@ updateExtentionName(const std::string &Input, size_t Next,
           CMakeFilePath = CMakeDirectory.c_str();
           CMakeFilePath = CMakeFilePath + "/" + SrcFile;
         } else {
-          CMakeFilePath = SrcFile;
-        }
+          std::string FileName = llvm::sys::path::filename(SrcFile).str();
+          SmallString<512> _SrcFile(SrcFile);
+          llvm::sys::path::remove_filename(_SrcFile);
+          std::string ParentPath = _SrcFile.c_str();
 
+          auto LastDotPos = ParentPath.find_last_of('.');
+          if (LastDotPos != std::string::npos) {
+            auto PrexPos = ParentPath.find('/', LastDotPos);
+            if (PrexPos != std::string::npos)
+              ParentPath = ParentPath.substr(PrexPos + 1);
+          }
+
+          CMakeFilePath = ParentPath + "/" + FileName;
+        }
         if (llvm::StringRef(File).ends_with(CMakeFilePath)) {
           HasCudaSyntax = true;
           break;

--- a/clang/lib/DPCT/PatternRewriter.cpp
+++ b/clang/lib/DPCT/PatternRewriter.cpp
@@ -414,38 +414,57 @@ updateExtentionName(const std::string &Input, size_t Next,
     Pos = Pos == 0 ? 0 : Pos + 1;
     std::string SrcFile = Input.substr(Pos, Next + strlen(".cpp") - Pos);
     bool HasCudaSyntax = false;
-    for (const auto &File : MainSrcFilesHasCudaSyntex) {
+    for (const auto &_File : MainSrcFilesHasCudaSyntex) {
+
+      llvm::SmallString<512> File(_File);
+      llvm::sys::path::native(File);
+
+#ifdef _WIN32
+      if (llvm::sys::path::filename(FileName).lower() == "cmakelists.txt") {
+#else
       if (llvm::sys::path::filename(FileName) == "CMakeLists.txt") {
+#endif
         // In a CMakeLists.txt file, the relative directory path for a source
         // file is the location of the CMakeLists.txt file itself
 
-        std::string CMakeFilePath;
+        llvm::SmallString<512> CMakeFilePath;
         if (llvm::sys::path::filename(SrcFile) == SrcFile) {
           // To get the directory path where CMake script is located
           SmallString<512> CMakeDirectory(FileName);
           llvm::sys::path::replace_path_prefix(
-              CMakeDirectory, OutRoot.getCanonicalPath().str() + "/", "");
+              CMakeDirectory, OutRoot.getCanonicalPath().str(), ".");
+          llvm::sys::path::remove_dots(CMakeDirectory,
+                                       /* remove_dot_dot= */ true);
           llvm::sys::path::remove_filename(CMakeDirectory);
 
-          CMakeFilePath = CMakeDirectory.c_str();
-          CMakeFilePath = CMakeFilePath + "/" + SrcFile;
+          std::string TempFile = CMakeDirectory.c_str();
+          TempFile = TempFile + "/" + SrcFile;
+          CMakeFilePath = TempFile.c_str();
+
+          llvm::sys::path::native(CMakeFilePath);
         } else {
           std::string FileName = llvm::sys::path::filename(SrcFile).str();
           SmallString<512> _SrcFile(SrcFile);
           llvm::sys::path::remove_dots(_SrcFile, /* remove_dot_dot= */ true);
-          llvm::sys::path::replace_path_prefix(_SrcFile, "${CMAKE_SOURCE_DIR}/",
-                                               "");
+          llvm::sys::path::replace_path_prefix(_SrcFile, "${CMAKE_SOURCE_DIR}",
+                                               ".");
+          llvm::sys::path::remove_dots(_SrcFile, /* remove_dot_dot= */ true);
           llvm::sys::path::remove_filename(_SrcFile);
           std::string ParentPath = _SrcFile.c_str();
 
           auto LastDotPos = ParentPath.find_last_of('.');
           if (LastDotPos != std::string::npos) {
+#ifdef _WIN32
+            auto PrexPos = ParentPath.find('\\', LastDotPos);
+#else
             auto PrexPos = ParentPath.find('/', LastDotPos);
+#endif
             if (PrexPos != std::string::npos)
               ParentPath = ParentPath.substr(PrexPos + 1);
           }
 
           CMakeFilePath = ParentPath + "/" + FileName;
+          llvm::sys::path::native(CMakeFilePath);
         }
         if (llvm::StringRef(File).ends_with(CMakeFilePath)) {
           HasCudaSyntax = true;

--- a/clang/lib/DPCT/PatternRewriter.cpp
+++ b/clang/lib/DPCT/PatternRewriter.cpp
@@ -413,11 +413,6 @@ updateExtentionName(const std::string &Input, size_t Next,
     }
     Pos = Pos == 0 ? 0 : Pos + 1;
     std::string SrcFile = Input.substr(Pos, Next + strlen(".cpp") - Pos);
-
-    SmallString<512> _SrcFile(SrcFile);
-    llvm::sys::path::replace_path_prefix(_SrcFile, "${CMAKE_SOURCE_DIR}/", "");
-    SrcFile = _SrcFile.c_str();
-
     bool HasCudaSyntax = false;
     for (const auto &File : MainSrcFilesHasCudaSyntex) {
       if (llvm::sys::path::filename(FileName) == "CMakeLists.txt") {
@@ -437,6 +432,9 @@ updateExtentionName(const std::string &Input, size_t Next,
         } else {
           std::string FileName = llvm::sys::path::filename(SrcFile).str();
           SmallString<512> _SrcFile(SrcFile);
+          llvm::sys::path::remove_dots(_SrcFile, /* remove_dot_dot= */ true);
+          llvm::sys::path::replace_path_prefix(_SrcFile, "${CMAKE_SOURCE_DIR}/",
+                                               "");
           llvm::sys::path::remove_filename(_SrcFile);
           std::string ParentPath = _SrcFile.c_str();
 

--- a/clang/test/dpct/cmake_migration/case_065/CMakeLists_outer.ref
+++ b/clang/test/dpct/cmake_migration/case_065/CMakeLists_outer.ref
@@ -4,4 +4,6 @@ add_subdirectory(priv)
 
 add_library(nvcv_types SHARED
     Image.cpp
+    ${CMAKE_SOURCE_DIR}/priv/foo.cpp.dp.cpp
+    ${CMAKE_SOURCE_DIR}/../infrastructure/Utilities.cpp.dp.cpp
 )

--- a/clang/test/dpct/cmake_migration/case_065/CMakeLists_outer.ref
+++ b/clang/test/dpct/cmake_migration/case_065/CMakeLists_outer.ref
@@ -6,4 +6,5 @@ add_library(nvcv_types SHARED
     Image.cpp
     ${CMAKE_SOURCE_DIR}/priv/foo.cpp.dp.cpp
     ${CMAKE_SOURCE_DIR}/../infrastructure/Utilities.cpp.dp.cpp
+    ${CMAKE_SOURCE_DIR}/../../infrastructure/bar.cpp.dp.cpp
 )

--- a/clang/test/dpct/cmake_migration/case_065/MainSourceFiles.yaml
+++ b/clang/test/dpct/cmake_migration/case_065/MainSourceFiles.yaml
@@ -44,7 +44,8 @@ MainSourceFilesDigest:
     Digest:          80a9873e8ab8a95f59e7f11682db7690
   - MainSourceFile:  '/path/to/infrastructure/Utilities.cpp'
     Digest:          5fba1ea8b69476a153fc01f408e467b8
-
+  - MainSourceFile:  '/path/to/infrastructure/bar.cpp'
+    Digest:          4fba1ea8b69476a153fc01f408e467b8
 DpctVersion:     19.0.0
 MainHelperFileName: ''
 USMLevel:        ''

--- a/clang/test/dpct/cmake_migration/case_065/MainSourceFiles.yaml
+++ b/clang/test/dpct/cmake_migration/case_065/MainSourceFiles.yaml
@@ -40,6 +40,11 @@ Replacements:
 MainSourceFilesDigest:
   - MainSourceFile:  '/path/to/src/nvcv_types/priv/Image.cpp'
     Digest:          80a9873e8ab8a95f59e7f11682db7690
+  - MainSourceFile:  '/path/to/src/nvcv_types/priv/foo.cpp'
+    Digest:          80a9873e8ab8a95f59e7f11682db7690
+  - MainSourceFile:  '/path/to/infrastructure/Utilities.cpp'
+    Digest:          5fba1ea8b69476a153fc01f408e467b8
+
 DpctVersion:     19.0.0
 MainHelperFileName: ''
 USMLevel:        ''

--- a/clang/test/dpct/cmake_migration/case_065/nvcv_types/CMakeLists.txt
+++ b/clang/test/dpct/cmake_migration/case_065/nvcv_types/CMakeLists.txt
@@ -4,4 +4,6 @@ add_subdirectory(priv)
 
 add_library(nvcv_types SHARED
     Image.cpp
+    ${CMAKE_SOURCE_DIR}/priv/foo.cpp
+    ${CMAKE_SOURCE_DIR}/../infrastructure/Utilities.cpp
 )

--- a/clang/test/dpct/cmake_migration/case_065/nvcv_types/CMakeLists.txt
+++ b/clang/test/dpct/cmake_migration/case_065/nvcv_types/CMakeLists.txt
@@ -6,4 +6,5 @@ add_library(nvcv_types SHARED
     Image.cpp
     ${CMAKE_SOURCE_DIR}/priv/foo.cpp
     ${CMAKE_SOURCE_DIR}/../infrastructure/Utilities.cpp
+    ${CMAKE_SOURCE_DIR}/../../infrastructure/bar.cpp
 )


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>