### PR TITLE
[Bug][Help] Fixed helper options printing for pattern-rewriter & dpct

### DIFF
--- a/clang/include/clang/DPCT/DPCTOptions.inc
+++ b/clang/include/clang/DPCT/DPCTOptions.inc
@@ -28,7 +28,7 @@
 #define DPCT_OPTION(TEMPLATE, TYPE, NAME, ...)                                 \
   clang::dpct::DpctOption<TEMPLATE, TYPE, llvm::cl::parser<TYPE>> NAME(        \
       clang::dpct::DpctOptionNameKind::OPT_##NAME, __VA_ARGS__,                \
-      llvm::cl::cat(DPCTCat));
+      llvm::cl::cat(CtHelpCatAll));
 #define DPCT_OPTION_ACTIONS(...)                                               \
   { __VA_ARGS__ }
 
@@ -193,7 +193,7 @@ DPCT_PATH_OPTION(
         " directory, if input\nsource files are not provided. "
         "If input source files are provided, the directory\n"
         "of the first input source file is used."),
-    llvm::cl::value_desc("dir"), llvm::cl::cat(DPCTBasicCat),
+    llvm::cl::value_desc("dir"), llvm::cl::cat(CtHelpCatBasic),
     llvm::cl::Optional)
 
 DPCT_PATH_OPTION(
@@ -205,7 +205,7 @@ DPCT_PATH_OPTION(
         "The directory path for root of generated files. A directory is "
         "created if it\n"
         "does not exist. Default: dpct_output."),
-    llvm::cl::value_desc("dir"), llvm::cl::cat(DPCTBasicCat),
+    llvm::cl::value_desc("dir"), llvm::cl::cat(CtHelpCatBasic),
     llvm::cl::Optional)
 
 DPCT_PATH_OPTION(
@@ -216,7 +216,7 @@ DPCT_PATH_OPTION(
                         clang::dpct::DpctActionKind::DAK_BuildScript),
     "cuda-include-path",
     llvm::cl::desc("The directory path of the CUDA header files."),
-    llvm::cl::value_desc("dir"), cat(DPCTCat), cat(DPCTBasicCat),
+    llvm::cl::value_desc("dir"), cat(CtHelpCatAll), cat(CtHelpCatBasic),
     llvm::cl::Optional)
 
 DPCT_PATH_OPTION(
@@ -235,7 +235,7 @@ DPCT_PATH_OPTION(
         "specified, the report will go to stdout. The report files are created "
         "in the\n"
         "directory, specified by -out-root."),
-    llvm::cl::value_desc("prefix"), llvm::cl::cat(DPCTReportGenCat),
+    llvm::cl::value_desc("prefix"), llvm::cl::cat(CtHelpCatReportGen),
     llvm::cl::Optional)
 
 DPCT_FLAG_OPTION(
@@ -244,7 +244,7 @@ DPCT_FLAG_OPTION(
     "report-only",
     llvm::cl::desc("Generate migration reports only. No SYCL "
                    "code will be generated. Default: off."),
-    llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTReportGenCat))
+    llvm::cl::cat(CtHelpCatAll), llvm::cl::cat(CtHelpCatReportGen))
 
 DPCT_FLAG_OPTION(
     KeepOriginalCode, clang::dpct::DpctOptionClass::OC_Attribute,
@@ -252,7 +252,7 @@ DPCT_FLAG_OPTION(
     "keep-original-code",
     llvm::cl::desc("Keep the original code in comments of "
                    "generated SYCL files. Default: off.\n"),
-    llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTCodeGenCat))
+    llvm::cl::cat(CtHelpCatAll), llvm::cl::cat(CtHelpCatCodeGen))
 
 #ifdef DPCT_DEBUG_BUILD
 DPCT_ENUM_OPTION(
@@ -284,7 +284,7 @@ DPCT_ENUM_OPTION(
             false)),
     llvm::cl::desc("Specify the type of migration report. Values are:\n"),
     llvm::cl::init(ReportTypeEnum::RTE_NotSetType),
-    llvm::cl::value_desc("value"), llvm::cl::cat(DPCTReportGenCat),
+    llvm::cl::value_desc("value"), llvm::cl::cat(CtHelpCatReportGen),
     llvm::cl::Optional)
 
 #else
@@ -315,7 +315,7 @@ DPCT_ENUM_OPTION(
             false)),
     llvm::cl::desc("Specify the type of migration report. Values are:\n"),
     llvm::cl::init(ReportTypeEnum::RTE_NotSetType),
-    llvm::cl::value_desc("value"), llvm::cl::cat(DPCTReportGenCat),
+    llvm::cl::value_desc("value"), llvm::cl::cat(CtHelpCatReportGen),
     llvm::cl::Optional)
 #endif
 
@@ -339,7 +339,7 @@ DPCT_ENUM_OPTION(
             false)),
     llvm::cl::desc("Specify the format of the migration reports:\n"),
     llvm::cl::init(ReportFormatEnum::RFE_NotSetFormat),
-    llvm::cl::value_desc("value"), llvm::cl::cat(DPCTReportGenCat),
+    llvm::cl::value_desc("value"), llvm::cl::cat(CtHelpCatReportGen),
     llvm::cl::Optional)
 
 DPCT_OPTION(clang::dpct::list, std::string, SuppressWarnings,
@@ -347,14 +347,14 @@ DPCT_OPTION(clang::dpct::list, std::string, SuppressWarnings,
             DPCT_OPTION_ACTIONS(clang::dpct::DpctActionKind::DAK_Migration),
             "suppress-warnings", llvm::cl::desc(SuppressWarningsMessage),
             llvm::cl::value_desc("value"), llvm::cl::CommaSeparated,
-            llvm::cl::cat(DPCTWarningsCat))
+            llvm::cl::cat(CtHelpCatWarnings))
 
 DPCT_FLAG_OPTION(
     SuppressWarningsAll, clang::dpct::DpctOptionClass::OC_Attribute,
     DPCT_OPTION_ACTIONS(clang::dpct::DpctActionKind::DAK_Migration),
     "suppress-warnings-all",
     llvm::cl::desc("Suppress all migration warnings. Default: off."),
-    llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTWarningsCat))
+    llvm::cl::cat(CtHelpCatAll), llvm::cl::cat(CtHelpCatWarnings))
 
 DPCT_FLAG_OPTION(StopOnParseErr, clang::dpct::DpctOptionClass::OC_Attribute,
                  DPCT_OPTION_ACTIONS(clang::dpct::DpctActionKind::DAK_Migration,
@@ -362,7 +362,7 @@ DPCT_FLAG_OPTION(StopOnParseErr, clang::dpct::DpctOptionClass::OC_Attribute,
                  "stop-on-parse-err",
                  llvm::cl::desc("Stop migration and generation of reports if "
                                 "parsing errors happened. Default: off. \n"),
-                 llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTBasicCat))
+                 llvm::cl::cat(CtHelpCatAll), llvm::cl::cat(CtHelpCatBasic))
 
 DPCT_FLAG_OPTION(
     CheckUnicodeSecurity, clang::dpct::DpctOptionClass::OC_Attribute,
@@ -373,7 +373,7 @@ DPCT_FLAG_OPTION(
                    "that can be exploited by using\n"
                    "bi-directional formatting codes and homoglyphs in "
                    "identifiers. Default: off.\n"),
-    llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTCodeGenCat))
+    llvm::cl::cat(CtHelpCatAll), llvm::cl::cat(CtHelpCatCodeGen))
 
 DPCT_FLAG_OPTION(
     EnablepProfiling, clang::dpct::DpctOptionClass::OC_Attribute,
@@ -384,7 +384,7 @@ DPCT_FLAG_OPTION(
         "Enable SYCL queue profiling in helper functions. default: auto (when "
         "set to\nauto, the enable-profiling option will only be used if the "
         "tool deduces that profiling is required during migration).\n"),
-    llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTCodeGenCat))
+    llvm::cl::cat(CtHelpCatAll), llvm::cl::cat(CtHelpCatCodeGen))
 
 DPCT_FLAG_OPTION(
     SyclNamedLambda, clang::dpct::DpctOptionClass::OC_Attribute,
@@ -392,7 +392,7 @@ DPCT_FLAG_OPTION(
                         clang::dpct::DpctActionKind::DAK_Analysis),
     "sycl-named-lambda",
     llvm::cl::desc("Generate kernels with the kernel name. Default: off.\n"),
-    llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTCodeGenCat))
+    llvm::cl::cat(CtHelpCatAll), llvm::cl::cat(CtHelpCatCodeGen))
 
 DPCT_ENUM_OPTION(
     clang::dpct::opt, OutputVerbosityLevel, OutputVerbosity,
@@ -416,7 +416,7 @@ DPCT_ENUM_OPTION(
                                "Only messages from clang.", false)),
     llvm::cl::desc("Set the output verbosity level:"),
     llvm::cl::init(OutputVerbosityLevel::OVL_Diagnostics),
