### PR TITLE
[SYCLomatic] Fix incorrect migration of  thrust::iterator_difference<int *>::type in one corner case

### DIFF
--- a/clang/lib/DPCT/RulesLang/RulesLang.cpp
+++ b/clang/lib/DPCT/RulesLang/RulesLang.cpp
@@ -1041,25 +1041,27 @@ void TypeInDeclRule::runRule(const MatchFinder::MatchResult &Result) {
       auto Parents = Result.Context->getParents(TSL);
       if (!Parents.empty()) {
         const auto &NNSL = Parents[0].get<NestedNameSpecifierLoc>();
+
+        // To migrate "type" in case like "typename
+        // thrust::iterator_difference<int
+        // *>::type Var".
         if (TypeStr.find("iterator_difference") != std::string::npos && NNSL) {
           auto Parents2 = Result.Context->getParents(*NNSL);
           if (!Parents2.empty()) {
             const auto &NNSL2 = Parents2[0].get<TypeLoc>();
-            auto EndLoc = NNSL2->getEndLoc();
 
-            // Check if "::type" needs replacement (only needed for
-            // thrust::iterator_difference)
-            Token Tok;
-            Lexer::getRawToken(EndLoc, Tok, *SM, LOpts, true);
-            auto TypeNameStr =
-                Tok.isAnyIdentifier() ? Tok.getRawIdentifier().str() : "";
-            Lexer::getRawToken(TSL.getBeginLoc(), Tok, *SM, LOpts, true);
-            auto TemplateNameStr =
-                Tok.isAnyIdentifier() ? Tok.getRawIdentifier().str() : "";
-            if (TypeNameStr == "type" &&
-                TemplateNameStr == "iterator_difference") {
-              emplaceTransformation(
-                  new ReplaceText(EndLoc, 4, std::string("difference_type")));
+            if (NNSL2 && NNSL2->getType().getAsString().find(
+                             "thrust::iterator") != std::string::npos) {
+
+              auto EndLoc = NNSL2->getEndLoc();
+              Token Tok;
+              Lexer::getRawToken(TSL.getBeginLoc(), Tok, *SM, LOpts, true);
+              auto TemplateNameStr =
+                  Tok.isAnyIdentifier() ? Tok.getRawIdentifier().str() : "";
+              if (TemplateNameStr == "iterator_difference") {
+                emplaceTransformation(
+                    new ReplaceText(EndLoc, 4, std::string("difference_type")));
+              }
             }
           }
         }

--- a/clang/test/dpct/thrust-it-diff.cu
+++ b/clang/test/dpct/thrust-it-diff.cu
@@ -26,3 +26,4 @@ public:
 // CHECK: typename std::iterator_traits<int *>::difference_type IDTVarDecl;
 typename thrust::iterator_difference<int *>::type IDTVarDecl;
 
+

--- a/clang/test/dpct/thrust-it-diff.cu
+++ b/clang/test/dpct/thrust-it-diff.cu
@@ -24,6 +24,6 @@ public:
   typename thrust::iterator_difference<Iterator>::type IDTFieldDecl;
 };
 
-// TODO:
+// CHECK: typename std::iterator_traits<int *>::difference_type IDTVarDecl;
 typename thrust::iterator_difference<int *>::type IDTVarDecl;
 #endif

--- a/clang/test/dpct/thrust-it-diff.cu
+++ b/clang/test/dpct/thrust-it-diff.cu
@@ -4,7 +4,6 @@
 // RUN: FileCheck --input-file %T/thrust-it-diff/thrust-it-diff.dp.cpp --match-full-lines %s
 // RUN: %if build_lit %{icpx -c -fsycl -DNO_BUILD_TEST  %T/thrust-it-diff/thrust-it-diff.dp.cpp -o %T/thrust-it-diff/thrust-it-diff.dp.o %}
 
-#ifndef NO_BUILD_TEST
 // CHECK: #include <oneapi/dpl/execution>
 // CHECK-NEXT: #include <oneapi/dpl/algorithm>
 // CHECK-NEXT: #include <sycl/sycl.hpp>
@@ -26,4 +25,4 @@ public:
 
 // CHECK: typename std::iterator_traits<int *>::difference_type IDTVarDecl;
 typename thrust::iterator_difference<int *>::type IDTVarDecl;
-#endif
+


### PR DESCRIPTION
 Signed-off-by: chenwei.sun <chenwei.sun@intel.com>