### PR TITLE
[SYCLomatic] Fix the <cmath> header file not found issue

### DIFF
--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -3086,6 +3086,9 @@ void Generic_GCC::GCCInstallationDetector::ScanLibDirForGCCTriple(
           continue; // Saw this path before; no need to look at it again.
       if (CandidateVersion.isOlderThan(4, 1, 1))
         continue;
+      #ifdef SYCLomatic_CUSTOMIZATION
+      this->CandidateVersion.push_back(CandidateVersion);
+      #endif // SYCLomatic_CUSTOMIZATION
       if (CandidateVersion <= Version)
         continue;
 
@@ -3532,11 +3535,20 @@ bool Generic_GCC::addGCCLibStdCxxIncludePaths(
                                CC1Args))
     return true;
 
+#ifdef SYCLomatic_CUSTOMIZATION
+  for (auto Candidate : GCCInstallation.GetCandidateVersion()) {
+    if (addLibStdCXXIncludePaths(
+            LibDir.str() + "/../include/c++/" + Candidate.Text, DebianMultiarch,
+            Multilib.includeSuffix(), DriverArgs, CC1Args, /*Debian=*/true))
+      return true;
+  }
+#else
   // Detect Debian g++-multiarch-incdir.diff.
   if (addLibStdCXXIncludePaths(LibDir.str() + "/../include/c++/" + Version.Text,
                                DebianMultiarch, Multilib.includeSuffix(),
                                DriverArgs, CC1Args, /*Debian=*/true))
     return true;
