### PR TITLE
[SYCLomatic] Remove the suffix -s or -es of the verbs when there is no subject in option descriptions

### DIFF
--- a/clang/include/clang/DPCT/DPCTOptions.inc
+++ b/clang/include/clang/DPCT/DPCTOptions.inc
@@ -250,7 +250,7 @@ DPCT_FLAG_OPTION(
     KeepOriginalCode, clang::dpct::DpctOptionClass::OC_Attribute,
     DPCT_OPTION_ACTIONS(clang::dpct::DpctActionKind::DAK_Migration),
     "keep-original-code",
-    llvm::cl::desc("Keeps the original code in comments of "
+    llvm::cl::desc("Keep the original code in comments of "
                    "generated SYCL files. Default: off.\n"),
     llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTCodeGenCat))
 
@@ -282,7 +282,7 @@ DPCT_ENUM_OPTION(
             "file name has the .stats\n"
             "suffix added (default)",
             false)),
-    llvm::cl::desc("Specifies the type of migration report. Values are:\n"),
+    llvm::cl::desc("Specify the type of migration report. Values are:\n"),
     llvm::cl::init(ReportTypeEnum::RTE_NotSetType),
     llvm::cl::value_desc("value"), llvm::cl::cat(DPCTReportGenCat),
     llvm::cl::Optional)
@@ -313,7 +313,7 @@ DPCT_ENUM_OPTION(
             "file name has the .stats\n"
             "suffix added (default)",
             false)),
-    llvm::cl::desc("Specifies the type of migration report. Values are:\n"),
+    llvm::cl::desc("Specify the type of migration report. Values are:\n"),
     llvm::cl::init(ReportTypeEnum::RTE_NotSetType),
     llvm::cl::value_desc("value"), llvm::cl::cat(DPCTReportGenCat),
     llvm::cl::Optional)
@@ -353,7 +353,7 @@ DPCT_FLAG_OPTION(
     SuppressWarningsAll, clang::dpct::DpctOptionClass::OC_Attribute,
     DPCT_OPTION_ACTIONS(clang::dpct::DpctActionKind::DAK_Migration),
     "suppress-warnings-all",
-    llvm::cl::desc("Suppresses all migration warnings. Default: off."),
+    llvm::cl::desc("Suppress all migration warnings. Default: off."),
     llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTWarningsCat))
 
 DPCT_FLAG_OPTION(StopOnParseErr, clang::dpct::DpctOptionClass::OC_Attribute,
@@ -391,7 +391,7 @@ DPCT_FLAG_OPTION(
     DPCT_OPTION_ACTIONS(clang::dpct::DpctActionKind::DAK_Migration,
                         clang::dpct::DpctActionKind::DAK_Analysis),
     "sycl-named-lambda",
-    llvm::cl::desc("Generates kernels with the kernel name. Default: off.\n"),
+    llvm::cl::desc("Generate kernels with the kernel name. Default: off.\n"),
     llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTCodeGenCat))
 
 DPCT_ENUM_OPTION(
@@ -414,7 +414,7 @@ DPCT_ENUM_OPTION(
             "'silent' and warnings, errors, and notes from dpct.", false),
         DPCT_OPTION_ENUM_VALUE("silent", int(OutputVerbosityLevel::OVL_Silent),
                                "Only messages from clang.", false)),
-    llvm::cl::desc("Sets the output verbosity level:"),
+    llvm::cl::desc("Set the output verbosity level:"),
     llvm::cl::init(OutputVerbosityLevel::OVL_Diagnostics),
     llvm::cl::value_desc("value"), llvm::cl::cat(DPCTWarningsCat),
     llvm::cl::Optional)
