### PR TITLE
[SYCLomatic] Keep the type cast during the migration of store functions

### DIFF
--- a/clang/lib/DPCT/RulesLang/Math/RewriterHalfPrecisionConversionAndDataMovement.cpp
+++ b/clang/lib/DPCT/RulesLang/Math/RewriterHalfPrecisionConversionAndDataMovement.cpp
@@ -1021,8 +1021,7 @@ RewriterMap dpct::createHalfPrecisionConversionAndDataMovementRewriterMap() {
               EMPTY_FACTORY_ENTRY("__stcg"),
               EMPTY_FACTORY_ENTRY("__stcg"),
               WARNING_FACTORY_ENTRY(
-                  "__stcg",
-                  ASSIGN_FACTORY_ENTRY("__stcg", DEREF(ARG_WC(0)), ARG(1)),
+                  "__stcg", ASSIGN_FACTORY_ENTRY("__stcg", DEREF(0), ARG(1)),
                   Diagnostics::MATH_EMULATION_EXPRESSION, std::string("__stcg"),
                   std::string("'='"))))
       // __stcs
@@ -1033,8 +1032,7 @@ RewriterMap dpct::createHalfPrecisionConversionAndDataMovementRewriterMap() {
               EMPTY_FACTORY_ENTRY("__stcs"),
               EMPTY_FACTORY_ENTRY("__stcs"),
               WARNING_FACTORY_ENTRY(
-                  "__stcs",
-                  ASSIGN_FACTORY_ENTRY("__stcs", DEREF(ARG_WC(0)), ARG(1)),
+                  "__stcs", ASSIGN_FACTORY_ENTRY("__stcs", DEREF(0), ARG(1)),
                   Diagnostics::MATH_EMULATION_EXPRESSION, std::string("__stcs"),
                   std::string("'='"))))
       // __stwb
@@ -1045,8 +1043,7 @@ RewriterMap dpct::createHalfPrecisionConversionAndDataMovementRewriterMap() {
               EMPTY_FACTORY_ENTRY("__stwb"),
               EMPTY_FACTORY_ENTRY("__stwb"),
               WARNING_FACTORY_ENTRY(
-                  "__stwb",
-                  ASSIGN_FACTORY_ENTRY("__stwb", DEREF(ARG_WC(0)), ARG(1)),
+                  "__stwb", ASSIGN_FACTORY_ENTRY("__stwb", DEREF(0), ARG(1)),
                   Diagnostics::MATH_EMULATION_EXPRESSION, std::string("__stwb"),
                   std::string("'='"))))
       // __stwt
@@ -1057,8 +1054,7 @@ RewriterMap dpct::createHalfPrecisionConversionAndDataMovementRewriterMap() {
               EMPTY_FACTORY_ENTRY("__stwt"),
               EMPTY_FACTORY_ENTRY("__stwt"),
               WARNING_FACTORY_ENTRY(
-                  "__stwt",
-                  ASSIGN_FACTORY_ENTRY("__stwt", DEREF(ARG_WC(0)), ARG(1)),
+                  "__stwt", ASSIGN_FACTORY_ENTRY("__stwt", DEREF(0), ARG(1)),
                   Diagnostics::MATH_EMULATION_EXPRESSION, std::string("__stwt"),
                   std::string("'='"))))
       // __uint2half_rd

--- a/clang/test/dpct/math/bfloat16/bfloat16.cu
+++ b/clang/test/dpct/math/bfloat16/bfloat16.cu
@@ -585,6 +585,29 @@ __global__ void test_conversions_device(__nv_bfloat16 *deviceArrayBFloat16) {
   __stwt(deviceArrayBFloat16, bf16);
   __stwt(&bf16_2, bf16);
   __stwt(&bf162_2, bf162);
+
+  int4 value;
+  __nv_bfloat16* target;
+  // CHECK: /*
+  // CHECK-NEXT: DPCT1098:{{[0-9]+}}: The '=' expression is used instead of the __stcg call. These two expressions do not provide the exact same functionality. Check the generated code for potential precision and/or performance issues.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: *(reinterpret_cast<sycl::int4 *>(target)) = value;
+  // CHECK-NEXT: /*
+  // CHECK-NEXT: DPCT1098:{{[0-9]+}}: The '=' expression is used instead of the __stcs call. These two expressions do not provide the exact same functionality. Check the generated code for potential precision and/or performance issues.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: *(reinterpret_cast<sycl::int4 *>(target)) = value;
+  // CHECK-NEXT: /*
+  // CHECK-NEXT: DPCT1098:{{[0-9]+}}: The '=' expression is used instead of the __stwb call. These two expressions do not provide the exact same functionality. Check the generated code for potential precision and/or performance issues.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: *(reinterpret_cast<sycl::int4 *>(target)) = value;
+  // CHECK-NEXT: /*
+  // CHECK-NEXT: DPCT1098:{{[0-9]+}}: The '=' expression is used instead of the __stwt call. These two expressions do not provide the exact same functionality. Check the generated code for potential precision and/or performance issues.
+  // CHECK-NEXT: */
+  // CHECK-NEXT: *(reinterpret_cast<sycl::int4 *>(target)) = value;
+  __stcg(reinterpret_cast<int4 *>(target), value);
+  __stcs(reinterpret_cast<int4 *>(target), value);
+  __stwb(reinterpret_cast<int4 *>(target), value);
+  __stwt(reinterpret_cast<int4 *>(target), value);
 }
 
 // CHECK: void test_conversions() {


### PR DESCRIPTION
Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>