### PR TITLE
[Bug] Corrected accessing the last event in the in_order queue

### DIFF
--- a/clang/lib/DPCT/AnalysisInfo.cpp
+++ b/clang/lib/DPCT/AnalysisInfo.cpp
@@ -6667,8 +6667,19 @@ KernelPrinter &KernelCallExpr::SubmitStmtsList::print(KernelPrinter &Printer) {
       Printer.line("cgh.depends_on(dpct::get_current_device().get_in_order_"
                    "queues_last_events());");
     } else {
+      Printer.line("#ifdef __INTEL_LLVM_COMPILER");
+      Printer.newLine();
       Printer.line("cgh.depends_on(dpct::get_default_queue().ext_oneapi_get_"
                    "last_event());");
+      Printer.newLine();
+      Printer.line("#else");
+      Printer.newLine();
+      Printer.line("auto e_opt = dpct::get_default_queue().ext_oneapi_get_last_"
+                   "event();");
+      Printer.newLine();
+      Printer.line("if (e_opt) cgh.depends_on(*e_opt);");
+      Printer.newLine();
+      Printer.line("#endif");
     }
     Printer.newLine();
   }

--- a/clang/runtime/dpct-rt/include/dpct/device.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/device.hpp
@@ -592,7 +592,14 @@ public:
     lock.unlock();
     for (const auto &q : current_queues) {
       if (q->is_in_order()) {
+#ifdef __INTEL_LLVM_COMPILER
         last_events.push_back(q->ext_oneapi_get_last_event());
+#else
+        auto last_event = q->ext_oneapi_get_last_event();
+        if (last_event) {
+          last_events.push_back(*last_event);
+        }
+#endif
       }
     }
     // Guard the destruct of current_queues to make sure the ref count is safe.

--- a/clang/test/dpct/kernel_implicit_sync.cu
+++ b/clang/test/dpct/kernel_implicit_sync.cu
@@ -27,7 +27,12 @@ int main() {
 
 // CHECK:  s1->submit(
 // CHECK:      [&](sycl::handler &cgh) {
+// CHECK:#ifdef __INTEL_LLVM_COMPILER
 // CHECK:        cgh.depends_on(dpct::get_default_queue().ext_oneapi_get_last_event());
+// CHECK:#else
+// CHECK:        auto e_opt = dpct::get_default_queue().ext_oneapi_get_last_event();
+// CHECK:        if (e_opt) cgh.depends_on(*e_opt);
+// CHECK:#endif
 // CHECK:        cgh.parallel_for(
 // CHECK:          sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
 // CHECK:          [=](sycl::nd_item<3> item_ct1) {


### PR DESCRIPTION
This PR corrects the mechanism to access the last event in the in_order queue which was changed from `sycl::event` to `std::optional<sycl::event>` in [PR#16645](https://github.com/intel/llvm/pull/16645)