### PR TITLE
[SYCLomatic] Fix parser error for libear when building SYCLomatic with GCC 14

### DIFF
--- a/clang/tools/scan-build-py/lib/libear/ear.c
+++ b/clang/tools/scan-build-py/lib/libear/ear.c
@@ -521,7 +521,7 @@ const char *get_intercept_stub_path(void) {
 }
 
 static int call_stat(const char *pathname, struct stat *statbuf) {
-  typedef int (*func)(const char *, struct statbuf *);
+  typedef int (*func)(const char *, struct stat *);
   DLSYM(func, fp, "stat");
   int const result = (*fp)(pathname, statbuf);
   return result;


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>