### PR TITLE
[Bug][Python Migration] Added support for parsing Python syntax inside blocks like (), [] & {}

### DIFF
--- a/clang/lib/DPCT/MigrateScript/MigratePythonBuildScript.cpp
+++ b/clang/lib/DPCT/MigrateScript/MigratePythonBuildScript.cpp
@@ -73,7 +73,8 @@ applyPythonMigrationRules(const clang::tooling::UnifiedPath InRoot,
     for (const auto &PythonSyntaxEntry : PythonBuildInRules) {
       const auto &PR = PythonSyntaxEntry.second;
       if (!PR.In.empty() || !PR.Out.empty()) {
-        Buffer = applyPatternRewriter(PR, Buffer);
+        Buffer = applyPatternRewriter(PR, Buffer, Entry.first.getPath().str(),
+                                      "", OutRoot);
       }
     }
   }

--- a/clang/lib/DPCT/UserDefinedRules/PatternRewriter.cpp
+++ b/clang/lib/DPCT/UserDefinedRules/PatternRewriter.cpp
@@ -9,10 +9,10 @@
 #include "UserDefinedRules/PatternRewriter.h"
 #include "AnalysisInfo.h"
 #include "Diagnostics/Diagnostics.h"
+#include "FileGenerator/GenFiles.h"
 #include "MigrateScript/MigrateCmakeScript.h"
 #include "MigrateScript/MigratePythonBuildScript.h"
 #include "UserDefinedRules/UserDefinedRules.h"
-#include "FileGenerator/GenFiles.h"
 
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Path.h"
@@ -24,7 +24,6 @@
 #include <unordered_map>
 #include <variant>
 #include <vector>
