### PR TITLE
[SYCLomatic] Refine migration of thrust::transform_reduce to fix incorrect policy migration when the policy argument is "thrust::cuda::par.on(stream)"

### DIFF
--- a/clang/lib/DPCT/APINamesThrust.inc
+++ b/clang/lib/DPCT/APINamesThrust.inc
@@ -153,18 +153,10 @@ CONDITIONAL_FACTORY_ENTRY(
                            CALL("std::transform_reduce",
                                 ARG("oneapi::dpl::execution::seq"), ARG(0),
                                 ARG(1), ARG(3), ARG(4), ARG(2)))),
-    CONDITIONAL_FACTORY_ENTRY(
-        CheckThrustArgType(0, "thrust::device_ptr"),
         CALL_FACTORY_ENTRY(
             "thrust::transform_reduce",
-            CALL("std::transform_reduce",
-                 CALL("oneapi::dpl::execution::make_device_policy", QUEUESTR),
-                 ARG(1), ARG(2), ARG(4), ARG(5), ARG(3))),
-        CALL_FACTORY_ENTRY("thrust::transform_reduce",
-                           CALL("std::transform_reduce",
-                                ARG("oneapi::dpl::execution::seq"), ARG(1),
-                                ARG(2), ARG(4), ARG(5), ARG(3)))))
-
+            CALL("std::transform_reduce", makeMappedThrustPolicyEnum(0),
+            ARG(1), ARG(2), ARG(4), ARG(5), ARG(3))))
 
 // thrust::swap
 CALL_FACTORY_ENTRY("thrust::swap",  CALL("std::swap",  ARG(0), ARG(1)))

