### PR TITLE
[SYCLomatic] Migrate types used while casting stream and events

### DIFF
--- a/clang/lib/DPCT/RulesLang/RulesLang.cpp
+++ b/clang/lib/DPCT/RulesLang/RulesLang.cpp
@@ -4367,11 +4367,12 @@ void StreamAPICallRule::runRule(const MatchFinder::MatchResult &Result) {
         StreamName = "{{NEEDREPLACEQ" + std::to_string(Index) + "}}.";
         ReplStr = StreamName + "ext_oneapi_empty()";
       } else {
-        StreamName = getStmtSpelling(StreamArg);
+        ExprAnalysis EA(StreamArg);
+        ReplStr = EA.getReplacedString();
         if (needExtraParensInMemberExpr(StreamArg)) {
-          StreamName = "(" + StreamName + ")";
+          ReplStr = "(" + ReplStr + ")";
         }
-        ReplStr = StreamName + "->" + "ext_oneapi_empty()";
+        ReplStr = ReplStr + "->" + "ext_oneapi_empty()";
       }
       if (IsAssigned) {
         ReplStr = MapNames::getCheckErrorMacroName() + "((" + ReplStr + "))";
@@ -4414,7 +4415,12 @@ void StreamAPICallRule::runRule(const MatchFinder::MatchResult &Result) {
 
         StmtStr0 = "{{NEEDREPLACEQ" + std::to_string(Index) + "}}.";
       } else {
-        StmtStr0 = getStmtSpelling(CE->getArg(0)) + "->";
+        ExprAnalysis StreamArgEA(StreamArg);
+        StmtStr0 = StreamArgEA.getReplacedString();
+        if (needExtraParensInMemberExpr(StreamArg)) {
+          StmtStr0 = "(" + StmtStr0 + ")";
+        }
+        StmtStr0 += "->";
       }
       ReplStr = StmtStr0 + "ext_oneapi_submit_barrier({" +
                 StmtStr1 + "})";

--- a/clang/test/dpct/driver-stream-and-event.cu
+++ b/clang/test/dpct/driver-stream-and-event.cu
@@ -29,6 +29,10 @@ void foo(){
   CUresult streamStatus = cuStreamQuery(s);
   if (streamStatus == CUDA_SUCCESS);
 
+  unsigned long long stream_addr;
+  // CHECK: ((dpct::queue_ptr)stream_addr)->ext_oneapi_empty();
+  cuStreamQuery((CUstream)stream_addr);
+
   //CHECK: s->wait();
   cuStreamSynchronize(s);
 
@@ -38,6 +42,10 @@ void foo(){
   //CHECK: s->ext_oneapi_submit_barrier({*e});
   cuEventCreate(&e, CU_EVENT_DEFAULT);
   cuStreamWaitEvent(s, e, 0);
+
+  unsigned long long event_addr;
+  // CHECK: ((dpct::queue_ptr)stream_addr)->ext_oneapi_submit_barrier({*(dpct::event_ptr)event_addr});
+  cuStreamWaitEvent((CUstream)stream_addr, (CUevent)event_addr, 0);
 
   //CHECK: /*
   //CHECK-NEXT: DPCT1012:{{[0-9]+}}: Detected kernel execution time measurement pattern and generated an initial code for time measurements in SYCL. You can change the way time is measured depending on your goals.


### PR DESCRIPTION
While handing the arguments passed to the following stream APIs, the types used for casting are migrated as well in this PR.
* cuSteamQuery
* cuStreamWWaitEvent

Signed-off-by: [Deepak Raj H R](Deepak.raj.h.r@intel.com)