### PR TITLE
[Bug][LIT][NFC] Fix test mechanism for lit tests

### DIFF
--- a/clang/test/dpct/check_header_files.cpp
+++ b/clang/test/dpct/check_header_files.cpp
@@ -1,202 +1,82 @@
 // RUN: mkdir %T/check_header_files
 // RUN: dpct --out-root %T/check_header_files/out --gen-helper-function --cuda-include-path="%cuda-path/include" || true
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/atomic.hpp  %S/../../runtime/dpct-rt/include/dpct/atomic.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/blas_utils.hpp  %S/../../runtime/dpct-rt/include/dpct/blas_utils.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/device.hpp  %S/../../runtime/dpct-rt/include/dpct/device.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/dpct.hpp  %S/../../runtime/dpct-rt/include/dpct/dpct.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/dpl_utils.hpp  %S/../../runtime/dpct-rt/include/dpct/dpl_utils.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/image.hpp  %S/../../runtime/dpct-rt/include/dpct/image.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/kernel.hpp  %S/../../runtime/dpct-rt/include/dpct/kernel.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/memory.hpp  %S/../../runtime/dpct-rt/include/dpct/memory.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/util.hpp  %S/../../runtime/dpct-rt/include/dpct/util.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/rng_utils.hpp  %S/../../runtime/dpct-rt/include/dpct/rng_utils.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/lib_common_utils.hpp  %S/../../runtime/dpct-rt/include/dpct/lib_common_utils.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/ccl_utils.hpp  %S/../../runtime/dpct-rt/include/dpct/ccl_utils.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/dnnl_utils.hpp  %S/../../runtime/dpct-rt/include/dpct/dnnl_utils.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/sparse_utils.hpp  %S/../../runtime/dpct-rt/include/dpct/sparse_utils.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/fft_utils.hpp  %S/../../runtime/dpct-rt/include/dpct/fft_utils.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/lapack_utils.hpp  %S/../../runtime/dpct-rt/include/dpct/lapack_utils.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/group_utils.hpp  %S/../../runtime/dpct-rt/include/dpct/group_utils.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/blas_gemm_utils.hpp  %S/../../runtime/dpct-rt/include/dpct/blas_gemm_utils.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/compat_service.hpp  %S/../../runtime/dpct-rt/include/dpct/compat_service.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/dpl_extras/algorithm.h  %S/../../runtime/dpct-rt/include/dpct/dpl_extras/algorithm.h >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/dpl_extras/functional.h  %S/../../runtime/dpct-rt/include/dpct/dpl_extras/functional.h >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/dpl_extras/iterators.h  %S/../../runtime/dpct-rt/include/dpct/dpl_extras/iterators.h >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/dpl_extras/iterator_adaptor.h  %S/../../runtime/dpct-rt/include/dpct/dpl_extras/iterator_adaptor.h >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/dpl_extras/memory.h  %S/../../runtime/dpct-rt/include/dpct/dpl_extras/memory.h >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/dpl_extras/numeric.h  %S/../../runtime/dpct-rt/include/dpct/dpl_extras/numeric.h >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/dpl_extras/vector.h  %S/../../runtime/dpct-rt/include/dpct/dpl_extras/vector.h >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/dpl_extras/dpcpp_extensions.h  %S/../../runtime/dpct-rt/include/dpct/dpl_extras/dpcpp_extensions.h >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/dpl_extras/iterator_adaptor.h  %S/../../runtime/dpct-rt/include/dpct/dpl_extras/iterator_adaptor.h >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/detail/group_utils_detail.hpp  %S/../../runtime/dpct-rt/include/dpct/detail/group_utils_detail.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/detail/math_detail.hpp  %S/../../runtime/dpct-rt/include/dpct/detail/math_detail.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/detail/memory_detail.hpp  %S/../../runtime/dpct-rt/include/dpct/detail/memory_detail.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/detail/lib_common_utils_detail.hpp  %S/../../runtime/dpct-rt/include/dpct/detail/lib_common_utils_detail.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/detail/blas_utils_detail.hpp  %S/../../runtime/dpct-rt/include/dpct/detail/blas_utils_detail.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/detail/lapack_utils_detail.hpp  %S/../../runtime/dpct-rt/include/dpct/detail/lapack_utils_detail.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/detail/rng_utils_detail.hpp  %S/../../runtime/dpct-rt/include/dpct/detail/rng_utils_detail.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/detail/sparse_utils_detail.hpp  %S/../../runtime/dpct-rt/include/dpct/detail/sparse_utils_detail.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/detail/dnnl_utils_detail.hpp  %S/../../runtime/dpct-rt/include/dpct/detail/dnnl_utils_detail.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/detail/blas_gemm_utils_detail.hpp  %S/../../runtime/dpct-rt/include/dpct/detail/blas_gemm_utils_detail.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
-// RUN: echo "begin" > %T/check_header_files/diff_res.txt
 // RUN: diff %T/check_header_files/out/include/dpct/detail/ccl_utils_detail.hpp  %S/../../runtime/dpct-rt/include/dpct/detail/ccl_utils_detail.hpp >> %T/check_header_files/diff_res.txt
-// RUN: echo "end" >> %T/check_header_files/diff_res.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/check_header_files/diff_res.txt
 
 // RUN: rm -rf %T/check_header_files
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/check_header_files.cpp
+++ b/clang/test/dpct/check_header_files.cpp
@@ -200,4 +200,3 @@
 
 // CHECK: begin
 // CHECK-NEXT: end
-

--- a/clang/test/dpct/cmake_migration/case_001/case_001_framework.cpp
+++ b/clang/test/dpct/cmake_migration/case_001/case_001_framework.cpp
@@ -11,31 +11,31 @@
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out_1/input.cmake >> %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/sub_expected.txt %T/out_1/subdir/sub_input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
-// CHECK: begin
-// CHECK-NEXT: end
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // RUN: dpct -in-root ./ -out-root out_2 ./input.cmake ./subdir/sub_input.cmake --migrate-build-script-only --migrate-build-script=CMake
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out_2/input.cmake >> %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/sub_expected.txt %T/out_2/subdir/sub_input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
-// CHECK: begin
-// CHECK-NEXT: end
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // RUN: dpct -in-root ./ -out-root out_3 --cuda-include-path="%cuda-path/include" --migrate-build-script=CMake -p ./
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out_3/input.cmake >> %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/sub_expected.txt %T/out_3/subdir/sub_input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
-// CHECK: begin
-// CHECK-NEXT: end
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
+
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/src/expected.cpp.txt %T/out_3/input.dp.cpp >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
-// CHECK: begin
-// CHECK-NEXT: end
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // The command below is used to test if dpct.cmake has been write to the output directory
 // RUN: diff --strip-trailing-cr %T/out_1/dpct.cmake %T/out_1/dpct.cmake
 // RUN: diff --strip-trailing-cr %T/out_2/dpct.cmake %T/out_2/dpct.cmake
 // RUN: diff --strip-trailing-cr %T/out_3/dpct.cmake %T/out_3/dpct.cmake
