### PR TITLE
[SYCLomatic] Disable 21 math APIs migration with -use-syclcompat.

### DIFF
--- a/clang/lib/DPCT/Rewriters/Math/RewriterHalf2ArithmeticFunctions.cpp
+++ b/clang/lib/DPCT/Rewriters/Math/RewriterHalf2ArithmeticFunctions.cpp
@@ -236,13 +236,18 @@ RewriterMap dpct::createHalf2ArithmeticFunctionsRewriterMap() {
                            LITERAL("{0.f, 0.f}"), LITERAL("{1.f, 1.f}"))))),
           MATH_API_REWRITER_EXPERIMENTAL_BFLOAT16(
               "__hfma2_sat",
-              CALL_FACTORY_ENTRY(
-                  "__hfma2_sat",
-                  CALL(MapNames::getDpctNamespace() + "clamp",
-                       CALL(MapNames::getClNamespace(false, true) +
-                                "ext::oneapi::experimental::fma",
-                            ARG(0), ARG(1), ARG(2)),
-                       LITERAL("{0.f, 0.f}"), LITERAL("{1.f, 1.f}"))),
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__hfma2_sat",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__hfma2_sat")),
+                  CALL_FACTORY_ENTRY(
+                      "__hfma2_sat",
+                      CALL(MapNames::getDpctNamespace() + "clamp",
+                           CALL(MapNames::getClNamespace(false, true) +
+                                    "ext::oneapi::experimental::fma",
+                                ARG(0), ARG(1), ARG(2)),
+                           LITERAL("{0.f, 0.f}"), LITERAL("{1.f, 1.f}")))),
               CONDITIONAL_FACTORY_ENTRY(
                   UseSYCLCompat,
                   UNSUPPORT_FACTORY_ENTRY("__hfma2_sat",

--- a/clang/lib/DPCT/Rewriters/Math/RewriterSIMDIntrinsics.cpp
+++ b/clang/lib/DPCT/Rewriters/Math/RewriterSIMDIntrinsics.cpp
@@ -397,13 +397,20 @@ RewriterMap dpct::createSIMDIntrinsicsRewriterMap() {
                                               "ext::intel::math::vcmpeq2",
                                           ARG(0), ARG(1)))),
               EMPTY_FACTORY_ENTRY("__vcmpeq2"),
-              FEATURE_REQUEST_FACTORY(
-                  HelperFeatureEnum::device_ext,
-                  CALL_FACTORY_ENTRY(
-                      "__vcmpeq2",
-                      CALL(MapNames::getDpctNamespace() + "vectorized_binary<" +
-                               MapNames::getClNamespace() + "ushort2>",
-                           ARG(0), ARG(1), LITERAL("std::equal_to<>()"))))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__vcmpeq2",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__vcmpeq2")),
+                  FEATURE_REQUEST_FACTORY(
+                      HelperFeatureEnum::device_ext,
+                      CALL_FACTORY_ENTRY("__vcmpeq2",
+                                         CALL(MapNames::getDpctNamespace() +
+                                                  "vectorized_binary<" +
+                                                  MapNames::getClNamespace() +
+                                                  "ushort2>",
+                                              ARG(0), ARG(1),
+                                              LITERAL("std::equal_to<>()")))))))
       // __vcmpeq4
       MATH_API_REWRITER_DEVICE(
           "__vcmpeq4",
@@ -416,13 +423,20 @@ RewriterMap dpct::createSIMDIntrinsicsRewriterMap() {
                                               "ext::intel::math::vcmpeq4",
                                           ARG(0), ARG(1)))),
               EMPTY_FACTORY_ENTRY("__vcmpeq4"),
