### PR TITLE
[SYCLomatic] Add support for handling CU_EVENT_* enum

### DIFF
--- a/clang/lib/DPCT/Diagnostics/Diagnostics.inc
+++ b/clang/lib/DPCT/Diagnostics/Diagnostics.inc
@@ -296,6 +296,8 @@ DEF_WARNING(SPARSE_NNZ, 1134, MEDIUM_LEVEL, "The tool cannot deduce the consumer
 DEF_COMMENT(SPARSE_NNZ, 1134, MEDIUM_LEVEL, "The tool cannot deduce the consumer API (\"dpct::sparse::csrgemm\") of this API, and this API has 2 arguments depending on the 8th and the 12th parameters of the consumer API. Please replace the 2 arguments tagged as \"dpct_placeholder\" with the corresponding value.")
 DEF_WARNING(JOINT_MATRIX_SHAPE, 1135, HIGH_LEVEL, "Please check if joint_matrix implementations support the combination of data type and matrix shape type in the target hardware.")
 DEF_COMMENT(JOINT_MATRIX_SHAPE, 1135, HIGH_LEVEL, "Please check if joint_matrix implementations support the combination of data type and matrix shape type in the target hardware.")
+DEF_WARNING(UNSUPPORTED_EVENT_FEATURE, 1136, LOW_LEVEL, "SYCL event does not support the feature enabled in CUDA event created with flag \"%0\".")
+DEF_COMMENT(UNSUPPORTED_EVENT_FEATURE, 1136, LOW_LEVEL, "SYCL event does not support the feature enabled in CUDA event created with flag \"{0}\".")
 // clang-format on
 
 #undef DEF_COMMENT

--- a/clang/lib/DPCT/Diagnostics/Diagnostics.inc
+++ b/clang/lib/DPCT/Diagnostics/Diagnostics.inc
@@ -58,8 +58,8 @@ DEF_WARNING(TIME_MEASUREMENT_FOUND, 1012, MEDIUM_LEVEL, "Detected kernel executi
 DEF_COMMENT(TIME_MEASUREMENT_FOUND, 1012, MEDIUM_LEVEL, "Detected kernel execution time measurement pattern and generated an initial code for time measurements in SYCL. You can change the way time is measured depending on your goals.")
 DEF_WARNING(ROUNDING_MODE_UNSUPPORTED, 1013, MEDIUM_LEVEL, "The rounding mode could not be specified and the generated code may have different accuracy than the original code. Verify the correctness. SYCL math built-in function rounding mode is aligned with OpenCL C 1.2 standard.")
 DEF_COMMENT(ROUNDING_MODE_UNSUPPORTED, 1013, MEDIUM_LEVEL, "The rounding mode could not be specified and the generated code may have different accuracy than the original code. Verify the correctness. SYCL math built-in function rounding mode is aligned with OpenCL C 1.2 standard.")
-DEF_WARNING(STREAM_FLAG_PRIORITY_NOT_SUPPORTED, 1014, MEDIUM_LEVEL, "The flag and priority options are not supported for SYCL queues. The output parameter(s) are set to 0.")
-DEF_COMMENT(STREAM_FLAG_PRIORITY_NOT_SUPPORTED, 1014, MEDIUM_LEVEL, "The flag and priority options are not supported for SYCL queues. The output parameter(s) are set to 0.")
+DEF_WARNING(UNSUPPORTED_FEATURE_IN_SYCL, 1014, MEDIUM_LEVEL, "The %0 %1 not supported for SYCL %2. The output parameter(s) %1 set to 0.")
+DEF_COMMENT(UNSUPPORTED_FEATURE_IN_SYCL, 1014, MEDIUM_LEVEL, "The {0} {1} not supported for SYCL {2}. The output parameter(s) {1} set to 0.")
 DEF_WARNING(PRINTF_FUNC_MIGRATION_WARNING, 1015, LOW_LEVEL, "Output needs adjustment.")
 DEF_COMMENT(PRINTF_FUNC_MIGRATION_WARNING, 1015, LOW_LEVEL, "Output needs adjustment.")
 DEF_WARNING(NOT_SUPPORTED_PARAMETERS_VALUE, 1016, LOW_LEVEL, "deprecated")
@@ -296,8 +296,6 @@ DEF_WARNING(SPARSE_NNZ, 1134, MEDIUM_LEVEL, "The tool cannot deduce the consumer
 DEF_COMMENT(SPARSE_NNZ, 1134, MEDIUM_LEVEL, "The tool cannot deduce the consumer API (\"dpct::sparse::csrgemm\") of this API, and this API has 2 arguments depending on the 8th and the 12th parameters of the consumer API. Please replace the 2 arguments tagged as \"dpct_placeholder\" with the corresponding value.")
 DEF_WARNING(JOINT_MATRIX_SHAPE, 1135, HIGH_LEVEL, "Please check if joint_matrix implementations support the combination of data type and matrix shape type in the target hardware.")
 DEF_COMMENT(JOINT_MATRIX_SHAPE, 1135, HIGH_LEVEL, "Please check if joint_matrix implementations support the combination of data type and matrix shape type in the target hardware.")
-DEF_WARNING(UNSUPPORTED_EVENT_FEATURE, 1136, LOW_LEVEL, "A SYCL event does not support the feature of a CUDA event enabled with flag \"%0\".")
-DEF_COMMENT(UNSUPPORTED_EVENT_FEATURE, 1136, LOW_LEVEL, "A SYCL event does not support the feature of a CUDA event enabled with flag \"{0}\".")
 // clang-format on
 
 #undef DEF_COMMENT

--- a/clang/lib/DPCT/Diagnostics/Diagnostics.inc
+++ b/clang/lib/DPCT/Diagnostics/Diagnostics.inc
@@ -296,8 +296,8 @@ DEF_WARNING(SPARSE_NNZ, 1134, MEDIUM_LEVEL, "The tool cannot deduce the consumer
 DEF_COMMENT(SPARSE_NNZ, 1134, MEDIUM_LEVEL, "The tool cannot deduce the consumer API (\"dpct::sparse::csrgemm\") of this API, and this API has 2 arguments depending on the 8th and the 12th parameters of the consumer API. Please replace the 2 arguments tagged as \"dpct_placeholder\" with the corresponding value.")
 DEF_WARNING(JOINT_MATRIX_SHAPE, 1135, HIGH_LEVEL, "Please check if joint_matrix implementations support the combination of data type and matrix shape type in the target hardware.")
 DEF_COMMENT(JOINT_MATRIX_SHAPE, 1135, HIGH_LEVEL, "Please check if joint_matrix implementations support the combination of data type and matrix shape type in the target hardware.")
-DEF_WARNING(UNSUPPORTED_EVENT_FEATURE, 1136, LOW_LEVEL, "SYCL event does not support the feature enabled in CUDA event created with flag \"%0\".")
-DEF_COMMENT(UNSUPPORTED_EVENT_FEATURE, 1136, LOW_LEVEL, "SYCL event does not support the feature enabled in CUDA event created with flag \"{0}\".")
+DEF_WARNING(UNSUPPORTED_EVENT_FEATURE, 1136, LOW_LEVEL, "A SYCL event does not support the feature of a CUDA event enabled with flag \"%0\".")
+DEF_COMMENT(UNSUPPORTED_EVENT_FEATURE, 1136, LOW_LEVEL, "A SYCL event does not support the feature of a CUDA event enabled with flag \"{0}\".")
 // clang-format on
 
 #undef DEF_COMMENT

--- a/clang/lib/DPCT/RulesLang/RulesLang.cpp
+++ b/clang/lib/DPCT/RulesLang/RulesLang.cpp
@@ -2569,6 +2569,10 @@ void EventAPICallRule::registerMatcher(MatchFinder &MF) {
                                unless(parentStmt())))
                     .bind("eventAPICallUsed"),
                 this);
+  MF.addMatcher(
+      declRefExpr(to(enumConstantDecl(hasType(enumDecl(hasName("CUevent_flags_enum"))))))
+          .bind("eventEnum"),
+      this);
 }
 
 bool isEqualOperator(const Stmt *S) {
@@ -2879,6 +2883,14 @@ bool EventAPICallRule::isEventElapsedTimeFollowed(const CallExpr *Expr) {
 }
 
 void EventAPICallRule::runRule(const MatchFinder::MatchResult &Result) {
+  if (auto *DRE = getNodeAsType<DeclRefExpr>(Result, "eventEnum")) {
+    if (auto *EC = dyn_cast<EnumConstantDecl>(DRE->getDecl())) {
+      std::string EName = EC->getName().str();
+      report(DRE->getBeginLoc(), Diagnostics::UNSUPPORTED_EVENT_FEATURE, false, EName);
+      emplaceTransformation(new ReplaceStmt(DRE, "0x0"));
+    }
+  }
+
   bool IsAssigned = false;
   const CallExpr *CE = getNodeAsType<CallExpr>(Result, "eventAPICall");
   if (!CE) {

--- a/clang/lib/DPCT/RulesLang/RulesLang.cpp
+++ b/clang/lib/DPCT/RulesLang/RulesLang.cpp
@@ -2888,8 +2888,9 @@ void EventAPICallRule::runRule(const MatchFinder::MatchResult &Result) {
       std::string EName = EC->getName().str();
       report(DRE->getBeginLoc(), Diagnostics::UNSUPPORTED_EVENT_FEATURE, false,
              EName);
-      emplaceTransformation(new ReplaceStmt(DRE, "0x0"));
+      emplaceTransformation(new ReplaceStmt(DRE, "0"));
     }
+    return;
   }
 
   bool IsAssigned = false;

--- a/clang/lib/DPCT/RulesLang/RulesLang.cpp
+++ b/clang/lib/DPCT/RulesLang/RulesLang.cpp
@@ -2886,8 +2886,8 @@ void EventAPICallRule::runRule(const MatchFinder::MatchResult &Result) {
   if (auto *DRE = getNodeAsType<DeclRefExpr>(Result, "eventEnum")) {
     if (auto *EC = dyn_cast<EnumConstantDecl>(DRE->getDecl())) {
       std::string EName = EC->getName().str();
-      report(DRE->getBeginLoc(), Diagnostics::UNSUPPORTED_FEATURE_IN_SYCL, false,
-             EName, "is", "event");
+      report(DRE->getBeginLoc(), Diagnostics::UNSUPPORTED_FEATURE_IN_SYCL,
+             false, EName, "is", "event");
       emplaceTransformation(new ReplaceStmt(DRE, "0"));
     }
     return;
@@ -4261,8 +4261,8 @@ void StreamAPICallRule::runRule(const MatchFinder::MatchResult &Result) {
     emplaceTransformation(new ReplaceStmt(CE, ReplStr));
   } else if (FuncName == "cudaStreamGetFlags" ||
              FuncName == "cudaStreamGetPriority") {
-    report(CE->getBeginLoc(), Diagnostics::UNSUPPORTED_FEATURE_IN_SYCL,
-           false, "flag and priority options", "are", "queues");
+    report(CE->getBeginLoc(), Diagnostics::UNSUPPORTED_FEATURE_IN_SYCL, false,
+           "flag and priority options", "are", "queues");
     auto StmtStr1 = getStmtSpelling(CE->getArg(1));
     std::string ReplStr{"*("};
     ReplStr += StmtStr1;

--- a/clang/lib/DPCT/RulesLang/RulesLang.cpp
+++ b/clang/lib/DPCT/RulesLang/RulesLang.cpp
@@ -2569,10 +2569,10 @@ void EventAPICallRule::registerMatcher(MatchFinder &MF) {
                                unless(parentStmt())))
                     .bind("eventAPICallUsed"),
                 this);
-  MF.addMatcher(
-      declRefExpr(to(enumConstantDecl(hasType(enumDecl(hasName("CUevent_flags_enum"))))))
-          .bind("eventEnum"),
-      this);
+  MF.addMatcher(declRefExpr(to(enumConstantDecl(hasType(
+                                enumDecl(hasName("CUevent_flags_enum"))))))
+                    .bind("eventEnum"),
+                this);
 }
 
 bool isEqualOperator(const Stmt *S) {
@@ -2886,7 +2886,8 @@ void EventAPICallRule::runRule(const MatchFinder::MatchResult &Result) {
   if (auto *DRE = getNodeAsType<DeclRefExpr>(Result, "eventEnum")) {
     if (auto *EC = dyn_cast<EnumConstantDecl>(DRE->getDecl())) {
       std::string EName = EC->getName().str();
-      report(DRE->getBeginLoc(), Diagnostics::UNSUPPORTED_EVENT_FEATURE, false, EName);
+      report(DRE->getBeginLoc(), Diagnostics::UNSUPPORTED_EVENT_FEATURE, false,
+             EName);
       emplaceTransformation(new ReplaceStmt(DRE, "0x0"));
     }
   }

--- a/clang/lib/DPCT/RulesLang/RulesLang.cpp
+++ b/clang/lib/DPCT/RulesLang/RulesLang.cpp
@@ -2886,8 +2886,8 @@ void EventAPICallRule::runRule(const MatchFinder::MatchResult &Result) {
   if (auto *DRE = getNodeAsType<DeclRefExpr>(Result, "eventEnum")) {
     if (auto *EC = dyn_cast<EnumConstantDecl>(DRE->getDecl())) {
       std::string EName = EC->getName().str();
-      report(DRE->getBeginLoc(), Diagnostics::UNSUPPORTED_EVENT_FEATURE, false,
-             EName);
+      report(DRE->getBeginLoc(), Diagnostics::UNSUPPORTED_FEATURE_IN_SYCL, false,
+             EName, "is", "event");
       emplaceTransformation(new ReplaceStmt(DRE, "0"));
     }
     return;
@@ -4261,8 +4261,8 @@ void StreamAPICallRule::runRule(const MatchFinder::MatchResult &Result) {
     emplaceTransformation(new ReplaceStmt(CE, ReplStr));
   } else if (FuncName == "cudaStreamGetFlags" ||
              FuncName == "cudaStreamGetPriority") {
-    report(CE->getBeginLoc(), Diagnostics::STREAM_FLAG_PRIORITY_NOT_SUPPORTED,
-           false);
+    report(CE->getBeginLoc(), Diagnostics::UNSUPPORTED_FEATURE_IN_SYCL,
+           false, "flag and priority options", "are", "queues");
     auto StmtStr1 = getStmtSpelling(CE->getArg(1));
     std::string ReplStr{"*("};
     ReplStr += StmtStr1;

--- a/clang/test/dpct/driver-stream-and-event.cu
+++ b/clang/test/dpct/driver-stream-and-event.cu
@@ -164,16 +164,16 @@ void test_cuEventRecord_crash(CUevent hEvent, CUstream hStream)
 
 unsigned getEventFlags(bool enabledSyncBlock) {
   // CHECK: /*
-  // CHECK-NEXT: DPCT1136:{{[0-9]+}}: SYCL event does not support the feature enabled in CUDA event created with flag "CU_EVENT_DISABLE_TIMING".
+  // CHECK-NEXT: DPCT1136:{{[0-9]+}}: A SYCL event does not support the feature of a CUDA event enabled with flag "CU_EVENT_DISABLE_TIMING".
   // CHECK-NEXT: */
-  // CHECK-NEXT: unsigned flags = 0x0;
+  // CHECK-NEXT: unsigned flags = 0;
   unsigned flags = CU_EVENT_DISABLE_TIMING;
 
   if (enabledSyncBlock)
     // CHECK: /*
-    // CHECK-NEXT: DPCT1136:{{[0-9]+}}: SYCL event does not support the feature enabled in CUDA event created with flag "CU_EVENT_BLOCKING_SYNC".
+    // CHECK-NEXT: DPCT1136:{{[0-9]+}}: A SYCL event does not support the feature of a CUDA event enabled with flag "CU_EVENT_BLOCKING_SYNC".
     // CHECK-NEXT: */
-    // CHECK-NEXT: flags |= 0x0;
+    // CHECK-NEXT: flags |= 0;
     flags |= CU_EVENT_BLOCKING_SYNC;
 
   return flags;

--- a/clang/test/dpct/driver-stream-and-event.cu
+++ b/clang/test/dpct/driver-stream-and-event.cu
@@ -161,3 +161,20 @@ void test_cuEventRecord_crash(CUevent hEvent, CUstream hStream)
   // CHECK: int result = DPCT_CHECK_ERROR(*(dpct::event_ptr)hEvent = ((dpct::queue_ptr)hStream)->ext_oneapi_submit_barrier());
   CUresult result = cuEventRecord((CUevent)hEvent, (CUstream)hStream);
 }
+
+unsigned getEventFlags(bool enabledSyncBlock) {
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1136:{{[0-9]+}}: SYCL event does not support the feature enabled in CUDA event created with flag "CU_EVENT_DISABLE_TIMING".
+  // CHECK-NEXT: */
+  // CHECK-NEXT: unsigned flags = 0x0;
+  unsigned flags = CU_EVENT_DISABLE_TIMING;
+
+  if (enabledSyncBlock)
+    // CHECK: /*
+    // CHECK-NEXT: DPCT1136:{{[0-9]+}}: SYCL event does not support the feature enabled in CUDA event created with flag "CU_EVENT_BLOCKING_SYNC".
+    // CHECK-NEXT: */
+    // CHECK-NEXT: flags |= 0x0;
+    flags |= CU_EVENT_BLOCKING_SYNC;
+
+  return flags;
+}

--- a/clang/test/dpct/driver-stream-and-event.cu
+++ b/clang/test/dpct/driver-stream-and-event.cu
@@ -164,14 +164,14 @@ void test_cuEventRecord_crash(CUevent hEvent, CUstream hStream)
 
 unsigned getEventFlags(bool enabledSyncBlock) {
   // CHECK: /*
-  // CHECK-NEXT: DPCT1136:{{[0-9]+}}: A SYCL event does not support the feature of a CUDA event enabled with flag "CU_EVENT_DISABLE_TIMING".
+  // CHECK-NEXT: DPCT1014:{{[0-9]+}}: The CU_EVENT_DISABLE_TIMING is not supported for SYCL event. The output parameter(s) is set to 0.
   // CHECK-NEXT: */
   // CHECK-NEXT: unsigned flags = 0;
   unsigned flags = CU_EVENT_DISABLE_TIMING;
 
   if (enabledSyncBlock)
     // CHECK: /*
-    // CHECK-NEXT: DPCT1136:{{[0-9]+}}: A SYCL event does not support the feature of a CUDA event enabled with flag "CU_EVENT_BLOCKING_SYNC".
+    // CHECK-NEXT: DPCT1014:{{[0-9]+}}: The CU_EVENT_BLOCKING_SYNC is not supported for SYCL event. The output parameter(s) is set to 0.
     // CHECK-NEXT: */
     // CHECK-NEXT: flags |= 0;
     flags |= CU_EVENT_BLOCKING_SYNC;


### PR DESCRIPTION
cuEventCreate can create events based on how host thread behaves while waiting for the event to finish. 
Signed-off-by: [Deepak Raj H R](Deepak.raj.h.r@intel.com)