+
+// CHECK: begin
+// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_001/case_001_framework.cpp
+++ b/clang/test/dpct/cmake_migration/case_001/case_001_framework.cpp
@@ -7,35 +7,19 @@
 // RUN: cp %S/src/compile_commands.json ./compile_commands.json
 
 // RUN: dpct -in-root ./ -out-root out_1 ./input.cmake ./subdir/sub_input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out_1/input.cmake >> %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/sub_expected.txt %T/out_1/subdir/sub_input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // RUN: dpct -in-root ./ -out-root out_2 ./input.cmake ./subdir/sub_input.cmake --migrate-build-script-only --migrate-build-script=CMake
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out_2/input.cmake >> %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/sub_expected.txt %T/out_2/subdir/sub_input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // RUN: dpct -in-root ./ -out-root out_3 --cuda-include-path="%cuda-path/include" --migrate-build-script=CMake -p ./
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out_3/input.cmake >> %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/sub_expected.txt %T/out_3/subdir/sub_input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/src/expected.cpp.txt %T/out_3/input.dp.cpp >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // The command below is used to test if dpct.cmake has been write to the output directory
 // RUN: diff --strip-trailing-cr %T/out_1/dpct.cmake %T/out_1/dpct.cmake
 // RUN: diff --strip-trailing-cr %T/out_2/dpct.cmake %T/out_2/dpct.cmake
 // RUN: diff --strip-trailing-cr %T/out_3/dpct.cmake %T/out_3/dpct.cmake
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_002/case_002_project.cpp
+++ b/clang/test/dpct/cmake_migration/case_002/case_002_project.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_002/case_002_project.cpp
+++ b/clang/test/dpct/cmake_migration/case_002/case_002_project.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_003/case_003_add_executable.cpp
+++ b/clang/test/dpct/cmake_migration/case_003/case_003_add_executable.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_003/case_003_add_executable.cpp
+++ b/clang/test/dpct/cmake_migration/case_003/case_003_add_executable.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_004/case_004_target_link_libraries.cpp
+++ b/clang/test/dpct/cmake_migration/case_004/case_004_target_link_libraries.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_004/case_004_target_link_libraries.cpp
+++ b/clang/test/dpct/cmake_migration/case_004/case_004_target_link_libraries.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_005/case_005_set_property.cpp
+++ b/clang/test/dpct/cmake_migration/case_005/case_005_set_property.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_005/case_005_set_property.cpp
+++ b/clang/test/dpct/cmake_migration/case_005/case_005_set_property.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_006/case_006_cuda_add_executable.cpp
+++ b/clang/test/dpct/cmake_migration/case_006/case_006_cuda_add_executable.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_006/case_006_cuda_add_executable.cpp
+++ b/clang/test/dpct/cmake_migration/case_006/case_006_cuda_add_executable.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_007/case_007_cuda_compile_fatbin.cpp
+++ b/clang/test/dpct/cmake_migration/case_007/case_007_cuda_compile_fatbin.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_007/case_007_cuda_compile_fatbin.cpp
+++ b/clang/test/dpct/cmake_migration/case_007/case_007_cuda_compile_fatbin.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_008/case_008_find_package.cpp
+++ b/clang/test/dpct/cmake_migration/case_008/case_008_find_package.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_008/case_008_find_package.cpp
+++ b/clang/test/dpct/cmake_migration/case_008/case_008_find_package.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_009/case_009_cmake_minimum_required.cpp
+++ b/clang/test/dpct/cmake_migration/case_009/case_009_cmake_minimum_required.cpp
@@ -3,10 +3,4 @@
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: cp %S/vars_def.cmake ./vars_def.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake ./vars_def.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_009/case_009_cmake_minimum_required.cpp
+++ b/clang/test/dpct/cmake_migration/case_009/case_009_cmake_minimum_required.cpp
@@ -6,6 +6,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_010/case_010_file_commands.cpp
+++ b/clang/test/dpct/cmake_migration/case_010/case_010_file_commands.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_010/case_010_file_commands.cpp
+++ b/clang/test/dpct/cmake_migration/case_010/case_010_file_commands.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_011/case_011_target_compile_features.cpp
+++ b/clang/test/dpct/cmake_migration/case_011/case_011_target_compile_features.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_011/case_011_target_compile_features.cpp
+++ b/clang/test/dpct/cmake_migration/case_011/case_011_target_compile_features.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only --cuda-include-path="%cuda-path/include"
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_012/case_012_cuda_add_cufft_to_target.cpp
+++ b/clang/test/dpct/cmake_migration/case_012/case_012_cuda_add_cufft_to_target.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_012/case_012_cuda_add_cufft_to_target.cpp
+++ b/clang/test/dpct/cmake_migration/case_012/case_012_cuda_add_cufft_to_target.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_013/case_013_cuda_compile_cubin.cpp
+++ b/clang/test/dpct/cmake_migration/case_013/case_013_cuda_compile_cubin.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_013/case_013_cuda_compile_cubin.cpp
+++ b/clang/test/dpct/cmake_migration/case_013/case_013_cuda_compile_cubin.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_014/case_014_cmake_cxx_standard.cpp
+++ b/clang/test/dpct/cmake_migration/case_014/case_014_cmake_cxx_standard.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_014/case_014_cmake_cxx_standard.cpp
+++ b/clang/test/dpct/cmake_migration/case_014/case_014_cmake_cxx_standard.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake  --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_015/case_015_set_target_properties.cpp
+++ b/clang/test/dpct/cmake_migration/case_015/case_015_set_target_properties.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_015/case_015_set_target_properties.cpp
+++ b/clang/test/dpct/cmake_migration/case_015/case_015_set_target_properties.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_016/case_016_user_defined_functions.cpp
+++ b/clang/test/dpct/cmake_migration/case_016/case_016_user_defined_functions.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_016/case_016_user_defined_functions.cpp
+++ b/clang/test/dpct/cmake_migration/case_016/case_016_user_defined_functions.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_017/case_017_cmake_cxx_compiler.cpp
+++ b/clang/test/dpct/cmake_migration/case_017/case_017_cmake_cxx_compiler.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_017/case_017_cmake_cxx_compiler.cpp
+++ b/clang/test/dpct/cmake_migration/case_017/case_017_cmake_cxx_compiler.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_018/case_018_cuda_compile.cpp
+++ b/clang/test/dpct/cmake_migration/case_018/case_018_cuda_compile.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_018/case_018_cuda_compile.cpp
+++ b/clang/test/dpct/cmake_migration/case_018/case_018_cuda_compile.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_019/case_019_CUDA_VERSION.cpp
+++ b/clang/test/dpct/cmake_migration/case_019/case_019_CUDA_VERSION.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_019/case_019_CUDA_VERSION.cpp
+++ b/clang/test/dpct/cmake_migration/case_019/case_019_CUDA_VERSION.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_020/case_020_user_defined_variables.cpp
+++ b/clang/test/dpct/cmake_migration/case_020/case_020_user_defined_variables.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_020/case_020_user_defined_variables.cpp
+++ b/clang/test/dpct/cmake_migration/case_020/case_020_user_defined_variables.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only --cuda-include-path="%cuda-path/include"
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_021/case_021_add_compile_options.cpp
+++ b/clang/test/dpct/cmake_migration/case_021/case_021_add_compile_options.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_021/case_021_add_compile_options.cpp
+++ b/clang/test/dpct/cmake_migration/case_021/case_021_add_compile_options.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only --cuda-include-path="%cuda-path/include"
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_022/case_022_target_compile_options.cpp
+++ b/clang/test/dpct/cmake_migration/case_022/case_022_target_compile_options.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake  --migrate-build-script-only --cuda-include-path="%cuda-path/include"
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_022/case_022_target_compile_options.cpp
+++ b/clang/test/dpct/cmake_migration/case_022/case_022_target_compile_options.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_023/case_023_cuda_compile_ptx.cpp
+++ b/clang/test/dpct/cmake_migration/case_023/case_023_cuda_compile_ptx.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_023/case_023_cuda_compile_ptx.cpp
+++ b/clang/test/dpct/cmake_migration/case_023/case_023_cuda_compile_ptx.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_024/case_024_CUDA_HAS_FP16.cpp
+++ b/clang/test/dpct/cmake_migration/case_024/case_024_CUDA_HAS_FP16.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_024/case_024_CUDA_HAS_FP16.cpp
+++ b/clang/test/dpct/cmake_migration/case_024/case_024_CUDA_HAS_FP16.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only --cuda-include-path="%cuda-path/include"
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_025/case_025_cuda_add_library.cpp
+++ b/clang/test/dpct/cmake_migration/case_025/case_025_cuda_add_library.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_025/case_025_cuda_add_library.cpp
+++ b/clang/test/dpct/cmake_migration/case_025/case_025_cuda_add_library.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_026/case_026_execute_process.cpp
+++ b/clang/test/dpct/cmake_migration/case_026/case_026_execute_process.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_026/case_026_execute_process.cpp
+++ b/clang/test/dpct/cmake_migration/case_026/case_026_execute_process.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_027/case_027_CMAKE_CUDA_COMPILER.cpp
+++ b/clang/test/dpct/cmake_migration/case_027/case_027_CMAKE_CUDA_COMPILER.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // RUN: dpct  ./input.cmake --migrate-build-script-only
 // RUN: rm dpct_output/input.cmake