-              FEATURE_REQUEST_FACTORY(
-                  HelperFeatureEnum::device_ext,
-                  CALL_FACTORY_ENTRY(
-                      "__vcmpeq4",
-                      CALL(MapNames::getDpctNamespace() + "vectorized_binary<" +
-                               MapNames::getClNamespace() + "uchar4>",
-                           ARG(0), ARG(1), LITERAL("std::equal_to<>()"))))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__vcmpeq4",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__vcmpeq4")),
+                  FEATURE_REQUEST_FACTORY(
+                      HelperFeatureEnum::device_ext,
+                      CALL_FACTORY_ENTRY("__vcmpeq4",
+                                         CALL(MapNames::getDpctNamespace() +
+                                                  "vectorized_binary<" +
+                                                  MapNames::getClNamespace() +
+                                                  "uchar4>",
+                                              ARG(0), ARG(1),
+                                              LITERAL("std::equal_to<>()")))))))
       // __vcmpges2
       MATH_API_REWRITER_DEVICE(
           "__vcmpges2",
@@ -435,14 +449,20 @@ RewriterMap dpct::createSIMDIntrinsicsRewriterMap() {
                                               "ext::intel::math::vcmpges2",
                                           ARG(0), ARG(1)))),
               EMPTY_FACTORY_ENTRY("__vcmpges2"),
-              FEATURE_REQUEST_FACTORY(
-                  HelperFeatureEnum::device_ext,
-                  CALL_FACTORY_ENTRY(
-                      "__vcmpges2",
-                      CALL(MapNames::getDpctNamespace() + "vectorized_binary<" +
-                               MapNames::getClNamespace() + "short2>",
-                           ARG(0), ARG(1),
-                           LITERAL("std::greater_equal<>()"))))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__vcmpges2",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__vcmpges2")),
+                  FEATURE_REQUEST_FACTORY(
+                      HelperFeatureEnum::device_ext,
+                      CALL_FACTORY_ENTRY(
+                          "__vcmpges2",
+                          CALL(MapNames::getDpctNamespace() +
+                                   "vectorized_binary<" +
+                                   MapNames::getClNamespace() + "short2>",
+                               ARG(0), ARG(1),
+                               LITERAL("std::greater_equal<>()")))))))
       // __vcmpges4
       MATH_API_REWRITER_DEVICE(
           "__vcmpges4",
@@ -455,14 +475,20 @@ RewriterMap dpct::createSIMDIntrinsicsRewriterMap() {
                                               "ext::intel::math::vcmpges4",
                                           ARG(0), ARG(1)))),
               EMPTY_FACTORY_ENTRY("__vcmpges4"),
-              FEATURE_REQUEST_FACTORY(
-                  HelperFeatureEnum::device_ext,
-                  CALL_FACTORY_ENTRY(
-                      "__vcmpges4",
-                      CALL(MapNames::getDpctNamespace() + "vectorized_binary<" +
-                               MapNames::getClNamespace() + "char4>",
-                           ARG(0), ARG(1),
-                           LITERAL("std::greater_equal<>()"))))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__vcmpges4",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__vcmpges4")),
+                  FEATURE_REQUEST_FACTORY(
+                      HelperFeatureEnum::device_ext,
+                      CALL_FACTORY_ENTRY(
+                          "__vcmpges4",
+                          CALL(MapNames::getDpctNamespace() +
+                                   "vectorized_binary<" +
+                                   MapNames::getClNamespace() + "char4>",
+                               ARG(0), ARG(1),
+                               LITERAL("std::greater_equal<>()")))))))
       // __vcmpgeu2
       MATH_API_REWRITER_DEVICE(
           "__vcmpgeu2",
@@ -475,14 +501,20 @@ RewriterMap dpct::createSIMDIntrinsicsRewriterMap() {
                                               "ext::intel::math::vcmpgeu2",
                                           ARG(0), ARG(1)))),
               EMPTY_FACTORY_ENTRY("__vcmpgeu2"),
-              FEATURE_REQUEST_FACTORY(
-                  HelperFeatureEnum::device_ext,
-                  CALL_FACTORY_ENTRY(
-                      "__vcmpgeu2",
-                      CALL(MapNames::getDpctNamespace() + "vectorized_binary<" +
-                               MapNames::getClNamespace() + "ushort2>",
-                           ARG(0), ARG(1),
-                           LITERAL("std::greater_equal<>()"))))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__vcmpgeu2",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__vcmpgeu2")),
+                  FEATURE_REQUEST_FACTORY(
+                      HelperFeatureEnum::device_ext,
+                      CALL_FACTORY_ENTRY(
+                          "__vcmpgeu2",
+                          CALL(MapNames::getDpctNamespace() +
+                                   "vectorized_binary<" +
+                                   MapNames::getClNamespace() + "ushort2>",
+                               ARG(0), ARG(1),
+                               LITERAL("std::greater_equal<>()")))))))
       // __vcmpgeu4
       MATH_API_REWRITER_DEVICE(
           "__vcmpgeu4",
@@ -495,14 +527,20 @@ RewriterMap dpct::createSIMDIntrinsicsRewriterMap() {
                                               "ext::intel::math::vcmpgeu4",
                                           ARG(0), ARG(1)))),
               EMPTY_FACTORY_ENTRY("__vcmpgeu4"),
