### PR TITLE
[SYCLomatic] Disable 22 math APIs migration with -use-syclcompat.

### DIFF
--- a/clang/lib/DPCT/Rewriters/Math/RewriterHalf2ArithmeticFunctions.cpp
+++ b/clang/lib/DPCT/Rewriters/Math/RewriterHalf2ArithmeticFunctions.cpp
@@ -119,11 +119,17 @@ RewriterMap dpct::createHalf2ArithmeticFunctionsRewriterMap() {
                                MapNames::getClNamespace() + "half2>",
                            BO(BinaryOperatorKind::BO_Add, ARG(0), ARG(1)),
                            LITERAL("{0.f, 0.f}"), LITERAL("{1.f, 1.f}"))),
-                  CALL_FACTORY_ENTRY(
-                      "__hadd2_sat",
-                      CALL(MapNames::getDpctNamespace() + "clamp",
-                           BO(BinaryOperatorKind::BO_Add, ARG(0), ARG(1)),
-                           LITERAL("{0.f, 0.f}"), LITERAL("{1.f, 1.f}"))))))
+                  CONDITIONAL_FACTORY_ENTRY(
+                      UseSYCLCompat,
+                      UNSUPPORT_FACTORY_ENTRY("__hadd2_sat",
+                                              Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                              LITERAL("__hadd2_sat")),
+                      CALL_FACTORY_ENTRY(
+                          "__hadd2_sat",
+                          CALL(MapNames::getDpctNamespace() + "clamp",
+                               BO(BinaryOperatorKind::BO_Add, ARG(0), ARG(1)),
+                               LITERAL("{0.f, 0.f}"),
+                               LITERAL("{1.f, 1.f}")))))))
       // __hcmadd
       MATH_API_REWRITER_DEVICE(
           "__hcmadd",
@@ -138,12 +144,17 @@ RewriterMap dpct::createHalf2ArithmeticFunctionsRewriterMap() {
                                                   "ext::intel::math::hcmadd",
                                               ARG(0), ARG(1), ARG(2))))),
               EMPTY_FACTORY_ENTRY("__hcmadd"),
-              CALL_FACTORY_ENTRY("__hcmadd",
-                                 CALL(MapNames::getDpctNamespace() +
-                                          (DpctGlobalInfo::useSYCLCompat()
-                                               ? "cmul_add"
-                                               : "complex_mul_add"),
-                                      ARG(0), ARG(1), ARG(2)))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__hcmadd",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__hcmadd")),
+                  CALL_FACTORY_ENTRY("__hcmadd",
+                                     CALL(MapNames::getDpctNamespace() +
+                                              (DpctGlobalInfo::useSYCLCompat()
+                                                   ? "cmul_add"
+                                                   : "complex_mul_add"),
+                                          ARG(0), ARG(1), ARG(2))))))
       // __hfma2
       MATH_API_REWRITER_DEVICE_OVERLOAD(
           CheckArgType(0, "__half2"),
@@ -232,15 +243,20 @@ RewriterMap dpct::createHalf2ArithmeticFunctionsRewriterMap() {
                                 "ext::oneapi::experimental::fma",
                             ARG(0), ARG(1), ARG(2)),
                        LITERAL("{0.f, 0.f}"), LITERAL("{1.f, 1.f}"))),
