### PR TITLE
[External Resource Interop][Semaphores] Added support for 2 more semaphore types

### DIFF
--- a/clang/examples/DPCT/Runtime/cudaDestroyExternalMemory.cu
+++ b/clang/examples/DPCT/Runtime/cudaDestroyExternalMemory.cu
@@ -1,0 +1,7 @@
+// Option: --use-experimental-features=bindless_images
+
+void test(cudaExternalMemory_t extMem) {
+  // Start
+  cudaDestroyExternalMemory(extMem /*cudaExternalMemory_t*/);
+  // End
+}

--- a/clang/examples/DPCT/Runtime/cudaDestroyExternalSemaphore.cu
+++ b/clang/examples/DPCT/Runtime/cudaDestroyExternalSemaphore.cu
@@ -1,0 +1,7 @@
+// Option: --use-experimental-features=bindless_images
+
+void test(cudaExternalSemaphore_t extSem) {
+  // Start
+  cudaDestroyExternalSemaphore(extSem /*cudaExternalSemaphore_t*/);
+  // End
+}

--- a/clang/examples/DPCT/Runtime/cudaExternalMemoryGetMappedBuffer.cu
+++ b/clang/examples/DPCT/Runtime/cudaExternalMemoryGetMappedBuffer.cu
@@ -1,0 +1,10 @@
+// Option: --use-experimental-features=bindless_images
+
+void test(void **devPtr, cudaExternalMemory_t extMem,
+          const cudaExternalMemoryBufferDesc *bufferDesc) {
+  // Start
+  cudaExternalMemoryGetMappedBuffer(
+      devPtr /*void ***/, extMem /*cudaExternalMemory_t*/,
+      bufferDesc /*const cudaExternalMemoryBufferDesc **/);
+  // End
+}

--- a/clang/examples/DPCT/Runtime/cudaExternalMemoryGetMappedMipmappedArray.cu
+++ b/clang/examples/DPCT/Runtime/cudaExternalMemoryGetMappedMipmappedArray.cu
@@ -1,0 +1,10 @@
+// Option: --use-experimental-features=bindless_images
+
+void test(cudaMipmappedArray_t *mipmap, cudaExternalMemory_t extMem,
+          const cudaExternalMemoryMipmappedArrayDesc *mipmapDesc) {
+  // Start
+  cudaExternalMemoryGetMappedMipmappedArray(
+      mipmap /*cudaMipmappedArray_t **/, extMem /*cudaExternalMemory_t*/,
+      mipmapDesc /*const cudaExternalMemoryMipmappedArrayDesc **/);
+  // End
+}

--- a/clang/examples/DPCT/Runtime/cudaImportExternalMemory.cu
+++ b/clang/examples/DPCT/Runtime/cudaImportExternalMemory.cu
@@ -1,0 +1,10 @@
+// Option: --use-experimental-features=bindless_images
+
+void test(cudaExternalMemory_t *extMem,
+          const cudaExternalMemoryHandleDesc *memHandleDesc) {
+  // Start
+  cudaImportExternalMemory(
+      extMem /*cudaExternalMemory_t **/,
+      memHandleDesc /*const cudaExternalMemoryHandleDesc **/);
+  // End
+}

--- a/clang/examples/DPCT/Runtime/cudaImportExternalSemaphore.cu
+++ b/clang/examples/DPCT/Runtime/cudaImportExternalSemaphore.cu
@@ -1,0 +1,10 @@
+// Option: --use-experimental-features=bindless_images
+
+void test(cudaExternalSemaphore_t *extSem,
+          const cudaExternalSemaphoreHandleDesc *semHandleDesc) {
+  // Start
+  cudaImportExternalSemaphore(
+      extSem /*cudaExternalSemaphore_t **/,
+      semHandleDesc /*const cudaExternalSemaphoreHandleDesc **/);
+  // End
+}

--- a/clang/examples/DPCT/Runtime/cudaSignalExternalSemaphoresAsync.cu
+++ b/clang/examples/DPCT/Runtime/cudaSignalExternalSemaphoresAsync.cu
@@ -1,0 +1,16 @@
+// Option: --use-experimental-features=bindless_images
+
+void test(const cudaExternalSemaphore_t *extSemArray,
+          const cudaExternalSemaphoreSignalParams *paramsArray,
+          unsigned int numExtSems, cudaStream_t stream = 0) {
+  // Start
+  cudaSignalExternalSemaphoresAsync(
+      extSemArray /*const cudaExternalSemaphore_t **/,
+      paramsArray /*const cudaExternalSemaphoreSignalParams **/,
+      numExtSems /*unsigned int*/);
+  cudaSignalExternalSemaphoresAsync(
+      extSemArray /*const cudaExternalSemaphore_t **/,
+      paramsArray /*const cudaExternalSemaphoreSignalParams **/,
+      numExtSems /*unsigned int*/, stream /*cudaStream_t*/);
+  // End
+}