-              FEATURE_REQUEST_FACTORY(
-                  HelperFeatureEnum::device_ext,
-                  CALL_FACTORY_ENTRY(
-                      "__vcmpgeu4",
-                      CALL(MapNames::getDpctNamespace() + "vectorized_binary<" +
-                               MapNames::getClNamespace() + "uchar4>",
-                           ARG(0), ARG(1),
-                           LITERAL("std::greater_equal<>()"))))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__vcmpgeu4",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__vcmpgeu4")),
+                  FEATURE_REQUEST_FACTORY(
+                      HelperFeatureEnum::device_ext,
+                      CALL_FACTORY_ENTRY(
+                          "__vcmpgeu4",
+                          CALL(MapNames::getDpctNamespace() +
+                                   "vectorized_binary<" +
+                                   MapNames::getClNamespace() + "uchar4>",
+                               ARG(0), ARG(1),
+                               LITERAL("std::greater_equal<>()")))))))
       // __vcmpgts2
       MATH_API_REWRITER_DEVICE(
           "__vcmpgts2",
@@ -515,13 +553,19 @@ RewriterMap dpct::createSIMDIntrinsicsRewriterMap() {
                                               "ext::intel::math::vcmpgts2",
                                           ARG(0), ARG(1)))),
               EMPTY_FACTORY_ENTRY("__vcmpgts2"),
-              FEATURE_REQUEST_FACTORY(
-                  HelperFeatureEnum::device_ext,
-                  CALL_FACTORY_ENTRY(
-                      "__vcmpgts2",
-                      CALL(MapNames::getDpctNamespace() + "vectorized_binary<" +
-                               MapNames::getClNamespace() + "short2>",
-                           ARG(0), ARG(1), LITERAL("std::greater<>()"))))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__vcmpgts2",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__vcmpgts2")),
+                  FEATURE_REQUEST_FACTORY(
+                      HelperFeatureEnum::device_ext,
+                      CALL_FACTORY_ENTRY(
+                          "__vcmpgts2",
+                          CALL(MapNames::getDpctNamespace() +
+                                   "vectorized_binary<" +
+                                   MapNames::getClNamespace() + "short2>",
+                               ARG(0), ARG(1), LITERAL("std::greater<>()")))))))
       // __vcmpgts4
       MATH_API_REWRITER_DEVICE(
           "__vcmpgts4",
@@ -534,13 +578,19 @@ RewriterMap dpct::createSIMDIntrinsicsRewriterMap() {
                                               "ext::intel::math::vcmpgts4",
                                           ARG(0), ARG(1)))),
               EMPTY_FACTORY_ENTRY("__vcmpgts4"),
-              FEATURE_REQUEST_FACTORY(
-                  HelperFeatureEnum::device_ext,
-                  CALL_FACTORY_ENTRY(
-                      "__vcmpgts4",
-                      CALL(MapNames::getDpctNamespace() + "vectorized_binary<" +
-                               MapNames::getClNamespace() + "char4>",
-                           ARG(0), ARG(1), LITERAL("std::greater<>()"))))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__vcmpgts4",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__vcmpgts4")),
+                  FEATURE_REQUEST_FACTORY(
+                      HelperFeatureEnum::device_ext,
+                      CALL_FACTORY_ENTRY(
+                          "__vcmpgts4",
+                          CALL(MapNames::getDpctNamespace() +
+                                   "vectorized_binary<" +
+                                   MapNames::getClNamespace() + "char4>",
+                               ARG(0), ARG(1), LITERAL("std::greater<>()")))))))
       // __vcmpgtu2
       MATH_API_REWRITER_DEVICE(
           "__vcmpgtu2",
@@ -553,13 +603,19 @@ RewriterMap dpct::createSIMDIntrinsicsRewriterMap() {
                                               "ext::intel::math::vcmpgtu2",
                                           ARG(0), ARG(1)))),
               EMPTY_FACTORY_ENTRY("__vcmpgtu2"),