-              CALL_FACTORY_ENTRY("__hfma2_sat",
-                                 CALL(MapNames::getDpctNamespace() + "clamp",
-                                      BO(BinaryOperatorKind::BO_Add,
-                                         BO(BinaryOperatorKind::BO_Mul,
-                                            makeCallArgCreatorWithCall(0),
-                                            makeCallArgCreatorWithCall(1)),
-                                         makeCallArgCreatorWithCall(2)),
-                                      LITERAL("{0.f, 0.f}"),
-                                      LITERAL("{1.f, 1.f}")))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__hfma2_sat",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__hfma2_sat")),
+                  CALL_FACTORY_ENTRY(
+                      "__hfma2_sat",
+                      CALL(MapNames::getDpctNamespace() + "clamp",
+                           BO(BinaryOperatorKind::BO_Add,
+                              BO(BinaryOperatorKind::BO_Mul,
+                                 makeCallArgCreatorWithCall(0),
+                                 makeCallArgCreatorWithCall(1)),
+                              makeCallArgCreatorWithCall(2)),
+                           LITERAL("{0.f, 0.f}"), LITERAL("{1.f, 1.f}"))))))
       // __hmul2
       MATH_API_REWRITER_DEVICE(
           "__hmul2",
@@ -296,11 +312,17 @@ RewriterMap dpct::createHalf2ArithmeticFunctionsRewriterMap() {
                                MapNames::getClNamespace() + "half2>",
                            BO(BinaryOperatorKind::BO_Mul, ARG(0), ARG(1)),
                            LITERAL("{0.f, 0.f}"), LITERAL("{1.f, 1.f}"))),
-                  CALL_FACTORY_ENTRY(
-                      "__hmul2_sat",
-                      CALL(MapNames::getDpctNamespace() + "clamp",
-                           BO(BinaryOperatorKind::BO_Mul, ARG(0), ARG(1)),
-                           LITERAL("{0.f, 0.f}"), LITERAL("{1.f, 1.f}"))))))
+                  CONDITIONAL_FACTORY_ENTRY(
+                      UseSYCLCompat,
+                      UNSUPPORT_FACTORY_ENTRY("__hmul2_sat",
+                                              Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                              LITERAL("__hmul2_sat")),
+                      CALL_FACTORY_ENTRY(
+                          "__hmul2_sat",
+                          CALL(MapNames::getDpctNamespace() + "clamp",
+                               BO(BinaryOperatorKind::BO_Mul, ARG(0), ARG(1)),
+                               LITERAL("{0.f, 0.f}"),
+                               LITERAL("{1.f, 1.f}")))))))
       // __hneg2
       MATH_API_REWRITER_DEVICE(
           "__hneg2",
@@ -372,11 +394,17 @@ RewriterMap dpct::createHalf2ArithmeticFunctionsRewriterMap() {
                                MapNames::getClNamespace() + "half2>",
                            BO(BinaryOperatorKind::BO_Sub, ARG(0), ARG(1)),
                            LITERAL("{0.f, 0.f}"), LITERAL("{1.f, 1.f}"))),