--- a/clang/examples/DPCT/Runtime/cudaWaitExternalSemaphoresAsync.cu
+++ b/clang/examples/DPCT/Runtime/cudaWaitExternalSemaphoresAsync.cu
@@ -1,0 +1,16 @@
+// Option: --use-experimental-features=bindless_images
+
+void test(const cudaExternalSemaphore_t *extSemArray,
+          const cudaExternalSemaphoreWaitParams *paramsArray,
+          unsigned int numExtSems, cudaStream_t stream = 0) {
+  // Start
+  cudaWaitExternalSemaphoresAsync(
+      extSemArray /*const cudaExternalSemaphore_t **/,
+      paramsArray /*const cudaExternalSemaphoreWaitParams **/,
+      numExtSems /*unsigned int*/);
+  cudaWaitExternalSemaphoresAsync(
+      extSemArray /*const cudaExternalSemaphore_t **/,
+      paramsArray /*const cudaExternalSemaphoreWaitParams **/,
+      numExtSems /*unsigned int*/, stream /*cudaStream_t*/);
+  // End
+}

--- a/clang/lib/DPCT/RuleInfra/MapNames.cpp
+++ b/clang/lib/DPCT/RuleInfra/MapNames.cpp
@@ -1601,6 +1601,18 @@ void MapNames::setExplicitNamespaceMap(
                ? getExpNamespace() +
                      "external_semaphore_handle_type::win32_nt_dx12_fence"
                : "cudaExternalSemaphoreHandleTypeD3D12Fence")},
