### PR TITLE
[SYCLomatic] Fix for device_iterator trivial copyable (and device copyable)

### DIFF
--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/memory.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/memory.h
@@ -571,14 +571,8 @@ public:
   device_iterator() : Base(nullptr), idx(0) {}
   device_iterator(T *vec, std::size_t index) : Base(vec), idx(index) {}
   device_iterator(const Base &dev_ptr) : Base(dev_ptr), idx(0) {}
-  template <sycl::access_mode inMode>
-  device_iterator(const device_iterator<T> &in)
-      : Base(in.ptr), idx(in.idx) {} // required for iter_mode
-  device_iterator &operator=(const device_iterator &in) {
-    Base::operator=(in);
-    idx = in.idx;
-    return *this;
-  }
+  device_iterator(const device_iterator &in) = default;
+  device_iterator &operator=(const device_iterator &in) = default;
 
   reference operator*() const { return *(Base::ptr + idx); }
 

--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/memory.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/memory.h
@@ -571,6 +571,9 @@ public:
   device_iterator() : Base(nullptr), idx(0) {}
   device_iterator(T *vec, std::size_t index) : Base(vec), idx(index) {}
   device_iterator(const Base &dev_ptr) : Base(dev_ptr), idx(0) {}
+  template <sycl::access_mode inMode>
+  device_iterator(const device_iterator<T> &in)
+      : Base(in.ptr), idx(in.idx) {} // required for iter_mode
   device_iterator(const device_iterator &in) = default;
   device_iterator &operator=(const device_iterator &in) = default;
 


### PR DESCRIPTION
`device_iterator` (USM available) is meant to be passed directly into sycl kernels, but was not technically sycl device-copyable, because of a non-default copy assignment operator (making it lose trivially copyable).
This non-default function is actually unnecessary, and can be defaulted with the same result.  Making it default ensures trivial copyability and therefore sycl device-copyable.  A requirement of sycl-device copyable was added to oneDPL "passed directly" types to conform to the SYCL specification.  

Added tests in https://github.com/oneapi-src/SYCLomatic-test/pull/915 to confirm sycl device-copyable for `device_iterator` and similar types.

Note: 
This leaves in place an (I think unused) API for the copy constructor which doesn't make a lot of sense, but is there to match the USM_NONE version with an explicit template argument to describe the access mode of a buffer we are copying from.  We could consider removing this API but I don't want to remove a public API in this PR.  It is orthogonal to trivial copyability here.