@@ -12,6 +13,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/dpct_output/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_027/case_027_CMAKE_CUDA_COMPILER.cpp
+++ b/clang/test/dpct/cmake_migration/case_027/case_027_CMAKE_CUDA_COMPILER.cpp
@@ -2,18 +2,9 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // RUN: dpct  ./input.cmake --migrate-build-script-only
 // RUN: rm dpct_output/input.cmake
 // RUN: dpct  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/dpct_output/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_028/case_028_comments_inlined.cpp
+++ b/clang/test/dpct/cmake_migration/case_028/case_028_comments_inlined.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_028/case_028_comments_inlined.cpp
+++ b/clang/test/dpct/cmake_migration/case_028/case_028_comments_inlined.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_029/case_029_enable_language.cpp
+++ b/clang/test/dpct/cmake_migration/case_029/case_029_enable_language.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_029/case_029_enable_language.cpp
+++ b/clang/test/dpct/cmake_migration/case_029/case_029_enable_language.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_030/case_030_cuda_include_directories.cpp
+++ b/clang/test/dpct/cmake_migration/case_030/case_030_cuda_include_directories.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_030/case_030_cuda_include_directories.cpp
+++ b/clang/test/dpct/cmake_migration/case_030/case_030_cuda_include_directories.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_031/case_031_include_directories.cpp
+++ b/clang/test/dpct/cmake_migration/case_031/case_031_include_directories.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_031/case_031_include_directories.cpp
+++ b/clang/test/dpct/cmake_migration/case_031/case_031_include_directories.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_032/case_032_link_libraries.cpp
+++ b/clang/test/dpct/cmake_migration/case_032/case_032_link_libraries.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_032/case_032_link_libraries.cpp
+++ b/clang/test/dpct/cmake_migration/case_032/case_032_link_libraries.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_033/case_033_cuda_add_cublas_to_target.cpp
+++ b/clang/test/dpct/cmake_migration/case_033/case_033_cuda_add_cublas_to_target.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_033/case_033_cuda_add_cublas_to_target.cpp
+++ b/clang/test/dpct/cmake_migration/case_033/case_033_cuda_add_cublas_to_target.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_034/case_034_cuda_std.cpp
+++ b/clang/test/dpct/cmake_migration/case_034/case_034_cuda_std.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_034/case_034_cuda_std.cpp
+++ b/clang/test/dpct/cmake_migration/case_034/case_034_cuda_std.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_035/case_035_cuda_bit_device_code.cpp
+++ b/clang/test/dpct/cmake_migration/case_035/case_035_cuda_bit_device_code.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_035/case_035_cuda_bit_device_code.cpp
+++ b/clang/test/dpct/cmake_migration/case_035/case_035_cuda_bit_device_code.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_036/case_036_enable_language.cpp
+++ b/clang/test/dpct/cmake_migration/case_036/case_036_enable_language.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_036/case_036_enable_language.cpp
+++ b/clang/test/dpct/cmake_migration/case_036/case_036_enable_language.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_037/case_037_foreach.cpp
+++ b/clang/test/dpct/cmake_migration/case_037/case_037_foreach.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_037/case_037_foreach.cpp
+++ b/clang/test/dpct/cmake_migration/case_037/case_037_foreach.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_038/case_038_add_library.cpp
+++ b/clang/test/dpct/cmake_migration/case_038/case_038_add_library.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_038/case_038_add_library.cpp
+++ b/clang/test/dpct/cmake_migration/case_038/case_038_add_library.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_039/case_039_add_link_options.cpp
+++ b/clang/test/dpct/cmake_migration/case_039/case_039_add_link_options.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_039/case_039_add_link_options.cpp
+++ b/clang/test/dpct/cmake_migration/case_039/case_039_add_link_options.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_040/case_040_test_warning_msg.cpp
+++ b/clang/test/dpct/cmake_migration/case_040/case_040_test_warning_msg.cpp
@@ -6,6 +6,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_040/case_040_test_warning_msg.cpp
+++ b/clang/test/dpct/cmake_migration/case_040/case_040_test_warning_msg.cpp
@@ -2,13 +2,6 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only > migration.log 2>&1
-
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end
 
 // grep "input.cmake:1:warning:DPCT3000:0: Migration of syntax \"cuda_select_nvcc_arch_flags\" is not supported. You may need to adjust the code." ./migration.log