-                  CALL_FACTORY_ENTRY(
-                      "__hsub2_sat",
-                      CALL(MapNames::getDpctNamespace() + "clamp",
-                           BO(BinaryOperatorKind::BO_Sub, ARG(0), ARG(1)),
-                           LITERAL("{0.f, 0.f}"), LITERAL("{1.f, 1.f}"))))))
+                  CONDITIONAL_FACTORY_ENTRY(
+                      UseSYCLCompat,
+                      UNSUPPORT_FACTORY_ENTRY("__hsub2_sat",
+                                              Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                              LITERAL("__hsub2_sat")),
+                      CALL_FACTORY_ENTRY(
+                          "__hsub2_sat",
+                          CALL(MapNames::getDpctNamespace() + "clamp",
+                               BO(BinaryOperatorKind::BO_Sub, ARG(0), ARG(1)),
+                               LITERAL("{0.f, 0.f}"),
+                               LITERAL("{1.f, 1.f}")))))))
       // h2div
       MATH_API_REWRITER_DEVICE(
           "h2div",

--- a/clang/lib/DPCT/Rewriters/Math/RewriterHalf2ComparisonFunctions.cpp
+++ b/clang/lib/DPCT/Rewriters/Math/RewriterHalf2ComparisonFunctions.cpp
@@ -286,10 +286,15 @@ RewriterMap dpct::createHalf2ComparisonFunctionsRewriterMap() {
               EMPTY_FACTORY_ENTRY("__heq2_mask"),
               EMPTY_FACTORY_ENTRY("__heq2_mask"),
               EMPTY_FACTORY_ENTRY("__heq2_mask"),
-              CALL_FACTORY_ENTRY(
-                  "__heq2_mask",
-                  CALL(MapNames::getDpctNamespace() + "compare_mask", ARG(0),
-                       ARG(1), LITERAL("std::equal_to<>()")))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__heq2_mask",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__heq2_mask")),
+                  CALL_FACTORY_ENTRY(
+                      "__heq2_mask",
+                      CALL(MapNames::getDpctNamespace() + "compare_mask",
+                           ARG(0), ARG(1), LITERAL("std::equal_to<>()"))))))
       // __hequ2
       MATH_API_REWRITER_DEVICE(
           "__hequ2",
@@ -317,10 +322,16 @@ RewriterMap dpct::createHalf2ComparisonFunctionsRewriterMap() {
               EMPTY_FACTORY_ENTRY("__hequ2_mask"),
               EMPTY_FACTORY_ENTRY("__hequ2_mask"),
               EMPTY_FACTORY_ENTRY("__hequ2_mask"),
-              CALL_FACTORY_ENTRY(
-                  "__hequ2_mask",
-                  CALL(MapNames::getDpctNamespace() + "unordered_compare_mask",
-                       ARG(0), ARG(1), LITERAL("std::equal_to<>()")))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__hequ2_mask",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__hequ2_mask")),
+                  CALL_FACTORY_ENTRY("__hequ2_mask",
+                                     CALL(MapNames::getDpctNamespace() +
+                                              "unordered_compare_mask",
+                                          ARG(0), ARG(1),
+                                          LITERAL("std::equal_to<>()"))))))
       // __hge2
       MATH_API_REWRITER_DEVICE(
           "__hge2",
@@ -348,10 +359,16 @@ RewriterMap dpct::createHalf2ComparisonFunctionsRewriterMap() {
               EMPTY_FACTORY_ENTRY("__hge2_mask"),
               EMPTY_FACTORY_ENTRY("__hge2_mask"),
               EMPTY_FACTORY_ENTRY("__hge2_mask"),
-              CALL_FACTORY_ENTRY(
-                  "__hge2_mask",
-                  CALL(MapNames::getDpctNamespace() + "compare_mask", ARG(0),
-                       ARG(1), LITERAL("std::greater_equal<>()")))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__hge2_mask",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__hge2_mask")),
+                  CALL_FACTORY_ENTRY(
+                      "__hge2_mask",
+                      CALL(MapNames::getDpctNamespace() + "compare_mask",
+                           ARG(0), ARG(1),
+                           LITERAL("std::greater_equal<>()"))))))
       // __hgeu2
       MATH_API_REWRITER_DEVICE(
           "__hgeu2",
@@ -380,10 +397,16 @@ RewriterMap dpct::createHalf2ComparisonFunctionsRewriterMap() {
               EMPTY_FACTORY_ENTRY("__hgeu2_mask"),
               EMPTY_FACTORY_ENTRY("__hgeu2_mask"),
               EMPTY_FACTORY_ENTRY("__hgeu2_mask"),
-              CALL_FACTORY_ENTRY(
-                  "__hgeu2_mask",
-                  CALL(MapNames::getDpctNamespace() + "unordered_compare_mask",
-                       ARG(0), ARG(1), LITERAL("std::greater_equal<>()")))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__hgeu2_mask",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__hgeu2_mask")),
+                  CALL_FACTORY_ENTRY("__hgeu2_mask",
+                                     CALL(MapNames::getDpctNamespace() +
+                                              "unordered_compare_mask",
+                                          ARG(0), ARG(1),
+                                          LITERAL("std::greater_equal<>()"))))))
       // __hgt2
       MATH_API_REWRITER_DEVICE(
           "__hgt2",
@@ -411,10 +434,15 @@ RewriterMap dpct::createHalf2ComparisonFunctionsRewriterMap() {
               EMPTY_FACTORY_ENTRY("__hgt2_mask"),
               EMPTY_FACTORY_ENTRY("__hgt2_mask"),
               EMPTY_FACTORY_ENTRY("__hgt2_mask"),
-              CALL_FACTORY_ENTRY(
-                  "__hgt2_mask",
-                  CALL(MapNames::getDpctNamespace() + "compare_mask", ARG(0),
-                       ARG(1), LITERAL("std::greater<>()")))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__hgt2_mask",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__hgt2_mask")),
+                  CALL_FACTORY_ENTRY(
+                      "__hgt2_mask",
+                      CALL(MapNames::getDpctNamespace() + "compare_mask",
+                           ARG(0), ARG(1), LITERAL("std::greater<>()"))))))
       // __hgtu2
       MATH_API_REWRITER_DEVICE(
           "__hgtu2",
@@ -442,10 +470,16 @@ RewriterMap dpct::createHalf2ComparisonFunctionsRewriterMap() {
               EMPTY_FACTORY_ENTRY("__hgtu2_mask"),
               EMPTY_FACTORY_ENTRY("__hgtu2_mask"),
               EMPTY_FACTORY_ENTRY("__hgtu2_mask"),
-              CALL_FACTORY_ENTRY(
-                  "__hgtu2_mask",
-                  CALL(MapNames::getDpctNamespace() + "unordered_compare_mask",
-                       ARG(0), ARG(1), LITERAL("std::greater<>()")))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__hgtu2_mask",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__hgtu2_mask")),
+                  CALL_FACTORY_ENTRY("__hgtu2_mask",
+                                     CALL(MapNames::getDpctNamespace() +
+                                              "unordered_compare_mask",
+                                          ARG(0), ARG(1),
+                                          LITERAL("std::greater<>()"))))))
       // __hisnan2
       MATH_API_REWRITER_DEVICE_OVERLOAD(
           CheckArgType(0, "__half2"),
@@ -510,10 +544,15 @@ RewriterMap dpct::createHalf2ComparisonFunctionsRewriterMap() {
               EMPTY_FACTORY_ENTRY("__hle2_mask"),
               EMPTY_FACTORY_ENTRY("__hle2_mask"),
               EMPTY_FACTORY_ENTRY("__hle2_mask"),
-              CALL_FACTORY_ENTRY(
-                  "__hle2_mask",
-                  CALL(MapNames::getDpctNamespace() + "compare_mask", ARG(0),
-                       ARG(1), LITERAL("std::less_equal<>()")))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__hle2_mask",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__hle2_mask")),
+                  CALL_FACTORY_ENTRY(
+                      "__hle2_mask",
+                      CALL(MapNames::getDpctNamespace() + "compare_mask",
+                           ARG(0), ARG(1), LITERAL("std::less_equal<>()"))))))
       // __hleu2
       MATH_API_REWRITER_DEVICE(
           "__hleu2",
@@ -541,10 +580,16 @@ RewriterMap dpct::createHalf2ComparisonFunctionsRewriterMap() {
               EMPTY_FACTORY_ENTRY("__hleu2_mask"),
               EMPTY_FACTORY_ENTRY("__hleu2_mask"),
               EMPTY_FACTORY_ENTRY("__hleu2_mask"),
-              CALL_FACTORY_ENTRY(
-                  "__hleu2_mask",
-                  CALL(MapNames::getDpctNamespace() + "unordered_compare_mask",
-                       ARG(0), ARG(1), LITERAL("std::less_equal<>()")))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__hleu2_mask",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__hleu2_mask")),
+                  CALL_FACTORY_ENTRY("__hleu2_mask",
+                                     CALL(MapNames::getDpctNamespace() +
+                                              "unordered_compare_mask",
+                                          ARG(0), ARG(1),
+                                          LITERAL("std::less_equal<>()"))))))
       // __hlt2
       MATH_API_REWRITER_DEVICE(
           "__hlt2",
@@ -572,10 +617,15 @@ RewriterMap dpct::createHalf2ComparisonFunctionsRewriterMap() {
               EMPTY_FACTORY_ENTRY("__hlt2_mask"),
               EMPTY_FACTORY_ENTRY("__hlt2_mask"),
               EMPTY_FACTORY_ENTRY("__hlt2_mask"),
-              CALL_FACTORY_ENTRY(
-                  "__hlt2_mask",
-                  CALL(MapNames::getDpctNamespace() + "compare_mask", ARG(0),
-                       ARG(1), LITERAL("std::less<>()")))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__hlt2_mask",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__hlt2_mask")),
+                  CALL_FACTORY_ENTRY(
+                      "__hlt2_mask",
+                      CALL(MapNames::getDpctNamespace() + "compare_mask",
+                           ARG(0), ARG(1), LITERAL("std::less<>()"))))))
       // __hltu2
       MATH_API_REWRITER_DEVICE(
           "__hltu2",
@@ -603,10 +653,16 @@ RewriterMap dpct::createHalf2ComparisonFunctionsRewriterMap() {
               EMPTY_FACTORY_ENTRY("__hltu2_mask"),
               EMPTY_FACTORY_ENTRY("__hltu2_mask"),
               EMPTY_FACTORY_ENTRY("__hltu2_mask"),
-              CALL_FACTORY_ENTRY(
-                  "__hltu2_mask",
-                  CALL(MapNames::getDpctNamespace() + "unordered_compare_mask",
-                       ARG(0), ARG(1), LITERAL("std::less<>()")))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__hltu2_mask",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__hltu2_mask")),
+                  CALL_FACTORY_ENTRY("__hltu2_mask",
+                                     CALL(MapNames::getDpctNamespace() +
+                                              "unordered_compare_mask",
+                                          ARG(0), ARG(1),
+                                          LITERAL("std::less<>()"))))))
       // __hmax2
       MATH_API_REWRITER_DEVICE_OVERLOAD(
           CheckArgType(0, "__half2"),
@@ -664,9 +720,15 @@ RewriterMap dpct::createHalf2ComparisonFunctionsRewriterMap() {
                                                   "ext::intel::math::hmax2_nan",
                                               ARG(0), ARG(1))))),
               EMPTY_FACTORY_ENTRY("__hmax2_nan"),