-    llvm::cl::value_desc("value"), llvm::cl::cat(DPCTWarningsCat),
+    llvm::cl::value_desc("value"), llvm::cl::cat(CtHelpCatWarnings),
     llvm::cl::Optional)
 
 DPCT_PATH_OPTION(
@@ -426,7 +426,7 @@ DPCT_PATH_OPTION(
     llvm::cl::desc("Redirect the stdout/stderr output to <file> in the output"
                    " directory specified\n"
                    "by the --out-root option."),
-    llvm::cl::value_desc("file"), llvm::cl::cat(DPCTWarningsCat),
+    llvm::cl::value_desc("file"), llvm::cl::cat(CtHelpCatWarnings),
     llvm::cl::Optional)
 
 DPCT_OPTION(clang::dpct::list, std::string, RuleFile,
@@ -437,7 +437,7 @@ DPCT_OPTION(clang::dpct::list, std::string, RuleFile,
             "rule-file",
             llvm::cl::desc("Specify the rule file path that "
                            "contains rules used for migration.\n"),
-            llvm::cl::value_desc("file"), llvm::cl::cat(DPCTAdvancedCat),
+            llvm::cl::value_desc("file"), llvm::cl::cat(CtHelpCatAdvanced),
             llvm::cl::ZeroOrMore)
 
 DPCT_ENUM_OPTION(
@@ -458,7 +458,8 @@ DPCT_ENUM_OPTION(
     llvm::cl::desc("Set the Unified Shared Memory (USM) level to use in "
                    "source code generation.\n"),
     llvm::cl::init(UsmLevel::UL_Restricted), llvm::cl::value_desc("value"),
-    llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTCodeGenCat), llvm::cl::Optional)
+    llvm::cl::cat(CtHelpCatAll), llvm::cl::cat(CtHelpCatCodeGen),
+    llvm::cl::Optional)
 
 DPCT_ENUM_OPTION(
     clang::dpct::opt, BuildScriptKind, BuildScript,
@@ -492,7 +493,7 @@ DPCT_ENUM_OPTION(
                                "Do not format any code.", false)),
     llvm::cl::desc("Set the range of formatting.\nThe values are:\n"),
     llvm::cl::init(format::FormatRange::migrated),
-    llvm::cl::value_desc("value"), llvm::cl::cat(DPCTAdvancedCat),
+    llvm::cl::value_desc("value"), llvm::cl::cat(CtHelpCatAdvanced),
     llvm::cl::Optional)
 
 DPCT_ENUM_OPTION(
@@ -511,7 +512,8 @@ DPCT_ENUM_OPTION(
                                "Use the Google coding style.", false)),
     llvm::cl::desc("Set the formatting style.\nThe values are:\n"),
     llvm::cl::init(DPCTFormatStyle::FS_Custom), llvm::cl::value_desc("value"),
