### PR TITLE
[SYCLomatic] Fix the migration of cub::ShuffleIndex

### DIFF
--- a/clang/lib/DPCT/CUBAPIMigration.cpp
+++ b/clang/lib/DPCT/CUBAPIMigration.cpp
@@ -1025,17 +1025,31 @@ void CubRule::processWarpLevelFuncCall(const CallExpr *CE, bool FuncCallUsed) {
     WarpSize = TA->get(0).getAsIntegral().getExtValue();
     std::string ValueType =
         TA->get(1).getAsType().getUnqualifiedType().getAsString();
-    auto MemberMask = CE->getArg(2);
-    auto Mask = dyn_cast<IntegerLiteral>(MemberMask);
-    if (Mask && Mask->getValue().getZExtValue() == 0xffffffff) {
-      const Expr *Value = CE->getArg(0);
-      const Expr *Lane = CE->getArg(1);
-      ExprAnalysis ValueEA(Value);
-      ExprAnalysis LaneEA(Lane);
-      auto DeviceFuncDecl = getImmediateOuterFuncDecl(CE);
-      Repl = DpctGlobalInfo::getSubGroup(CE, DeviceFuncDecl) + ".shuffle(" +
-             ValueEA.getReplacedString() + ", " + LaneEA.getReplacedString() +
-             ")";
+    const auto *MemberMask = CE->getArg(2);
+    const auto *Mask = dyn_cast<IntegerLiteral>(MemberMask);
+    const Expr *Value = CE->getArg(0);
+    const Expr *Lane = CE->getArg(1);
+    const auto *DeviceFuncDecl = getImmediateOuterFuncDecl(CE);
+    ExprAnalysis ValueEA(Value);
+    ExprAnalysis LaneEA(Lane);
+    llvm::raw_string_ostream OS(Repl);
+    if (Mask) {
+      if (Mask->getValue().getZExtValue() == 0xffffffff) {
+        OS << MapNames::getDpctNamespace() << "select_from_sub_group("
+           << DpctGlobalInfo::getSubGroup(CE, DeviceFuncDecl) << ", "
+           << ValueEA.getReplacedString() << ", " << LaneEA.getReplacedString();
+        if (WarpSize != 32)
+          OS << ", " << WarpSize;
+        OS << ')';
+      } else {
+        OS << MapNames::getDpctNamespace() << "experimental::"
+           << "select_from_sub_group(" << getStmtSpelling(Mask) << ", "
+           << DpctGlobalInfo::getSubGroup(CE, DeviceFuncDecl) << ", "
+           << ValueEA.getReplacedString() << ", " << LaneEA.getReplacedString();
+        if (WarpSize != 32)
+          OS << ", " << WarpSize;
+        OS << ')';
+      }
       emplaceTransformation(new ReplaceStmt(CE, Repl));
       if (DeviceFuncDecl) {
         auto DI = DeviceFunctionDecl::LinkRedecls(DeviceFuncDecl);

--- a/clang/lib/DPCT/CUBAPIMigration.cpp
+++ b/clang/lib/DPCT/CUBAPIMigration.cpp
@@ -1051,12 +1051,6 @@ void CubRule::processWarpLevelFuncCall(const CallExpr *CE, bool FuncCallUsed) {
         OS << ')';
       }
       emplaceTransformation(new ReplaceStmt(CE, Repl));
-      if (DeviceFuncDecl) {
-        auto DI = DeviceFunctionDecl::LinkRedecls(DeviceFuncDecl);
-        if (DI) {
-          DI->addSubGroupSizeRequest(WarpSize, CE->getBeginLoc(), "shuffle");
-        }
-      }
     } else {
       report(CE->getBeginLoc(), Diagnostics::API_NOT_MIGRATED, false,
              GetFunctionName(CE));

--- a/clang/test/dpct/cub/warplevel/shuffle.cu
+++ b/clang/test/dpct/cub/warplevel/shuffle.cu
@@ -92,11 +92,11 @@ int main() {
   cudaMallocManaged(&dev_data, TotalThread * sizeof(int));
 
   init_data(dev_data, TotalThread);
-//CHECK:  q_ct1.parallel_for(
-//CHECK-NEXT:            sycl::nd_range<3>(GridSize * BlockSize, BlockSize),
-//CHECK-NEXT:            [=](sycl::nd_item<3> item_ct1) {{\[\[}}intel::reqd_sub_group_size(32){{\]\]}} {
-//CHECK-NEXT:              ShuffleIndexKernel1(dev_data, item_ct1);
-//CHECK-NEXT:            });
+  // CHECK:  q_ct1.parallel_for(
+  // CHECK-NEXT:            sycl::nd_range<3>(GridSize * BlockSize, BlockSize),
+  // CHECK-NEXT:            [=](sycl::nd_item<3> item_ct1) {
+  // CHECK-NEXT:              ShuffleIndexKernel1(dev_data, item_ct1);
+  // CHECK-NEXT:            });
   ShuffleIndexKernel1<<<GridSize, BlockSize>>>(dev_data);
   cudaDeviceSynchronize();
   verify_data(dev_data, TotalThread);
@@ -104,7 +104,7 @@ int main() {
   init_data(dev_data, TotalThread);
   // CHECK:    q_ct1.parallel_for(
   // CHECK-NEXT:            sycl::nd_range<3>(GridSize * BlockSize, BlockSize),
-  // CHECK-NEXT:            [=](sycl::nd_item<3> item_ct1) {{\[\[}}intel::reqd_sub_group_size(32){{\]\]}} {
+  // CHECK-NEXT:            [=](sycl::nd_item<3> item_ct1) {
   // CHECK-NEXT:              ShuffleIndexKernel2(dev_data, item_ct1);
   // CHECK-NEXT:            });
   ShuffleIndexKernel2<<<GridSize, BlockSize>>>(dev_data);


### PR DESCRIPTION
`sycl::sub_group::shuffle` was removed from latest SYCL compiler.