### PR TITLE
[Py Build Script][Bug] Minor bug fixes for Python script migration

### DIFF
--- a/clang/test/dpct/python_migration/case_004/expected.py
+++ b/clang/test/dpct/python_migration/case_004/expected.py
@@ -1,1 +1,13 @@
-cuda_sources = list(glob.glob(os.path.join(extensions_cuda_dir, "*.cpp")))
+cuda_sources = list(glob.glob(os.path.join(extensions_cuda_dir, "*.dp.cpp")))
+
+# srcs in normal args (single & double quotes)
+## single quote
+out = func('foo.cpp', 'bar.dp.cpp')
+## double quotes
+out = func("foo.cpp", "bar.dp.cpp")
+
+# srcs in list arg
+## single quote
+out = func(['foo.cpp', 'bar.dp.cpp'])
+## double quotes
+out = func(["foo.cpp", "bar.dp.cpp"])

--- a/clang/test/dpct/python_migration/case_004/input.py
+++ b/clang/test/dpct/python_migration/case_004/input.py
@@ -1,1 +1,13 @@
 cuda_sources = list(glob.glob(os.path.join(extensions_cuda_dir, "*.cu")))
+
+# srcs in normal args (single & double quotes)
+## single quote
+out = func('foo.cpp', 'bar.cu')
+## double quotes
+out = func("foo.cpp", "bar.cu")
+
+# srcs in list arg
+## single quote
+out = func(['foo.cpp', 'bar.cu'])
+## double quotes
+out = func(["foo.cpp", "bar.cu"])

--- a/clang/test/dpct/python_migration/case_005/expected.py
+++ b/clang/test/dpct/python_migration/case_005/expected.py
@@ -1,7 +1,7 @@
 setup(
     name='quant_cuda',
     ext_modules=[cpp_extension.DPCPPExtension(
-        'quant_cuda', ['quant_cuda.cpp', 'quant_cuda_kernel.cpp']
+        'quant_cuda', ["quant_cuda.cpp", 'quant_cuda_kernel.dp.cpp']
     , include_dirs=cpp_extension.include_paths(),)],
     cmdclass={'build_ext': cpp_extension.DpcppBuildExtension}
 )

--- a/clang/test/dpct/python_migration/case_005/input.py
+++ b/clang/test/dpct/python_migration/case_005/input.py
@@ -1,7 +1,7 @@
 setup(
     name='quant_cuda',
     ext_modules=[cpp_extension.CUDAExtension(
-        'quant_cuda', ['quant_cuda.cpp', 'quant_cuda_kernel.cu']
+        'quant_cuda', ["quant_cuda.cpp", 'quant_cuda_kernel.cu']
     )],
     cmdclass={'build_ext': cpp_extension.BuildExtension}
 )

--- a/clang/test/dpct/python_migration/case_007/MainSourceFiles.yaml
+++ b/clang/test/dpct/python_migration/case_007/MainSourceFiles.yaml
@@ -1,0 +1,83 @@
+---
+MainSourceFile:  '/path/to/MainSrcFiles_placehold'
+Replacements:
+  - FilePath:        '/path/to/src/foo.cpp'
+    Offset:          0
+    Length:          0
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/path/to/src/baz.cpp'
+    Offset:          0
+    Length:          0
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+
+MainSourceFilesDigest:
+  - MainSourceFile:  '/path/to/src/foo.cpp'
+    Digest:          e2636fb8d174ac319083b0306294d3bd
+    HasCUDASyntax:   true
+  - MainSourceFile:  '/path/to/src/baz.cpp'
+    Digest:          991d7e4825fc597205bf68f2eda27acd
+    HasCUDASyntax:   false
+DpctVersion:     19.0.0
+MainHelperFileName: ''
+USMLevel:        ''
+FeatureMap:      {}
+CompileTargets:  {}
+OptionMap:
+  AnalysisScopePath:
+    Value:           '/path/to//target'
+    Specified:       false
+  AsyncHandler:
+    Value:           'false'
+    Specified:       false
+  BuildScript:
+    Value:           '1'
+    Specified:       true
+  CodePinEnabled:
+    Value:           'false'
+    Specified:       false
+  CommentsEnabled:
+    Value:           'false'
+    Specified:       false
+  CompilationsDir:
+    Value:           '/path/to/build'
+    Specified:       true
+  CtadEnabled:
+    Value:           'false'
+    Specified:       false
+  EnablepProfiling:
+    Value:           'true'
+    Specified:       true
+  ExperimentalFlag:
+    Value:           '16384'
+    Specified:       true
+  ExplicitNamespace:
+    Value:           '20'
+    Specified:       false
+  ExtensionDDFlag:
+    Value:           '0'
+    Specified:       false
+  ExtensionDEFlag:
+    Value:           '4294967295'
+    Specified:       false
+  RuleFile:
+    Value:           ''
+    ValueVec:
+      - '/path/to/python_build_script_migration_rule_ipex.yaml'
+    Specified:       false
+  SyclNamedLambda:
+    Value:           'false'
+    Specified:       false
+  UsmLevel:
+    Value:           '1'
+    Specified:       false
+...

