### PR TITLE
[NFC][help] Updated warning count in --help ref text

### DIFF
--- a/clang/test/dpct/help_option_check/lin/help_all.txt
+++ b/clang/test/dpct/help_option_check/lin/help_all.txt
@@ -127,7 +127,7 @@ All DPCT options
   --rule-file=<file>                      - Specify the rule file for migration. Also, reference to the predefined rules in "extensions" directory in the root folder of the tool.
   --stop-on-parse-err                     - Stop migration and generation of reports if parsing errors happened. Default: off. 
   --suppress-warnings=<value>             - A comma separated list of migration warnings to suppress. Valid warning IDs range
-                                            from 1000 to 1135. Hyphen separated ranges are also allowed. For example:
+                                            from 1000 to 1136. Hyphen separated ranges are also allowed. For example:
                                             --suppress-warnings=1000-1010,1011.
   --suppress-warnings-all                 - Suppress all migration warnings. Default: off.
   --sycl-file-extension=<value>           - Specify the extension of migrated source file(s).

--- a/clang/test/dpct/help_option_check/win/help_all.txt
+++ b/clang/test/dpct/help_option_check/win/help_all.txt
@@ -126,7 +126,7 @@ All DPCT options
   --rule-file=<file>                      - Specify the rule file for migration. Also, reference to the predefined rules in "extensions" directory in the root folder of the tool.
   --stop-on-parse-err                     - Stop migration and generation of reports if parsing errors happened. Default: off. 
   --suppress-warnings=<value>             - A comma separated list of migration warnings to suppress. Valid warning IDs range
-                                            from 1000 to 1135. Hyphen separated ranges are also allowed. For example:
+                                            from 1000 to 1136. Hyphen separated ranges are also allowed. For example:
                                             --suppress-warnings=1000-1010,1011.
   --suppress-warnings-all                 - Suppress all migration warnings. Default: off.
   --sycl-file-extension=<value>           - Specify the extension of migrated source file(s).


### PR DESCRIPTION
This PR updates the latest help message ref text by considering the newly added warning 1136 in [PR#2644](https://github.com/oneapi-src/SYCLomatic/pull/2644)