### PR TITLE
[SYCLomatic] Fix incorrect test for texture types

### DIFF
--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -13147,12 +13147,11 @@ void TextureRule::registerMatcher(MatchFinder &MF) {
       this);
 
   MF.addMatcher(
-      declRefExpr(
-          to(enumConstantDecl(hasType(enumDecl(hasAnyName(
-              "cudaTextureAddressMode", "cudaTextureFilterMode",
-              "cudaChannelFormatKind", "cudaResourceType",
-              "CUarray_format_enum", "CUaddress_mode_enum",
-              "CUfilter_mode_enum"))))))
+      declRefExpr(to(enumConstantDecl(hasType(enumDecl(hasAnyName(
+                      "cudaTextureAddressMode", "cudaTextureFilterMode",
+                      "cudaChannelFormatKind", "cudaResourceType",
+                      "CUarray_format_enum", "CUaddress_mode_enum",
+                      "CUfilter_mode_enum"))))))
           .bind("texEnum"),
       this);
 

--- a/clang/lib/DPCT/ASTTraversal.cpp
+++ b/clang/lib/DPCT/ASTTraversal.cpp
@@ -13146,7 +13146,8 @@ void TextureRule::registerMatcher(MatchFinder &MF) {
           to(enumConstantDecl(hasType(enumDecl(hasAnyName(
               "cudaTextureAddressMode", "cudaTextureFilterMode",
               "cudaChannelFormatKind", "cudaResourceType",
-              "CUarray_format_enum", "CUaddress_mode", "CUfilter_mode"))))))
+              "CUarray_format_enum", "CUaddress_mode_enum",
+              "CUfilter_mode_enum"))))))
           .bind("texEnum"),
       this);
 

--- a/clang/test/dpct/texture_driver.cu
+++ b/clang/test/dpct/texture_driver.cu
@@ -224,3 +224,30 @@ void test_texref() {
   CUDA_ARRAY_DESCRIPTOR desc;
   cuTexRefSetAddress2D(tex, &desc, dptr, b);
 }
+
+// CHECK: sycl::addressing_mode AddrMode[] = {
+// CHECK-NEXT:     sycl::addressing_mode::repeat, sycl::addressing_mode::clamp_to_edge,
+// CHECK-NEXT:     sycl::addressing_mode::clamp};
+CUaddress_mode AddrMode[] =
+{
+  CU_TR_ADDRESS_MODE_WRAP,
+  CU_TR_ADDRESS_MODE_CLAMP,
+  CU_TR_ADDRESS_MODE_BORDER
+};
+
+// CHECK: sycl::filtering_mode FltMode[] = {
+// CHECK-NEXT:     sycl::filtering_mode::nearest, sycl::filtering_mode::linear};
+CUfilter_mode FltMode[] =
+{
+  CU_TR_FILTER_MODE_POINT,
+  CU_TR_FILTER_MODE_LINEAR
+};
+
+// CHECK: void TestAssignment(sycl::addressing_mode a) {
+// CHECK-NEXT:   if (a == sycl::addressing_mode::repeat);
+// CHECK-NEXT:   if (a == sycl::addressing_mode::clamp_to_edge);
+// CHECK-NEXT: }
+void TestAssignment(CUaddress_mode a) {
+  if (a == CU_TR_ADDRESS_MODE_WRAP);
+  if (a == CU_TR_ADDRESS_MODE_CLAMP);
+}

--- a/clang/test/dpct/texture_driver.cu
+++ b/clang/test/dpct/texture_driver.cu
@@ -224,10 +224,12 @@ void test_texref() {
   CUDA_ARRAY_DESCRIPTOR desc;
   cuTexRefSetAddress2D(tex, &desc, dptr, b);
 }
-
-// CHECK: sycl::addressing_mode AddrMode[] = {
-// CHECK-NEXT:     sycl::addressing_mode::repeat, sycl::addressing_mode::clamp_to_edge,
-// CHECK-NEXT:     sycl::addressing_mode::clamp};
+// CHECK: sycl::addressing_mode AddrMode[] =
+// CHECK-NEXT: {
+// CHECK-NEXT:   sycl::addressing_mode::repeat,
+// CHECK-NEXT:   sycl::addressing_mode::clamp_to_edge,
+// CHECK-NEXT:   sycl::addressing_mode::clamp
+// CHECK-NEXT: };
 CUaddress_mode AddrMode[] =
 {
   CU_TR_ADDRESS_MODE_WRAP,
@@ -235,8 +237,11 @@ CUaddress_mode AddrMode[] =
   CU_TR_ADDRESS_MODE_BORDER
 };
 
-// CHECK: sycl::filtering_mode FltMode[] = {
-// CHECK-NEXT:     sycl::filtering_mode::nearest, sycl::filtering_mode::linear};
+// CHECK: sycl::filtering_mode FltMode[] =
+// CHECK-NEXT: {
+// CHECK-NEXT:   sycl::filtering_mode::nearest,
+// CHECK-NEXT:   sycl::filtering_mode::linear
+// CHECK-NEXT: };
 CUfilter_mode FltMode[] =
 {
   CU_TR_FILTER_MODE_POINT,


### PR DESCRIPTION
https://github.com/oneapi-src/SYCLomatic/pull/2318/files breaks a LIT test due to incorrect _CHECK_ directive. This PR fixes it.