-              FEATURE_REQUEST_FACTORY(
-                  HelperFeatureEnum::device_ext,
-                  CALL_FACTORY_ENTRY(
-                      "__vcmpgtu2",
-                      CALL(MapNames::getDpctNamespace() + "vectorized_binary<" +
-                               MapNames::getClNamespace() + "ushort2>",
-                           ARG(0), ARG(1), LITERAL("std::greater<>()"))))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__vcmpgtu2",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__vcmpgtu2")),
+                  FEATURE_REQUEST_FACTORY(
+                      HelperFeatureEnum::device_ext,
+                      CALL_FACTORY_ENTRY(
+                          "__vcmpgtu2",
+                          CALL(MapNames::getDpctNamespace() +
+                                   "vectorized_binary<" +
+                                   MapNames::getClNamespace() + "ushort2>",
+                               ARG(0), ARG(1), LITERAL("std::greater<>()")))))))
       // __vcmpgtu4
       MATH_API_REWRITER_DEVICE(
           "__vcmpgtu4",
@@ -572,13 +628,19 @@ RewriterMap dpct::createSIMDIntrinsicsRewriterMap() {
                                               "ext::intel::math::vcmpgtu4",
                                           ARG(0), ARG(1)))),
               EMPTY_FACTORY_ENTRY("__vcmpgtu4"),
-              FEATURE_REQUEST_FACTORY(
-                  HelperFeatureEnum::device_ext,
-                  CALL_FACTORY_ENTRY(
-                      "__vcmpgtu4",
-                      CALL(MapNames::getDpctNamespace() + "vectorized_binary<" +
-                               MapNames::getClNamespace() + "uchar4>",
-                           ARG(0), ARG(1), LITERAL("std::greater<>()"))))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__vcmpgtu4",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__vcmpgtu4")),
+                  FEATURE_REQUEST_FACTORY(
+                      HelperFeatureEnum::device_ext,
+                      CALL_FACTORY_ENTRY(
+                          "__vcmpgtu4",
+                          CALL(MapNames::getDpctNamespace() +
+                                   "vectorized_binary<" +
+                                   MapNames::getClNamespace() + "uchar4>",
+                               ARG(0), ARG(1), LITERAL("std::greater<>()")))))))
       // __vcmples2
       MATH_API_REWRITER_DEVICE(
           "__vcmples2",
@@ -591,13 +653,20 @@ RewriterMap dpct::createSIMDIntrinsicsRewriterMap() {
                                               "ext::intel::math::vcmples2",
                                           ARG(0), ARG(1)))),
               EMPTY_FACTORY_ENTRY("__vcmples2"),
-              FEATURE_REQUEST_FACTORY(
-                  HelperFeatureEnum::device_ext,
-                  CALL_FACTORY_ENTRY(
-                      "__vcmples2",
-                      CALL(MapNames::getDpctNamespace() + "vectorized_binary<" +
-                               MapNames::getClNamespace() + "short2>",
-                           ARG(0), ARG(1), LITERAL("std::less_equal<>()"))))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__vcmples2",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__vcmples2")),
+                  FEATURE_REQUEST_FACTORY(
+                      HelperFeatureEnum::device_ext,
+                      CALL_FACTORY_ENTRY(
+                          "__vcmples2",
+                          CALL(MapNames::getDpctNamespace() +
+                                   "vectorized_binary<" +
+                                   MapNames::getClNamespace() + "short2>",
+                               ARG(0), ARG(1),
+                               LITERAL("std::less_equal<>()")))))))
       // __vcmples4
       MATH_API_REWRITER_DEVICE(
           "__vcmples4",
@@ -610,13 +679,20 @@ RewriterMap dpct::createSIMDIntrinsicsRewriterMap() {
                                               "ext::intel::math::vcmples4",
                                           ARG(0), ARG(1)))),
               EMPTY_FACTORY_ENTRY("__vcmples4"),
