### PR TITLE
[SYCLomatic] Refine warning message for SYCLomatic parser to use "dpct/c2s ignoring argument:" instead of "error: unknown argument"

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -314,7 +314,9 @@ def err_arch_unsupported_isa
 
 def err_drv_I_dash_not_supported : Error<
   "'%0' not supported, please use -iquote instead">;
-def err_drv_unknown_argument : Error<"unknown argument: '%0'">;
+// SYCLomatic_CUSTOMIZATION begin
+def err_drv_unknown_argument : Error<"dpct/c2s ignoring argument: '%0'">;
+// SYCLomatic_CUSTOMIZATION end
 def err_drv_unknown_argument_with_suggestion : Error<
   "unknown argument '%0'; did you mean '%1'?">;
 def warn_drv_unknown_argument_clang_cl : Warning<

--- a/clang/test/dpct/parse_error_msgs/parse_error_msgs.cu
+++ b/clang/test/dpct/parse_error_msgs/parse_error_msgs.cu
@@ -1,0 +1,9 @@
+// RUN: dpct --format-range=none -out-root %T/ %s --cuda-include-path="%cuda-path/include" --extra-arg="-forward-unknown-to-host-compiler" > log.txt 2>&1
+// RUN: FileCheck --input-file %T/parse_error_msgs.dp.cpp --match-full-lines %s
+// RUN: grep -srn "dpct/c2s ignoring argument: .-forward-unknown-to-host-compile." ./log.txt
+
+#include "cuda.h"
+
+// CHECK: void g() {}
+__global__ void g() {}
+


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>