--- a/clang/test/dpct/cmake_migration/case_041/case_041_target_link_opts.cpp
+++ b/clang/test/dpct/cmake_migration/case_041/case_041_target_link_opts.cpp
@@ -6,10 +6,4 @@
 // RUN: cat migration1.log >> ./check.txt
 // RUN: FileCheck --match-full-lines --input-file check.txt check.txt
 
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_041/case_041_target_link_opts.cpp
+++ b/clang/test/dpct/cmake_migration/case_041/case_041_target_link_opts.cpp
@@ -9,6 +9,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_042/case_042_set_source_files_properties.cpp
+++ b/clang/test/dpct/cmake_migration/case_042/case_042_set_source_files_properties.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_042/case_042_set_source_files_properties.cpp
+++ b/clang/test/dpct/cmake_migration/case_042/case_042_set_source_files_properties.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_043/case_043_cuda_nvcc.cpp
+++ b/clang/test/dpct/cmake_migration/case_043/case_043_cuda_nvcc.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_043/case_043_cuda_nvcc.cpp
+++ b/clang/test/dpct/cmake_migration/case_043/case_043_cuda_nvcc.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_045/case_045_use_fast_math.cpp
+++ b/clang/test/dpct/cmake_migration/case_045/case_045_use_fast_math.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_045/case_045_use_fast_math.cpp
+++ b/clang/test/dpct/cmake_migration/case_045/case_045_use_fast_math.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_046/cuda_toolkit_n_sdk.cpp
+++ b/clang/test/dpct/cmake_migration/case_046/cuda_toolkit_n_sdk.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_046/cuda_toolkit_n_sdk.cpp
+++ b/clang/test/dpct/cmake_migration/case_046/cuda_toolkit_n_sdk.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_047/case_047_test_low_priority_yaml_rule.cpp
+++ b/clang/test/dpct/cmake_migration/case_047/case_047_test_low_priority_yaml_rule.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only --rule-file=%S/high_priority.yaml
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_047/case_047_test_low_priority_yaml_rule.cpp
+++ b/clang/test/dpct/cmake_migration/case_047/case_047_test_low_priority_yaml_rule.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_048/case_048_test_extension_name.cpp
+++ b/clang/test/dpct/cmake_migration/case_048/case_048_test_extension_name.cpp
@@ -4,10 +4,4 @@
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: cp %S/MainSourceFiles.yaml ./out/MainSourceFiles.yaml
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_048/case_048_test_extension_name.cpp
+++ b/clang/test/dpct/cmake_migration/case_048/case_048_test_extension_name.cpp
@@ -7,6 +7,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_049/case_049_CMAKE_CUDA_COMPILER_VERSION.cpp
+++ b/clang/test/dpct/cmake_migration/case_049/case_049_CMAKE_CUDA_COMPILER_VERSION.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_049/case_049_CMAKE_CUDA_COMPILER_VERSION.cpp
+++ b/clang/test/dpct/cmake_migration/case_049/case_049_CMAKE_CUDA_COMPILER_VERSION.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_050/case_050_CUDAToolkit_FOUND.cpp
+++ b/clang/test/dpct/cmake_migration/case_050/case_050_CUDAToolkit_FOUND.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_050/case_050_CUDAToolkit_FOUND.cpp
+++ b/clang/test/dpct/cmake_migration/case_050/case_050_CUDAToolkit_FOUND.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_052/case_052_CUDA_FOUND.cpp
+++ b/clang/test/dpct/cmake_migration/case_052/case_052_CUDA_FOUND.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_052/case_052_CUDA_FOUND.cpp
+++ b/clang/test/dpct/cmake_migration/case_052/case_052_CUDA_FOUND.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_053/case_053_configure_file_warning_msg.cpp
+++ b/clang/test/dpct/cmake_migration/case_053/case_053_configure_file_warning_msg.cpp
@@ -11,6 +11,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_053/case_053_configure_file_warning_msg.cpp
+++ b/clang/test/dpct/cmake_migration/case_053/case_053_configure_file_warning_msg.cpp
@@ -8,11 +8,4 @@
 // RUN: cat migration1.log >> ./check.txt
 // RUN: FileCheck --match-full-lines --input-file check.txt check.txt
 
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end
-

--- a/clang/test/dpct/cmake_migration/case_054/target_sources_n_includes_n_compile_lang.cpp
+++ b/clang/test/dpct/cmake_migration/case_054/target_sources_n_includes_n_compile_lang.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_054/target_sources_n_includes_n_compile_lang.cpp
+++ b/clang/test/dpct/cmake_migration/case_054/target_sources_n_includes_n_compile_lang.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_055/cuda_host_compiler_and_flags.cpp
+++ b/clang/test/dpct/cmake_migration/case_055/cuda_host_compiler_and_flags.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_055/cuda_host_compiler_and_flags.cpp
+++ b/clang/test/dpct/cmake_migration/case_055/cuda_host_compiler_and_flags.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_056/try_compile_n_try_run.cpp
+++ b/clang/test/dpct/cmake_migration/case_056/try_compile_n_try_run.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_056/try_compile_n_try_run.cpp
+++ b/clang/test/dpct/cmake_migration/case_056/try_compile_n_try_run.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_057/case_057_cmake_cuda_architectures.cpp
+++ b/clang/test/dpct/cmake_migration/case_057/case_057_cmake_cuda_architectures.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_057/case_057_cmake_cuda_architectures.cpp
+++ b/clang/test/dpct/cmake_migration/case_057/case_057_cmake_cuda_architectures.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_058/case_058_cuda_propagate_host_flags.cpp
+++ b/clang/test/dpct/cmake_migration/case_058/case_058_cuda_propagate_host_flags.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_058/case_058_cuda_propagate_host_flags.cpp
+++ b/clang/test/dpct/cmake_migration/case_058/case_058_cuda_propagate_host_flags.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_059/case_059_cuda_source_property_format.cpp
+++ b/clang/test/dpct/cmake_migration/case_059/case_059_cuda_source_property_format.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_059/case_059_cuda_source_property_format.cpp
+++ b/clang/test/dpct/cmake_migration/case_059/case_059_cuda_source_property_format.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_060/case_060_cuda_use_static_cuda_runtime.cpp
+++ b/clang/test/dpct/cmake_migration/case_060/case_060_cuda_use_static_cuda_runtime.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_060/case_060_cuda_use_static_cuda_runtime.cpp
+++ b/clang/test/dpct/cmake_migration/case_060/case_060_cuda_use_static_cuda_runtime.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_061/case_061_full_match.cpp
+++ b/clang/test/dpct/cmake_migration/case_061/case_061_full_match.cpp
@@ -3,13 +3,7 @@
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: cp %S/input.cmake ./input2.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end
 
 // RUN: test  -f %T/out/input.cmake
 // RUN: test  -f %T/out/dpct.cmake