-              FEATURE_REQUEST_FACTORY(
-                  HelperFeatureEnum::device_ext,
-                  CALL_FACTORY_ENTRY(
-                      "__vcmples4",
-                      CALL(MapNames::getDpctNamespace() + "vectorized_binary<" +
-                               MapNames::getClNamespace() + "char4>",
-                           ARG(0), ARG(1), LITERAL("std::less_equal<>()"))))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__vcmples4",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__vcmples4")),
+                  FEATURE_REQUEST_FACTORY(
+                      HelperFeatureEnum::device_ext,
+                      CALL_FACTORY_ENTRY(
+                          "__vcmples4",
+                          CALL(MapNames::getDpctNamespace() +
+                                   "vectorized_binary<" +
+                                   MapNames::getClNamespace() + "char4>",
+                               ARG(0), ARG(1),
+                               LITERAL("std::less_equal<>()")))))))
       // __vcmpleu2
       MATH_API_REWRITER_DEVICE(
           "__vcmpleu2",
@@ -629,13 +705,20 @@ RewriterMap dpct::createSIMDIntrinsicsRewriterMap() {
                                               "ext::intel::math::vcmpleu2",
                                           ARG(0), ARG(1)))),
               EMPTY_FACTORY_ENTRY("__vcmpleu2"),
-              FEATURE_REQUEST_FACTORY(
-                  HelperFeatureEnum::device_ext,
-                  CALL_FACTORY_ENTRY(
-                      "__vcmpleu2",
-                      CALL(MapNames::getDpctNamespace() + "vectorized_binary<" +
-                               MapNames::getClNamespace() + "ushort2>",
-                           ARG(0), ARG(1), LITERAL("std::less_equal<>()"))))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__vcmpleu2",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__vcmpleu2")),
+                  FEATURE_REQUEST_FACTORY(
+                      HelperFeatureEnum::device_ext,
+                      CALL_FACTORY_ENTRY(
+                          "__vcmpleu2",
+                          CALL(MapNames::getDpctNamespace() +
+                                   "vectorized_binary<" +
+                                   MapNames::getClNamespace() + "ushort2>",
+                               ARG(0), ARG(1),
+                               LITERAL("std::less_equal<>()")))))))
       // __vcmpleu4
       MATH_API_REWRITER_DEVICE(
           "__vcmpleu4",
@@ -648,13 +731,20 @@ RewriterMap dpct::createSIMDIntrinsicsRewriterMap() {
                                               "ext::intel::math::vcmpleu4",
                                           ARG(0), ARG(1)))),
               EMPTY_FACTORY_ENTRY("__vcmpleu4"),
-              FEATURE_REQUEST_FACTORY(
-                  HelperFeatureEnum::device_ext,
-                  CALL_FACTORY_ENTRY(
-                      "__vcmpleu4",
-                      CALL(MapNames::getDpctNamespace() + "vectorized_binary<" +
-                               MapNames::getClNamespace() + "uchar4>",
-                           ARG(0), ARG(1), LITERAL("std::less_equal<>()"))))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__vcmpleu4",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__vcmpleu4")),
+                  FEATURE_REQUEST_FACTORY(
+                      HelperFeatureEnum::device_ext,
+                      CALL_FACTORY_ENTRY(
+                          "__vcmpleu4",
+                          CALL(MapNames::getDpctNamespace() +
+                                   "vectorized_binary<" +
+                                   MapNames::getClNamespace() + "uchar4>",
+                               ARG(0), ARG(1),
+                               LITERAL("std::less_equal<>()")))))))
       // __vcmplts2
       MATH_API_REWRITER_DEVICE(
           "__vcmplts2",
@@ -667,13 +757,19 @@ RewriterMap dpct::createSIMDIntrinsicsRewriterMap() {
                                               "ext::intel::math::vcmplts2",
                                           ARG(0), ARG(1)))),
               EMPTY_FACTORY_ENTRY("__vcmplts2"),