-    llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTAdvancedCat), llvm::cl::Optional)
+    llvm::cl::cat(CtHelpCatAll), llvm::cl::cat(CtHelpCatAdvanced),
+    llvm::cl::Optional)
 
 DPCT_FLAG_OPTION(NoDRYPattern, clang::dpct::DpctOptionClass::OC_Attribute,
                  DPCT_OPTION_ACTIONS(clang::dpct::DpctActionKind::DAK_Migration,
@@ -520,7 +522,7 @@ DPCT_FLAG_OPTION(NoDRYPattern, clang::dpct::DpctOptionClass::OC_Attribute,
                  llvm::cl::desc("Do not use DRY (do not repeat yourself) "
                                 "pattern when functions from dpct\n"
                                 "namespace are inserted. Default: off.\n"),
-                 llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTCodeGenCat))
+                 llvm::cl::cat(CtHelpCatAll), llvm::cl::cat(CtHelpCatCodeGen))
 
 DPCT_FLAG_OPTION(
     ProcessAll, clang::dpct::DpctOptionClass::OC_Attribute,
@@ -532,7 +534,7 @@ DPCT_FLAG_OPTION(
                    "to the --out-root directory. The --in-root option should "
                    "be explicitly specified.\n"
                    "Default: off."),
-    llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTBasicCat))
+    llvm::cl::cat(CtHelpCatAll), llvm::cl::cat(CtHelpCatBasic))
 
 DPCT_FLAG_OPTION(
     EnableCodePin, clang::dpct::DpctOptionClass::OC_Attribute,
@@ -542,7 +544,7 @@ DPCT_FLAG_OPTION(
         "EXPERIMENTAL: Generate instrumented CUDA and SYCL code for debug and "
         "verification purposes in the directory <dir>_codepin_cuda and "
         "<dir>_codepin_sycl, where <dir> is specified by --out-root option."),
-    llvm::cl::cat(DPCTCat))
+    llvm::cl::cat(CtHelpCatAll))
 
 DPCT_FLAG_OPTION(
     EnableCTAD, clang::dpct::DpctOptionClass::OC_Attribute,
@@ -552,14 +554,14 @@ DPCT_FLAG_OPTION(
     llvm::cl::desc("Use a C++17 class template argument deduction (CTAD) in "
                    "your generated code.\n"
                    "Default: off."),
-    llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTCodeGenCat))
+    llvm::cl::cat(CtHelpCatAll), llvm::cl::cat(CtHelpCatCodeGen))
 
 DPCT_FLAG_OPTION(
     EnableComments, clang::dpct::DpctOptionClass::OC_Attribute,
     DPCT_OPTION_ACTIONS(clang::dpct::DpctActionKind::DAK_Migration), "comments",
     llvm::cl::desc(
         "Insert comments explaining the generated code. Default: off."),
-    llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTCodeGenCat))
+    llvm::cl::cat(CtHelpCatAll), llvm::cl::cat(CtHelpCatCodeGen))
 
 DPCT_FLAG_OPTION(
     AsyncHandler, clang::dpct::DpctOptionClass::OC_Attribute,
@@ -569,7 +571,7 @@ DPCT_FLAG_OPTION(
     llvm::cl::desc("Use async exception handler when creating new sycl::queue "
                    "with dpct::create_queue\nin addition to default "
                    "dpct::get_default_queue. Default: off."),
-    llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTCodeGenCat))
+    llvm::cl::cat(CtHelpCatAll), llvm::cl::cat(CtHelpCatCodeGen))
 
 DPCT_ENUM_OPTION(
     clang::dpct::opt, AssumedNDRangeDimEnum, NDRangeDim,
@@ -589,7 +591,7 @@ DPCT_ENUM_OPTION(
                    "nd_range to use in generated code.\n"
                    "The values are:\n"),
     llvm::cl::init(AssumedNDRangeDimEnum::ARE_Dim3),
-    llvm::cl::value_desc("value"), llvm::cl::cat(DPCTCodeGenCat),
+    llvm::cl::value_desc("value"), llvm::cl::cat(CtHelpCatCodeGen),
     llvm::cl::Optional)
 
 DPCT_ENUM_OPTION(
@@ -599,9 +601,11 @@ DPCT_ENUM_OPTION(
                         clang::dpct::DpctActionKind::DAK_Analysis),
     "use-explicit-namespace",
     DPCT_OPTION_VALUES(
-        DPCT_OPTION_ENUM_VALUE("dpct", int(clang::dpct::ExplicitNamespace::EN_DPCT),
+        DPCT_OPTION_ENUM_VALUE("dpct",
+                               int(clang::dpct::ExplicitNamespace::EN_DPCT),
                                "Generate code with dpct:: namespace.", false),
-        DPCT_OPTION_ENUM_VALUE("none", int(clang::dpct::ExplicitNamespace::EN_None),
+        DPCT_OPTION_ENUM_VALUE("none",
+                               int(clang::dpct::ExplicitNamespace::EN_None),
                                "Generate code without any namespaces. Cannot "
                                "be used with other values.",
                                false),
@@ -616,16 +620,15 @@ DPCT_ENUM_OPTION(
             "SYCL math functions.\n"
             "Cannot be used with cl or sycl values.",
             false),
-        DPCT_OPTION_ENUM_VALUE("syclcompat",
-                               int(clang::dpct::ExplicitNamespace::EN_SYCLCompat),
-                               "Generate code with syclcompat:: namespace.",
-                               false)),
+        DPCT_OPTION_ENUM_VALUE(
+            "syclcompat", int(clang::dpct::ExplicitNamespace::EN_SYCLCompat),
+            "Generate code with syclcompat:: namespace.", false)),
     llvm::cl::desc("Define the namespaces to use explicitly in generated "
                    "code. The <value> is a comma\n"
                    "separated list. Default: dpct/syclcompat, sycl.\n"
                    "Possible values are:"),
     llvm::cl::CommaSeparated, llvm::cl::value_desc("value"),
-    llvm::cl::cat(DPCTCodeGenCat), llvm::cl::ZeroOrMore)
+    llvm::cl::cat(CtHelpCatCodeGen), llvm::cl::ZeroOrMore)
 
 DPCT_ENUM_OPTION(
     clang::dpct::bits, DPCPPExtensionsDefaultEnabled, NoDPCPPExtensions,
@@ -664,7 +667,7 @@ DPCT_ENUM_OPTION(
                    "By default, these extensions are used in migrated code.\n"
                    "The values are:"),
     llvm::cl::CommaSeparated, llvm::cl::value_desc("value"),
-    llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTAdvancedCat),
+    llvm::cl::cat(CtHelpCatAll), llvm::cl::cat(CtHelpCatAdvanced),
     llvm::cl::ZeroOrMore)
 
 DPCT_ENUM_OPTION(
@@ -700,7 +703,7 @@ DPCT_ENUM_OPTION(
         "A comma-separated list of extensions to be used in migrated code.\n"
         "By default, these extensions are not used in migrated code."),
     llvm::cl::CommaSeparated, llvm::cl::value_desc("value"),
-    llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTAdvancedCat),
+    llvm::cl::cat(CtHelpCatAll), llvm::cl::cat(CtHelpCatAdvanced),
     llvm::cl::ZeroOrMore)
 
 DPCT_ENUM_OPTION(
@@ -814,7 +817,7 @@ DPCT_ENUM_OPTION(
         "By default, experimental features will not be used in migrated "
         "code.\nThe values are:\n"),
     llvm::cl::CommaSeparated, llvm::cl::value_desc("value"),
-    llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTAdvancedCat),
+    llvm::cl::cat(CtHelpCatAll), llvm::cl::cat(CtHelpCatAdvanced),
     llvm::cl::ZeroOrMore)
 
 DPCT_FLAG_OPTION(GenBuildScript, clang::dpct::DpctOptionClass::OC_Attribute,
@@ -823,7 +826,8 @@ DPCT_FLAG_OPTION(GenBuildScript, clang::dpct::DpctOptionClass::OC_Attribute,
                  "gen-build-script",
                  llvm::cl::desc("Generate makefile for migrated file(s) "
                                 "in -out-root directory. Default: off."),
-                 llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTBuildScriptCat))
+                 llvm::cl::cat(CtHelpCatAll),
+                 llvm::cl::cat(CtHelpCatBuildScript))
 
 DPCT_PATH_OPTION(
     BuildScriptFile, clang::dpct::DpctOptionClass::OC_Attribute,
@@ -832,7 +836,7 @@ DPCT_PATH_OPTION(
     llvm::cl::desc(
         "Specify the name of generated makefile for migrated file(s).\n"
         "Default name: Makefile.dpct."),
-    llvm::cl::value_desc("file"), llvm::cl::cat(DPCTBuildScriptCat),
+    llvm::cl::value_desc("file"), llvm::cl::cat(CtHelpCatBuildScript),
     llvm::cl::Optional)
 
 DPCT_FLAG_OPTION(
@@ -850,7 +854,7 @@ DPCT_OPTION(
                         clang::dpct::DpctActionKind::DAK_Analysis),
     "in-root-exclude",
     llvm::cl::desc("Exclude the specified directory or file from processing."),
-    llvm::cl::value_desc("dir|file"), llvm::cl::cat(DPCTBasicCat),
+    llvm::cl::value_desc("dir|file"), llvm::cl::cat(CtHelpCatBasic),
     llvm::cl::ZeroOrMore)
 
 DPCT_FLAG_OPTION(
@@ -861,7 +865,7 @@ DPCT_FLAG_OPTION(
     llvm::cl::desc("Generate SYCL code applying more aggressive assumptions "
                    "that potentially\n"
                    "may alter the semantics of your program. Default: off."),
-    llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTCodeGenCat))
+    llvm::cl::cat(CtHelpCatAll), llvm::cl::cat(CtHelpCatCodeGen))
 
 DPCT_FLAG_OPTION(
     NoIncrementalMigration, clang::dpct::DpctOptionClass::OC_Attribute,
@@ -881,7 +885,7 @@ DPCT_OPTION(
         "The directory path for the analysis scope of the source tree that "
         "needs to be migrated.\n"
         "Default: the value of --in-root."),
-    llvm::cl::value_desc("dir"), llvm::cl::cat(DPCTBasicCat),
+    llvm::cl::value_desc("dir"), llvm::cl::cat(CtHelpCatBasic),
     llvm::cl::ZeroOrMore)
 
 DPCT_FLAG_OPTION(
@@ -890,7 +894,7 @@ DPCT_FLAG_OPTION(
     "change-cuda-files-extension-only",
     llvm::cl::desc(
         "Limit extension change to .cu and .cuh files only. Default: off."),
-    llvm::cl::value_desc("file"), llvm::cl::cat(DPCTCodeGenCat))
+    llvm::cl::value_desc("file"), llvm::cl::cat(CtHelpCatCodeGen))
 
 DPCT_ENUM_OPTION(
     clang::dpct::opt, SYCLFileExtensionEnum, SYCLFileExtension,
@@ -917,7 +921,7 @@ DPCT_FLAG_OPTION(
     "gen-helper-function",
     llvm::cl::desc("Generate helper function files in the "
                    "--out-root directory. Default: off."),
-    llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTCodeGenCat))
+    llvm::cl::cat(CtHelpCatAll), llvm::cl::cat(CtHelpCatCodeGen))
 
 DPCT_FLAG_OPTION(
     PathToHelperFunction, clang::dpct::DpctOptionClass::OC_Action,
@@ -925,7 +929,7 @@ DPCT_FLAG_OPTION(
     "helper-function-dir",
     llvm::cl::desc(
         "Print the installation directory for helper function header files."),
-    llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTHelpInfoCat))
+    llvm::cl::cat(CtHelpCatAll), llvm::cl::cat(CtHelpCatHelpInfo))
 
 #ifndef _WIN32
 DPCT_FLAG_OPTION(
@@ -933,7 +937,8 @@ DPCT_FLAG_OPTION(
     DPCT_OPTION_ACTIONS(clang::dpct::DpctActionKind::DAK_Independent),
     "intercept-build",
     llvm::cl::desc("Intercept build tool to generate a compilation database."),
-    llvm::cl::value_desc("build command"), llvm::cl::cat(DPCTInterceptBuildCat))
+    llvm::cl::value_desc("build command"),
+    llvm::cl::cat(CtHelpCatInterceptBuild))
 #endif
 
 DPCT_FLAG_OPTION(
@@ -951,7 +956,7 @@ DPCT_OPTION(clang::dpct::opt, std::string, QueryAPIMapping,
             "query-api-mapping",
             llvm::cl::desc(
                 "Query functionally compatible SYCL API to migrate CUDA API."),
-            llvm::cl::value_desc("api"), llvm::cl::cat(DPCTQueryAPICat),
+            llvm::cl::value_desc("api"), llvm::cl::cat(CtHelpCatQueryAPI),
             llvm::cl::Optional)
 
 DPCT_ENUM_OPTION(
@@ -967,7 +972,8 @@ DPCT_ENUM_OPTION(
         false)),
     llvm::cl::desc("The preference of helper function usage in migration.\n"),
     llvm::cl::CommaSeparated, llvm::cl::value_desc("value"),
-    llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTCodeGenCat), llvm::cl::ZeroOrMore)
+    llvm::cl::cat(CtHelpCatAll), llvm::cl::cat(CtHelpCatCodeGen),
+    llvm::cl::ZeroOrMore)
 
 DPCT_FLAG_OPTION(
     UseSYCLCompat, clang::dpct::DpctOptionClass::OC_Attribute,
@@ -979,14 +985,14 @@ DPCT_FLAG_OPTION(
     llvm::cl::desc(
         "Use SYCLcompat header-only library (syclcompat:: namespace) to assist "
         "the migration of input source code.\nDefault: off.\n"),
-    llvm::cl::cat(DPCTCodeGenCat), llvm::cl::cat(DPCTCat))
+    llvm::cl::cat(CtHelpCatCodeGen), llvm::cl::cat(CtHelpCatAll))
 
 DPCT_FLAG_OPTION(
     AnalysisMode, clang::dpct::DpctOptionClass::OC_Action,
     DPCT_OPTION_ACTIONS(clang::dpct::DpctActionKind::DAK_Analysis),
     "analysis-mode",
     llvm::cl::desc("Only generate a report for porting effort. Default: off."),
-    llvm::cl::cat(DPCTCat), llvm::cl::cat(DPCTBasicCat))
+    llvm::cl::cat(CtHelpCatAll), llvm::cl::cat(CtHelpCatBasic))
 
 DPCT_PATH_OPTION(
     AnalysisModeOutputFile, clang::dpct::DpctOptionClass::OC_Attribute,
@@ -995,7 +1001,7 @@ DPCT_PATH_OPTION(
     llvm::cl::desc(
         "Specify the file where the analysis mode report is saved. Default: "
         "Output to stdout."),
-    llvm::cl::value_desc("file"), llvm::cl::cat(DPCTBasicCat))
+    llvm::cl::value_desc("file"), llvm::cl::cat(CtHelpCatBasic))
 
 DPCT_HIDDEN_OPTION(
     clang::dpct::opt, std::string, SDKPathOpt,
@@ -1029,7 +1035,7 @@ DPCT_HIDDEN_OPTION(
                    "pass information. "
                    "\"transformation\": Detailed migration pass "
                    "transformation information."),
-    llvm::cl::value_desc("[pass|transformation]"), llvm::cl::cat(DPCTCat),
+    llvm::cl::value_desc("[pass|transformation]"), llvm::cl::cat(CtHelpCatAll),
     llvm::cl::Optional)
 #endif
 