--- a/clang/test/dpct/cmake_migration/case_061/case_061_full_match.cpp
+++ b/clang/test/dpct/cmake_migration/case_061/case_061_full_match.cpp
@@ -6,6 +6,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_062/case_062_link_directories.cpp
+++ b/clang/test/dpct/cmake_migration/case_062/case_062_link_directories.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_062/case_062_link_directories.cpp
+++ b/clang/test/dpct/cmake_migration/case_062/case_062_link_directories.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_063/case_063_find_program.cpp
+++ b/clang/test/dpct/cmake_migration/case_063/case_063_find_program.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_063/case_063_find_program.cpp
+++ b/clang/test/dpct/cmake_migration/case_063/case_063_find_program.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_064/case_064_find_library.cpp
+++ b/clang/test/dpct/cmake_migration/case_064/case_064_find_library.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_064/case_064_find_library.cpp
+++ b/clang/test/dpct/cmake_migration/case_064/case_064_find_library.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_065/case_065_cpp_extention_migration.cpp
+++ b/clang/test/dpct/cmake_migration/case_065/case_065_cpp_extention_migration.cpp
@@ -5,14 +5,15 @@
 // RUN: cp %S/MainSourceFiles.yaml ./out
 // RUN: dpct -in-root ./ -out-root out   --migrate-build-script-only
 
-// RUN: echo "begin" > %T/diff_1.txt
-// RUN: diff --strip-trailing-cr %S/CMakeLists_outer.ref %T/out/nvcv_types/CMakeLists.txt >> %T/diff_1.txt
-// RUN: echo "end" >> %T/diff_1.txt
-// CHECK: begin
-// CHECK-NEXT: end
+// RUN: echo "begin" > %T/diff.txt
+// RUN: diff --strip-trailing-cr %S/CMakeLists_outer.ref %T/out/nvcv_types/CMakeLists.txt >> %T/diff.txt
+// RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
-// RUN: echo "begin" > %T/diff_2.txt
-// RUN: diff --strip-trailing-cr %S/CMakeLists_inner.ref %T/out/nvcv_types/priv/CMakeLists.txt >> %T/diff_2.txt
-// RUN: echo "end" >> %T/diff_2.txt
+// RUN: echo "begin" > %T/diff.txt
+// RUN: diff --strip-trailing-cr %S/CMakeLists_inner.ref %T/out/nvcv_types/priv/CMakeLists.txt >> %T/diff.txt
+// RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
+
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_065/case_065_cpp_extention_migration.cpp
+++ b/clang/test/dpct/cmake_migration/case_065/case_065_cpp_extention_migration.cpp
@@ -5,15 +5,6 @@
 // RUN: cp %S/MainSourceFiles.yaml ./out
 // RUN: dpct -in-root ./ -out-root out   --migrate-build-script-only
 
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/CMakeLists_outer.ref %T/out/nvcv_types/CMakeLists.txt >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/CMakeLists_inner.ref %T/out/nvcv_types/priv/CMakeLists.txt >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_066/case_066_optional_rules.cpp
+++ b/clang/test/dpct/cmake_migration/case_066/case_066_optional_rules.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_066/case_066_optional_rules.cpp
+++ b/clang/test/dpct/cmake_migration/case_066/case_066_optional_rules.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only --cuda-include-path="%cuda-path/include" --rule-file=%T/../../../../../../../extensions/cmake_rules/cmake_script_migration_rule_optional.yaml
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_067/case_067_target_precompile_headers.cpp
+++ b/clang/test/dpct/cmake_migration/case_067/case_067_target_precompile_headers.cpp
@@ -5,6 +5,7 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/cmake_migration/case_067/case_067_target_precompile_headers.cpp
+++ b/clang/test/dpct/cmake_migration/case_067/case_067_target_precompile_headers.cpp
@@ -2,10 +2,4 @@
 // RUN: cd %T
 // RUN: cp %S/input.cmake ./input.cmake
 // RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only --cuda-include-path="%cuda-path/include" --rule-file=%T/../../../../../../../extensions/cmake_rules/cmake_script_migration_rule_optional.yaml
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/codepin/copy_cmake/foo.cpp
+++ b/clang/test/dpct/codepin/copy_cmake/foo.cpp
@@ -9,14 +9,8 @@
 // DEFAULT: TestCMAKE.cmake
 // DEFAULT: test.cmake
 
-
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/cmake_expected %T/foo_codepin_cuda/CMakeLists.txt >> %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.cmake %T/foo_codepin_cuda/TestCMAKE.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck --input-file %T/diff.txt --check-prefix=CHECK %s
-// CHECK: begin
-// CHECK-NEXT:end
 
 #include <cuda.h>
 

--- a/clang/test/dpct/codepin/copy_makefile/vector_add.cu
+++ b/clang/test/dpct/codepin/copy_makefile/vector_add.cu
@@ -1,21 +1,14 @@
 // UNSUPPORTED: system-windows
 // RUN: dpct -out-root %T/vector_add %s --cuda-include-path="%cuda-path/include" --enable-codepin --gen-build-script -- -std=c++14  -x cuda --cuda-host-only
-// RUN: echo "begin" > %T/diff_sycl_makefile.txt
 // RUN: diff --strip-trailing-cr %S/expected_makefile %T/vector_add_codepin_sycl/Makefile.dpct >> %T/diff_sycl_makefile.txt
-// RUN: echo "end" >> %T/diff_sycl_makefile.txt
-// RUN: FileCheck --input-file %T/diff_sycl_makefile.txt --check-prefix=CHECK %s
 
 // RUN: cd %T/vector_add_codepin_cuda
 // RUN: ls > default.log
 // RUN: FileCheck --input-file default.log --match-full-lines %T/vector_add_codepin_sycl/vector_add.dp.cpp -check-prefix=DEFAULT
 // DEFAULT: Makefile
 
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.txt %T/vector_add_codepin_cuda/Makefile >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck --input-file %T/diff.txt --check-prefix=CHECK %s
-// CHECK: begin
-// CHECK-NEXT:end
+
 #include <cuda.h>
 #include <stdio.h>
 #define VECTOR_SIZE 256

--- a/clang/test/dpct/help_option_check/lin/help_option_check.cpp
+++ b/clang/test/dpct/help_option_check/lin/help_option_check.cpp
@@ -3,15 +3,9 @@
 // RUN: rm -rf %T/help_option_check && mkdir -p %T/help_option_check
 // RUN: cd %T/help_option_check
 
-// RUN: echo "begin" > %T/diff.txt
 // RUN: dpct --help > output.txt
 // RUN: diff --strip-trailing-cr %S/help_all.txt %T/help_option_check/output.txt >> %T/diff.txt
 // RUN: dpct --help=basic > output.txt
 // RUN: diff --strip-trailing-cr %S/help_basic.txt %T/help_option_check/output.txt >> %T/diff.txt
 // RUN: dpct --help=advanced > output.txt
 // RUN: diff --strip-trailing-cr %S/help_advanced.txt %T/help_option_check/output.txt >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/help_option_check/lin/help_option_check.cpp
+++ b/clang/test/dpct/help_option_check/lin/help_option_check.cpp
@@ -11,7 +11,7 @@
 // RUN: dpct --help=advanced > output.txt
 // RUN: diff --strip-trailing-cr %S/help_advanced.txt %T/help_option_check/output.txt >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