--- a/clang/test/dpct/python_migration/case_007/case_007_test_extension_name.cpp
+++ b/clang/test/dpct/python_migration/case_007/case_007_test_extension_name.cpp
@@ -1,0 +1,12 @@
+// RUN: rm -rf %T && mkdir -p %T
+// RUN: cd %T
+// RUN: mkdir -p out
+// RUN: cp %S/input.py ./input.py
+// RUN: cp %S/MainSourceFiles.yaml ./out/MainSourceFiles.yaml
+// RUN: dpct -in-root ./ -out-root out ./input.py --migrate-build-script-only
+// RUN: echo "begin" > %T/diff.txt
+// RUN: diff --strip-trailing-cr %S/expected.py %T/out/input.py >> %T/diff.txt
+// RUN: echo "end" >> %T/diff.txt
+
+// CHECK: begin
+// CHECK-NEXT: end

--- a/clang/test/dpct/python_migration/case_007/expected.py
+++ b/clang/test/dpct/python_migration/case_007/expected.py
@@ -1,0 +1,4 @@
+# baz.cpp is a C++ file
+out = func("bar.dp.cpp", "baz.cpp")
+# foo.cpp is a C++ file with CUDA syntax
+out = func("foo.cpp.dp.cpp", "bar.dp.cpp")

--- a/clang/test/dpct/python_migration/case_007/input.py
+++ b/clang/test/dpct/python_migration/case_007/input.py
@@ -1,0 +1,4 @@
+# baz.cpp is a C++ file
+out = func("bar.cu", "baz.cpp")
+# foo.cpp is a C++ file with CUDA syntax
+out = func("foo.cpp", "bar.cu")

--- a/clang/test/dpct/python_migration/case_008/case_008_comments.cpp
+++ b/clang/test/dpct/python_migration/case_008/case_008_comments.cpp
@@ -1,0 +1,10 @@
+// RUN: rm -rf %T && mkdir -p %T
+// RUN: cd %T
+// RUN: cp %S/input.py ./input.py
+// RUN: dpct -in-root ./ -out-root out ./input.py --migrate-build-script-only
+// RUN: echo "begin" > %T/diff.txt
+// RUN: diff --strip-trailing-cr %S/expected.py %T/out/input.py >> %T/diff.txt
+// RUN: echo "end" >> %T/diff.txt
+
+// CHECK: begin
+// CHECK-NEXT: end

--- a/clang/test/dpct/python_migration/case_008/expected.py
+++ b/clang/test/dpct/python_migration/case_008/expected.py
@@ -1,0 +1,3 @@
+# import torch
+import torch
+import intel_extension_for_pytorch

--- a/clang/test/dpct/python_migration/case_008/input.py
+++ b/clang/test/dpct/python_migration/case_008/input.py
@@ -1,0 +1,2 @@
+# import torch
+import torch

--- a/clang/tools/dpct/DpctOptRules/python_build_script_migration_rule_ipex.yaml
+++ b/clang/tools/dpct/DpctOptRules/python_build_script_migration_rule_ipex.yaml
@@ -133,6 +133,19 @@
   In: BuildExtension
   Out: DpcppBuildExtension
 
+- Rule: rule_cpp_file
+  Kind: PythonRule
+  Priority: Fallback
+  MatchMode: Partial
+  PythonSyntax: cpp_file
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In: ${arg}.cpp
+      Out: ${arg}.${rewrite_extention_name}
+
 - Rule: rule_cu_file
   Kind: PythonRule
   Priority: Fallback
@@ -144,7 +157,7 @@
     value:
       MatchMode: Full
       In: ${arg}.cu
-      Out: ${arg}.cpp
+      Out: ${arg}.${rewrite_extention_name}
 
 - Rule: rule_cuda_device_count
   Kind: PythonRule


### PR DESCRIPTION
This PR introduces below changes to Py build script migration
1. Change **cpp** & **cu** file extension names based on HasCudaSyntax attr of MainSourceFiles.yaml
2. Fix skipped file extension replacements bug when \" (double-quotes) are used
3. Skip single line comments