--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -87,19 +87,19 @@ extern UnifiedPath VcxprojFilePath;
 #endif
 } // namespace tooling
 namespace dpct {
-llvm::cl::OptionCategory &DPCTCat = llvm::cl::getDPCTCategory();
-llvm::cl::OptionCategory &DPCTBasicCat = llvm::cl::getDPCTBasicCategory();
-llvm::cl::OptionCategory &DPCTAdvancedCat = llvm::cl::getDPCTAdvancedCategory();
-llvm::cl::OptionCategory &DPCTCodeGenCat = llvm::cl::getDPCTCodeGenCategory();
-llvm::cl::OptionCategory &DPCTReportGenCat =
-    llvm::cl::getDPCTReportGenCategory();
-llvm::cl::OptionCategory &DPCTBuildScriptCat =
-    llvm::cl::getDPCTBuildScriptCategory();
-llvm::cl::OptionCategory &DPCTQueryAPICat = llvm::cl::getDPCTQueryAPICategory();
-llvm::cl::OptionCategory &DPCTWarningsCat = llvm::cl::getDPCTWarningsCategory();
-llvm::cl::OptionCategory &DPCTHelpInfoCat = llvm::cl::getDPCTHelpInfoCategory();
-llvm::cl::OptionCategory &DPCTInterceptBuildCat =
-    llvm::cl::getDPCTInterceptBuildCategory();
+llvm::cl::OptionCategory &CtHelpCatAll = llvm::cl::getCtHelpCat();
+llvm::cl::OptionCategory &CtHelpCatBasic = llvm::cl::getCtHelpCatBasic();
+llvm::cl::OptionCategory &CtHelpCatAdvanced = llvm::cl::getCtHelpCatAdvanced();
+llvm::cl::OptionCategory &CtHelpCatCodeGen = llvm::cl::getCtHelpCatCodeGen();
+llvm::cl::OptionCategory &CtHelpCatReportGen =
+    llvm::cl::getCtHelpCatReportGen();
+llvm::cl::OptionCategory &CtHelpCatBuildScript =
+    llvm::cl::getCtHelpCatBuildScript();
+llvm::cl::OptionCategory &CtHelpCatQueryAPI = llvm::cl::getCtHelpCatQueryAPI();
+llvm::cl::OptionCategory &CtHelpCatWarnings = llvm::cl::getCtHelpCatWarnings();
+llvm::cl::OptionCategory &CtHelpCatHelpInfo = llvm::cl::getCtHelpCatHelpInfo();
+llvm::cl::OptionCategory &CtHelpCatInterceptBuild =
+    llvm::cl::getCtHelpCatInterceptBuild();
 void initWarningIDs();
 } // namespace dpct
 } // namespace clang
@@ -138,7 +138,7 @@ static std::string SuppressWarningsMessage = "A comma separated list of migratio
 static AutoCompletePrinter AutoCompletePrinterInstance;
 static llvm::cl::opt<AutoCompletePrinter, true, llvm::cl::parser<std::string>> AutoComplete(
   "autocomplete", llvm::cl::desc("List all options or enums which have the specified prefix.\n"),
-  llvm::cl::cat(DPCTCat), llvm::cl::ReallyHidden, llvm::cl::location(AutoCompletePrinterInstance));
+  llvm::cl::cat(CtHelpCatAll), llvm::cl::ReallyHidden, llvm::cl::location(AutoCompletePrinterInstance));
 #endif
 // clang-format on
 