+#endif // SYCLomatic_CUSTOMIZATION
 
   // Try /../include/c++/$version (gcc --print-multiarch is empty).
   if (addLibStdCXXIncludePaths(LibDir.str() + "/../include/c++/" + Version.Text,

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -3087,6 +3087,7 @@ void Generic_GCC::GCCInstallationDetector::ScanLibDirForGCCTriple(
       if (CandidateVersion.isOlderThan(4, 1, 1))
         continue;
 #ifdef SYCLomatic_CUSTOMIZATION
+      // Store all the potential GCC version candidates.
       this->CandidateVersion.insert(CandidateVersion);
 #endif // SYCLomatic_CUSTOMIZATION
       if (CandidateVersion <= Version)
@@ -3536,6 +3537,8 @@ bool Generic_GCC::addGCCLibStdCxxIncludePaths(
     return true;
 
 #ifdef SYCLomatic_CUSTOMIZATION
+  // Detect Debian g++-multiarch-incdir.diff through the list of candidate, the
+  // potential GCC version sorts in descending orde.
   for (auto Candidate : GCCInstallation.GetCandidateVersion()) {
     if (addLibStdCXXIncludePaths(
             LibDir.str() + "/../include/c++/" + Candidate.Text, DebianMultiarch,

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -3086,9 +3086,9 @@ void Generic_GCC::GCCInstallationDetector::ScanLibDirForGCCTriple(
           continue; // Saw this path before; no need to look at it again.
       if (CandidateVersion.isOlderThan(4, 1, 1))
         continue;
-      #ifdef SYCLomatic_CUSTOMIZATION
+#ifdef SYCLomatic_CUSTOMIZATION
       this->CandidateVersion.push_back(CandidateVersion);
-      #endif // SYCLomatic_CUSTOMIZATION
+#endif // SYCLomatic_CUSTOMIZATION
       if (CandidateVersion <= Version)
         continue;
 
@@ -3103,6 +3103,10 @@ void Generic_GCC::GCCInstallationDetector::ScanLibDirForGCCTriple(
       // Linux.
       GCCInstallPath = (LibDir + "/" + LibSuffix + "/" + VersionText).str();
       GCCParentLibPath = (GCCInstallPath + "/../" + Suffix.ReversePath).str();
+#ifdef SYCLomatic_CUSTOMIZATION
+      std::sort(this->CandidateVersion.begin(), this->CandidateVersion.end(),
+                std::greater<GCCVersion>());
+#endif // SYCLomatic_CUSTOMIZATION
       IsValid = true;
     }
   }

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -3087,7 +3087,7 @@ void Generic_GCC::GCCInstallationDetector::ScanLibDirForGCCTriple(
       if (CandidateVersion.isOlderThan(4, 1, 1))
         continue;
 #ifdef SYCLomatic_CUSTOMIZATION
-      this->CandidateVersion.push_back(CandidateVersion);
+      this->CandidateVersion.insert(CandidateVersion);
 #endif // SYCLomatic_CUSTOMIZATION
       if (CandidateVersion <= Version)
         continue;
@@ -3103,10 +3103,6 @@ void Generic_GCC::GCCInstallationDetector::ScanLibDirForGCCTriple(
       // Linux.
       GCCInstallPath = (LibDir + "/" + LibSuffix + "/" + VersionText).str();
       GCCParentLibPath = (GCCInstallPath + "/../" + Suffix.ReversePath).str();
-#ifdef SYCLomatic_CUSTOMIZATION
-      std::sort(this->CandidateVersion.begin(), this->CandidateVersion.end(),
-                std::greater<GCCVersion>());
-#endif // SYCLomatic_CUSTOMIZATION
       IsValid = true;
     }
   }

--- a/clang/lib/Driver/ToolChains/Gnu.h
+++ b/clang/lib/Driver/ToolChains/Gnu.h
@@ -14,7 +14,6 @@
 #include "ROCm.h"
 #include "clang/Driver/Tool.h"
 #include "clang/Driver/ToolChain.h"
-#include <functional>
 #include <set>
 
 namespace clang {

--- a/clang/lib/Driver/ToolChains/Gnu.h
+++ b/clang/lib/Driver/ToolChains/Gnu.h
@@ -14,6 +14,7 @@
 #include "ROCm.h"
 #include "clang/Driver/Tool.h"
 #include "clang/Driver/ToolChain.h"
+#include <functional>
 #include <set>
 
 namespace clang {
@@ -212,7 +213,7 @@ public:
 
     GCCVersion Version;
 #ifdef SYCLomatic_CUSTOMIZATION
-    std::vector<GCCVersion> CandidateVersion;
+    std::set<GCCVersion, std::greater<GCCVersion>> CandidateVersion;
 #endif // SYCLomatic_CUSTOMIZATION
     // We retain the list of install paths that were considered and rejected in
     // order to print out detailed information in verbose mode.
@@ -253,9 +254,12 @@ public:
     /// Get the detected GCC version string.
     const GCCVersion &getVersion() const { return Version; }
 
-    #ifdef SYCLomatic_CUSTOMIZATION
-    const std::vector<GCCVersion> &GetCandidateVersion() const { return CandidateVersion; }
-    #endif // SYCLomatic_CUSTOMIZATION
+#ifdef SYCLomatic_CUSTOMIZATION
+    const std::set<GCCVersion, std::greater<GCCVersion>> &
+    GetCandidateVersion() const {
+      return CandidateVersion;
+    }
+#endif // SYCLomatic_CUSTOMIZATION
 
     /// Print information about the detected GCC installation.
     void print(raw_ostream &OS) const;

--- a/clang/lib/Driver/ToolChains/Gnu.h
+++ b/clang/lib/Driver/ToolChains/Gnu.h
@@ -212,6 +212,7 @@ public:
 
     GCCVersion Version;
 #ifdef SYCLomatic_CUSTOMIZATION
+    /// Collect all the potential versions of GCC libraries installed in the system.
     std::set<GCCVersion, std::greater<GCCVersion>> CandidateVersion;
 #endif // SYCLomatic_CUSTOMIZATION
     // We retain the list of install paths that were considered and rejected in
@@ -254,6 +255,7 @@ public:
     const GCCVersion &getVersion() const { return Version; }
 
 #ifdef SYCLomatic_CUSTOMIZATION
+    /// Get the potiential versions of GCC libraries installed in the system.
     const std::set<GCCVersion, std::greater<GCCVersion>> &
     GetCandidateVersion() const {
       return CandidateVersion;

--- a/clang/lib/Driver/ToolChains/Gnu.h
+++ b/clang/lib/Driver/ToolChains/Gnu.h
@@ -211,7 +211,9 @@ public:
     std::optional<Multilib> BiarchSibling;
 
     GCCVersion Version;
-
+#ifdef SYCLomatic_CUSTOMIZATION
+    std::vector<GCCVersion> CandidateVersion;
+#endif // SYCLomatic_CUSTOMIZATION
     // We retain the list of install paths that were considered and rejected in
     // order to print out detailed information in verbose mode.
     std::set<std::string> CandidateGCCInstallPaths;
@@ -250,6 +252,10 @@ public:
 
     /// Get the detected GCC version string.
     const GCCVersion &getVersion() const { return Version; }
+
+    #ifdef SYCLomatic_CUSTOMIZATION
+    const std::vector<GCCVersion> &GetCandidateVersion() const { return CandidateVersion; }
+    #endif // SYCLomatic_CUSTOMIZATION
 
     /// Print information about the detected GCC installation.
     void print(raw_ostream &OS) const;


### PR DESCRIPTION
On the ubuntu, when user installed the gcc package by "apt install gcc-<version>" and not installed the libstdc++ package, the clang will search the /usr/lib/gcc/x86_64-linux-gnu to get the latest GCC version as default one. The PR will compare all the candidate and use the gcc and libstdc++ all installed version.