### PR TITLE
[SYCLomatic][CMake] Fix bug that pattern "src/*foo*.cu" in CMake script is not migrated

### DIFF
--- a/clang/lib/DPCT/UserDefinedRules/PatternRewriter.cpp
+++ b/clang/lib/DPCT/UserDefinedRules/PatternRewriter.cpp
@@ -384,29 +384,34 @@ static int parseCodeElement(const MatchPattern &Suffix,
       continue;
     }
 
-    if (Character == '/' && Index < (Size - 1) && Input[Index + 1] == '/') {
-      Index += 2;
-      while (Index < Size && Input[Index] != '\n') {
+    if (SrcFileType != SourceFileType::SFT_CMakeScript &&
+        SrcFileType != SourceFileType::SFT_PySetupScript) {
+      // Skip single line comment for C/C++
+      if (Character == '/' && Index < (Size - 1) && Input[Index + 1] == '/') {
+        Index += 2;
+        while (Index < Size && Input[Index] != '\n') {
+          Index++;
+        }
+        if (Index >= Size) {
+          return -1;
+        }
         Index++;
+        continue;
       }
-      if (Index >= Size) {
-        return -1;
-      }
-      Index++;
-      continue;
-    }
 
-    if (Character == '/' && Index < (Size - 1) && Input[Index + 1] == '*') {
-      Index += 2;
-      while (Index < Size &&
-             !(Input[Index - 1] == '*' && Input[Index] == '/')) {
+      // Skip multi-line comments for C/C++
+      if (Character == '/' && Index < (Size - 1) && Input[Index + 1] == '*') {
+        Index += 2;
+        while (Index < Size &&
+               !(Input[Index - 1] == '*' && Input[Index] == '/')) {
+          Index++;
+        }
+        if (Index >= Size) {
+          return -1;
+        }
         Index++;
+        continue;
       }
-      if (Index >= Size) {
-        return -1;
-      }
-      Index++;
-      continue;
     }
 
     Index++;

--- a/clang/test/dpct/cmake_migration/case_010/expected.txt
+++ b/clang/test/dpct/cmake_migration/case_010/expected.txt
@@ -1,2 +1,6 @@
 file(GLOB REL_CUDA_SRC "file1.dp.cpp" "${CMAKE_SOURCE_DIR}/src/*.dp.cpp")
 file(GLOB SRCS *.cc *.dp.cpp *.dp.hpp)
+file(GLOB_RECURSE DECODE_KERNELS_SRCS
+     ${PROJECT_SOURCE_DIR}/src/generated/d*decode_head*.dp.cpp)
+file(GLOB_RECURSE PREFILL_KERNELS_SRCS
+     ${PROJECT_SOURCE_DIR}/src/generated/*prefill_head*.dp.cpp)

--- a/clang/test/dpct/cmake_migration/case_010/input.cmake
+++ b/clang/test/dpct/cmake_migration/case_010/input.cmake
@@ -1,2 +1,6 @@
 file(GLOB REL_CUDA_SRC "file1.cu" "${CMAKE_SOURCE_DIR}/src/*.cu")
 file(GLOB SRCS *.cc *.cu *.cuh)
+file(GLOB_RECURSE DECODE_KERNELS_SRCS
+     ${PROJECT_SOURCE_DIR}/src/generated/d*decode_head*.cu)
+file(GLOB_RECURSE PREFILL_KERNELS_SRCS
+     ${PROJECT_SOURCE_DIR}/src/generated/*prefill_head*.cu)


### PR DESCRIPTION
 Signed-off-by: chenwei.sun <chenwei.sun@intel.com>