@@ -693,8 +693,8 @@ int runDPCT(int argc, const char **argv) {
 #endif
   llvm::cl::SetVersionPrinter(
       [](llvm::raw_ostream &OS) { OS << printCTVersion() << "\n"; });
-  auto OptParser =
-      CommonOptionsParser::create(argc, argv, DPCTCat, llvm::cl::OneOrMore);
+  auto OptParser = CommonOptionsParser::create(argc, argv, CtHelpCatAll,
+                                               llvm::cl::OneOrMore);
   if (!OptParser) {
     if (OptParser.errorIsA<DPCTError>()) {
       llvm::Error NewE =

--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -78,6 +78,8 @@ using namespace clang::tooling;
 
 using namespace llvm::cl;
 
+extern bool isDPCT;
+
 namespace clang {
 namespace tooling {
 UnifiedPath getFormatSearchPath();
@@ -666,6 +668,7 @@ int showAPIMapping(std::string SrcAPI, std::string Option,
 }
 
 int runDPCT(int argc, const char **argv) {
+  isDPCT = true;
 
   if (argc < 2) {
     std::cout << CtHelpHint;

--- a/clang/tools/pattern-rewriter/src/driver.cpp
+++ b/clang/tools/pattern-rewriter/src/driver.cpp
@@ -113,18 +113,37 @@ static std::string fixLineEndings(const std::string &Input) {
   return OutputStream.str();
 }
 
+#ifdef SYCLomatic_CUSTOMIZATION
+llvm::cl::OptionCategory &getPatReCategory() {
+  static llvm::cl::OptionCategory PatReCategory("Pattern Rewriter options");
+  return PatReCategory;
+}
+#endif
+
 int main(int argc, char *argv[]) {
-  llvm::cl::opt<std::string> InputFilename(
-      llvm::cl::Positional, llvm::cl::desc("<input file>"),
-      llvm::cl::value_desc("filename"), llvm::cl::Required);
+  llvm::cl::opt<std::string> InputFilename(llvm::cl::Positional,
+                                           llvm::cl::desc("<input file>"),
+                                           llvm::cl::value_desc("filename"),
+#ifdef SYCLomatic_CUSTOMIZATION
+                                           llvm::cl::cat(getPatReCategory()),
+#endif
+                                           llvm::cl::Required);
 
   llvm::cl::opt<std::string> OutputFilename(
       "o", llvm::cl::desc("[required] Specify output filename"),
-      llvm::cl::value_desc("filename"), llvm::cl::Required);
+      llvm::cl::value_desc("filename"),
+#ifdef SYCLomatic_CUSTOMIZATION
+      llvm::cl::cat(getPatReCategory()),
+#endif
+      llvm::cl::Required);
 
   llvm::cl::opt<std::string> RulesFilename(
       "r", llvm::cl::desc("[required] Specify rules filename"),
-      llvm::cl::value_desc("filename"), llvm::cl::Required);
+      llvm::cl::value_desc("filename"),
+#ifdef SYCLomatic_CUSTOMIZATION
+      llvm::cl::cat(getPatReCategory()),
+#endif
+      llvm::cl::Required);
 
   llvm::cl::extrahelp MoreHelp(Examples);
 

--- a/clang/tools/pattern-rewriter/src/driver.cpp
+++ b/clang/tools/pattern-rewriter/src/driver.cpp
@@ -113,39 +113,30 @@ static std::string fixLineEndings(const std::string &Input) {
   return OutputStream.str();
 }
 
-#ifdef SYCLomatic_CUSTOMIZATION
 llvm::cl::OptionCategory &getPatReCategory() {
   static llvm::cl::OptionCategory PatReCategory("Pattern Rewriter options");
   return PatReCategory;
 }
-#endif
 
 int main(int argc, char *argv[]) {
-  llvm::cl::opt<std::string> InputFilename(llvm::cl::Positional,
-                                           llvm::cl::desc("<input file>"),
-                                           llvm::cl::value_desc("filename"),
-#ifdef SYCLomatic_CUSTOMIZATION
-                                           llvm::cl::cat(getPatReCategory()),
-#endif
-                                           llvm::cl::Required);
+  llvm::cl::opt<std::string> InputFilename(
+      llvm::cl::Positional, llvm::cl::desc("<input file>"),
+      llvm::cl::value_desc("filename"), llvm::cl::cat(getPatReCategory()),
+      llvm::cl::Required);
 
   llvm::cl::opt<std::string> OutputFilename(
       "o", llvm::cl::desc("[required] Specify output filename"),
-      llvm::cl::value_desc("filename"),
-#ifdef SYCLomatic_CUSTOMIZATION
-      llvm::cl::cat(getPatReCategory()),
-#endif
+      llvm::cl::value_desc("filename"), llvm::cl::cat(getPatReCategory()),
       llvm::cl::Required);
 
   llvm::cl::opt<std::string> RulesFilename(
       "r", llvm::cl::desc("[required] Specify rules filename"),
-      llvm::cl::value_desc("filename"),
-#ifdef SYCLomatic_CUSTOMIZATION
-      llvm::cl::cat(getPatReCategory()),
-#endif
+      llvm::cl::value_desc("filename"), llvm::cl::cat(getPatReCategory()),
       llvm::cl::Required);
 
   llvm::cl::extrahelp MoreHelp(Examples);
+
+  llvm::cl::HideUnrelatedOptions(getPatReCategory());
 
   llvm::cl::ParseCommandLineOptions(argc, argv, Description);
 

--- a/llvm/include/llvm/Support/CommandLine.h
+++ b/llvm/include/llvm/Support/CommandLine.h
@@ -197,17 +197,17 @@ public:
 // The general Option Category (used as default category).
 OptionCategory &getGeneralCategory();
 #ifdef SYCLomatic_CUSTOMIZATION
-OptionCategory &getDPCTCategory();
-OptionCategory &getDPCTBasicCategory();
-OptionCategory &getDPCTAdvancedCategory();
-OptionCategory &getDPCTCodeGenCategory();
-OptionCategory &getDPCTReportGenCategory();
-OptionCategory &getDPCTBuildScriptCategory();
-OptionCategory &getDPCTQueryAPICategory();
-OptionCategory &getDPCTWarningsCategory();
-OptionCategory &getDPCTHelpInfoCategory();
-OptionCategory &getDPCTInterceptBuildCategory();
-OptionCategory &getDPCTExamplesCategory();
+OptionCategory &getCtHelpCat();
+OptionCategory &getCtHelpCatBasic();
+OptionCategory &getCtHelpCatAdvanced();
+OptionCategory &getCtHelpCatCodeGen();
+OptionCategory &getCtHelpCatReportGen();
+OptionCategory &getCtHelpCatBuildScript();
+OptionCategory &getCtHelpCatQueryAPI();
+OptionCategory &getCtHelpCatWarnings();
+OptionCategory &getCtHelpCatHelpInfo();
+OptionCategory &getCtHelpCatInterceptBuild();
+OptionCategory &getCtExamplesCategory();
 #endif // SYCLomatic_CUSTOMIZATION
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -2346,8 +2346,8 @@ sortSubCommands(const SmallPtrSetImpl<SubCommand *> &SubMap,
 namespace {
 
 #ifdef SYCLomatic_CUSTOMIZATION
-/// HelpCategory defines various category groups for dpct options
-enum class HelpCategory {
+/// CtHelpCategory defines various category groups for dpct options
+enum class CtHelpCategory {
   HC_All,
   HC_Basic,
   HC_Advanced,
@@ -2368,7 +2368,8 @@ class HelpPrinter {
 protected:
   const bool ShowHidden;
 #ifdef SYCLomatic_CUSTOMIZATION
-  HelpCategory helpCatEnum = HelpCategory::HC_All;
+  bool isDPCT = false;
+  CtHelpCategory CtHelpCat = CtHelpCategory::HC_All;
 #endif // SYCLomatic_CUSTOMIZATION
   typedef SmallVector<std::pair<const char *, Option *>, 128>
       StrOptionPairVector;
@@ -2393,36 +2394,50 @@ protected:
 
 #ifdef SYCLomatic_CUSTOMIZATION
   // Store the user requested category
-  void setReqCategory(HelpCategory reqCatEnumVal) {
-    helpCatEnum = reqCatEnumVal;
+  void setReqCtHelpCategory(CtHelpCategory reqCtHelpCat) {
+    CtHelpCat = reqCtHelpCat;
   }
 
   // Return the user requested category
-  OptionCategory &getReqCategory(HelpCategory reqCatEnumVal) {
-    switch (reqCatEnumVal) {
-    case HelpCategory::HC_All:
-      return cl::getDPCTCategory();
-    case HelpCategory::HC_Basic:
-      return cl::getDPCTBasicCategory();
-    case HelpCategory::HC_Advanced:
-      return cl::getDPCTAdvancedCategory();
-    case HelpCategory::HC_CodeGen:
-      return cl::getDPCTCodeGenCategory();
-    case HelpCategory::HC_ReportGen:
-      return cl::getDPCTReportGenCategory();
-    case HelpCategory::HC_BuildScript:
-      return cl::getDPCTBuildScriptCategory();
-    case HelpCategory::HC_QueryAPI:
-      return cl::getDPCTQueryAPICategory();
-    case HelpCategory::HC_Warnings:
-      return cl::getDPCTWarningsCategory();
-    case HelpCategory::HC_HelpInfo:
-      return cl::getDPCTHelpInfoCategory();
-    case HelpCategory::HC_InterceptBuild:
-      return cl::getDPCTInterceptBuildCategory();
-    case HelpCategory::HC_Examples:
-      return cl::getDPCTExamplesCategory();
+  OptionCategory &getReqCtHelpCategory(CtHelpCategory reqCtHelpCat) {
+    switch (reqCtHelpCat) {
+    case CtHelpCategory::HC_All:
+      return cl::getCtHelpCat();
+    case CtHelpCategory::HC_Basic:
+      return cl::getCtHelpCatBasic();
+    case CtHelpCategory::HC_Advanced:
+      return cl::getCtHelpCatAdvanced();
+    case CtHelpCategory::HC_CodeGen:
+      return cl::getCtHelpCatCodeGen();
+    case CtHelpCategory::HC_ReportGen:
+      return cl::getCtHelpCatReportGen();
+    case CtHelpCategory::HC_BuildScript:
+      return cl::getCtHelpCatBuildScript();
+    case CtHelpCategory::HC_QueryAPI:
+      return cl::getCtHelpCatQueryAPI();
+    case CtHelpCategory::HC_Warnings:
+      return cl::getCtHelpCatWarnings();
+    case CtHelpCategory::HC_HelpInfo:
+      return cl::getCtHelpCatHelpInfo();
+    case CtHelpCategory::HC_InterceptBuild:
+      return cl::getCtHelpCatInterceptBuild();
+    case CtHelpCategory::HC_Examples:
+      return cl::getCtExamplesCategory();
     }
+  }
+
+  bool isPatReCat(OptionCategory *Category) {
+    if (Category->getName().starts_with("Pattern Rewriter"))
+      return true;
+
+    return false;
+  }
+
+  bool isDPCTCat(OptionCategory *Category) {
+    if (Category->getDescription().ends_with("DPCT options"))
+      return true;
+
+    return false;
   }
 #endif // SYCLomatic_CUSTOMIZATION
 
@@ -2453,9 +2468,14 @@ public:
     sortSubCommands(GlobalParser->RegisteredSubCommands, Subs);
 
 #ifdef SYCLomatic_CUSTOMIZATION
-    if (helpCatEnum == HelpCategory::HC_Examples) {
-      outs() << DPCTExamplesMsg;
-      return;
+    isDPCT = !strcmp((GlobalParser->ProgramName).c_str(), "dpct") ||
+             !strcmp((GlobalParser->ProgramName).c_str(), "c2s");
+
+    if (isDPCT) {
+      if (CtHelpCat == CtHelpCategory::HC_Examples) {
+        outs() << DPCTExamplesMsg;
+        return;
+      }
     }
 #endif // SYCLomatic_CUSTOMIZATION
 
@@ -2509,10 +2529,10 @@ public:
       MaxArgLen = std::max(MaxArgLen, Opts[i].second->getOptionWidth());
 
 #ifdef SYCLomatic_CUSTOMIZATION
-    OptionCategory &requestedCat(getReqCategory(helpCatEnum));
+    OptionCategory &reqCtHelpCat(getReqCtHelpCategory(CtHelpCat));
 
-    if (helpCatEnum != HelpCategory::HC_All)
-      outs() << "OPTIONS: " << requestedCat.getName() << "\n";
+    if (isDPCT && CtHelpCat != CtHelpCategory::HC_All)
+      outs() << "OPTIONS: " << reqCtHelpCat.getName() << "\n";
     else
       outs() << "OPTIONS:\n";
 #else
@@ -2526,30 +2546,34 @@ public:
                                        "files. These paths are looked up in "
                                        "the compilation database.\n\n";
 
-    outs() << CtHelpTrailMsg;
+    if (isDPCT) {
+      outs() << CtHelpTrailMsg;
 
-    if (helpCatEnum == HelpCategory::HC_All) {
-      outs() << DPCTExamplesMsg;
+      if (CtHelpCat == CtHelpCategory::HC_All) {
+        outs() << DPCTExamplesMsg;
+      }
     }
 #endif // SYCLomatic_CUSTOMIZATION
 
     // Print any extra help the user has declared.
 #ifdef SYCLomatic_CUSTOMIZATION
-    bool showDiagMsg = false;
+    bool showCtDiagMsg = false;
 
-    switch (helpCatEnum) {
-    case HelpCategory::HC_All:
-    case HelpCategory::HC_Advanced:
-    case HelpCategory::HC_Basic:
-    case HelpCategory::HC_BuildScript:
-    case HelpCategory::HC_CodeGen:
-      showDiagMsg = true;
-      break;
-    default:
-      showDiagMsg = false;
+    if (isDPCT) {
+      switch (CtHelpCat) {
+      case CtHelpCategory::HC_All:
+      case CtHelpCategory::HC_Advanced:
+      case CtHelpCategory::HC_Basic:
+      case CtHelpCategory::HC_BuildScript:
+      case CtHelpCategory::HC_CodeGen:
+        showCtDiagMsg = true;
+        break;
+      default:
+        break;
+      }
     }
 
-    if (showDiagMsg) {
+    if (!isDPCT || showCtDiagMsg) {
       for (const auto &I : GlobalParser->MoreHelp)
         outs() << I;
     }
@@ -2576,12 +2600,15 @@ public:
 
   // Make sure we inherit our base class's operator=()
   using HelpPrinter::operator=;
-  using HelpPrinter::setReqCategory;
+  using HelpPrinter::setReqCtHelpCategory;
 
 protected:
   void printOptions(StrOptionPairVector &Opts, size_t MaxArgLen) override {
     std::vector<OptionCategory *> SortedCategories;
     DenseMap<OptionCategory *, std::vector<Option *>> CategorizedOptions;
+
+    bool isPatRe =
+        !strcmp((GlobalParser->ProgramName).c_str(), "pattern-rewriter");
 
     // Collect registered option categories into vector in preparation for
     // sorting.
@@ -2606,7 +2633,7 @@ protected:
     }
 
 #ifdef SYCLomatic_CUSTOMIZATION
-    OptionCategory &requestedCat(getReqCategory(helpCatEnum));
+    OptionCategory &reqCtHelpCat(getReqCtHelpCategory(CtHelpCat));
 #endif // SYCLomatic_CUSTOMIZATION
 
     // Now do printing.
@@ -2617,7 +2644,13 @@ protected:
         continue;
 
 #ifdef SYCLomatic_CUSTOMIZATION
-      if (&requestedCat != Category)
+      if (isDPCT) {
+        if (!isDPCTCat(Category))
+          continue;
+        else if (&reqCtHelpCat != Category)
+          continue;
+      }
+      if (isPatRe && !isPatReCat(Category))
         continue;
 #endif // SYCLomatic_CUSTOMIZATION
 
@@ -2659,7 +2692,7 @@ public:
   // Invoke the printer.
   void operator=(bool Value);
 #ifdef SYCLomatic_CUSTOMIZATION
-  void operator=(HelpCategory Value);
+  void operator=(CtHelpCategory Value);
 #endif // SYCLomatic_CUSTOMIZATION
 };
 
@@ -2760,47 +2793,47 @@ struct CommandLineCommonOptions {
   // behaviour at runtime depending on whether one or more Option categories
   // have been declared.
 #ifdef SYCLomatic_CUSTOMIZATION
-  cl::opt<HelpPrinterWrapper, true, cl::parser<HelpCategory>> HOp{
+  cl::opt<HelpPrinterWrapper, true, cl::parser<CtHelpCategory>> HOp{
       "help",
       cl::values(
           cl::OptionEnumValue{
-              "", int(HelpCategory::HC_All),
+              "", int(CtHelpCategory::HC_All),
               "List all options in alphabetical order. (default)", true},
-          cl::OptionEnumValue{"basic", int(HelpCategory::HC_Basic),
+          cl::OptionEnumValue{"basic", int(CtHelpCategory::HC_Basic),
                               "List options for basic migration.", false},
-          cl::OptionEnumValue{"advanced", int(HelpCategory::HC_Advanced),
+          cl::OptionEnumValue{"advanced", int(CtHelpCategory::HC_Advanced),
                               "List options for advanced migration.", false},
-          cl::OptionEnumValue{"code-gen", int(HelpCategory::HC_CodeGen),
+          cl::OptionEnumValue{"code-gen", int(CtHelpCategory::HC_CodeGen),
                               "List options to customize how code is migrated.",
                               false},
           cl::OptionEnumValue{
-              "report-gen", int(HelpCategory::HC_ReportGen),
+              "report-gen", int(CtHelpCategory::HC_ReportGen),
               "List option(s) to control report generation during migration.",
               false},
-          cl::OptionEnumValue{"build-script", int(HelpCategory::HC_BuildScript),
-                              "List options to migrate build script(s).",
-                              false},
-          cl::OptionEnumValue{"query-api", int(HelpCategory::HC_QueryAPI),
+          cl::OptionEnumValue{
+              "build-script", int(CtHelpCategory::HC_BuildScript),
+              "List options to migrate build script(s).", false},
+          cl::OptionEnumValue{"query-api", int(CtHelpCategory::HC_QueryAPI),
                               "List options to query API mapping support.",
                               false},
           cl::OptionEnumValue{
-              "warnings", int(HelpCategory::HC_Warnings),
+              "warnings", int(CtHelpCategory::HC_Warnings),
               "List options to manage warnings generated by the tool.", false},
-          cl::OptionEnumValue{"help-info", int(HelpCategory::HC_HelpInfo),
+          cl::OptionEnumValue{"help-info", int(CtHelpCategory::HC_HelpInfo),
                               "List options to display tool information.",
                               false},
           cl::OptionEnumValue{"intercept-build",
-                              int(HelpCategory::HC_InterceptBuild),
+                              int(CtHelpCategory::HC_InterceptBuild),
                               "List options of intercept-build tool.", false},
-          cl::OptionEnumValue{"examples", int(HelpCategory::HC_Examples),
+          cl::OptionEnumValue{"examples", int(CtHelpCategory::HC_Examples),
                               "List examples of common DPCT options usage.",
                               false}),
       cl::desc("Display available options.\n"),
       cl::value_desc("value"),
       cl::location(WrappedNormalPrinter),
       cl::ValueOptional,
-      cl::cat(cl::getDPCTCategory()),
-      cl::cat(cl::getDPCTHelpInfoCategory()),
+      cl::cat(cl::getCtHelpCat()),
+      cl::cat(cl::getCtHelpCatHelpInfo()),
       cl::sub(*AllSubCommands)};
 #else
   cl::opt<HelpPrinterWrapper, true, parser<bool>> HOp{
@@ -2853,8 +2886,8 @@ struct CommandLineCommonOptions {
       cl::desc("Show the version of the tool."),
       cl::location(VersionPrinterInstance),
       cl::ValueDisallowed,
-      cl::cat(cl::getDPCTCategory()),
-      cl::cat(cl::getDPCTHelpInfoCategory())};
+      cl::cat(cl::getCtHelpCat()),
+      cl::cat(cl::getCtHelpCatHelpInfo())};
 #else
   cl::opt<VersionPrinter, true, parser<bool>>
       VersOp{"version", cl::desc("Display the version of this program"),
@@ -2887,48 +2920,56 @@ OptionCategory &cl::getGeneralCategory() {
   return GeneralCategory;
 }
 #ifdef SYCLomatic_CUSTOMIZATION
-OptionCategory &cl::getDPCTCategory() {
-  static OptionCategory DPCTCat{"dpct"};
-  return DPCTCat;
+// Make sure to add descriptions for all DPCT Help cat options and
+// end them with str "DPCT options" suffix for printOptions() to detect
+// whether a category belongs to DPCT or not
+OptionCategory &cl::getCtHelpCat() {
+  static OptionCategory CtHelpCatAll{"All", "All DPCT options"};
+  return CtHelpCatAll;
 }
-OptionCategory &cl::getDPCTBasicCategory() {
-  static OptionCategory DPCTBasicCat{"basic"};
-  return DPCTBasicCat;
+OptionCategory &cl::getCtHelpCatBasic() {
+  static OptionCategory CtHelpCatBasic{"Basic", "Basic DPCT options"};
+  return CtHelpCatBasic;
 }
-OptionCategory &cl::getDPCTAdvancedCategory() {
-  static OptionCategory DPCTAdvancedCat{"advanced"};
-  return DPCTAdvancedCat;
+OptionCategory &cl::getCtHelpCatAdvanced() {
+  static OptionCategory CtHelpCatAdvanced{"Advanced", "Advanced DPCT options"};
+  return CtHelpCatAdvanced;
 }
-OptionCategory &cl::getDPCTCodeGenCategory() {
-  static OptionCategory DPCTCodeGenCat{"code-gen"};
-  return DPCTCodeGenCat;
+OptionCategory &cl::getCtHelpCatCodeGen() {
+  static OptionCategory CtHelpCatCodeGen{"Code gen", "Code gen DPCT options"};
+  return CtHelpCatCodeGen;
 }
-OptionCategory &cl::getDPCTReportGenCategory() {
-  static OptionCategory DPCTReportGenCat{"report-gen"};
-  return DPCTReportGenCat;
+OptionCategory &cl::getCtHelpCatReportGen() {
+  static OptionCategory CtHelpCatReportGen{"Report gen",
+                                           "Report gen DPCT options"};
+  return CtHelpCatReportGen;
 }
-OptionCategory &cl::getDPCTBuildScriptCategory() {
-  static OptionCategory DPCTTBuildScriptCat{"build-script"};
+OptionCategory &cl::getCtHelpCatBuildScript() {
+  static OptionCategory DPCTTBuildScriptCat{"Build script",
+                                            "Build-script DPCT options"};
   return DPCTTBuildScriptCat;
 }
-OptionCategory &cl::getDPCTQueryAPICategory() {
-  static OptionCategory DPCTQueryAPICat{"query-api"};
-  return DPCTQueryAPICat;
+OptionCategory &cl::getCtHelpCatQueryAPI() {
+  static OptionCategory CtHelpCatQueryAPI{"Query api",
+                                          "Query-api DPCT options"};
+  return CtHelpCatQueryAPI;
 }
-OptionCategory &cl::getDPCTWarningsCategory() {
-  static OptionCategory DPCTWarningsCat{"warnings"};
-  return DPCTWarningsCat;
+OptionCategory &cl::getCtHelpCatWarnings() {
+  static OptionCategory CtHelpCatWarnings{"Warnings", "Warning DPCT options"};
+  return CtHelpCatWarnings;
 }
-OptionCategory &cl::getDPCTHelpInfoCategory() {
-  static OptionCategory DPCTHelpInfoCat{"help-info"};
-  return DPCTHelpInfoCat;
+OptionCategory &cl::getCtHelpCatHelpInfo() {
+  static OptionCategory CtHelpCatHelpInfo{"Help info",
+                                          "Help info DPCT options"};
+  return CtHelpCatHelpInfo;
 }
-OptionCategory &cl::getDPCTInterceptBuildCategory() {
-  static OptionCategory DPCTInterceptBuildCat{"intercept-build"};
-  return DPCTInterceptBuildCat;
+OptionCategory &cl::getCtHelpCatInterceptBuild() {
+  static OptionCategory CtHelpCatInterceptBuild{"Intercept build",
+                                                "Intercept-build DPCT options"};
+  return CtHelpCatInterceptBuild;
 }
-OptionCategory &cl::getDPCTExamplesCategory() {
-  static OptionCategory DPCTExamplesCat{"examples"};
+OptionCategory &cl::getCtExamplesCategory() {
+  static OptionCategory DPCTExamplesCat{"Examples", "Examples DPCT option"};
   return DPCTExamplesCat;
 }
 #endif // SYCLomatic_CUSTOMIZATION
@@ -2968,8 +3009,8 @@ void HelpPrinterWrapper::operator=(bool Value) {
 }
 
 #ifdef SYCLomatic_CUSTOMIZATION
-void HelpPrinterWrapper::operator=(HelpCategory Value) {
-  CategorizedPrinter.setReqCategory(Value);
+void HelpPrinterWrapper::operator=(CtHelpCategory Value) {
+  CategorizedPrinter.setReqCtHelpCategory(Value);
 
   *this = true;
 }

--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -47,6 +47,10 @@
 using namespace llvm;
 using namespace cl;
 
+#ifdef SYCLomatic_CUSTOMIZATION
+bool isDPCT = false;
+#endif // SYCLomatic_CUSTOMIZATION
+
 #define DEBUG_TYPE "commandline"
 
 //===----------------------------------------------------------------------===//
@@ -126,7 +130,6 @@ static inline bool isPrefixedOrGrouping(const Option *O) {
   return isGrouping(O) || O->getFormattingFlag() == cl::Prefix ||
          O->getFormattingFlag() == cl::AlwaysPrefix;
 }
-
 
 namespace {
 
@@ -1557,6 +1560,7 @@ bool CommandLineParser::ParseCommandLineOptions(int argc,
   };
 #ifndef _WIN32
   if ((argc >= FirstArg + 1) &&
+      (std::string(argv[FirstArg]).find("help") == std::string::npos) &&
       (std::string(argv[FirstArg]).find("intercept-build") !=
        std::string::npos)) {
     return HandleLongOptionCommand("intercept-build");
@@ -2368,7 +2372,6 @@ class HelpPrinter {
 protected:
   const bool ShowHidden;
 #ifdef SYCLomatic_CUSTOMIZATION
-  bool isDPCT = false;
   CtHelpCategory CtHelpCat = CtHelpCategory::HC_All;
 #endif // SYCLomatic_CUSTOMIZATION
   typedef SmallVector<std::pair<const char *, Option *>, 128>
@@ -2425,20 +2428,6 @@ protected:
       return cl::getCtExamplesCategory();
     }
   }
-
-  bool isPatReCat(OptionCategory *Category) {
-    if (Category->getName().starts_with("Pattern Rewriter"))
-      return true;
-
-    return false;
-  }
-
-  bool isDPCTCat(OptionCategory *Category) {
-    if (Category->getDescription().ends_with("DPCT options"))
-      return true;
-
-    return false;
-  }
 #endif // SYCLomatic_CUSTOMIZATION
 
 public:
@@ -2468,9 +2457,6 @@ public:
     sortSubCommands(GlobalParser->RegisteredSubCommands, Subs);
 
 #ifdef SYCLomatic_CUSTOMIZATION
-    isDPCT = !strcmp((GlobalParser->ProgramName).c_str(), "dpct") ||
-             !strcmp((GlobalParser->ProgramName).c_str(), "c2s");
-
     if (isDPCT) {
       if (CtHelpCat == CtHelpCategory::HC_Examples) {
         outs() << DPCTExamplesMsg;
@@ -2546,20 +2532,15 @@ public:
                                        "files. These paths are looked up in "
                                        "the compilation database.\n\n";
 
+    bool showCtDiagMsg = false;
+
     if (isDPCT) {
       outs() << CtHelpTrailMsg;
 
       if (CtHelpCat == CtHelpCategory::HC_All) {
         outs() << DPCTExamplesMsg;
       }
-    }
-#endif // SYCLomatic_CUSTOMIZATION
 
-    // Print any extra help the user has declared.
-#ifdef SYCLomatic_CUSTOMIZATION
-    bool showCtDiagMsg = false;
-
-    if (isDPCT) {
       switch (CtHelpCat) {
       case CtHelpCategory::HC_All:
       case CtHelpCategory::HC_Advanced:
@@ -2573,6 +2554,7 @@ public:
       }
     }
 
+    // Print any extra help the user has declared.
     if (!isDPCT || showCtDiagMsg) {
       for (const auto &I : GlobalParser->MoreHelp)
         outs() << I;
@@ -2600,15 +2582,13 @@ public:
 
   // Make sure we inherit our base class's operator=()
   using HelpPrinter::operator=;
+  using HelpPrinter::getReqCtHelpCategory;
   using HelpPrinter::setReqCtHelpCategory;
 
 protected:
   void printOptions(StrOptionPairVector &Opts, size_t MaxArgLen) override {
     std::vector<OptionCategory *> SortedCategories;
     DenseMap<OptionCategory *, std::vector<Option *>> CategorizedOptions;
-
-    bool isPatRe =
-        !strcmp((GlobalParser->ProgramName).c_str(), "pattern-rewriter");
 
     // Collect registered option categories into vector in preparation for
     // sorting.
@@ -2633,7 +2613,10 @@ protected:
     }
 
 #ifdef SYCLomatic_CUSTOMIZATION
-    OptionCategory &reqCtHelpCat(getReqCtHelpCategory(CtHelpCat));
+    if (CtHelpCat != CtHelpCategory::HC_All)
+      SortedCategories.erase(
+          std::find(SortedCategories.begin(), SortedCategories.end(),
+                    &getReqCtHelpCategory(CtHelpCategory::HC_All)));
 #endif // SYCLomatic_CUSTOMIZATION
 
     // Now do printing.
@@ -2642,17 +2625,6 @@ protected:
       const auto &CategoryOptions = CategorizedOptions[Category];
       if (CategoryOptions.empty())
         continue;
-
-#ifdef SYCLomatic_CUSTOMIZATION
-      if (isDPCT) {
-        if (!isDPCTCat(Category))
-          continue;
-        else if (&reqCtHelpCat != Category)
-          continue;
-      }
-      if (isPatRe && !isPatReCat(Category))
-        continue;
-#endif // SYCLomatic_CUSTOMIZATION
 
         // Print category information.
 #ifdef SYCLomatic_CUSTOMIZATION
@@ -2920,9 +2892,6 @@ OptionCategory &cl::getGeneralCategory() {
   return GeneralCategory;
 }
 #ifdef SYCLomatic_CUSTOMIZATION
-// Make sure to add descriptions for all DPCT Help cat options and
-// end them with str "DPCT options" suffix for printOptions() to detect
-// whether a category belongs to DPCT or not
 OptionCategory &cl::getCtHelpCat() {
   static OptionCategory CtHelpCatAll{"All", "All DPCT options"};
   return CtHelpCatAll;
@@ -3011,6 +2980,7 @@ void HelpPrinterWrapper::operator=(bool Value) {
 #ifdef SYCLomatic_CUSTOMIZATION
 void HelpPrinterWrapper::operator=(CtHelpCategory Value) {
   CategorizedPrinter.setReqCtHelpCategory(Value);
+  cl::HideUnrelatedOptions(CategorizedPrinter.getReqCtHelpCategory(Value));
 
   *this = true;
 }


### PR DESCRIPTION
This PR enables correct command line help options to be printed for each binary (dpct/ pattern-rewriter)

**DPCT:**
![image](https://github.com/user-attachments/assets/613b4a20-9edd-40bc-89d0-802e5830c9bb)

**Pattern Rewriter:**
![image](https://github.com/user-attachments/assets/736ae82a-b013-4452-93dc-d2ca0e34fe66)