-              CALL_FACTORY_ENTRY("__hmax2_nan",
-                                 CALL(MapNames::getDpctNamespace() + "fmax_nan",
-                                      ARG(0), ARG(1)))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__hmax2_nan",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__hmax2_nan")),
+                  CALL_FACTORY_ENTRY(
+                      "__hmax2_nan",
+                      CALL(MapNames::getDpctNamespace() + "fmax_nan", ARG(0),
+                           ARG(1))))))
       // __hmin2
       MATH_API_REWRITER_DEVICE_OVERLOAD(
           CheckArgType(0, "__half2"),
@@ -724,9 +786,15 @@ RewriterMap dpct::createHalf2ComparisonFunctionsRewriterMap() {
                                                   "ext::intel::math::hmin2_nan",
                                               ARG(0), ARG(1))))),
               EMPTY_FACTORY_ENTRY("__hmin2_nan"),
-              CALL_FACTORY_ENTRY("__hmin2_nan",
-                                 CALL(MapNames::getDpctNamespace() + "fmin_nan",
-                                      ARG(0), ARG(1)))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__hmin2_nan",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__hmin2_nan")),
+                  CALL_FACTORY_ENTRY(
+                      "__hmin2_nan",
+                      CALL(MapNames::getDpctNamespace() + "fmin_nan", ARG(0),
+                           ARG(1))))))
       // __hne2
       MATH_API_REWRITER_DEVICE(
           "__hne2",
@@ -754,10 +822,15 @@ RewriterMap dpct::createHalf2ComparisonFunctionsRewriterMap() {
               EMPTY_FACTORY_ENTRY("__hne2_mask"),
               EMPTY_FACTORY_ENTRY("__hne2_mask"),
               EMPTY_FACTORY_ENTRY("__hne2_mask"),
-              CALL_FACTORY_ENTRY(
-                  "__hne2_mask",
-                  CALL(MapNames::getDpctNamespace() + "compare_mask", ARG(0),
-                       ARG(1), LITERAL("std::not_equal_to<>()")))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__hne2_mask",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__hne2_mask")),
+                  CALL_FACTORY_ENTRY(
+                      "__hne2_mask",
+                      CALL(MapNames::getDpctNamespace() + "compare_mask",
+                           ARG(0), ARG(1), LITERAL("std::not_equal_to<>()"))))))
       // __hneu2
       MATH_API_REWRITER_DEVICE(
           "__hneu2",
@@ -785,8 +858,15 @@ RewriterMap dpct::createHalf2ComparisonFunctionsRewriterMap() {
               EMPTY_FACTORY_ENTRY("__hneu2_mask"),
               EMPTY_FACTORY_ENTRY("__hneu2_mask"),
               EMPTY_FACTORY_ENTRY("__hneu2_mask"),
-              CALL_FACTORY_ENTRY(
-                  "__hneu2_mask",
-                  CALL(MapNames::getDpctNamespace() + "unordered_compare_mask",
-                       ARG(0), ARG(1), LITERAL("std::not_equal_to<>()")))))};
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__hneu2_mask",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__hneu2_mask")),
+                  CALL_FACTORY_ENTRY(
+                      "__hneu2_mask",
+                      CALL(MapNames::getDpctNamespace() +
+                               "unordered_compare_mask",
+                           ARG(0), ARG(1),
+                           LITERAL("std::not_equal_to<>()"))))))};
 }