-              FEATURE_REQUEST_FACTORY(
-                  HelperFeatureEnum::device_ext,
-                  CALL_FACTORY_ENTRY(
-                      "__vcmplts2",
-                      CALL(MapNames::getDpctNamespace() + "vectorized_binary<" +
-                               MapNames::getClNamespace() + "short2>",
-                           ARG(0), ARG(1), LITERAL("std::less<>()"))))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__vcmplts2",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__vcmplts2")),
+                  FEATURE_REQUEST_FACTORY(
+                      HelperFeatureEnum::device_ext,
+                      CALL_FACTORY_ENTRY(
+                          "__vcmplts2",
+                          CALL(MapNames::getDpctNamespace() +
+                                   "vectorized_binary<" +
+                                   MapNames::getClNamespace() + "short2>",
+                               ARG(0), ARG(1), LITERAL("std::less<>()")))))))
       // __vcmplts4
       MATH_API_REWRITER_DEVICE(
           "__vcmplts4",
@@ -686,13 +782,19 @@ RewriterMap dpct::createSIMDIntrinsicsRewriterMap() {
                                               "ext::intel::math::vcmplts4",
                                           ARG(0), ARG(1)))),
               EMPTY_FACTORY_ENTRY("__vcmplts4"),
-              FEATURE_REQUEST_FACTORY(
-                  HelperFeatureEnum::device_ext,
-                  CALL_FACTORY_ENTRY(
-                      "__vcmplts4",
-                      CALL(MapNames::getDpctNamespace() + "vectorized_binary<" +
-                               MapNames::getClNamespace() + "char4>",
-                           ARG(0), ARG(1), LITERAL("std::less<>()"))))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__vcmplts4",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__vcmplts4")),
+                  FEATURE_REQUEST_FACTORY(
+                      HelperFeatureEnum::device_ext,
+                      CALL_FACTORY_ENTRY(
+                          "__vcmplts4",
+                          CALL(MapNames::getDpctNamespace() +
+                                   "vectorized_binary<" +
+                                   MapNames::getClNamespace() + "char4>",
+                               ARG(0), ARG(1), LITERAL("std::less<>()")))))))
       // __vcmpltu2
       MATH_API_REWRITER_DEVICE(
           "__vcmpltu2",
@@ -705,13 +807,19 @@ RewriterMap dpct::createSIMDIntrinsicsRewriterMap() {
                                               "ext::intel::math::vcmpltu2",
                                           ARG(0), ARG(1)))),
               EMPTY_FACTORY_ENTRY("__vcmpltu2"),
-              FEATURE_REQUEST_FACTORY(
-                  HelperFeatureEnum::device_ext,
-                  CALL_FACTORY_ENTRY(
-                      "__vcmpltu2",
-                      CALL(MapNames::getDpctNamespace() + "vectorized_binary<" +
-                               MapNames::getClNamespace() + "ushort2>",
-                           ARG(0), ARG(1), LITERAL("std::less<>()"))))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__vcmpltu2",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__vcmpltu2")),
+                  FEATURE_REQUEST_FACTORY(
+                      HelperFeatureEnum::device_ext,
+                      CALL_FACTORY_ENTRY(
+                          "__vcmpltu2",
+                          CALL(MapNames::getDpctNamespace() +
+                                   "vectorized_binary<" +
+                                   MapNames::getClNamespace() + "ushort2>",
+                               ARG(0), ARG(1), LITERAL("std::less<>()")))))))
       // __vcmpltu4
       MATH_API_REWRITER_DEVICE(
           "__vcmpltu4",
@@ -724,13 +832,19 @@ RewriterMap dpct::createSIMDIntrinsicsRewriterMap() {
                                               "ext::intel::math::vcmpltu4",
                                           ARG(0), ARG(1)))),
               EMPTY_FACTORY_ENTRY("__vcmpltu4"),