+      {"cudaExternalSemaphoreHandleTypeTimelineSemaphoreFd",
+       std::make_shared<EnumNameRule>(
+           DpctGlobalInfo::useExtBindlessImages()
+               ? getExpNamespace() +
+                     "external_semaphore_handle_type::timeline_fd"
+               : "cudaExternalSemaphoreHandleTypeTimelineSemaphoreFd")},
+      {"cudaExternalSemaphoreHandleTypeTimelineSemaphoreWin32",
+       std::make_shared<EnumNameRule>(
+           DpctGlobalInfo::useExtBindlessImages()
+               ? getExpNamespace() +
+                     "external_semaphore_handle_type::timeline_win32_nt_handle"
+               : "cudaExternalSemaphoreHandleTypeTimelineSemaphoreWin32")},
       {"NVSHMEM_TEAM_WORLD",
        std::make_shared<EnumNameRule>("ISHMEM_TEAM_WORLD")},
       {"NVSHMEM_TEAM_SHARED",

--- a/clang/lib/DPCT/RulesLang/APINamesGraphicsInterop.inc
+++ b/clang/lib/DPCT/RulesLang/APINamesGraphicsInterop.inc
@@ -201,11 +201,11 @@ CONDITIONAL_FACTORY_ENTRY(
         makeCheckNot(CheckArgIsDefaultCudaStream(3)),
         ASSIGNABLE_FACTORY(CALL_FACTORY_ENTRY("cudaSignalExternalSemaphoresAsync_v2",
                            CALL(MapNames::getDpctNamespace() +
-                                    "experimental::signal_external_semaphore",
+                                    "experimental::signal_external_semaphores",
                                 ARG(0), ARG(1), ARG(2), ARG(3)))),
         ASSIGNABLE_FACTORY(CALL_FACTORY_ENTRY("cudaSignalExternalSemaphoresAsync_v2",
                            CALL(MapNames::getDpctNamespace() +
-                                    "experimental::signal_external_semaphore",
+                                    "experimental::signal_external_semaphores",
                                 ARG(0), ARG(1), ARG(2))))),
     UNSUPPORT_FACTORY_ENTRY("cudaSignalExternalSemaphoresAsync_v2", Diagnostics::TRY_EXPERIMENTAL_FEATURE,
                             ARG("cudaSignalExternalSemaphoresAsync_v2"),
@@ -217,11 +217,11 @@ CONDITIONAL_FACTORY_ENTRY(
         makeCheckNot(CheckArgIsDefaultCudaStream(3)),
         ASSIGNABLE_FACTORY(CALL_FACTORY_ENTRY("cudaWaitExternalSemaphoresAsync_v2",
                            CALL(MapNames::getDpctNamespace() +
-                                    "experimental::wait_external_semaphore",
+                                    "experimental::wait_external_semaphores",
                                 ARG(0), ARG(1), ARG(2), ARG(3)))),
         ASSIGNABLE_FACTORY(CALL_FACTORY_ENTRY("cudaWaitExternalSemaphoresAsync_v2",
                            CALL(MapNames::getDpctNamespace() +
-                                    "experimental::wait_external_semaphore",
+                                    "experimental::wait_external_semaphores",
                                 ARG(0), ARG(1), ARG(2))))),
     UNSUPPORT_FACTORY_ENTRY("cudaWaitExternalSemaphoresAsync_v2", Diagnostics::TRY_EXPERIMENTAL_FEATURE,
                             ARG("cudaWaitExternalSemaphoresAsync_v2"),

--- a/clang/runtime/dpct-rt/include/dpct/bindless_images.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/bindless_images.hpp
@@ -1307,31 +1307,40 @@ inline void import_external_semaphore(external_sem_wrapper **extSem,
 /// parameters.
 /// \param [in] numExtSems Number of external semaphores to signal.
 /// \param [in] q_ptr The queue used to signal the external semaphore resource.
-inline void signal_external_semaphore(external_sem_wrapper **extSem,
-                                      external_sem_params *semSignalParams,
-                                      unsigned int numExtSems,
-                                      queue_ptr q_ptr = &get_default_queue()) {
+inline void signal_external_semaphores(external_sem_wrapper **extSem,
+                                       external_sem_params *semSignalParams,
+                                       unsigned int numExtSems,
+                                       queue_ptr q_ptr = &get_default_queue()) {
   for (int i = 0; i < numExtSems; i++) {
     auto extSemType = extSem[i]->get_handle_type();
+    switch (extSemType) {
 #ifdef _WIN32
-    if (extSemType == sycl::ext::oneapi::experimental::
-                          external_semaphore_handle_type::win32_nt_dx12_fence) {
+    case sycl::ext::oneapi::experimental::external_semaphore_handle_type::
+        win32_nt_dx12_fence:
+    case sycl::ext::oneapi::experimental::external_semaphore_handle_type::
+        timeline_win32_nt_handle:
       q_ptr->ext_oneapi_signal_external_semaphore(
           extSem[i]->get(), semSignalParams[i].get_value());
-    } else if (extSemType ==
-               sycl::ext::oneapi::experimental::external_semaphore_handle_type::
-                   win32_nt_handle) {
+      break;
+    case sycl::ext::oneapi::experimental::external_semaphore_handle_type::
+        win32_nt_handle:
       q_ptr->ext_oneapi_signal_external_semaphore(extSem[i]->get());
-    }
-#else
-    if (extSemType == sycl::ext::oneapi::experimental::
-                          external_semaphore_handle_type::opaque_fd) {
+      break;
+#else  // _WIN32
+    case sycl::ext::oneapi::experimental::external_semaphore_handle_type::
+        timeline_fd:
+      q_ptr->ext_oneapi_signal_external_semaphore(
+          extSem[i]->get(), semSignalParams[i].get_value());
+      break;
+    case sycl::ext::oneapi::experimental::external_semaphore_handle_type::
+        opaque_fd:
       q_ptr->ext_oneapi_signal_external_semaphore(extSem[i]->get());
-    }
+      break;
 #endif // _WIN32
-    else {
+    default:
       throw std::runtime_error(
           "Unsupported external semaphore resource handle type!");
+      break;
     }
   }
 }
@@ -1341,31 +1350,40 @@ inline void signal_external_semaphore(external_sem_wrapper **extSem,
 /// \param [in] semWaitParams Pointer to the external semaphore wait parameters.
 /// \param [in] numExtSems Number of external semaphores to wait.
 /// \param [in] q_ptr The queue used to wait on the external semaphore resource.
-inline void wait_external_semaphore(external_sem_wrapper **extSem,
-                                    external_sem_params *semWaitParams,
-                                    unsigned int numExtSems,
-                                    queue_ptr q_ptr = &get_default_queue()) {
+inline void wait_external_semaphores(external_sem_wrapper **extSem,
+                                     external_sem_params *semWaitParams,
+                                     unsigned int numExtSems,
+                                     queue_ptr q_ptr = &get_default_queue()) {
   for (int i = 0; i < numExtSems; i++) {
     auto extSemType = extSem[i]->get_handle_type();
+    switch (extSemType) {
 #ifdef _WIN32
-    if (extSemType == sycl::ext::oneapi::experimental::
-                          external_semaphore_handle_type::win32_nt_dx12_fence) {
+    case sycl::ext::oneapi::experimental::external_semaphore_handle_type::
+        win32_nt_dx12_fence:
+    case sycl::ext::oneapi::experimental::external_semaphore_handle_type::
+        timeline_win32_nt_handle:
       q_ptr->ext_oneapi_wait_external_semaphore(extSem[i]->get(),
                                                 semWaitParams[i].get_value());
-    } else if (extSemType ==
-               sycl::ext::oneapi::experimental::external_semaphore_handle_type::
-                   win32_nt_handle) {
+      break;
+    case sycl::ext::oneapi::experimental::external_semaphore_handle_type::
+        win32_nt_handle:
       q_ptr->ext_oneapi_wait_external_semaphore(extSem[i]->get());
-    }
-#else
-    if (extSemType == sycl::ext::oneapi::experimental::
-                          external_semaphore_handle_type::opaque_fd) {
+      break;
+#else  // _WIN32
+    case sycl::ext::oneapi::experimental::external_semaphore_handle_type::
+        timeline_fd:
+      q_ptr->ext_oneapi_wait_external_semaphore(extSem[i]->get(),
+                                                semWaitParams[i].get_value());
+      break;
+    case sycl::ext::oneapi::experimental::external_semaphore_handle_type::
+        opaque_fd:
       q_ptr->ext_oneapi_wait_external_semaphore(extSem[i]->get());
-    }
+      break;
 #endif // _WIN32
-    else {
+    default:
       throw std::runtime_error(
           "Unsupported external semaphore resource handle type!");
+      break;
     }
   }
 }

--- a/clang/test/dpct/externalResInterop.cu
+++ b/clang/test/dpct/externalResInterop.cu
@@ -109,10 +109,14 @@ int main() {
   memHandleDesc.type = cudaExternalMemoryHandleTypeOpaqueWin32Kmt;
 #endif // !NO_BUILD_TEST
 
-  // CHECK: semHandleDesc.set_handle_type(sycl::ext::oneapi::experimental::external_semaphore_handle_type::win32_nt_handle);
+  // CHECK: semHandleDesc.set_handle_type(sycl::ext::oneapi::experimental::external_semaphore_handle_type::timeline_win32_nt_handle);
+  // CHECK-NEXT: semHandleDesc.set_handle_type(sycl::ext::oneapi::experimental::external_semaphore_handle_type::timeline_fd);
+  // CHECK-NEXT: semHandleDesc.set_handle_type(sycl::ext::oneapi::experimental::external_semaphore_handle_type::win32_nt_handle);
   // CHECK-NEXT: semHandleDesc.set_handle_type(sycl::ext::oneapi::experimental::external_semaphore_handle_type::win32_nt_dx12_fence);
   // CHECK-NEXT: semHandleDesc.set_handle_type(sycl::ext::oneapi::experimental::external_semaphore_handle_type::opaque_fd);
   // CHECK-NEXT: semHandleDesc.set_handle_type(semHandleType);
+  semHandleDesc.type = cudaExternalSemaphoreHandleTypeTimelineSemaphoreWin32;
+  semHandleDesc.type = cudaExternalSemaphoreHandleTypeTimelineSemaphoreFd;
   semHandleDesc.type = cudaExternalSemaphoreHandleTypeOpaqueWin32;
   semHandleDesc.type = cudaExternalSemaphoreHandleTypeD3D12Fence;
   semHandleDesc.type = cudaExternalSemaphoreHandleTypeOpaqueFd;
@@ -365,10 +369,10 @@ int main() {
   // CHECK-WINDOWS-NEXT: DPCT1136:{{[0-9]+}}: SYCL Bindless Images extension only supports importing external resource using NT handle on Windows. If assert(semHandleDesc.get_win32_handle()) fails, you may need to adjust the code to use (semHandleDesc.get_win32_handle()).
   // CHECK-WINDOWS-NEXT: */
   // CHECK: dpct::experimental::import_external_semaphore(&extSem, &semHandleDesc);
-  // CHECK-NEXT: dpct::experimental::signal_external_semaphore(&extSem, &signalParams, 1);
-  // CHECK-NEXT: dpct::experimental::signal_external_semaphore(extSemArr, signalParamsArr, numExtSems, stream);
-  // CHECK-NEXT: dpct::experimental::wait_external_semaphore(&extSem, &waitParams, 1);
-  // CHECK-NEXT: dpct::experimental::wait_external_semaphore(extSemArr, waitParamsArr, numExtSems, stream);
+  // CHECK-NEXT: dpct::experimental::signal_external_semaphores(&extSem, &signalParams, 1);
+  // CHECK-NEXT: dpct::experimental::signal_external_semaphores(extSemArr, signalParamsArr, numExtSems, stream);
+  // CHECK-NEXT: dpct::experimental::wait_external_semaphores(&extSem, &waitParams, 1);
+  // CHECK-NEXT: dpct::experimental::wait_external_semaphores(extSemArr, waitParamsArr, numExtSems, stream);
   // CHECK-NEXT: delete extSem;
   cudaImportExternalSemaphore(&extSem, &semHandleDesc);
   cudaSignalExternalSemaphoresAsync(&extSem, &signalParams, 1);

--- a/clang/test/dpct/query_api_mapping/Runtime/test_external_resource_interop.cu
+++ b/clang/test/dpct/query_api_mapping/Runtime/test_external_resource_interop.cu
@@ -1,0 +1,74 @@
+// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2
+// UNSUPPORTED: v8.0, v9.0, v9.1, v9.2
+
+// RUN: dpct --cuda-include-path="%cuda-path/include" --query-api-mapping=cudaImportExternalMemory | FileCheck %s -check-prefix=CUDA_IMPORT_EXTERNAL_MEMORY
+// CUDA_IMPORT_EXTERNAL_MEMORY: CUDA API:
+// CUDA_IMPORT_EXTERNAL_MEMORY-NEXT:    cudaImportExternalMemory(
+// CUDA_IMPORT_EXTERNAL_MEMORY-NEXT:        extMem /*cudaExternalMemory_t **/,
+// CUDA_IMPORT_EXTERNAL_MEMORY-NEXT:        memHandleDesc /*const cudaExternalMemoryHandleDesc **/);
+// CUDA_IMPORT_EXTERNAL_MEMORY-NEXT: Is migrated to (with the option --use-experimental-features=bindless_images):
+// CUDA_IMPORT_EXTERNAL_MEMORY-NEXT:    dpct::experimental::import_external_memory(extMem, memHandleDesc);
+
+// RUN: dpct --cuda-include-path="%cuda-path/include" --query-api-mapping=cudaExternalMemoryGetMappedBuffer | FileCheck %s -check-prefix=CUDA_EXTERNAL_MEMORY_GET_MAPPED_BUFFER
+// CUDA_EXTERNAL_MEMORY_GET_MAPPED_BUFFER: CUDA API:
+// CUDA_EXTERNAL_MEMORY_GET_MAPPED_BUFFER-NEXT:    cudaExternalMemoryGetMappedBuffer(
+// CUDA_EXTERNAL_MEMORY_GET_MAPPED_BUFFER-NEXT:        devPtr /*void ***/, extMem /*cudaExternalMemory_t*/,
+// CUDA_EXTERNAL_MEMORY_GET_MAPPED_BUFFER-NEXT:        bufferDesc /*const cudaExternalMemoryBufferDesc **/);
+// CUDA_EXTERNAL_MEMORY_GET_MAPPED_BUFFER-NEXT: Is migrated to (with the option --use-experimental-features=bindless_images):
+// CUDA_EXTERNAL_MEMORY_GET_MAPPED_BUFFER-NEXT:    *devPtr = sycl::ext::oneapi::experimental::map_external_linear_memory(extMem, bufferDesc->get_res_size(), bufferDesc->get_mem_offset(), dpct::get_in_order_queue());
+
+// RUN: dpct --cuda-include-path="%cuda-path/include" --query-api-mapping=cudaExternalMemoryGetMappedMipmappedArray | FileCheck %s -check-prefix=CUDA_EXTERNAL_MEMORY_GET_MAPPED_MIPMAPPED_ARRAY
+// CUDA_EXTERNAL_MEMORY_GET_MAPPED_MIPMAPPED_ARRAY: CUDA API:
+// CUDA_EXTERNAL_MEMORY_GET_MAPPED_MIPMAPPED_ARRAY-NEXT:    cudaExternalMemoryGetMappedMipmappedArray(
+// CUDA_EXTERNAL_MEMORY_GET_MAPPED_MIPMAPPED_ARRAY-NEXT:        mipmap /*cudaMipmappedArray_t **/, extMem /*cudaExternalMemory_t*/,
+// CUDA_EXTERNAL_MEMORY_GET_MAPPED_MIPMAPPED_ARRAY-NEXT:        mipmapDesc /*const cudaExternalMemoryMipmappedArrayDesc **/);
+// CUDA_EXTERNAL_MEMORY_GET_MAPPED_MIPMAPPED_ARRAY-NEXT: Is migrated to (with the option --use-experimental-features=bindless_images):
+// CUDA_EXTERNAL_MEMORY_GET_MAPPED_MIPMAPPED_ARRAY-NEXT:    mipmap = new dpct::experimental::image_mem_wrapper(extMem, mipmapDesc);
+
+// RUN: dpct --cuda-include-path="%cuda-path/include" --query-api-mapping=cudaDestroyExternalMemory | FileCheck %s -check-prefix=CUDA_DESTROY_EXTERNAL_MEMORY
+// CUDA_DESTROY_EXTERNAL_MEMORY: CUDA API:
+// CUDA_DESTROY_EXTERNAL_MEMORY-NEXT:    cudaDestroyExternalMemory(extMem /*cudaExternalMemory_t*/);
+// CUDA_DESTROY_EXTERNAL_MEMORY-NEXT: Is migrated to (with the option --use-experimental-features=bindless_images):
+// CUDA_DESTROY_EXTERNAL_MEMORY-NEXT:    sycl::ext::oneapi::experimental::release_external_memory(extMem, dpct::get_in_order_queue());
+
+// RUN: dpct --cuda-include-path="%cuda-path/include" --query-api-mapping=cudaImportExternalSemaphore | FileCheck %s -check-prefix=CUDA_IMPORT_EXTERNAL_SEMAPHORE
+// CUDA_IMPORT_EXTERNAL_SEMAPHORE: CUDA API:
+// CUDA_IMPORT_EXTERNAL_SEMAPHORE-NEXT:    cudaImportExternalSemaphore(
+// CUDA_IMPORT_EXTERNAL_SEMAPHORE-NEXT:        extSem /*cudaExternalSemaphore_t **/,
+// CUDA_IMPORT_EXTERNAL_SEMAPHORE-NEXT:        semHandleDesc /*const cudaExternalSemaphoreHandleDesc **/);
+// CUDA_IMPORT_EXTERNAL_SEMAPHORE-NEXT: Is migrated to (with the option --use-experimental-features=bindless_images):
+// CUDA_IMPORT_EXTERNAL_SEMAPHORE-NEXT:    dpct::experimental::import_external_semaphore(extSem, semHandleDesc);
+
+// RUN: dpct --cuda-include-path="%cuda-path/include" --query-api-mapping=cudaSignalExternalSemaphoresAsync | FileCheck %s -check-prefix=CUDA_SIGNAL_EXTERNAL_SEMAPHORES_ASYNC
+// CUDA_SIGNAL_EXTERNAL_SEMAPHORES_ASYNC: CUDA API:
+// CUDA_SIGNAL_EXTERNAL_SEMAPHORES_ASYNC-NEXT:    cudaSignalExternalSemaphoresAsync(
+// CUDA_SIGNAL_EXTERNAL_SEMAPHORES_ASYNC-NEXT:        extSemArray /*const cudaExternalSemaphore_t **/,
+// CUDA_SIGNAL_EXTERNAL_SEMAPHORES_ASYNC-NEXT:        paramsArray /*const cudaExternalSemaphoreSignalParams **/,
+// CUDA_SIGNAL_EXTERNAL_SEMAPHORES_ASYNC-NEXT:        numExtSems /*unsigned int*/);
+// CUDA_SIGNAL_EXTERNAL_SEMAPHORES_ASYNC-NEXT:    cudaSignalExternalSemaphoresAsync(
+// CUDA_SIGNAL_EXTERNAL_SEMAPHORES_ASYNC-NEXT:        extSemArray /*const cudaExternalSemaphore_t **/,
+// CUDA_SIGNAL_EXTERNAL_SEMAPHORES_ASYNC-NEXT:        paramsArray /*const cudaExternalSemaphoreSignalParams **/,
+// CUDA_SIGNAL_EXTERNAL_SEMAPHORES_ASYNC-NEXT:        numExtSems /*unsigned int*/, stream /*cudaStream_t*/);
+// CUDA_SIGNAL_EXTERNAL_SEMAPHORES_ASYNC-NEXT: Is migrated to (with the option --use-experimental-features=bindless_images):
+// CUDA_SIGNAL_EXTERNAL_SEMAPHORES_ASYNC-NEXT:    dpct::experimental::signal_external_semaphores(extSemArray, paramsArray, numExtSems);
+// CUDA_SIGNAL_EXTERNAL_SEMAPHORES_ASYNC-NEXT:    dpct::experimental::signal_external_semaphores(extSemArray, paramsArray, numExtSems, stream);
+
+// RUN: dpct --cuda-include-path="%cuda-path/include" --query-api-mapping=cudaWaitExternalSemaphoresAsync | FileCheck %s -check-prefix=CUDA_WAIT_EXTERNAL_SEMAPHORES_ASYNC
+// CUDA_WAIT_EXTERNAL_SEMAPHORES_ASYNC: CUDA API:
+// CUDA_WAIT_EXTERNAL_SEMAPHORES_ASYNC-NEXT:    cudaWaitExternalSemaphoresAsync(
+// CUDA_WAIT_EXTERNAL_SEMAPHORES_ASYNC-NEXT:        extSemArray /*const cudaExternalSemaphore_t **/,
+// CUDA_WAIT_EXTERNAL_SEMAPHORES_ASYNC-NEXT:        paramsArray /*const cudaExternalSemaphoreWaitParams **/,
+// CUDA_WAIT_EXTERNAL_SEMAPHORES_ASYNC-NEXT:        numExtSems /*unsigned int*/);
+// CUDA_WAIT_EXTERNAL_SEMAPHORES_ASYNC-NEXT:    cudaWaitExternalSemaphoresAsync(
+// CUDA_WAIT_EXTERNAL_SEMAPHORES_ASYNC-NEXT:        extSemArray /*const cudaExternalSemaphore_t **/,
+// CUDA_WAIT_EXTERNAL_SEMAPHORES_ASYNC-NEXT:        paramsArray /*const cudaExternalSemaphoreWaitParams **/,
+// CUDA_WAIT_EXTERNAL_SEMAPHORES_ASYNC-NEXT:        numExtSems /*unsigned int*/, stream /*cudaStream_t*/);
+// CUDA_WAIT_EXTERNAL_SEMAPHORES_ASYNC-NEXT: Is migrated to (with the option --use-experimental-features=bindless_images):
+// CUDA_WAIT_EXTERNAL_SEMAPHORES_ASYNC-NEXT:    dpct::experimental::wait_external_semaphores(extSemArray, paramsArray, numExtSems);
+// CUDA_WAIT_EXTERNAL_SEMAPHORES_ASYNC-NEXT:    dpct::experimental::wait_external_semaphores(extSemArray, paramsArray, numExtSems, stream);
+
+// RUN: dpct --cuda-include-path="%cuda-path/include" --query-api-mapping=cudaDestroyExternalSemaphore | FileCheck %s -check-prefix=CUDA_DESTROY_EXTERNAL_SEMAPHORE
+// CUDA_DESTROY_EXTERNAL_SEMAPHORE: CUDA API:
+// CUDA_DESTROY_EXTERNAL_SEMAPHORE-NEXT:    cudaDestroyExternalSemaphore(extSem /*cudaExternalSemaphore_t*/);
+// CUDA_DESTROY_EXTERNAL_SEMAPHORE-NEXT: Is migrated to (with the option --use-experimental-features=bindless_images):
+// CUDA_DESTROY_EXTERNAL_SEMAPHORE-NEXT:    delete extSem;

--- a/clang/test/dpct/query_api_mapping/Runtime/test_graphics_interop.cu
+++ b/clang/test/dpct/query_api_mapping/Runtime/test_graphics_interop.cu
@@ -46,10 +46,10 @@
 // RUN: dpct --cuda-include-path="%cuda-path/include" --query-api-mapping=cudaGraphicsUnmapResources | FileCheck %s -check-prefix=CUDA_GRAPHICS_UNMAP_RESOURCES
 // CUDA_GRAPHICS_UNMAP_RESOURCES: CUDA API:
 // CUDA_GRAPHICS_UNMAP_RESOURCES-NEXT:    cudaGraphicsUnmapResources(c /*int*/,
-// CUDA_GRAPHICS_UNMAP_RESOURCES-NEXT:                             r /*cudaGraphicsResource_t **/);
+// CUDA_GRAPHICS_UNMAP_RESOURCES-NEXT:                               r /*cudaGraphicsResource_t **/);
 // CUDA_GRAPHICS_UNMAP_RESOURCES-NEXT:    cudaGraphicsUnmapResources(c /*int*/,
-// CUDA_GRAPHICS_UNMAP_RESOURCES-NEXT:                             r /*cudaGraphicsResource_t **/,
-// CUDA_GRAPHICS_UNMAP_RESOURCES-NEXT:                             s /*cudaStream_t*/);
+// CUDA_GRAPHICS_UNMAP_RESOURCES-NEXT:                               r /*cudaGraphicsResource_t **/,
+// CUDA_GRAPHICS_UNMAP_RESOURCES-NEXT:                               s /*cudaStream_t*/);
 // CUDA_GRAPHICS_UNMAP_RESOURCES-NEXT: Is migrated to (with the option --use-experimental-features=bindless_images):
 // CUDA_GRAPHICS_UNMAP_RESOURCES-NEXT:    dpct::experimental::unmap_resources(c, r);
 // CUDA_GRAPHICS_UNMAP_RESOURCES-NEXT:    dpct::experimental::unmap_resources(c, r, s);

--- a/clang/test/dpct/query_api_mapping/test_all.cu
+++ b/clang/test/dpct/query_api_mapping/test_all.cu
@@ -1114,6 +1114,8 @@
 // CHECK-NEXT: cudaCreateChannelDesc
 // CHECK-NEXT: cudaCreateTextureObject
 // CHECK-NEXT: cudaCtxResetPersistingL2Cache
+// CHECK-NEXT: cudaDestroyExternalMemory
+// CHECK-NEXT: cudaDestroyExternalSemaphore
 // CHECK-NEXT: cudaDestroyTextureObject
 // CHECK-NEXT: cudaDeviceCanAccessPeer
 // CHECK-NEXT: cudaDeviceDisablePeerAccess
@@ -1135,6 +1137,8 @@
 // CHECK-NEXT: cudaEventQuery
 // CHECK-NEXT: cudaEventRecord
 // CHECK-NEXT: cudaEventSynchronize
+// CHECK-NEXT: cudaExternalMemoryGetMappedBuffer
+// CHECK-NEXT: cudaExternalMemoryGetMappedMipmappedArray
 // CHECK-NEXT: cudaFree
 // CHECK-NEXT: cudaFreeArray
 // CHECK-NEXT: cudaFreeHost
@@ -1168,6 +1172,8 @@
 // CHECK-NEXT: cudaHostGetFlags
 // CHECK-NEXT: cudaHostRegister
 // CHECK-NEXT: cudaHostUnregister
+// CHECK-NEXT: cudaImportExternalMemory
+// CHECK-NEXT: cudaImportExternalSemaphore
 // CHECK-NEXT: cudaLaunchCooperativeKernel
 // CHECK-NEXT: cudaLaunchKernel
 // CHECK-NEXT: cudaMalloc
@@ -1213,6 +1219,7 @@
 // CHECK-NEXT: cudaRuntimeGetVersion
 // CHECK-NEXT: cudaSetDevice
 // CHECK-NEXT: cudaSetDeviceFlags
+// CHECK-NEXT: cudaSignalExternalSemaphoresAsync
 // CHECK-NEXT: cudaStreamAddCallback
 // CHECK-NEXT: cudaStreamAttachMemAsync
 // CHECK-NEXT: cudaStreamBeginCapture
@@ -1233,6 +1240,7 @@
 // CHECK-NEXT: cudaThreadSetLimit
 // CHECK-NEXT: cudaThreadSynchronize
 // CHECK-NEXT: cudaUnbindTexture
+// CHECK-NEXT: cudaWaitExternalSemaphoresAsync
 // CHECK-NEXT: cudnnActivationBackward
 // CHECK-NEXT: cudnnActivationForward
 // CHECK-NEXT: cudnnAddTensor


### PR DESCRIPTION
This PR adds support for 2 more Semaphore types:
- timeline_fd
- timeline_win32_nt_handle

As well as adds all the external resource interop APIs to QAP test case