--- a/clang/lib/DPCT/Rewriters/Math/RewriterHalfArithmeticFunctions.cpp
+++ b/clang/lib/DPCT/Rewriters/Math/RewriterHalfArithmeticFunctions.cpp
@@ -153,12 +153,17 @@ RewriterMap dpct::createHalfArithmeticFunctionsRewriterMap() {
                                 ARG(1), ARG(2)))))),
           MATH_API_REWRITER_EXPERIMENTAL_BFLOAT16(
               "__hfma_relu",
-              CALL_FACTORY_ENTRY(
-                  "__hfma_relu",
-                  CALL(MapNames::getDpctNamespace() + "relu",
-                       CALL(MapNames::getClNamespace(false, true) +
-                                "ext::oneapi::experimental::fma",
-                            ARG(0), ARG(1), ARG(2)))),
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__hfma_relu",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__hfma_relu")),
+                  CALL_FACTORY_ENTRY(
+                      "__hfma_relu",
+                      CALL(MapNames::getDpctNamespace() + "relu",
+                           CALL(MapNames::getClNamespace(false, true) +
+                                    "ext::oneapi::experimental::fma",
+                                ARG(0), ARG(1), ARG(2))))),
               EMPTY_FACTORY_ENTRY("__hfma_relu")))
       // __hfma_sat
       MATH_API_REWRITER_DEVICE_OVERLOAD(

--- a/clang/lib/DPCT/Rewriters/Math/RewriterHalfComparisonFunctions.cpp
+++ b/clang/lib/DPCT/Rewriters/Math/RewriterHalfComparisonFunctions.cpp
@@ -291,9 +291,15 @@ RewriterMap dpct::createHalfComparisonFunctionsRewriterMap() {
                                                   "ext::intel::math::hmax_nan",
                                               ARG(0), ARG(1))))),
               EMPTY_FACTORY_ENTRY("__hmax_nan"),