-              FEATURE_REQUEST_FACTORY(
-                  HelperFeatureEnum::device_ext,
-                  CALL_FACTORY_ENTRY(
-                      "__vcmpltu4",
-                      CALL(MapNames::getDpctNamespace() + "vectorized_binary<" +
-                               MapNames::getClNamespace() + "uchar4>",
-                           ARG(0), ARG(1), LITERAL("std::less<>()"))))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__vcmpltu4",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__vcmpltu4")),
+                  FEATURE_REQUEST_FACTORY(
+                      HelperFeatureEnum::device_ext,
+                      CALL_FACTORY_ENTRY(
+                          "__vcmpltu4",
+                          CALL(MapNames::getDpctNamespace() +
+                                   "vectorized_binary<" +
+                                   MapNames::getClNamespace() + "uchar4>",
+                               ARG(0), ARG(1), LITERAL("std::less<>()")))))))
       // __vcmpne2
       MATH_API_REWRITER_DEVICE(
           "__vcmpne2",
@@ -743,13 +857,20 @@ RewriterMap dpct::createSIMDIntrinsicsRewriterMap() {
                                               "ext::intel::math::vcmpne2",
                                           ARG(0), ARG(1)))),
               EMPTY_FACTORY_ENTRY("__vcmpne2"),
-              FEATURE_REQUEST_FACTORY(
-                  HelperFeatureEnum::device_ext,
-                  CALL_FACTORY_ENTRY(
-                      "__vcmpne2",
-                      CALL(MapNames::getDpctNamespace() + "vectorized_binary<" +
-                               MapNames::getClNamespace() + "ushort2>",
-                           ARG(0), ARG(1), LITERAL("std::not_equal_to<>()"))))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__vcmpne2",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__vcmpne2")),
+                  FEATURE_REQUEST_FACTORY(
+                      HelperFeatureEnum::device_ext,
+                      CALL_FACTORY_ENTRY(
+                          "__vcmpne2",
+                          CALL(MapNames::getDpctNamespace() +
+                                   "vectorized_binary<" +
+                                   MapNames::getClNamespace() + "ushort2>",
+                               ARG(0), ARG(1),
+                               LITERAL("std::not_equal_to<>()")))))))
       // __vcmpne4
       MATH_API_REWRITER_DEVICE(
           "__vcmpne4",
@@ -762,13 +883,20 @@ RewriterMap dpct::createSIMDIntrinsicsRewriterMap() {
                                               "ext::intel::math::vcmpne4",
                                           ARG(0), ARG(1)))),
               EMPTY_FACTORY_ENTRY("__vcmpne4"),
