### PR TITLE
 [SYCLomatic] Fix the regression that only the input file should be migrated if both the input file and the option "--migrate-build-script-only" are specified in the command line

### DIFF
--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -467,18 +467,14 @@ static void loadMainSrcFileInfo(clang::tooling::UnifiedPath OutRoot) {
   std::string YamlFilePath = appendPath(OutRoot.getCanonicalPath().str(),
                                         DpctGlobalInfo::getYamlFileName());
   auto PreTU = std::make_shared<clang::tooling::TranslationUnitReplacements>();
-  printf("YamlFilePath:[%s]\n", YamlFilePath.c_str());
   if (llvm::sys::fs::exists(YamlFilePath)) {
-    printf("YamlFilePath:[%s]\n", YamlFilePath.c_str());
     if (loadFromYaml(YamlFilePath, *PreTU) != 0) {
       llvm::errs() << getLoadYamlFailWarning(YamlFilePath);
     }
   }
   for (auto &Entry : PreTU->MainSourceFilesDigest) {
-    if (Entry.HasCUDASyntax) {
-      printf("############[%s]\n", Entry.MainSourceFile.c_str());
+    if (Entry.HasCUDASyntax)
       MainSrcFilesHasCudaSyntex.insert(Entry.MainSourceFile);
-    }
   }
 
   // Currently, when "--use-experimental-features=device_global" and

--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -467,14 +467,18 @@ static void loadMainSrcFileInfo(clang::tooling::UnifiedPath OutRoot) {
   std::string YamlFilePath = appendPath(OutRoot.getCanonicalPath().str(),
                                         DpctGlobalInfo::getYamlFileName());
   auto PreTU = std::make_shared<clang::tooling::TranslationUnitReplacements>();
+  printf("YamlFilePath:[%s]\n", YamlFilePath.c_str());
   if (llvm::sys::fs::exists(YamlFilePath)) {
+    printf("YamlFilePath:[%s]\n", YamlFilePath.c_str());
     if (loadFromYaml(YamlFilePath, *PreTU) != 0) {
       llvm::errs() << getLoadYamlFailWarning(YamlFilePath);
     }
   }
   for (auto &Entry : PreTU->MainSourceFilesDigest) {
-    if (Entry.HasCUDASyntax)
+    if (Entry.HasCUDASyntax) {
+      printf("############[%s]\n", Entry.MainSourceFile.c_str());
       MainSrcFilesHasCudaSyntex.insert(Entry.MainSourceFile);
+    }
   }
 
   // Currently, when "--use-experimental-features=device_global" and
@@ -1322,7 +1326,10 @@ int runDPCT(int argc, const char **argv) {
   }
   // OC_Action: only migrate Build scripts.
   if (MigrateBuildScriptOnly) {
-    doBuildScriptMigration();
+    loadMainSrcFileInfo(OutRootPath);
+    collectBuildScriptsSpecified(OptParser, InRootPath, OutRootPath);
+    migrateBuildScripts(InRootPath, OutRootPath);
+
     ShowStatus(MigrationBuildScriptCompleted);
     dpctExit(MigrationSucceeded, false);
   }

--- a/clang/test/dpct/cmake_migration/case_061/case_061_full_match.cpp
+++ b/clang/test/dpct/cmake_migration/case_061/case_061_full_match.cpp
@@ -1,6 +1,7 @@
 // RUN: rm -rf %T && mkdir -p %T
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
+// RUN: cp %S/input.cmake ./input2.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
@@ -8,3 +9,7 @@
 
 // CHECK: begin
 // CHECK-NEXT: end
+
+// RUN: test  -f %T/out/input.cmake
+// RUN: test  -f %T/out/dpct.cmake
+// RUN: test ! -f %T/out/input2.cmake

--- a/clang/test/dpct/python_migration/case_009/case_009_cpp_extension.cpp
+++ b/clang/test/dpct/python_migration/case_009/case_009_cpp_extension.cpp
@@ -1,6 +1,7 @@
 // RUN: rm -rf %T && mkdir -p %T
 // RUN: cd %T
 // RUN: cp %S/input.py ./input.py
+// RUN: cp %S/input.py ./input2.py
 
 // RUN: dpct -in-root ./ -out-root out_pytorch ./input.py --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_pytorch.yaml
 // RUN: echo "begin" > %T/diff.txt
@@ -15,3 +16,9 @@
 // RUN: echo "end" >> %T/diff.txt
 // CHECK: begin
 // CHECK-NEXT: end
+
+// RUN: test  -f %T/out_ipex/input.py
+// RUN: test ! -f %T/out_ipex/input2.py
+
+// RUN: test  -f %T/out_pytorch/input.py
+// RUN: test ! -f %T/out_pytorch/input2.py


### PR DESCRIPTION
 Signed-off-by: chenwei.sun <chenwei.sun@intel.com>