-// RUN: cat %T/diff.txt | FileCheck %s
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/help_option_check/win/help_option_check.cpp
+++ b/clang/test/dpct/help_option_check/win/help_option_check.cpp
@@ -3,15 +3,9 @@
 // RUN: rm -rf %T/help_option_check && mkdir -p %T/help_option_check
 // RUN: cd %T/help_option_check
 
-// RUN: echo "begin" > %T/diff.txt
 // RUN: dpct --help > output.txt
 // RUN: diff --strip-trailing-cr %S/help_all.txt %T/help_option_check/output.txt >> %T/diff.txt
 // RUN: dpct --help=basic > output.txt
 // RUN: diff --strip-trailing-cr %S/help_basic.txt %T/help_option_check/output.txt >> %T/diff.txt
 // RUN: dpct --help=advanced > output.txt
 // RUN: diff --strip-trailing-cr %S/help_advanced.txt %T/help_option_check/output.txt >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/help_option_check/win/help_option_check.cpp
+++ b/clang/test/dpct/help_option_check/win/help_option_check.cpp
@@ -11,7 +11,7 @@
 // RUN: dpct --help=advanced > output.txt
 // RUN: diff --strip-trailing-cr %S/help_advanced.txt %T/help_option_check/output.txt >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
-// RUN: cat %T/diff.txt | FileCheck %s
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/pattern-rewriter/000_custom_point/test.cpp
+++ b/clang/test/dpct/pattern-rewriter/000_custom_point/test.cpp
@@ -3,6 +3,7 @@
 // RUN: echo "begin" > %t/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.hpp %t/output.hpp >> %t/diff.txt
 // RUN: echo "end" >> %t/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %t/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/pattern-rewriter/000_custom_point/test.cpp
+++ b/clang/test/dpct/pattern-rewriter/000_custom_point/test.cpp
@@ -1,9 +1,3 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: pattern-rewriter %S/input.hpp -r %S/rules.yaml -o %t/output.hpp
-// RUN: echo "begin" > %t/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.hpp %t/output.hpp >> %t/diff.txt
-// RUN: echo "end" >> %t/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %t/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/pattern-rewriter/001_call_macro/test.cpp
+++ b/clang/test/dpct/pattern-rewriter/001_call_macro/test.cpp
@@ -3,6 +3,7 @@
 // RUN: echo "begin" > %t/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.hpp %t/output.hpp >> %t/diff.txt
 // RUN: echo "end" >> %t/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %t/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/pattern-rewriter/001_call_macro/test.cpp
+++ b/clang/test/dpct/pattern-rewriter/001_call_macro/test.cpp
@@ -1,9 +1,3 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: pattern-rewriter %S/input.hpp -r %S/rules.yaml -o %t/output.hpp
-// RUN: echo "begin" > %t/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.hpp %t/output.hpp >> %t/diff.txt
-// RUN: echo "end" >> %t/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %t/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/pattern-rewriter/002_line_comment/test.cpp
+++ b/clang/test/dpct/pattern-rewriter/002_line_comment/test.cpp
@@ -3,6 +3,7 @@
 // RUN: echo "begin" > %t/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.hpp %t/output.hpp >> %t/diff.txt
 // RUN: echo "end" >> %t/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %t/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/pattern-rewriter/002_line_comment/test.cpp
+++ b/clang/test/dpct/pattern-rewriter/002_line_comment/test.cpp
@@ -1,9 +1,3 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: pattern-rewriter %S/input.hpp -r %S/rules.yaml -o %t/output.hpp
-// RUN: echo "begin" > %t/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.hpp %t/output.hpp >> %t/diff.txt
-// RUN: echo "end" >> %t/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %t/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/pattern-rewriter/003_block_comment/test.cpp
+++ b/clang/test/dpct/pattern-rewriter/003_block_comment/test.cpp
@@ -3,6 +3,7 @@
 // RUN: echo "begin" > %t/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.hpp %t/output.hpp >> %t/diff.txt
 // RUN: echo "end" >> %t/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %t/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/pattern-rewriter/003_block_comment/test.cpp
+++ b/clang/test/dpct/pattern-rewriter/003_block_comment/test.cpp
@@ -1,9 +1,3 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: pattern-rewriter %S/input.hpp -r %S/rules.yaml -o %t/output.hpp
-// RUN: echo "begin" > %t/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.hpp %t/output.hpp >> %t/diff.txt
-// RUN: echo "end" >> %t/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %t/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/pattern-rewriter/004_char_literal/test.cpp
+++ b/clang/test/dpct/pattern-rewriter/004_char_literal/test.cpp
@@ -3,6 +3,7 @@
 // RUN: echo "begin" > %t/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.hpp %t/output.hpp >> %t/diff.txt
 // RUN: echo "end" >> %t/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %t/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/pattern-rewriter/004_char_literal/test.cpp
+++ b/clang/test/dpct/pattern-rewriter/004_char_literal/test.cpp
@@ -1,9 +1,3 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: pattern-rewriter %S/input.hpp -r %S/rules.yaml -o %t/output.hpp
-// RUN: echo "begin" > %t/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.hpp %t/output.hpp >> %t/diff.txt
-// RUN: echo "end" >> %t/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %t/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/pattern-rewriter/005_string_literal/test.cpp
+++ b/clang/test/dpct/pattern-rewriter/005_string_literal/test.cpp
@@ -3,6 +3,7 @@
 // RUN: echo "begin" > %t/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.hpp %t/output.hpp >> %t/diff.txt
 // RUN: echo "end" >> %t/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %t/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/pattern-rewriter/005_string_literal/test.cpp
+++ b/clang/test/dpct/pattern-rewriter/005_string_literal/test.cpp
@@ -1,9 +1,3 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: pattern-rewriter %S/input.hpp -r %S/rules.yaml -o %t/output.hpp
-// RUN: echo "begin" > %t/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.hpp %t/output.hpp >> %t/diff.txt
-// RUN: echo "end" >> %t/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %t/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/pattern-rewriter/006_indentation/test.cpp
+++ b/clang/test/dpct/pattern-rewriter/006_indentation/test.cpp
@@ -3,6 +3,7 @@
 // RUN: echo "begin" > %t/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.hpp %t/output.hpp >> %t/diff.txt
 // RUN: echo "end" >> %t/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %t/diff.txt
 
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/pattern-rewriter/006_indentation/test.cpp
+++ b/clang/test/dpct/pattern-rewriter/006_indentation/test.cpp
@@ -1,9 +1,3 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: pattern-rewriter %S/input.hpp -r %S/rules.yaml -o %t/output.hpp
-// RUN: echo "begin" > %t/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.hpp %t/output.hpp >> %t/diff.txt
-// RUN: echo "end" >> %t/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %t/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/process-all-test4/p_test_4.cu
+++ b/clang/test/dpct/process-all-test4/p_test_4.cu
@@ -8,7 +8,6 @@
 // RUN: %if build_lit %{icpx -c -fsycl %T/dpct-output/p_test_4.dp.cpp -o %T/dpct-output/p_test_4.dp.o %}
 // RUN: FileCheck --match-full-lines --input-file %T/dpct-output/readme_4.txt %T/dpct-output/readme_4.txt
 
