### PR TITLE
[Bug][Ext Mem Interop] Corrected the behavior of importing external memory using NT handle name

### DIFF
--- a/clang/lib/DPCT/Diagnostics/Diagnostics.inc
+++ b/clang/lib/DPCT/Diagnostics/Diagnostics.inc
@@ -296,8 +296,8 @@ DEF_WARNING(SPARSE_NNZ, 1134, MEDIUM_LEVEL, "The tool cannot deduce the consumer
 DEF_COMMENT(SPARSE_NNZ, 1134, MEDIUM_LEVEL, "The tool cannot deduce the consumer API (\"dpct::sparse::csrgemm\") of this API, and this API has 2 arguments depending on the 8th and the 12th parameters of the consumer API. Please replace the 2 arguments tagged as \"dpct_placeholder\" with the corresponding value.")
 DEF_WARNING(JOINT_MATRIX_SHAPE, 1135, HIGH_LEVEL, "Please check if joint_matrix implementations support the combination of data type and matrix shape type in the target hardware.")
 DEF_COMMENT(JOINT_MATRIX_SHAPE, 1135, HIGH_LEVEL, "Please check if joint_matrix implementations support the combination of data type and matrix shape type in the target hardware.")
-DEF_WARNING(UNSUPPORTED_EXTMEM_WIN_HANDLE, 1136, HIGH_LEVEL, "Bindless images extension only supports importing external resource memory using NT handle on Windows. If assert(%0.get_win32_handle()) fails, you may need to adjust the code to use (%0.get_win32_handle()).")
-DEF_COMMENT(UNSUPPORTED_EXTMEM_WIN_HANDLE, 1136, HIGH_LEVEL, "Bindless images extension only supports importing external resource memory using NT handle on Windows. If assert({0}.get_win32_handle()) fails, you may need to adjust the code to use ({0}.get_win32_handle()).")
+DEF_WARNING(UNSUPPORTED_EXTMEM_WIN_HANDLE, 1136, HIGH_LEVEL, "SYCL Bindless Images extension only supports importing external resource memory using NT handle on Windows. If assert(%0.get_win32_handle()) fails, you may need to adjust the code to use (%0.get_win32_handle()).")
+DEF_COMMENT(UNSUPPORTED_EXTMEM_WIN_HANDLE, 1136, HIGH_LEVEL, "SYCL Bindless Images extension only supports importing external resource memory using NT handle on Windows. If assert({0}.get_win32_handle()) fails, you may need to adjust the code to use ({0}.get_win32_handle()).")
 // clang-format on
 
 #undef DEF_COMMENT

--- a/clang/lib/DPCT/Diagnostics/Diagnostics.inc
+++ b/clang/lib/DPCT/Diagnostics/Diagnostics.inc
@@ -296,6 +296,8 @@ DEF_WARNING(SPARSE_NNZ, 1134, MEDIUM_LEVEL, "The tool cannot deduce the consumer
 DEF_COMMENT(SPARSE_NNZ, 1134, MEDIUM_LEVEL, "The tool cannot deduce the consumer API (\"dpct::sparse::csrgemm\") of this API, and this API has 2 arguments depending on the 8th and the 12th parameters of the consumer API. Please replace the 2 arguments tagged as \"dpct_placeholder\" with the corresponding value.")
 DEF_WARNING(JOINT_MATRIX_SHAPE, 1135, HIGH_LEVEL, "Please check if joint_matrix implementations support the combination of data type and matrix shape type in the target hardware.")
 DEF_COMMENT(JOINT_MATRIX_SHAPE, 1135, HIGH_LEVEL, "Please check if joint_matrix implementations support the combination of data type and matrix shape type in the target hardware.")
+DEF_WARNING(UNSUPPORTED_EXTMEM_WIN_HANDLE, 1136, HIGH_LEVEL, "Bindless images extension only supports importing external resource memory using NT handle on Windows. If assert(%0.get_win32_handle()) fails, you may need to adjust the code to use (%0.get_win32_handle()).")
+DEF_COMMENT(UNSUPPORTED_EXTMEM_WIN_HANDLE, 1136, HIGH_LEVEL, "Bindless images extension only supports importing external resource memory using NT handle on Windows. If assert({0}.get_win32_handle()) fails, you may need to adjust the code to use ({0}.get_win32_handle()).")
 // clang-format on
 
 #undef DEF_COMMENT

--- a/clang/lib/DPCT/RulesLang/RulesLangGraphicsInterop.cpp
+++ b/clang/lib/DPCT/RulesLang/RulesLangGraphicsInterop.cpp
@@ -193,6 +193,23 @@ void GraphicsInteropRule::runRule(
       return;
     }
 
+#ifdef __WIN32
+    if (Name == "cudaImportExternalMemory") {
+      if (auto ICE = dyn_cast<ImplicitCastExpr>(CE->getArg(1))) {
+        if (auto UO = dyn_cast<UnaryOperator>(ICE->getSubExpr())) {
+          if (UO->getOpcode() == UO_AddrOf) {
+            if (auto MemHandleDescDRE =
+                    dyn_cast<DeclRefExpr>(UO->getSubExpr())) {
+              report(CE->getBeginLoc(),
+                     Diagnostics::UNSUPPORTED_EXTMEM_WIN_HANDLE, false,
+                     MemHandleDescDRE->getDecl()->getNameAsString());
+            }
+          }
+        }
+      }
+    }
+#endif // __WIN32
+
     ExprAnalysis EA(CE);
     emplaceTransformation(EA.getReplacement());
     EA.applyAllSubExprRepl();

--- a/clang/runtime/dpct-rt/include/dpct/bindless_images.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/bindless_images.hpp
@@ -1082,13 +1082,9 @@ import_external_memory(sycl::ext::oneapi::experimental::external_mem *extMem,
             memHandleDesc->get_res_size()},
         get_default_queue());
   } else if (memHandleDesc->get_win32_obj_name()) {
-    *extMem = sycl::ext::oneapi::experimental::import_external_memory(
-        sycl::ext::oneapi::experimental::external_mem_descriptor<
-            sycl::ext::oneapi::experimental::resource_win32_name>{
-            {memHandleDesc->get_win32_obj_name()},
-            memHandleDesc->get_handle_type(),
-            memHandleDesc->get_res_size()},
-        get_default_queue());
+    throw std::runtime_error("Importing external resource using Windows NT name"
+                             " type is not supported. Only NT handle type is"
+                             " supported");
   }
 #else
   if (memHandleDesc->get_fd_handle() != -1) {

--- a/clang/test/dpct/externalResInterop.cu
+++ b/clang/test/dpct/externalResInterop.cu
@@ -171,6 +171,9 @@ int main() {
 
 
   /// calls
+  // CHECK-WINDOWS: /*
+  // CHECK-WINDOWS-NEXT: DPCT1136:{{[0-9]+}}: Bindless images extension only supports importing external resource memory using NT handle on Windows. If assert(memHandleDesc.get_win32_handle()) fails, you may need to adjust the code to use (memHandleDesc.get_win32_handle()).
+  // CHECK-WINDOWS-NEXT: */
   // CHECK: dpct::experimental::import_external_memory(&extMem, &memHandleDesc);
   // CHECK-NEXT: mipmap = new dpct::experimental::image_mem_wrapper(extMem, &mipmappedArrDesc);
   // CHECK-NEXT: devPtr = sycl::ext::oneapi::experimental::map_external_linear_memory(extMem, (&bufferDesc)->get_res_size(), (&bufferDesc)->get_mem_offset(), q_ct1);

--- a/clang/test/dpct/externalResInterop.cu
+++ b/clang/test/dpct/externalResInterop.cu
@@ -172,7 +172,7 @@ int main() {
 
   /// calls
   // CHECK-WINDOWS: /*
-  // CHECK-WINDOWS-NEXT: DPCT1136:{{[0-9]+}}: Bindless images extension only supports importing external resource memory using NT handle on Windows. If assert(memHandleDesc.get_win32_handle()) fails, you may need to adjust the code to use (memHandleDesc.get_win32_handle()).
+  // CHECK-WINDOWS-NEXT: DPCT1136:{{[0-9]+}}: SYCL Bindless Images extension only supports importing external resource memory using NT handle on Windows. If assert(memHandleDesc.get_win32_handle()) fails, you may need to adjust the code to use (memHandleDesc.get_win32_handle()).
   // CHECK-WINDOWS-NEXT: */
   // CHECK: dpct::experimental::import_external_memory(&extMem, &memHandleDesc);
   // CHECK-NEXT: mipmap = new dpct::experimental::image_mem_wrapper(extMem, &mipmappedArrDesc);


### PR DESCRIPTION
This PR enables correctly throwing exception when external resource is imported using NT handle name on Windows