### PR TITLE
[SYCLomatic] Use pointer definitions for `device_ptr`

### DIFF
--- a/clang/runtime/dpct-rt/include/dpct/device.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/device.hpp
@@ -83,7 +83,12 @@ typedef sycl::event *event_ptr;
 
 typedef sycl::queue *queue_ptr;
 
-typedef char *device_ptr;
+#if defined(_WIN64) || defined(__LP64__)
+typedef unsigned long long device_ptr;
+#else
+typedef unsigned int device;
+#endif
+
 
 using queue_callback = std::function<void (queue_ptr, int, void*)>;
 


### PR DESCRIPTION
Signed-off-by: [Deepak Raj H R](Deepak.raj.h.r@intel.com)