-
 #include "cuda_runtime.h"
 #include <stdio.h>
 

--- a/clang/test/dpct/python_migration/case_001/case_001_framework.cpp
+++ b/clang/test/dpct/python_migration/case_001/case_001_framework.cpp
@@ -9,46 +9,45 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected_pytorch.py %T/out_pytorch_1/input.py >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
-// CHECK: begin
-// CHECK-NEXT: end
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // RUN: dpct -in-root ./ -out-root out_pytorch_2 --migrate-build-script-only --migrate-build-script=CMake,Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_pytorch.yaml
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected_pytorch.py %T/out_pytorch_2/input.py >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
-// CHECK: begin
-// CHECK-NEXT: end
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
+
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.cmake %T/out_pytorch_2/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
-// CHECK: begin
-// CHECK-NEXT: end
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // RUN: dpct -in-root ./ -out-root out_ipex_1 --cuda-include-path="%cuda-path/include" --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_ipex.yaml -p ./
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected_ipex.py %T/out_ipex_1/input.py >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
-// CHECK: begin
-// CHECK-NEXT: end
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
+
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/src/expected.cpp.txt %T/out_ipex_1/input.dp.cpp >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
-// CHECK: begin
-// CHECK-NEXT: end
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // RUN: dpct -in-root ./ -out-root out_ipex_2 --cuda-include-path="%cuda-path/include" --migrate-build-script=CMake,Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_ipex.yaml -p ./
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected_ipex.py %T/out_ipex_2/input.py >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
-// CHECK: begin
-// CHECK-NEXT: end
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
+
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.cmake %T/out_ipex_2/input.cmake >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
-// CHECK: begin
-// CHECK-NEXT: end
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
+
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/src/expected.cpp.txt %T/out_ipex_2/input.dp.cpp >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
+
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/python_migration/case_001/case_001_framework.cpp
+++ b/clang/test/dpct/python_migration/case_001/case_001_framework.cpp
@@ -6,48 +6,21 @@
 // RUN: cp %S/src/compile_commands.json ./compile_commands.json
 
 // RUN: dpct -in-root ./ -out-root out_pytorch_1 --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_pytorch.yaml
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected_pytorch.py %T/out_pytorch_1/input.py >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // RUN: dpct -in-root ./ -out-root out_pytorch_2 --migrate-build-script-only --migrate-build-script=CMake,Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_pytorch.yaml
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected_pytorch.py %T/out_pytorch_2/input.py >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.cmake %T/out_pytorch_2/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // RUN: dpct -in-root ./ -out-root out_ipex_1 --cuda-include-path="%cuda-path/include" --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_ipex.yaml -p ./
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected_ipex.py %T/out_ipex_1/input.py >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/src/expected.cpp.txt %T/out_ipex_1/input.dp.cpp >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // RUN: dpct -in-root ./ -out-root out_ipex_2 --cuda-include-path="%cuda-path/include" --migrate-build-script=CMake,Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_ipex.yaml -p ./
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected_ipex.py %T/out_ipex_2/input.py >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.cmake %T/out_ipex_2/input.cmake >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/src/expected.cpp.txt %T/out_ipex_2/input.dp.cpp >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/python_migration/case_001/include_rule_file/include_rule_file.cpp
+++ b/clang/test/dpct/python_migration/case_001/include_rule_file/include_rule_file.cpp
@@ -6,9 +6,4 @@
 // RUN: echo "!include %T/rules/b/b5.yaml" >> %T/rules/python_build_script_migration_rule_inc.yaml
 
 // RUN: dpct -in-root ./ --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/rules/python_build_script_migration_rule_inc.yaml input.py
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.py %T/dpct_output/input.py >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/python_migration/case_001/include_rule_file/include_rule_file.cpp
+++ b/clang/test/dpct/python_migration/case_001/include_rule_file/include_rule_file.cpp
@@ -9,5 +9,6 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.py %T/dpct_output/input.py >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/python_migration/case_002/case_002_import_torch_ext.cpp
+++ b/clang/test/dpct/python_migration/case_002/case_002_import_torch_ext.cpp
@@ -6,12 +6,13 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected_pytorch.py %T/out_pytorch/input.py >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
-// CHECK: begin
-// CHECK-NEXT: end
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // RUN: dpct -in-root ./ -out-root out_ipex ./input.py --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_ipex.yaml
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected_ipex.py %T/out_ipex/input.py >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
+
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/python_migration/case_002/case_002_import_torch_ext.cpp
+++ b/clang/test/dpct/python_migration/case_002/case_002_import_torch_ext.cpp
@@ -3,16 +3,7 @@
 // RUN: cp %S/input.py ./input.py
 
 // RUN: dpct -in-root ./ -out-root out_pytorch ./input.py --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_pytorch.yaml
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected_pytorch.py %T/out_pytorch/input.py >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // RUN: dpct -in-root ./ -out-root out_ipex ./input.py --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_ipex.yaml
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected_ipex.py %T/out_ipex/input.py >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/python_migration/case_003/case_003_torch_classes.cpp
+++ b/clang/test/dpct/python_migration/case_003/case_003_torch_classes.cpp
@@ -6,12 +6,13 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected_pytorch.py %T/out_pytorch/input.py >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
-// CHECK: begin
-// CHECK-NEXT: end
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // RUN: dpct -in-root ./ -out-root out_ipex ./input.py --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_ipex.yaml
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected_ipex.py %T/out_ipex/input.py >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
+
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/python_migration/case_003/case_003_torch_classes.cpp
+++ b/clang/test/dpct/python_migration/case_003/case_003_torch_classes.cpp
@@ -3,16 +3,7 @@
 // RUN: cp %S/input.py ./input.py
 
 // RUN: dpct -in-root ./ -out-root out_pytorch ./input.py --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_pytorch.yaml
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected_pytorch.py %T/out_pytorch/input.py >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // RUN: dpct -in-root ./ -out-root out_ipex ./input.py --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_ipex.yaml
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected_ipex.py %T/out_ipex/input.py >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/python_migration/case_004/case_004_cuda_src_ext.cpp
+++ b/clang/test/dpct/python_migration/case_004/case_004_cuda_src_ext.cpp
@@ -3,16 +3,7 @@
 // RUN: cp %S/input.py ./input.py
 
 // RUN: dpct -in-root ./ -out-root out_pytorch ./input.py --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_pytorch.yaml
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.py %T/out_pytorch/input.py >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // RUN: dpct -in-root ./ -out-root out_ipex ./input.py --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_ipex.yaml
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.py %T/out_ipex/input.py >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/python_migration/case_004/case_004_cuda_src_ext.cpp
+++ b/clang/test/dpct/python_migration/case_004/case_004_cuda_src_ext.cpp
@@ -6,12 +6,13 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.py %T/out_pytorch/input.py >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
-// CHECK: begin
-// CHECK-NEXT: end
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // RUN: dpct -in-root ./ -out-root out_ipex ./input.py --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_ipex.yaml
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.py %T/out_ipex/input.py >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
+
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/python_migration/case_005/case_005_setup.cpp
+++ b/clang/test/dpct/python_migration/case_005/case_005_setup.cpp
@@ -6,12 +6,13 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected_pytorch.py %T/out_pytorch/input.py >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
-// CHECK: begin
-// CHECK-NEXT: end
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // RUN: dpct -in-root ./ -out-root out_ipex ./input.py --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_ipex.yaml
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected_ipex.py %T/out_ipex/input.py >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
+
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/python_migration/case_005/case_005_setup.cpp
+++ b/clang/test/dpct/python_migration/case_005/case_005_setup.cpp
@@ -3,16 +3,7 @@
 // RUN: cp %S/input.py ./input.py
 
 // RUN: dpct -in-root ./ -out-root out_pytorch ./input.py --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_pytorch.yaml
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected_pytorch.py %T/out_pytorch/input.py >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // RUN: dpct -in-root ./ -out-root out_ipex ./input.py --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_ipex.yaml
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected_ipex.py %T/out_ipex/input.py >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/python_migration/case_006/case_006_torch_cuda.cpp
+++ b/clang/test/dpct/python_migration/case_006/case_006_torch_cuda.cpp
@@ -3,16 +3,7 @@
 // RUN: cp %S/input.py ./input.py
 
 // RUN: dpct -in-root ./ -out-root out_pytorch ./input.py --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_pytorch.yaml
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.py %T/out_pytorch/input.py >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // RUN: dpct -in-root ./ -out-root out_ipex ./input.py --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_ipex.yaml
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.py %T/out_ipex/input.py >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/python_migration/case_006/case_006_torch_cuda.cpp
+++ b/clang/test/dpct/python_migration/case_006/case_006_torch_cuda.cpp
@@ -6,12 +6,13 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.py %T/out_pytorch/input.py >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
-// CHECK: begin
-// CHECK-NEXT: end
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // RUN: dpct -in-root ./ -out-root out_ipex ./input.py --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_ipex.yaml
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.py %T/out_ipex/input.py >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
+
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/python_migration/case_007/case_007_test_extension_name.cpp
+++ b/clang/test/dpct/python_migration/case_007/case_007_test_extension_name.cpp
@@ -7,16 +7,7 @@
 // RUN: cp %S/MainSourceFiles.yaml ./out_ipex/MainSourceFiles.yaml
 
 // RUN: dpct -in-root ./ -out-root out_pytorch ./input.py --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_pytorch.yaml
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.py %T/out_pytorch/input.py >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // RUN: dpct -in-root ./ -out-root out_ipex ./input.py --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_ipex.yaml
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.py %T/out_ipex/input.py >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/python_migration/case_007/case_007_test_extension_name.cpp
+++ b/clang/test/dpct/python_migration/case_007/case_007_test_extension_name.cpp
@@ -10,12 +10,13 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.py %T/out_pytorch/input.py >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
-// CHECK: begin
-// CHECK-NEXT: end
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // RUN: dpct -in-root ./ -out-root out_ipex ./input.py --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_ipex.yaml
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected.py %T/out_ipex/input.py >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
+
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/python_migration/case_008/case_008_comments.cpp
+++ b/clang/test/dpct/python_migration/case_008/case_008_comments.cpp
@@ -6,12 +6,13 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected_pytorch.py %T/out_pytorch/input.py >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
-// CHECK: begin
-// CHECK-NEXT: end
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // RUN: dpct -in-root ./ -out-root out_ipex ./input.py --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_ipex.yaml
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected_ipex.py %T/out_ipex/input.py >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
+
 // CHECK: begin
 // CHECK-NEXT: end

