### PR TITLE
[SYCLomatic] Refine `lit.local.cfg` not to skip the lit test specified when the dependent library is available

### DIFF
--- a/clang/test/dpct/lit.local.cfg
+++ b/clang/test/dpct/lit.local.cfg
@@ -124,9 +124,10 @@ else:
 
 # Run the dpct sanity test.
 if not config.unsupported:
-    skipped_cases = ["cudnn_sanity.cu", "nccl_sanity.cu", "nvshmem.cu", "cutensor.cu"]
-    complete_process = run_sanity("cudnn_sanity.cu")
+    skipped_cases = []
     err_message = ""
+
+    complete_process = run_sanity("cudnn_sanity.cu")
     if complete_process.returncode != 0:
         if "'cudnn.h' file not found" in complete_process.stdout:
             err_message += "'cudnn.h' header file not found in platform. " + \
@@ -134,26 +135,27 @@ if not config.unsupported:
                           "export cudnn.h in CPATH\n"
             skipped_cases.extend(get_skipped_cases_with_string("<cudnn.h>"))
     complete_process = run_sanity("nccl_sanity.cu")
+
     if complete_process.returncode != 0:
         if "'nccl.h' file not found" in complete_process.stdout:
             err_message += "'nccl.h' header file not found in platform. " + \
                           "Please make sure install the header file of NCCL and " + \
                           "export nccl.h in CPATH.\n"
             skipped_cases.extend(get_skipped_cases_with_string("<nccl.h>"))
+
     complete_process = run_sanity("nvshmem.cu")
-    if complete_process.returncode != 0:
-        if "'nvshmem.h' file not found" in complete_process.stdout:
-            err_message += "'nvshmem.h' header file not found in platform. " + \
-                          "Please make sure install the header file of nvshmem and " + \
-                          "export nvshmem.h in CPATH.\n"
-            skipped_cases.extend(get_skipped_cases_with_string("<nccl.h>"))
+    if "'nvshmem.h' file not found" in complete_process.stdout:
+        err_message += "'nvshmem.h' header file not found in platform. " + \
+                        "Please make sure install the header file of nvshmem and " + \
+                        "export nvshmem.h in CPATH.\n"
+        skipped_cases.extend(get_skipped_cases_with_string("<nvshmem.h>"))
+
     complete_process = run_sanity("cutensor.cu")
-    if complete_process.returncode != 0:
-        if "'cutensor.h' file not found" in complete_process.stdout:
-            err_message += "'cutensor.h' header file not found in platform. " + \
-                          "Please make sure install the header file of cuTENSOR and " + \
-                          "export cutensor.h in CPATH.\n"
-            skipped_cases.extend(get_skipped_cases_with_string("<cutensor.h>"))
+    if "'cutensor.h' file not found" in complete_process.stdout:
+        err_message += "'cutensor.h' header file not found in platform. " + \
+                        "Please make sure install the header file of cuTENSOR and " + \
+                        "export cutensor.h in CPATH.\n"
+        skipped_cases.extend(get_skipped_cases_with_string("<cutensor.h>"))
 
     if (err_message):
         sys.stderr.write(err_message)


### PR DESCRIPTION
 Signed-off-by: chenwei.sun <chenwei.sun@intel.com>