-              FEATURE_REQUEST_FACTORY(
-                  HelperFeatureEnum::device_ext,
-                  CALL_FACTORY_ENTRY(
-                      "__vcmpne4",
-                      CALL(MapNames::getDpctNamespace() + "vectorized_binary<" +
-                               MapNames::getClNamespace() + "uchar4>",
-                           ARG(0), ARG(1), LITERAL("std::not_equal_to<>()"))))))
+              CONDITIONAL_FACTORY_ENTRY(
+                  UseSYCLCompat,
+                  UNSUPPORT_FACTORY_ENTRY("__vcmpne4",
+                                          Diagnostics::UNSUPPORT_SYCLCOMPAT,
+                                          LITERAL("__vcmpne4")),
+                  FEATURE_REQUEST_FACTORY(
+                      HelperFeatureEnum::device_ext,
+                      CALL_FACTORY_ENTRY(
+                          "__vcmpne4",
+                          CALL(MapNames::getDpctNamespace() +
+                                   "vectorized_binary<" +
+                                   MapNames::getClNamespace() + "uchar4>",
+                               ARG(0), ARG(1),
+                               LITERAL("std::not_equal_to<>()")))))))
       // __vhaddu2
       MATH_API_REWRITER_DEVICE(
           "__vhaddu2",

--- a/clang/test/dpct/math/cuda-math-syclcompat.cu
+++ b/clang/test/dpct/math/cuda-math-syclcompat.cu
@@ -11,6 +11,7 @@
 __global__ void kernelFuncBfloat162Arithmetic() {
   __nv_bfloat16 bf16, bf16_1, bf16_2, bf16_3;
   __nv_bfloat162 bf162, bf162_1, bf162_2, bf162_3;
+  unsigned u, u_1, u_2;
   // CHECK: /*
   // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__hadd2_sat" is not currently supported with SYCLcompat. Please adjust the code manually.
   // CHECK-NEXT: */
@@ -105,5 +106,86 @@ __global__ void kernelFuncBfloat162Arithmetic() {
   // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__hcmadd" is not currently supported with SYCLcompat. Please adjust the code manually.
   // CHECK-NEXT: */
   h2_2 = __hcmadd(h2, h2_1, h2_2);
+
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__vcmpeq2" is not currently supported with SYCLcompat. Please adjust the code manually.
+  // CHECK-NEXT: */
+  u_2 = __vcmpeq2(u, u_1);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__vcmpeq4" is not currently supported with SYCLcompat. Please adjust the code manually.
+  // CHECK-NEXT: */
+  u_2 = __vcmpeq4(u, u_1);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__vcmpges2" is not currently supported with SYCLcompat. Please adjust the code manually.
+  // CHECK-NEXT: */
+  u_2 = __vcmpges2(u, u_1);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__vcmpges4" is not currently supported with SYCLcompat. Please adjust the code manually.
+  // CHECK-NEXT: */
+  u_2 = __vcmpges4(u, u_1);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__vcmpgeu2" is not currently supported with SYCLcompat. Please adjust the code manually.
+  // CHECK-NEXT: */
+  u_2 = __vcmpgeu2(u, u_1);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__vcmpgeu4" is not currently supported with SYCLcompat. Please adjust the code manually.
+  // CHECK-NEXT: */
+  u_2 = __vcmpgeu4(u, u_1);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__vcmpgts2" is not currently supported with SYCLcompat. Please adjust the code manually.
+  // CHECK-NEXT: */
+  u_2 = __vcmpgts2(u, u_1);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__vcmpgts4" is not currently supported with SYCLcompat. Please adjust the code manually.
+  // CHECK-NEXT: */
+  u_2 = __vcmpgts4(u, u_1);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__vcmpgtu2" is not currently supported with SYCLcompat. Please adjust the code manually.
+  // CHECK-NEXT: */
+  u_2 = __vcmpgtu2(u, u_1);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__vcmpgtu4" is not currently supported with SYCLcompat. Please adjust the code manually.
+  // CHECK-NEXT: */
+  u_2 = __vcmpgtu4(u, u_1);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__vcmples2" is not currently supported with SYCLcompat. Please adjust the code manually.
+  // CHECK-NEXT: */
+  u_2 = __vcmples2(u, u_1);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__vcmples4" is not currently supported with SYCLcompat. Please adjust the code manually.
+  // CHECK-NEXT: */
+  u_2 = __vcmples4(u, u_1);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__vcmpleu2" is not currently supported with SYCLcompat. Please adjust the code manually.
+  // CHECK-NEXT: */
+  u_2 = __vcmpleu2(u, u_1);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__vcmpleu4" is not currently supported with SYCLcompat. Please adjust the code manually.
+  // CHECK-NEXT: */
+  u_2 = __vcmpleu4(u, u_1);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__vcmplts2" is not currently supported with SYCLcompat. Please adjust the code manually.
+  // CHECK-NEXT: */
+  u_2 = __vcmplts2(u, u_1);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__vcmplts4" is not currently supported with SYCLcompat. Please adjust the code manually.
+  // CHECK-NEXT: */
+  u_2 = __vcmplts4(u, u_1);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__vcmpltu2" is not currently supported with SYCLcompat. Please adjust the code manually.
+  // CHECK-NEXT: */
+  u_2 = __vcmpltu2(u, u_1);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__vcmpltu4" is not currently supported with SYCLcompat. Please adjust the code manually.
+  // CHECK-NEXT: */
+  u_2 = __vcmpltu4(u, u_1);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__vcmpne2" is not currently supported with SYCLcompat. Please adjust the code manually.
+  // CHECK-NEXT: */
+  u_2 = __vcmpne2(u, u_1);
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1131:{{[0-9]+}}: The migration of "__vcmpne4" is not currently supported with SYCLcompat. Please adjust the code manually.
+  // CHECK-NEXT: */
+  u_2 = __vcmpne4(u, u_1);
 }
 #endif


### PR DESCRIPTION
Signed-off-by: Tang, Jiajun jiajun.tang@intel.com