--- a/clang/test/dpct/python_migration/case_008/case_008_comments.cpp
+++ b/clang/test/dpct/python_migration/case_008/case_008_comments.cpp
@@ -3,16 +3,7 @@
 // RUN: cp %S/input.py ./input.py
 
 // RUN: dpct -in-root ./ -out-root out_pytorch ./input.py --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_pytorch.yaml
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected_pytorch.py %T/out_pytorch/input.py >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // RUN: dpct -in-root ./ -out-root out_ipex ./input.py --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_ipex.yaml
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected_ipex.py %T/out_ipex/input.py >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end

--- a/clang/test/dpct/python_migration/case_009/case_009_cpp_extension.cpp
+++ b/clang/test/dpct/python_migration/case_009/case_009_cpp_extension.cpp
@@ -7,13 +7,14 @@
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected_pytorch.py %T/out_pytorch/input.py >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
-// CHECK: begin
-// CHECK-NEXT: end
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // RUN: dpct -in-root ./ -out-root out_ipex ./input.py --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_ipex.yaml
 // RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected_ipex.py %T/out_ipex/input.py >> %T/diff.txt
 // RUN: echo "end" >> %T/diff.txt
+// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
+
 // CHECK: begin
 // CHECK-NEXT: end
 

--- a/clang/test/dpct/python_migration/case_009/case_009_cpp_extension.cpp
+++ b/clang/test/dpct/python_migration/case_009/case_009_cpp_extension.cpp
@@ -4,19 +4,10 @@
 // RUN: cp %S/input.py ./input2.py
 
 // RUN: dpct -in-root ./ -out-root out_pytorch ./input.py --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_pytorch.yaml
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected_pytorch.py %T/out_pytorch/input.py >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
 
 // RUN: dpct -in-root ./ -out-root out_ipex ./input.py --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_ipex.yaml
-// RUN: echo "begin" > %T/diff.txt
 // RUN: diff --strip-trailing-cr %S/expected_ipex.py %T/out_ipex/input.py >> %T/diff.txt
-// RUN: echo "end" >> %T/diff.txt
-// RUN: FileCheck %s --match-full-lines --input-file %T/diff.txt
-
-// CHECK: begin
-// CHECK-NEXT: end
 
 // RUN: test  -f %T/out_ipex/input.py
 // RUN: test ! -f %T/out_ipex/input2.py


### PR DESCRIPTION
This PR aims to fix the lit test mechanism used to check the similarity between input and expected files

In the current lit test cases of SYCLomatic, we -
1. diff the contents of input and expected files and
2. check the begin and end statements in diff.txt

But the 2nd step is essential useless without the `FileCheck` command that specifies the input file to check the begin and end statements in.

We can fix this in 2 ways -
1. Add `FileCheck %s --input-file %T/diff.txt` before `// CHECK: begin`
2. Remove `// CHECK` lines altogether and rely on `diff` command to find the differences between input and expected file contents

The first commit in this PR uses 1st way
The second commit uses 2nd way upon suggestion from @tomflinda to simplify the test case