-
 
 namespace clang {
 namespace dpct {
@@ -62,8 +61,26 @@ static bool isWhitespace(char Character) {
 
 static bool isNotWhitespace(char Character) { return !isWhitespace(Character); }
 
+static bool isLeftDelimiter(char Character) {
+  return Character == '{' || Character == '[' || Character == '(';
+}
+
 static bool isRightDelimiter(char Character) {
   return Character == '}' || Character == ']' || Character == ')';
+}
+
+static char getRightDelimiter(char Character) {
+  char rightChar = '\0';
+
+  if (Character == '{') {
+    rightChar = '}';
+  } else if (Character == '[') {
+    rightChar = ']';
+  } else if (Character == '(') {
+    rightChar = ')';
+  }
+
+  return rightChar;
 }
 
 static int detectIndentation(const std::string &Input, int Start) {
@@ -243,7 +260,7 @@ static int parseCodeElement(const MatchPattern &Suffix,
 
 static int parseBlock(char LeftDelimiter, char RightDelimiter,
                       const std::string &Input, const int Start,
-                      RuleMatchMode Mode) {
+                      RuleMatchMode Mode, const MatchPattern &Suffix = {}) {
   const int Size = Input.size();
   int Index = Start;
 
@@ -252,25 +269,28 @@ static int parseBlock(char LeftDelimiter, char RightDelimiter,
   }
   Index++;
 
-  Index = parseCodeElement({}, Input, Index, Mode);
-  if (Index == -1) {
+  auto Next = parseCodeElement(Suffix, Input, Index, Mode);
+  if (Next == -1) {
+    Index = parseCodeElement({}, Input, Index, Mode);
+  } else {
+    Index = Next;
+  }
+
+  if (Index == -1 || Index >= Size) {
     return -1;
   }
 
-  if (Index >= Size || Input[Index] != RightDelimiter) {
-    return -1;
-  }
-  Index++;
   return Index;
 }
 
 static int parseCodeElement(const MatchPattern &Suffix,
                             const std::string &Input, const int Start,
                             RuleMatchMode Mode) {
+  bool IsPythonScript = (SrcFileType == SourceFileType::SFT_PySetupScript);
+
   int Index = Start;
   const int Size = Input.size();
   while (Index >= 0 && Index < Size) {
-
     if (SrcFileType == SourceFileType::SFT_CMakeScript ||
         SrcFileType == SourceFileType::SFT_PySetupScript) {
       if (Input[Index] == '#') {
@@ -281,11 +301,12 @@ static int parseCodeElement(const MatchPattern &Suffix,
     }
 
     const auto Character = Input[Index];
-    if (SrcFileType != SourceFileType::SFT_PySetupScript) {
+    if (!IsPythonScript) {
       if (Suffix.size() == 0 && Character == '"') {
         return Index;
       }
     }
+
     if (Suffix.size() > 0) {
       std::optional<MatchResult> SuffixMatch;
 
@@ -300,19 +321,20 @@ static int parseCodeElement(const MatchPattern &Suffix,
       }
     }
 
-    if (Character == '{') {
-      Index = parseBlock('{', '}', Input, Index, Mode);
-      continue;
-    }
+    if (isLeftDelimiter(Character)) {
+      char RightDelimiter = getRightDelimiter(Character);
 
-    if (Character == '[') {
-      Index = parseBlock('[', ']', Input, Index, Mode);
-      continue;
-    }
-
-    if (Character == '(') {
-      Index = parseBlock('(', ')', Input, Index, Mode);
-      continue;
+      if (IsPythonScript) {
+        Index =
+            parseBlock(Character, RightDelimiter, Input, Index, Mode, Suffix);
+      } else {
+        Index = parseBlock(Character, RightDelimiter, Input, Index, Mode);
+      }
+      if (Index != -1 && isRightDelimiter(Input[Index])) {
+        Index++;
+        continue;
+      } else
+        return Index;
     }
 
     if (isRightDelimiter(Input[Index])) {
@@ -394,6 +416,7 @@ static int parseCodeElement(const MatchPattern &Suffix,
 
     Index++;
   }
+
   return Suffix.size() == 0 ? Index : -1;
 }
 
@@ -402,11 +425,22 @@ static int parseCodeElement(const MatchPattern &Suffix,
 static bool isIdentifiedChar(char Char) {
 
   if ((Char >= 'a' && Char <= 'z') || (Char >= 'A' && Char <= 'Z') ||
-      (Char >= '0' && Char <= '9') || (Char == '_') || (Char == '-')) {
+      (Char >= '0' && Char <= '9') || (Char == '_')) {
     return true;
+  } else if (SrcFileType == SourceFileType::SFT_CMakeScript) {
+    if (Char == '-')
+      return true;
   }
 
   return false;
+}
+
+static bool isValidFilePrefix(char Char) {
+  return isIdentifiedChar(Char) || Char == '.' || Char == '/' || Char == '\\';
+}
+
+static bool isValidFilePostfix(char Char) {
+  return !(isIdentifiedChar(Char) || Char == '.');
 }
 
 static void applyExtenstionNameChange(
@@ -414,8 +448,16 @@ static void applyExtenstionNameChange(
     std::unordered_map<std::string, std::string> &Bindings,
     const std::string &FileName, const clang::tooling::UnifiedPath &OutRoot,
     std::string ExtensionType) {
+
+  // Check for valid postfix for a file name
+  if (!isValidFilePostfix(Input[Next + ExtensionType.length() + 1])) {
+    Bindings["rewrite_extention_name"] = std::move(ExtensionType);
+    return;
+  }
+
   size_t Pos = Next - 1;
-  for (; Pos > 0 && !isWhitespace(Input[Pos]); Pos--) {
+  // Find the starting position of the file name
+  for (; Pos > 0 && isValidFilePrefix(Input[Pos]); Pos--) {
   }
   Pos = Pos == 0 ? 0 : Pos + 1;
   if (Input[Pos] == '"' || Input[Pos] == '\'')
@@ -477,6 +519,11 @@ static void applyExtenstionNameChange(
         llvm::sys::path::native(CMakeFilePath);
       }
       if (llvm::StringRef(File).ends_with(CMakeFilePath)) {
+        HasCudaSyntax = true;
+        break;
+      }
+    } else if (llvm::sys::path::filename(FileName).ends_with(".py")) {
+      if (llvm::StringRef(File).ends_with(SrcFile)) {
         HasCudaSyntax = true;
         break;
       }

--- a/clang/lib/DPCT/UserDefinedRules/PatternRewriter.cpp
+++ b/clang/lib/DPCT/UserDefinedRules/PatternRewriter.cpp
@@ -256,7 +256,7 @@ findMatch(const MatchPattern &Pattern, const std::string &Input,
 
 static int parseCodeElement(const MatchPattern &Suffix,
                             const std::string &Input, const int Start,
-                            RuleMatchMode Mode);
+                            RuleMatchMode Mode, bool IsInsideBlock = false);
 
 static int parseBlock(char LeftDelimiter, char RightDelimiter,
                       const std::string &Input, const int Start,
@@ -269,12 +269,7 @@ static int parseBlock(char LeftDelimiter, char RightDelimiter,
   }
   Index++;
 
-  auto Next = parseCodeElement(Suffix, Input, Index, Mode);
-  if (Next == -1) {
-    Index = parseCodeElement({}, Input, Index, Mode);
-  } else {
-    Index = Next;
-  }
+  Index = parseCodeElement(Suffix, Input, Index, Mode, true);
 
   if (Index == -1 || Index >= Size) {
     return -1;
@@ -285,9 +280,7 @@ static int parseBlock(char LeftDelimiter, char RightDelimiter,
 
 static int parseCodeElement(const MatchPattern &Suffix,
                             const std::string &Input, const int Start,
-                            RuleMatchMode Mode) {
-  bool IsPythonScript = (SrcFileType == SourceFileType::SFT_PySetupScript);
-
+                            RuleMatchMode Mode, bool IsInsideBlock) {
   int Index = Start;
   const int Size = Input.size();
   while (Index >= 0 && Index < Size) {
@@ -301,10 +294,8 @@ static int parseCodeElement(const MatchPattern &Suffix,
     }
 
     const auto Character = Input[Index];
-    if (!IsPythonScript) {
-      if (Suffix.size() == 0 && Character == '"') {
-        return Index;
-      }
+    if (Suffix.size() == 0 && Character == '"') {
+      return Index;
     }
 
     if (Suffix.size() > 0) {
@@ -316,15 +307,19 @@ static int parseCodeElement(const MatchPattern &Suffix,
         return Index;
       }
 
-      if (isRightDelimiter(Character) || Index == Size - 1) {
+      if (Index == Size - 1) {
         return -1;
+      }
+
+      if (isRightDelimiter(Character)) {
+        return IsInsideBlock ? Index : -1;
       }
     }
 
     if (isLeftDelimiter(Character)) {
       char RightDelimiter = getRightDelimiter(Character);
 
-      if (IsPythonScript) {
+      if (SrcFileType == SourceFileType::SFT_PySetupScript) {
         Index =
             parseBlock(Character, RightDelimiter, Input, Index, Mode, Suffix);
       } else {
@@ -459,9 +454,9 @@ static void applyExtenstionNameChange(
   // Find the starting position of the file name
   for (; Pos > 0 && isValidFilePrefix(Input[Pos]); Pos--) {
   }
-  Pos = Pos == 0 ? 0 : Pos + 1;
-  if (Input[Pos] == '"' || Input[Pos] == '\'')
-    Pos += 1;
+  if (!isValidFilePrefix(Input[Pos]))
+    Pos++;
+
   std::string SrcFile = Input.substr(Pos, Next + ExtensionType.length() +
                                               1 /*strlen of "."*/ - Pos);
   bool HasCudaSyntax = false;
@@ -523,7 +518,10 @@ static void applyExtenstionNameChange(
         break;
       }
     } else if (llvm::sys::path::filename(FileName).ends_with(".py")) {
-      if (llvm::StringRef(File).ends_with(SrcFile)) {
+      llvm::SmallString<512> _SrcFile(SrcFile);
+      llvm::sys::path::native(_SrcFile);
+
+      if (llvm::StringRef(File).ends_with(_SrcFile)) {
         HasCudaSyntax = true;
         break;
       }

--- a/clang/test/dpct/python_migration/case_007/MainSourceFiles.yaml
+++ b/clang/test/dpct/python_migration/case_007/MainSourceFiles.yaml
@@ -19,11 +19,35 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
+  - FilePath:        '/path/to/src/bar.cpp'
+    Offset:          0
+    Length:          0
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/path/to/dst/bar.cpp'
+    Offset:          0
+    Length:          0
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
 
 MainSourceFilesDigest:
   - MainSourceFile:  '/path/to/src/foo.cpp'
     Digest:          e2636fb8d174ac319083b0306294d3bd
     HasCUDASyntax:   true
+  - MainSourceFile:  '/path/to/src/bar.cpp'
+    Digest:          e2636fb8d174ac319083b0306294d3bd
+    HasCUDASyntax:   true
+  - MainSourceFile:  '/path/to/dst/bar.cpp'
+    Digest:          e2636fb8d174ac319083b0306294d3bd
+    HasCUDASyntax:   false
   - MainSourceFile:  '/path/to/src/baz.cpp'
     Digest:          991d7e4825fc597205bf68f2eda27acd
     HasCUDASyntax:   false

--- a/clang/test/dpct/python_migration/case_007/expected.py
+++ b/clang/test/dpct/python_migration/case_007/expected.py
@@ -1,5 +1,13 @@
 # baz.cpp is a C++ file
 out = func("bar.dp.cpp", "baz.cpp")
+
 # foo.cpp is a C++ file with CUDA syntax
 out = func("foo.cpp.dp.cpp", "bar.dp.cpp")
-out = func(["foo.cpp.dp.cpp", "bar.dp.cpp"])
+
+# src/bar.cpp is a C++ file with CUDA syntax
+# dst/bar.cpp is a C++ file
+out = func("src/bar.cpp.dp.cpp", "dst/bar.cpp")
+
+("foo.cpp.dp.cpp", ("bar.dp.cpp", ("baz.cpp"), ("foo.cpp.dp.cpp", ), ["foo.cpp.dp.cpp"], ("foo.cpp.dp.cpp"), {"foo.cpp.dp.cpp"}, "foo.cpp.dp.cpp"))
+["foo.cpp.dp.cpp", ["bar.dp.cpp", ["baz.cpp"], ["foo.cpp.dp.cpp", ], ["foo.cpp.dp.cpp"], ("foo.cpp.dp.cpp"), {"foo.cpp.dp.cpp"}, "foo.cpp.dp.cpp"]]
+{"foo.cpp.dp.cpp", {"bar.dp.cpp", {"baz.cpp"}, {"foo.cpp.dp.cpp", }, ["foo.cpp.dp.cpp"], ("foo.cpp.dp.cpp"), {"foo.cpp.dp.cpp"}, "foo.cpp.dp.cpp"}}

--- a/clang/test/dpct/python_migration/case_007/input.py
+++ b/clang/test/dpct/python_migration/case_007/input.py
@@ -1,5 +1,13 @@
 # baz.cpp is a C++ file
 out = func("bar.cu", "baz.cpp")
+
 # foo.cpp is a C++ file with CUDA syntax
 out = func("foo.cpp", "bar.cu")
-out = func(["foo.cpp", "bar.cu"])
+
+# src/bar.cpp is a C++ file with CUDA syntax
+# dst/bar.cpp is a C++ file
+out = func("src/bar.cpp", "dst/bar.cpp")
+
+("foo.cpp", ("bar.cu", ("baz.cpp"), ("foo.cpp", ), ["foo.cpp"], ("foo.cpp"), {"foo.cpp"}, "foo.cpp"))
+["foo.cpp", ["bar.cu", ["baz.cpp"], ["foo.cpp", ], ["foo.cpp"], ("foo.cpp"), {"foo.cpp"}, "foo.cpp"]]
+{"foo.cpp", {"bar.cu", {"baz.cpp"}, {"foo.cpp", }, ["foo.cpp"], ("foo.cpp"), {"foo.cpp"}, "foo.cpp"}}

--- a/clang/tools/dpct/extensions/python_rules/python_build_script_migration_rule_pytorch_common.yaml
+++ b/clang/tools/dpct/extensions/python_rules/python_build_script_migration_rule_pytorch_common.yaml
@@ -34,6 +34,19 @@
       In: ${arg}.cpp
       Out: ${arg}.${rewrite_extention_name}
 
+- Rule: rule_cpp_file_in_dict
+  Kind: PythonRule
+  Priority: Fallback
+  MatchMode: Partial
+  PythonSyntax: cpp_file_in_dict
+  In: "{${value}}"
+  Out: "{${value}}"
+  Subrules:
+    value:
+      MatchMode: Full
+      In: ${arg}.cpp
+      Out: ${arg}.${rewrite_extention_name}
+
 - Rule: rule_cu_file_in_func
   Kind: PythonRule
   Priority: Fallback
@@ -54,6 +67,19 @@
   PythonSyntax: cu_file_in_list
   In: "[${value}]"
   Out: "[${value}]"
+  Subrules:
+    value:
+      MatchMode: Full
+      In: ${arg}.cu
+      Out: ${arg}.${rewrite_extention_name}
+
+- Rule: rule_cu_file_in_dict
+  Kind: PythonRule
+  Priority: Fallback
+  MatchMode: Partial
+  PythonSyntax: cu_file_in_dict
+  In: "{${value}}"
+  Out: "{${value}}"
   Subrules:
     value:
       MatchMode: Full


### PR DESCRIPTION
This PR adds support for parsing Python syntax inside blocks like 

- tuples - ()
- lists - []
- dicts - {}