### PR TITLE
[Bug][PyTorch] Removed unnecessary YAML rule for ATen header

### DIFF
--- a/clang/tools/dpct/DpctOptRules/pytorch_api.yaml
+++ b/clang/tools/dpct/DpctOptRules/pytorch_api.yaml
@@ -1,11 +1,5 @@
 ---
 # ATen cuda rules
-- Rule: rule_ATen_core_Tensor_h
-  Kind: Header
-  Priority: Takeover
-  In: ATen/core/Tensor.h
-  Out: "<ATen/core/Tensor.h>"
-
 - Rule: rule_ATen_cuda_CUDAContext_h
   Kind: Header
   Priority: Takeover


### PR DESCRIPTION
Removed unnecessary YAML rule introduced by [PR#2422](https://github.com/oneapi-src/SYCLomatic/pull/2422/files#diff-5944a28b688462e7c272a2696dd79729d080e603fe7b372af85034ebe112fcf8R6)