@@ -423,7 +423,7 @@ DPCT_PATH_OPTION(
     OutputFile, clang::dpct::DpctOptionClass::OC_Attribute,
     DPCT_OPTION_ACTIONS(clang::dpct::DpctActionKind::DAK_Migration),
     "output-file",
-    llvm::cl::desc("Redirects the stdout/stderr output to <file> in the output"
+    llvm::cl::desc("Redirect the stdout/stderr output to <file> in the output"
                    " directory specified\n"
                    "by the --out-root option."),
     llvm::cl::value_desc("file"), llvm::cl::cat(DPCTWarningsCat),
@@ -435,7 +435,7 @@ DPCT_OPTION(clang::dpct::list, std::string, RuleFile,
                                 clang::dpct::DpctActionKind::DAK_BuildScript,
                                 clang::dpct::DpctActionKind::DAK_Analysis),
             "rule-file",
-            llvm::cl::desc("Specifies the rule file path that "
+            llvm::cl::desc("Specify the rule file path that "
                            "contains rules used for migration.\n"),
             llvm::cl::value_desc("file"), llvm::cl::cat(DPCTAdvancedCat),
             llvm::cl::ZeroOrMore)
@@ -455,7 +455,7 @@ DPCT_ENUM_OPTION(
         DPCT_OPTION_ENUM_VALUE(
             "restricted", int(UsmLevel::UL_Restricted),
             "Uses USM API for memory management migration. (default)", false)),
-    llvm::cl::desc("Sets the Unified Shared Memory (USM) level to use in "
+    llvm::cl::desc("Set the Unified Shared Memory (USM) level to use in "
                    "source code generation.\n"),
     llvm::cl::init(UsmLevel::UL_Restricted), llvm::cl::value_desc("value"),
     llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTCodeGenCat), llvm::cl::Optional)
@@ -479,13 +479,13 @@ DPCT_ENUM_OPTION(
     "format-range",
     DPCT_OPTION_VALUES(
         DPCT_OPTION_ENUM_VALUE("all", int(format::FormatRange::all),
-                               "Formats all code.", false),
+                               "Format all code.", false),
         DPCT_OPTION_ENUM_VALUE("migrated", int(format::FormatRange::migrated),
-                               "Only formats the migrated code (default).",
+                               "Only format the migrated code (default).",
                                false),
         DPCT_OPTION_ENUM_VALUE("none", int(format::FormatRange::none),
                                "Do not format any code.", false)),
-    llvm::cl::desc("Sets the range of formatting.\nThe values are:\n"),
+    llvm::cl::desc("Set the range of formatting.\nThe values are:\n"),
     llvm::cl::init(format::FormatRange::migrated),
     llvm::cl::value_desc("value"), llvm::cl::cat(DPCTAdvancedCat),
     llvm::cl::Optional)
@@ -504,7 +504,7 @@ DPCT_ENUM_OPTION(
                                "Use the LLVM coding style.", false),
         DPCT_OPTION_ENUM_VALUE("google", int(DPCTFormatStyle::FS_Google),
                                "Use the Google coding style.", false)),
-    llvm::cl::desc("Sets the formatting style.\nThe values are:\n"),
+    llvm::cl::desc("Set the formatting style.\nThe values are:\n"),
     llvm::cl::init(DPCTFormatStyle::FS_Custom), llvm::cl::value_desc("value"),
     llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTAdvancedCat), llvm::cl::Optional)
 