--- a/clang/test/dpct/thrust-for-h2o4gpu.cu
+++ b/clang/test/dpct/thrust-for-h2o4gpu.cu
@@ -309,16 +309,19 @@ void foo() {
 
  {
   int data[10];
+  cudaStream_t stream;
   //CHECK: dpct::device_pointer<int> begin = dpct::get_device_pointer(&data[0]);
   //CHECK-NEXT: dpct::device_pointer<int> end=begin + 10;
   //CHECK-NEXT: bool h_result = std::transform_reduce(oneapi::dpl::execution::make_device_policy(q_ct1), begin, end, 0, std::plus<bool>(), isfoo_test<int>());
   //CHECK-NEXT: bool h_result_1 = std::transform_reduce(oneapi::dpl::execution::seq, begin, end, 0, std::plus<bool>(), isfoo_test<int>());
+  //CHECK-NEXT: bool h_result_2 = std::transform_reduce(oneapi::dpl::execution::make_device_policy(*stream), begin, end, 0, std::plus<bool>(), isfoo_test<int>());
   //CHECK-NEXT: auto ptrs = std::make_tuple(begin, end);
   //CHECK-NEXT: int num = std::get<1>(ptrs) - std::get<0>(ptrs);
   thrust::device_ptr<int> begin = thrust::device_pointer_cast(&data[0]);
   thrust::device_ptr<int> end=begin + 10;
   bool h_result = thrust::transform_reduce(begin, end, isfoo_test<int>(), 0, thrust::plus<bool>());
   bool h_result_1 = thrust::transform_reduce(thrust::seq, begin, end, isfoo_test<int>(), 0, thrust::plus<bool>());
+  bool h_result_2 = thrust::transform_reduce(thrust::cuda::par.on(stream), begin, end, isfoo_test<int>(), 0, thrust::plus<bool>());
   auto ptrs = thrust::make_tuple(begin, end);
   int num = thrust::get<1>(ptrs) - thrust::get<0>(ptrs);
  }

--- a/clang/test/dpct/thrust-reduce.cu
+++ b/clang/test/dpct/thrust-reduce.cu
@@ -84,6 +84,7 @@ void thrust_test() {
   thrust::host_vector<int> h_data(data, data + 6);
   int result;
   MyAlloctor thrust_allocator;
+  cudaStream_t stream;
 
   // CHECK:  result = std::reduce(oneapi::dpl::execution::seq, data, data + 6);
   // CHECK-NEXT:  result = std::reduce(oneapi::dpl::execution::seq, data, data + 6);
@@ -104,6 +105,7 @@ void thrust_test() {
   // CHECK-NEXT:  result = std::reduce(oneapi::dpl::execution::seq, h_data.begin(), h_data.begin() + 6, -1, oneapi::dpl::maximum<int>());
   // CHECK-NEXT:  result = std::reduce(oneapi::dpl::execution::seq, h_data.begin(), h_data.begin() + 6, -1, oneapi::dpl::maximum<int>());
   // CHECK-NEXT:  result = std::reduce(oneapi::dpl::execution::make_device_policy(q_ct1), d_data.begin(), d_data.begin() + 6, -1, oneapi::dpl::maximum<int>());
+  // CHECK-NEXT:  result = std::reduce(oneapi::dpl::execution::make_device_policy(*stream), d_data.begin(), d_data.begin() + 6, -1, oneapi::dpl::maximum<int>());
   result = thrust::reduce(thrust::host, data, data + 6);
   result = thrust::reduce(data, data + 6);
   result = thrust::reduce(thrust::host, data, data + 6, 1);
@@ -123,4 +125,5 @@ void thrust_test() {
   result = thrust::reduce(thrust::host, h_data.begin(), h_data.begin() + 6, -1, thrust::maximum<int>());
   result = thrust::reduce(h_data.begin(), h_data.begin() + 6, -1, thrust::maximum<int>());
   result = thrust::reduce(thrust::cuda::par(thrust_allocator), d_data.begin(), d_data.begin() + 6, -1, thrust::maximum<int>());
+  result = thrust::reduce(thrust::cuda::par.on(stream), d_data.begin(), d_data.begin() + 6, -1, thrust::maximum<int>());
 }

--- a/clang/test/dpct/thrust-reduce.cu
+++ b/clang/test/dpct/thrust-reduce.cu
@@ -84,7 +84,6 @@ void thrust_test() {
   thrust::host_vector<int> h_data(data, data + 6);
   int result;
   MyAlloctor thrust_allocator;
-  cudaStream_t stream;
 
   // CHECK:  result = std::reduce(oneapi::dpl::execution::seq, data, data + 6);
   // CHECK-NEXT:  result = std::reduce(oneapi::dpl::execution::seq, data, data + 6);
@@ -105,7 +104,6 @@ void thrust_test() {
   // CHECK-NEXT:  result = std::reduce(oneapi::dpl::execution::seq, h_data.begin(), h_data.begin() + 6, -1, oneapi::dpl::maximum<int>());
   // CHECK-NEXT:  result = std::reduce(oneapi::dpl::execution::seq, h_data.begin(), h_data.begin() + 6, -1, oneapi::dpl::maximum<int>());
   // CHECK-NEXT:  result = std::reduce(oneapi::dpl::execution::make_device_policy(q_ct1), d_data.begin(), d_data.begin() + 6, -1, oneapi::dpl::maximum<int>());
-  // CHECK-NEXT:  result = std::reduce(oneapi::dpl::execution::make_device_policy(*stream), d_data.begin(), d_data.begin() + 6, -1, oneapi::dpl::maximum<int>());
   result = thrust::reduce(thrust::host, data, data + 6);
   result = thrust::reduce(data, data + 6);
   result = thrust::reduce(thrust::host, data, data + 6, 1);
@@ -125,5 +123,4 @@ void thrust_test() {
   result = thrust::reduce(thrust::host, h_data.begin(), h_data.begin() + 6, -1, thrust::maximum<int>());
   result = thrust::reduce(h_data.begin(), h_data.begin() + 6, -1, thrust::maximum<int>());
   result = thrust::reduce(thrust::cuda::par(thrust_allocator), d_data.begin(), d_data.begin() + 6, -1, thrust::maximum<int>());
-  result = thrust::reduce(thrust::cuda::par.on(stream), d_data.begin(), d_data.begin() + 6, -1, thrust::maximum<int>());
 }


### PR DESCRIPTION
 Signed-off-by: chenwei.sun <chenwei.sun@intel.com>