### PR TITLE
[SYCLomatic] Support migration for `cuGetErrorName` API

### DIFF
--- a/clang/lib/DPCT/RulesLang/APINamesDriver.inc
+++ b/clang/lib/DPCT/RulesLang/APINamesDriver.inc
@@ -15,6 +15,13 @@ WARNING_FACTORY_ENTRY(
                              CALL(MapNames::getDpctNamespace() + "get_error_string_dummy", ARG_WC(0)))),
         Diagnostics::ERROR_HANDLING_API_REPLACED_BY_DUMMY)
 
+WARNING_FACTORY_ENTRY(
+    "cuGetErrorName",
+    ASSIGNABLE_FACTORY(
+        ASSIGN_FACTORY_ENTRY("cuGetErrorName", DEREF(1),
+                             CALL(MapNames::getDpctNamespace() + "get_error_string_dummy", ARG_WC(0)))),
+        Diagnostics::ERROR_HANDLING_API_REPLACED_BY_DUMMY)
+
 FEATURE_REQUEST_FACTORY(
     HelperFeatureEnum::device_ext,
     ASSIGNABLE_FACTORY(ASSIGN_FACTORY_ENTRY(

--- a/clang/lib/DPCT/RulesLang/RulesLang.cpp
+++ b/clang/lib/DPCT/RulesLang/RulesLang.cpp
@@ -8201,7 +8201,8 @@ void DriverDeviceAPIRule::registerMatcher(ast_matchers::MatchFinder &MF) {
     return hasAnyName(
         "cuDeviceGet", "cuDeviceComputeCapability", "cuDriverGetVersion",
         "cuDeviceGetCount", "cuDeviceGetAttribute", "cuDeviceGetName",
-        "cuDeviceGetUuid", "cuDeviceGetUuid_v2", "cuGetErrorString");
+        "cuDeviceGetUuid", "cuDeviceGetUuid_v2", "cuGetErrorString",
+        "cuGetErrorName");
   };
 
   MF.addMatcher(

--- a/clang/lib/DPCT/RulesLang/RulesLang.cpp
+++ b/clang/lib/DPCT/RulesLang/RulesLang.cpp
@@ -8198,11 +8198,11 @@ void DriverModuleAPIRule::runRule(
 void DriverDeviceAPIRule::registerMatcher(ast_matchers::MatchFinder &MF) {
 
   auto DriverDeviceAPI = [&]() {
-    return hasAnyName(
-        "cuDeviceGet", "cuDeviceComputeCapability", "cuDriverGetVersion",
-        "cuDeviceGetCount", "cuDeviceGetAttribute", "cuDeviceGetName",
-        "cuDeviceGetUuid", "cuDeviceGetUuid_v2", "cuGetErrorString",
-        "cuGetErrorName");
+    return hasAnyName("cuDeviceGet", "cuDeviceComputeCapability",
+                      "cuDriverGetVersion", "cuDeviceGetCount",
+                      "cuDeviceGetAttribute", "cuDeviceGetName",
+                      "cuDeviceGetUuid", "cuDeviceGetUuid_v2",
+                      "cuGetErrorString", "cuGetErrorName");
   };
 
   MF.addMatcher(

--- a/clang/lib/DPCT/SrcAPI/APINames.inc
+++ b/clang/lib/DPCT/SrcAPI/APINames.inc
@@ -1536,7 +1536,7 @@ ENTRY(__match_any_sync, __match_any_sync, true, NO_FLAG, P4, "comment")
 ENTRY(__match_all_sync, __match_all_sync, true, NO_FLAG, P4, "comment")
 
 // Error Handling
-ENTRY(cuGetErrorName, cuGetErrorName, false, NO_FLAG, P4, "comment")
+ENTRY(cuGetErrorName, cuGetErrorName, true, NO_FLAG, P4, "Successful")
 ENTRY(cuGetErrorString, cuGetErrorString, true, NO_FLAG, P4, "comment")
 
 // Initialization

--- a/clang/test/dpct/cuda-get-error-string.cu
+++ b/clang/test/dpct/cuda-get-error-string.cu
@@ -137,6 +137,18 @@ const char *test_function() {
 //CHECK-NEXT:  err_s = dpct::get_error_string_dummy(e);
   cuGetErrorString(e, &err_s);
 
+//CHECK:  /*
+//CHECK-NEXT:  DPCT1009:{{[0-9]+}}: SYCL reports errors using exceptions and does not use error codes. Please replace the "get_error_string_dummy(...)" with a real error-handling function.
+//CHECK-NEXT:  */
+//CHECK-NEXT:  err_s = dpct::get_error_string_dummy(e);
+  cuGetErrorName(e, &err_s);
+
+//CHECK-NEXT:  /*
+//CHECK-NEXT:  DPCT1009:{{[0-9]+}}: SYCL reports errors using exceptions and does not use error codes. Please replace the "get_error_string_dummy(...)" with a real error-handling function.
+//CHECK-NEXT:  */
+//CHECK-NEXT:  c = dpct::get_error_string_dummy({{[0-9]+}});
+  cuGetErrorName(CUDA_ERROR_OUT_OF_MEMORY, &err_s);
+
 //CHECK:/*
 //CHECK-NEXT:DPCT1009:{{[0-9]+}}: SYCL reports errors using exceptions and does not use error codes. Please replace the "get_error_string_dummy(...)" with a real error-handling function.
 //CHECK-NEXT:*/

--- a/clang/test/dpct/cuda-get-error-string.cu
+++ b/clang/test/dpct/cuda-get-error-string.cu
@@ -143,10 +143,10 @@ const char *test_function() {
 //CHECK-NEXT:  err_s = dpct::get_error_string_dummy(e);
   cuGetErrorName(e, &err_s);
 
-//CHECK-NEXT:  /*
+//CHECK:  /*
 //CHECK-NEXT:  DPCT1009:{{[0-9]+}}: SYCL reports errors using exceptions and does not use error codes. Please replace the "get_error_string_dummy(...)" with a real error-handling function.
 //CHECK-NEXT:  */
-//CHECK-NEXT:  c = dpct::get_error_string_dummy({{[0-9]+}});
+//CHECK-NEXT:  err_s = dpct::get_error_string_dummy({{[0-9]+}});
   cuGetErrorName(CUDA_ERROR_OUT_OF_MEMORY, &err_s);
 
 //CHECK:/*


### PR DESCRIPTION
As SYCL has exception-based error handling, `cuGetErrorName` is replaced with a dummy method from DPCT with a suggestion to replace the dummy method based on the requirement.

Signed-off-by: [Deepak Raj H R](Deepak.raj.h.r@intel.com)