@@ -522,7 +522,7 @@ DPCT_FLAG_OPTION(
     DPCT_OPTION_ACTIONS(clang::dpct::DpctActionKind::DAK_Migration,
                         clang::dpct::DpctActionKind::DAK_Analysis),
     "process-all",
-    llvm::cl::desc("Migrates or copies all files, except hidden, from the "
+    llvm::cl::desc("Migrate or copies all files, except hidden, from the "
                    "--in-root directory\n"
                    "to the --out-root directory. The --in-root option should "
                    "be explicitly specified.\n"
@@ -580,7 +580,7 @@ DPCT_ENUM_OPTION(
         DPCT_OPTION_ENUM_VALUE(
             "3", 3, "Generate kernel code assuming 3D nd_range (default).",
             false)),
-    llvm::cl::desc("Provides a hint to the tool on the dimensionality of "
+    llvm::cl::desc("Provide a hint to the tool on the dimensionality of "
                    "nd_range to use in generated code.\n"
                    "The values are:\n"),
     llvm::cl::init(AssumedNDRangeDimEnum::ARE_Dim3),
@@ -615,7 +615,7 @@ DPCT_ENUM_OPTION(
                                int(ExplicitNamespace::EN_SYCLCompat),
                                "Generate code with syclcompat:: namespace.",
                                false)),
-    llvm::cl::desc("Defines the namespaces to use explicitly in generated "
+    llvm::cl::desc("Define the namespaces to use explicitly in generated "
                    "code. The <value> is a comma\n"
                    "separated list. Default: dpct/syclcompat, sycl.\n"
                    "Possible values are:"),
@@ -805,7 +805,7 @@ DPCT_FLAG_OPTION(GenBuildScript, clang::dpct::DpctOptionClass::OC_Attribute,
                  DPCT_OPTION_ACTIONS(clang::dpct::DpctActionKind::DAK_Migration,
                                      clang::dpct::DpctActionKind::DAK_Analysis),
                  "gen-build-script",
-                 llvm::cl::desc("Generates makefile for migrated file(s) "
+                 llvm::cl::desc("Generate makefile for migrated file(s) "
                                 "in -out-root directory. Default: off."),
                  llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTBuildScriptCat))
 
@@ -814,7 +814,7 @@ DPCT_PATH_OPTION(
     DPCT_OPTION_ACTIONS(clang::dpct::DpctActionKind::DAK_Migration),
     "build-script-file",
     llvm::cl::desc(
-        "Specifies the name of generated makefile for migrated file(s).\n"
+        "Specify the name of generated makefile for migrated file(s).\n"
         "Default name: Makefile.dpct."),
     llvm::cl::value_desc("file"), llvm::cl::cat(DPCTBuildScriptCat),
     llvm::cl::Optional)
@@ -833,7 +833,7 @@ DPCT_OPTION(
                         clang::dpct::DpctActionKind::DAK_Migration,
                         clang::dpct::DpctActionKind::DAK_Analysis),
     "in-root-exclude",
-    llvm::cl::desc("Excludes the specified directory or file from processing."),
+    llvm::cl::desc("Exclude the specified directory or file from processing."),
     llvm::cl::value_desc("dir|file"), llvm::cl::cat(DPCTBasicCat),
     llvm::cl::ZeroOrMore)
 
@@ -842,7 +842,7 @@ DPCT_FLAG_OPTION(
     DPCT_OPTION_ACTIONS(clang::dpct::DpctActionKind::DAK_Analysis,
                         clang::dpct::DpctActionKind::DAK_Migration),
     "optimize-migration",
-    llvm::cl::desc("Generates SYCL code applying more aggressive assumptions "
+    llvm::cl::desc("Generate SYCL code applying more aggressive assumptions "
                    "that potentially\n"
                    "may alter the semantics of your program. Default: off."),
     llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTCodeGenCat))
@@ -852,7 +852,7 @@ DPCT_FLAG_OPTION(
     DPCT_OPTION_ACTIONS(clang::dpct::DpctActionKind::DAK_Analysis,
                         clang::dpct::DpctActionKind::DAK_Migration),
     "no-incremental-migration",
-    llvm::cl::desc("Tells the tool to not perform an incremental migration.\n"
+    llvm::cl::desc("Tell the tool to not perform an incremental migration.\n"
                    "Default: off (incremental migration happens)."))
 
 DPCT_PATH_OPTION(
@@ -888,7 +888,7 @@ DPCT_ENUM_OPTION(
                                false),
         DPCT_OPTION_ENUM_VALUE("cpp", int(SYCLFileExtensionEnum::CPP),
                                "Use extension '.cpp' and '.hpp'.", false)),
-    llvm::cl::desc("Specifies the extension of migrated source file(s).\nThe "
+    llvm::cl::desc("Specify the extension of migrated source file(s).\nThe "
                    "values are:\n"),
     llvm::cl::init(SYCLFileExtensionEnum::DP_CPP),
     llvm::cl::value_desc("value"), llvm::cl::Optional)
@@ -973,7 +973,7 @@ DPCT_PATH_OPTION(
     DPCT_OPTION_ACTIONS(clang::dpct::DpctActionKind::DAK_Analysis),
     "analysis-mode-output-file",
     llvm::cl::desc(
-        "Specifies the file where the analysis mode report is saved. Default: "
+        "Specify the file where the analysis mode report is saved. Default: "
         "Output to stdout."),
     llvm::cl::value_desc("file"), llvm::cl::cat(DPCTBasicCat))
 

--- a/clang/tools/scan-build-py/lib/libscanbuild/arguments.py
+++ b/clang/tools/scan-build-py/lib/libscanbuild/arguments.py
@@ -509,14 +509,14 @@ def parser_build_log(parser):
     parser.add_argument(
         "--parse-build-log",
         metavar="<file>",
-        help="""Specifies the file path of the build log.""")
+        help="""Specify the file path of the build log.""")
 
 def parser_work_directory(parser):
     parser.add_argument(
         "--work-directory",
         metavar="<path>",
         default=argparse.SUPPRESS,
-        help="""Specifies the working directory of the command that generates the build log specified by option --parse-build-log.
+        help="""Specify the working directory of the command that generates the build log specified by option --parse-build-log.
                  (default: the directory of build log file specified by option --parse-build-log)""")
 
 def parser_add_linker_entry(parser):

--- a/docs/_include_files/options_def.rst
+++ b/docs/_include_files/options_def.rst
@@ -35,7 +35,7 @@ to be migrated. Default: the value of ``--in-root``.
 
 .. _desc-assume-nd-range-dim:
 
-Provides a hint to the tool on the dimensionality of nd_range to use in
+Provide a hint to the tool on the dimensionality of nd_range to use in
 generated code. The values are:
 
 - ``=1``: Generate kernel code assuming 1D ``nd_range`` where possible, and 3D
@@ -52,7 +52,7 @@ generated code. The values are:
 
 .. _desc-build-script-file:
 
-Specifies the name of generated makefile for migrated file(s). Default name:
+Specify the name of generated makefile for migrated file(s). Default name:
 ``Makefile.dpct``.
 
 .. _end-build-script-file:
@@ -159,12 +159,12 @@ arguments for the migration command.
 
 .. _desc-format-range:
 
-Sets the range of formatting.
+Set the range of formatting.
 
 The values are:
 
-- ``=all``: Formats all code.
-- ``=migrated``: Only formats the migrated code (default).
+- ``=all``: Format all code.
+- ``=migrated``: Only format the migrated code (default).
 - ``=none``: Do not format any code.
 
 .. _end-format-range:
@@ -177,7 +177,7 @@ The values are:
 
 .. _desc-format-style:
 
-Sets the formatting style.
+Set the formatting style.
 
 The values are:
 
@@ -205,7 +205,7 @@ Example for the .clang-format file content:
 
 .. _desc-gen-build-script:
 
-Generates makefile for migrated file(s) in ``-out-root`` directory.
+Generate makefile for migrated file(s) in ``-out-root`` directory.
 Default: ``off``.
 
 .. _end-gen-build-script:
@@ -313,7 +313,7 @@ Details:
 
 .. _desc-in-root-exclude:
 
-Excludes the specified directory or file from processing.
+Exclude the specified directory or file from processing.
 
 .. _end-in-root-exclude:
 
@@ -325,7 +325,7 @@ Excludes the specified directory or file from processing.
 
 .. _desc-keep-original-code:
 
-Keeps the original code in the comments of generated SYCL files. Default: ``off``.
+Keep the original code in the comments of generated SYCL files. Default: ``off``.
 
 .. _end-keep-original-code:
 
@@ -374,7 +374,7 @@ Do not use a Don't Repeat Yourself (DRY) pattern when functions from the
 
 .. _desc-no-incremental-migration:
 
-Tells the tool to not perform an incremental migration. Default: ``off``
+Tell the tool to not perform an incremental migration. Default: ``off``
 (incremental migration happens).
 
 .. _end-no-incremental-migration:
@@ -387,7 +387,7 @@ Tells the tool to not perform an incremental migration. Default: ``off``
 
 .. _desc-optimize-migration:
 
-Generates SYCL code applying more aggressive assumptions that
+Generate SYCL code applying more aggressive assumptions that
 potentially may alter the semantics of your program. Default: ``off``.
 
 .. _end-optimize-migration:
@@ -427,7 +427,7 @@ To limit file extension changes to ``.cu`` and ``.cuh`` files only, use the
 
 .. _desc-output-file:
 
-Redirects the ``stdout``/``stderr`` output to ``<file>`` in the
+Redirect the ``stdout``/``stderr`` output to ``<file>`` in the
 output directory specified by the ``--out-root`` option.
 
 .. _end-output-file:
@@ -440,7 +440,7 @@ output directory specified by the ``--out-root`` option.
 
 .. _desc-output-verbosity:
 
-Sets the output verbosity level:
+Set the output verbosity level:
 
 - ``=detailed``: 'normal' and messages about which file is being processed.
 - ``=diagnostics``: 'detailed' and information about the detected conflicts
@@ -472,7 +472,7 @@ Alias for ``--compilation-database``.
 
 .. _desc-process-all:
 
-Migrates or copies all files, except hidden, from the ``--in-root``
+Migrate or copy all files, except hidden, from the ``--in-root``
 directory to the ``--out-root`` directory. The ``--in-root`` option should
 be explicitly specified. Default: ``off``.
 
@@ -566,7 +566,7 @@ Generate migration reports only. No SYCL code will be generated. Default: ``off`
 
 .. _desc-report-type:
 
-Specifies the type of migration report. Values are:
+Specify the type of migration report. Values are:
 
 - ``=all``: All of the migration reports.
 - ``=apis``: Information about API signatures that need migration and the
@@ -587,7 +587,7 @@ Specifies the type of migration report. Values are:
 
 .. _desc-rule-file:
 
-Specifies the rule file path that contains rules used for migration.
+Specify the rule file path that contains rules used for migration.
 
 .. _end-rule-file:
 
@@ -625,7 +625,7 @@ example: ``-suppress-warnings=1000-1010,1011``.
 
 .. _desc-suppress-warnings-all:
 
-Suppresses all migration warnings. Default: ``off``.
+Suppress all migration warnings. Default: ``off``.
 
 .. _end-suppress-warnings-all:
 
@@ -637,7 +637,7 @@ Suppresses all migration warnings. Default: ``off``.
 
 .. _desc-sycl-named-lambda:
 
-Generates kernels with the kernel name. Default: ``off``.
+Generate kernels with the kernel name. Default: ``off``.
 
 .. _end-sycl-named-lambda:
 
@@ -709,7 +709,7 @@ The values are:
 
 .. _desc-use-explicit-namespace:
 
-Defines the namespaces to use explicitly in generated code. The value is
+Define the namespaces to use explicitly in generated code. The value is
 a comma-separated list. Default: ``dpct, sycl``.
 
 Possible values are:
@@ -731,7 +731,7 @@ Possible values are:
 
 .. _desc-usm-level:
 
-Sets the Unified Shared Memory (USM) level to use in source code generation:
+Set the Unified Shared Memory (USM) level to use in source code generation:
 
 - ``=none``: Uses helper functions from |tool_name| header files
   for memory management migration.
@@ -759,7 +759,7 @@ used to guide the migration.
 
 .. _desc-version:
 
-Shows the version of the tool.
+Show the version of the tool.
 
 .. _end-version:
 
@@ -789,7 +789,7 @@ Same as -p.
 
 .. _desc-gen-helper-func:
 
-Generates helper function files in the ``--out-root`` directory. Default: ``off``.
+Generate helper function files in the ``--out-root`` directory. Default: ``off``.
 
 .. _end-gen-helper-func:
 
@@ -811,7 +811,7 @@ Only generate a report for porting effort. Default: ``off``.
 
 .. _desc-analysis-mode-output-file:
 
-Specifies the file where the analysis mode report is saved. Default: Output to ``stdout``.
+Specify the file where the analysis mode report is saved. Default: Output to ``stdout``.
 
 .. _end-analysis-mode-output-file:
 
@@ -878,7 +878,7 @@ EXPERIMENTAL: Only migrate the build script(s). Default: ``off``.
 
 .. _desc-sycl-file-extension:
 
-Specifies the extension of migrated source file(s).
+Specify the extension of migrated source file(s).
 The values are:
 
 - ``=dp-cpp``: Use extension '.dp.cpp' and '.dp.hpp' (default).
@@ -918,12 +918,12 @@ The following table lists `intercept-build` tool command line options.
      - Do not generate linker entry in compilation database if the `--no-linker-entry`
        option is present. Default: disabled.
    * - `--parse-build-log <file>`
-     - Specifies the file path of the build log.
+     - Specify the file path of the build log.
    * - `--verbose`, `-v`
      - Enable verbose output from `intercept-build`. A second, third, and fourth
        flag increases verbosity.
    * - `--work-directory <path>`
-     - Specifies the working directory of the command that generates the build log
+     - Specify the working directory of the command that generates the build log
        specified by option `-parse-build-log`. Default: the directory of build log
        file specified by option `-parse-build-log`.
 

--- a/docs/_include_files/options_def.rst
+++ b/docs/_include_files/options_def.rst
@@ -35,7 +35,7 @@ to be migrated. Default: the value of ``--in-root``.
 
 .. _desc-assume-nd-range-dim:
 
-Provide a hint to the tool on the dimensionality of nd_range to use in
+Provides a hint to the tool on the dimensionality of nd_range to use in
 generated code. The values are:
 
 - ``=1``: Generate kernel code assuming 1D ``nd_range`` where possible, and 3D
@@ -52,7 +52,7 @@ generated code. The values are:
 
 .. _desc-build-script-file:
 
-Specify the name of generated makefile for migrated file(s). Default name:
+Specifies the name of generated makefile for migrated file(s). Default name:
 ``Makefile.dpct``.
 
 .. _end-build-script-file:
@@ -159,12 +159,12 @@ arguments for the migration command.
 
 .. _desc-format-range:
 
-Set the range of formatting.
+Sets the range of formatting.
 
 The values are:
 
-- ``=all``: Format all code.
-- ``=migrated``: Only format the migrated code (default).
+- ``=all``: Formats all code.
+- ``=migrated``: Only formats the migrated code (default).
 - ``=none``: Do not format any code.
 
 .. _end-format-range:
@@ -177,7 +177,7 @@ The values are:
 
 .. _desc-format-style:
 
-Set the formatting style.
+Sets the formatting style.
 
 The values are:
 
@@ -205,7 +205,7 @@ Example for the .clang-format file content:
 
 .. _desc-gen-build-script:
 
-Generate makefile for migrated file(s) in ``-out-root`` directory.
+Generates makefile for migrated file(s) in ``-out-root`` directory.
 Default: ``off``.
 
 .. _end-gen-build-script:
@@ -313,7 +313,7 @@ Details:
 
 .. _desc-in-root-exclude:
 
-Exclude the specified directory or file from processing.
+Excludes the specified directory or file from processing.
 
 .. _end-in-root-exclude:
 
@@ -325,7 +325,7 @@ Exclude the specified directory or file from processing.
 
 .. _desc-keep-original-code:
 
-Keep the original code in the comments of generated SYCL files. Default: ``off``.
+Keeps the original code in the comments of generated SYCL files. Default: ``off``.
 
 .. _end-keep-original-code:
 
@@ -374,7 +374,7 @@ Do not use a Don't Repeat Yourself (DRY) pattern when functions from the
 
 .. _desc-no-incremental-migration:
 
-Tell the tool to not perform an incremental migration. Default: ``off``
+Tells the tool to not perform an incremental migration. Default: ``off``
 (incremental migration happens).
 
 .. _end-no-incremental-migration:
@@ -387,7 +387,7 @@ Tell the tool to not perform an incremental migration. Default: ``off``
 
 .. _desc-optimize-migration:
 
-Generate SYCL code applying more aggressive assumptions that
+Generates SYCL code applying more aggressive assumptions that
 potentially may alter the semantics of your program. Default: ``off``.
 
 .. _end-optimize-migration:
@@ -427,7 +427,7 @@ To limit file extension changes to ``.cu`` and ``.cuh`` files only, use the
 
 .. _desc-output-file:
 
-Redirect the ``stdout``/``stderr`` output to ``<file>`` in the
+Redirects the ``stdout``/``stderr`` output to ``<file>`` in the
 output directory specified by the ``--out-root`` option.
 
 .. _end-output-file:
@@ -440,7 +440,7 @@ output directory specified by the ``--out-root`` option.
 
 .. _desc-output-verbosity:
 
-Set the output verbosity level:
+Sets the output verbosity level:
 
 - ``=detailed``: 'normal' and messages about which file is being processed.
 - ``=diagnostics``: 'detailed' and information about the detected conflicts
@@ -472,7 +472,7 @@ Alias for ``--compilation-database``.
 
 .. _desc-process-all:
 
-Migrate or copy all files, except hidden, from the ``--in-root``
+Migrates or copies all files, except hidden, from the ``--in-root``
 directory to the ``--out-root`` directory. The ``--in-root`` option should
 be explicitly specified. Default: ``off``.
 
@@ -566,7 +566,7 @@ Generate migration reports only. No SYCL code will be generated. Default: ``off`
 
 .. _desc-report-type:
 
-Specify the type of migration report. Values are:
+Specifies the type of migration report. Values are:
 
 - ``=all``: All of the migration reports.
 - ``=apis``: Information about API signatures that need migration and the
@@ -587,7 +587,7 @@ Specify the type of migration report. Values are:
 
 .. _desc-rule-file:
 
-Specify the rule file path that contains rules used for migration.
+Specifies the rule file path that contains rules used for migration.
 
 .. _end-rule-file:
 
@@ -625,7 +625,7 @@ example: ``-suppress-warnings=1000-1010,1011``.
 
 .. _desc-suppress-warnings-all:
 
-Suppress all migration warnings. Default: ``off``.
+Suppresses all migration warnings. Default: ``off``.
 
 .. _end-suppress-warnings-all:
 
@@ -637,7 +637,7 @@ Suppress all migration warnings. Default: ``off``.
 
 .. _desc-sycl-named-lambda:
 
-Generate kernels with the kernel name. Default: ``off``.
+Generates kernels with the kernel name. Default: ``off``.
 
 .. _end-sycl-named-lambda:
 
@@ -709,7 +709,7 @@ The values are:
 
 .. _desc-use-explicit-namespace:
 
-Define the namespaces to use explicitly in generated code. The value is
+Defines the namespaces to use explicitly in generated code. The value is
 a comma-separated list. Default: ``dpct, sycl``.
 
 Possible values are:
@@ -731,7 +731,7 @@ Possible values are:
 
 .. _desc-usm-level:
 
-Set the Unified Shared Memory (USM) level to use in source code generation:
+Sets the Unified Shared Memory (USM) level to use in source code generation:
 
 - ``=none``: Uses helper functions from |tool_name| header files
   for memory management migration.
@@ -759,7 +759,7 @@ used to guide the migration.
 
 .. _desc-version:
 
-Show the version of the tool.
+Shows the version of the tool.
 
 .. _end-version:
 
@@ -789,7 +789,7 @@ Same as -p.
 
 .. _desc-gen-helper-func:
 
-Generate helper function files in the ``--out-root`` directory. Default: ``off``.
+Generates helper function files in the ``--out-root`` directory. Default: ``off``.
 
 .. _end-gen-helper-func:
 
@@ -811,7 +811,7 @@ Only generate a report for porting effort. Default: ``off``.
 
 .. _desc-analysis-mode-output-file:
 
-Specify the file where the analysis mode report is saved. Default: Output to ``stdout``.
+Specifies the file where the analysis mode report is saved. Default: Output to ``stdout``.
 
 .. _end-analysis-mode-output-file:
 
@@ -878,7 +878,7 @@ EXPERIMENTAL: Only migrate the build script(s). Default: ``off``.
 
 .. _desc-sycl-file-extension:
 
-Specify the extension of migrated source file(s).
+Specifies the extension of migrated source file(s).
 The values are:
 
 - ``=dp-cpp``: Use extension '.dp.cpp' and '.dp.hpp' (default).
@@ -918,12 +918,12 @@ The following table lists `intercept-build` tool command line options.
      - Do not generate linker entry in compilation database if the `--no-linker-entry`
        option is present. Default: disabled.
    * - `--parse-build-log <file>`
-     - Specify the file path of the build log.
+     - Specifies the file path of the build log.
    * - `--verbose`, `-v`
      - Enable verbose output from `intercept-build`. A second, third, and fourth
        flag increases verbosity.
    * - `--work-directory <path>`
-     - Specify the working directory of the command that generates the build log
+     - Specifies the working directory of the command that generates the build log
        specified by option `-parse-build-log`. Default: the directory of build log
        file specified by option `-parse-build-log`.
 

--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -2858,7 +2858,7 @@ struct CommandLineCommonOptions {
 #ifdef SYCLomatic_CUSTOMIZATION
   cl::opt<VersionPrinter, true, parser<bool>> VersOp{
       "version",
-      cl::desc("Shows the version of the tool."),
+      cl::desc("Show the version of the tool."),
       cl::location(VersionPrinterInstance),
       cl::ValueDisallowed,
       cl::cat(cl::getDPCTCategory()),


### PR DESCRIPTION
Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>