### PR TITLE
[SYCLomatic] Fix bug that `dpct.cmake` is copied into out-root directory when both `--migrate-build-script=Python` and `--migrate-build-script-only`are specified

### DIFF
--- a/clang/lib/DPCT/DPCT.cpp
+++ b/clang/lib/DPCT/DPCT.cpp
@@ -525,7 +525,8 @@ static void loadMainSrcFileInfo(clang::tooling::UnifiedPath OutRoot) {
       llvm::errs() << getLoadYamlFailWarning(YamlFilePath);
     }
 
-    if (MigrateBuildScriptOnly || DpctGlobalInfo::migrateCMakeScripts()) {
+    if (MigrateBuildScriptOnly && !DpctGlobalInfo::migratePythonScripts() ||
+        DpctGlobalInfo::migrateCMakeScripts()) {
       std::string Major = PreTU->SDKVersionMajor;
       std::string Minor = PreTU->SDKVersionMinor;
       if (!Major.empty() && !Minor.empty()) {

--- a/clang/test/dpct/python_migration/case_006/MainSourceFiles.yaml
+++ b/clang/test/dpct/python_migration/case_006/MainSourceFiles.yaml
@@ -1,0 +1,103 @@
+---
+MainSourceFile:  '/path/to/MainSrcFiles_placehold'
+Replacements:
+  - FilePath:        '/path/to/src/foo.cpp'
+    Offset:          0
+    Length:          0
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/path/to/src/baz.cpp'
+    Offset:          0
+    Length:          0
+    ReplacementText: ''
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  
+MainSourceFilesDigest:
+  - MainSourceFile:  '/path/to/src/foo.cpp'
+    Digest:          e2636fb8d174ac319083b0306294d3bd
+    HasCUDASyntax:   true
+  - MainSourceFile:  '/path/to/src/baz.cpp'
+    Digest:          991d7e4825fc597205bf68f2eda27acd
+    HasCUDASyntax:   true
+  - MainSourceFile:  '/path/to/src/layer.cudnn.cpp'
+    Digest:          991d7e4825fc597205bf68f2eda27ace
+    HasCUDASyntax:   true
+  - MainSourceFile:  '/path/to/chash/chash.c'
+    Digest:          9f681b5a2cafa7dff67d7e4ac13d1302
+    HasCUDASyntax:   true
+  - MainSourceFile:  '/path/to/cchash/cchash.cc'
+    Digest:          9f681b5a2cafa7dff67d7e4ac13d1303
+    HasCUDASyntax:   true
+  - MainSourceFile:  '/path/to/cxxhash/cxxhash.cxx'
+    Digest:          9f681b5a2cafa7dff67d7e4ac13d1304
+    HasCUDASyntax:   true
+  - MainSourceFile:  '/path/to/cxxhash/cpphash.cpp'
+    Digest:          9f681b5a2cafa7dff67d7e4ac13d1305
+    HasCUDASyntax:   true
+  - MainSourceFile:  '/path/to/chash/chash.c'
+    Digest:          9f681b5a2cafa7dff67d7e4ac13d1302
+    HasCUDASyntax:   false
+DpctVersion:     19.0.0
+SDKVersionMajor: '12'
+SDKVersionMinor: '0'
+MainHelperFileName: ''
+USMLevel:        ''
+FeatureMap:      {}
+CompileTargets:  {}
+OptionMap:
+  AnalysisScopePath:
+    Value:           '/path/to//target'
+    Specified:       false
+  AsyncHandler:
+    Value:           'false'
+    Specified:       false
+  BuildScript:
+    Value:           '1'
+    Specified:       true
+  CodePinEnabled:
+    Value:           'false'
+    Specified:       false
+  CommentsEnabled:
+    Value:           'false'
+    Specified:       false
+  CompilationsDir:
+    Value:           '/path/to/build'
+    Specified:       true
+  CtadEnabled:
+    Value:           'false'
+    Specified:       false
+  EnablepProfiling:
+    Value:           'true'
+    Specified:       true
+  ExperimentalFlag:
+    Value:           '16384'
+    Specified:       true
+  ExplicitNamespace:
+    Value:           '20'
+    Specified:       false
+  ExtensionDDFlag:
+    Value:           '0'
+    Specified:       false
+  ExtensionDEFlag:
+    Value:           '4294967295'
+    Specified:       false
+  RuleFile:
+    Value:           ''
+    ValueVec:
+      - '/path/to/cmake_script_migration_rule.yaml'
+    Specified:       false
+  SyclNamedLambda:
+    Value:           'false'
+    Specified:       false
+  UsmLevel:
+    Value:           '1'
+    Specified:       false
+...

--- a/clang/test/dpct/python_migration/case_006/case_006_torch_cuda.cpp
+++ b/clang/test/dpct/python_migration/case_006/case_006_torch_cuda.cpp
@@ -7,3 +7,9 @@
 
 // RUN: dpct -in-root ./ -out-root out_ipex ./input.py --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_ipex.yaml
 // RUN: diff --strip-trailing-cr %S/expected.py %T/out_ipex/input.py >> %T/diff.txt
+
+// RUN: mkdir -p %T/out_pytorch1
+// RUN: cp %S/MainSourceFiles.yaml %T/out_pytorch1/MainSourceFiles.yaml
+// RUN: dpct -in-root ./ -out-root out_pytorch1 ./input.py --migrate-build-script-only --migrate-build-script=Python --rule-file=%T/../../../../../../../extensions/python_rules/python_build_script_migration_rule_pytorch.yaml
+// dpct.cmake should not be copied into %T/out_pytorch1 direcotrtory.
+// RUN: test ! -f %T/out_pytorch1/dpct.cmake


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>