-              CALL_FACTORY_ENTRY("__hmax_nan",
-                                 CALL(MapNames::getDpctNamespace() + "fmax_nan",
-                                      ARG(0), ARG(1)))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__hmax_nan",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__hmax_nan")),
+                  CALL_FACTORY_ENTRY(
+                      "__hmax_nan",
+                      CALL(MapNames::getDpctNamespace() + "fmax_nan", ARG(0),
+                           ARG(1))))))
       // __hmin
       MATH_API_REWRITER_DEVICE_OVERLOAD(
           CheckArgType(0, "__half"),
@@ -335,9 +341,15 @@ RewriterMap dpct::createHalfComparisonFunctionsRewriterMap() {
                                                   "ext::intel::math::hmin_nan",
                                               ARG(0), ARG(1))))),
               EMPTY_FACTORY_ENTRY("__hmin_nan"),
-              CALL_FACTORY_ENTRY("__hmin_nan",
-                                 CALL(MapNames::getDpctNamespace() + "fmin_nan",
-                                      ARG(0), ARG(1)))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__hmin_nan",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__hmin_nan")),
+                  CALL_FACTORY_ENTRY(
+                      "__hmin_nan",
+                      CALL(MapNames::getDpctNamespace() + "fmin_nan", ARG(0),
+                           ARG(1))))))
       // __hne
       MATH_API_REWRITER_DEVICE(
           "__hne",

--- a/clang/test/dpct/math/cuda-math-syclcompat.cu
+++ b/clang/test/dpct/math/cuda-math-syclcompat.cu
@@ -1,5 +1,5 @@
-// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2
-// UNSUPPORTED: v8.0, v9.0, v9.1, v9.2, v10.0, v10.1, v10.2
+// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.1, cuda-11.2, cuda-11.3, cuda-11.4, cuda-11.5, cuda-11.6, cuda-11.7, cuda-11.8
+// UNSUPPORTED: v8.0, v9.0, v9.1, v9.2, v10.0, v10.1, v10.2, v11.0, v11.1, v11.2, v11.3, v11.4, v11.5, v11.6, v11.7, v11.8
 // RUN: dpct --format-range=none -out-root %T/math/cuda-math-syclcompat %s -use-syclcompat --cuda-include-path="%cuda-path/include" -- -x cuda --cuda-host-only --std=c++14
 // RUN: FileCheck --input-file %T/math/cuda-math-syclcompat/cuda-math-syclcompat.dp.cpp --match-full-lines %s
 // RUN: %if build_lit %{icpx -c -fsycl -DBUILD_TEST %T/math/cuda-math-syclcompat/cuda-math-syclcompat.dp.cpp -o %T/math/cuda-math-syclcompat/cuda-math-syclcompat.dp.o %}
@@ -9,12 +9,101 @@
 
 #ifndef BUILD_TEST
 __global__ void kernelFuncBfloat162Arithmetic() {
+  __nv_bfloat16 bf16, bf16_1, bf16_2, bf16_3;
   __nv_bfloat162 bf162, bf162_1, bf162_2, bf162_3;
-  // CHECK: bf162 = syclcompat::cmul_add(bf162_1, bf162_2, bf162_3);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__hadd2_sat" is not supported with SYCLcompat currently, please adjust the code manually.
+  // CHECK-NEXT: */
+  bf162 = __hadd2_sat(bf162_1, bf162_2);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__hcmadd" is not supported with SYCLcompat currently, please adjust the code manually.
+  // CHECK-NEXT: */
   bf162 = __hcmadd(bf162_1, bf162_2, bf162_3);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__hfma2_sat" is not supported with SYCLcompat currently, please adjust the code manually.
+  // CHECK-NEXT: */
+  bf162 = __hfma2_sat(bf162_1, bf162_2, bf162_3);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__hmul2_sat" is not supported with SYCLcompat currently, please adjust the code manually.
+  // CHECK-NEXT: */
+  bf162 = __hmul2_sat(bf162_1, bf162_2);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__hsub2_sat" is not supported with SYCLcompat currently, please adjust the code manually.
+  // CHECK-NEXT: */
+  bf162 = __hsub2_sat(bf162_1, bf162_2);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__heq2_mask" is not supported with SYCLcompat currently, please adjust the code manually.
+  // CHECK-NEXT: */
+  bf162 = __heq2_mask(bf162_1, bf162_2);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__hequ2_mask" is not supported with SYCLcompat currently, please adjust the code manually.
+  // CHECK-NEXT: */
+  bf162 = __hequ2_mask(bf162_1, bf162_2);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__hge2_mask" is not supported with SYCLcompat currently, please adjust the code manually.
+  // CHECK-NEXT: */
+  bf162 = __hge2_mask(bf162_1, bf162_2);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__hgeu2_mask" is not supported with SYCLcompat currently, please adjust the code manually.
+  // CHECK-NEXT: */
+  bf162 = __hgeu2_mask(bf162_1, bf162_2);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__hgt2_mask" is not supported with SYCLcompat currently, please adjust the code manually.
+  // CHECK-NEXT: */
+  bf162 = __hgt2_mask(bf162_1, bf162_2);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__hgtu2_mask" is not supported with SYCLcompat currently, please adjust the code manually.
+  // CHECK-NEXT: */
+  bf162 = __hgtu2_mask(bf162_1, bf162_2);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__hle2_mask" is not supported with SYCLcompat currently, please adjust the code manually.
+  // CHECK-NEXT: */
+  bf162 = __hle2_mask(bf162_1, bf162_2);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__hleu2_mask" is not supported with SYCLcompat currently, please adjust the code manually.
+  // CHECK-NEXT: */
+  bf162 = __hleu2_mask(bf162_1, bf162_2);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__hlt2_mask" is not supported with SYCLcompat currently, please adjust the code manually.
+  // CHECK-NEXT: */
+  bf162 = __hlt2_mask(bf162_1, bf162_2);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__hltu2_mask" is not supported with SYCLcompat currently, please adjust the code manually.
+  // CHECK-NEXT: */
+  bf162 = __hltu2_mask(bf162_1, bf162_2);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__hmax2_nan" is not supported with SYCLcompat currently, please adjust the code manually.
+  // CHECK-NEXT: */
+  bf162 = __hmax2_nan(bf162_1, bf162_2);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__hmin2_nan" is not supported with SYCLcompat currently, please adjust the code manually.
+  // CHECK-NEXT: */
+  bf162 = __hmin2_nan(bf162_1, bf162_2);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__hne2_mask" is not supported with SYCLcompat currently, please adjust the code manually.
+  // CHECK-NEXT: */
+  bf162 = __hne2_mask(bf162_1, bf162_2);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__hneu2_mask" is not supported with SYCLcompat currently, please adjust the code manually.
+  // CHECK-NEXT: */
+  bf162 = __hneu2_mask(bf162_1, bf162_2);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1007:{{[0-9]+}}: Migration of __hfma_relu is not supported.
+  // CHECK-NEXT: */
+  bf16 = __hfma_relu(bf16_1, bf16_2, bf16_3);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__hmax_nan" is not supported with SYCLcompat currently, please adjust the code manually.
+  // CHECK-NEXT: */
+  bf16 = __hmax_nan(bf16_1, bf16_2);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__hmin_nan" is not supported with SYCLcompat currently, please adjust the code manually.
+  // CHECK-NEXT: */
+  bf16 = __hmin_nan(bf16_1, bf16_2);
 
   __half2 h2, h2_1, h2_2;
-  // CHECK: h2_2 = syclcompat::cmul_add(h2, h2_1, h2_2);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__hcmadd" is not supported with SYCLcompat currently, please adjust the code manually.
+  // CHECK-NEXT: */
   h2_2 = __hcmadd(h2, h2_1, h2_2);
 }
 #endif


### PR DESCRIPTION
Signed-off-by: Tang, Jiajun jiajun.tang@intel.com