### PR TITLE
[SYCLomatic][NFC] Skip nvshmem cases when headers are not available

### DIFF
--- a/clang/test/dpct/lit.local.cfg
+++ b/clang/test/dpct/lit.local.cfg
@@ -143,7 +143,7 @@ if not config.unsupported:
                           "export nccl.h in CPATH.\n"
             skipped_cases.extend(get_skipped_cases_with_string("<nccl.h>"))
 
-    complete_process = run_sanity("nvshmem.cu")
+    complete_process = run_sanity("nvshmem/library_setup_exit_query.cu")
     if "'nvshmem.h' file not found" in complete_process.stdout:
         err_message += "'nvshmem.h' header file not found in platform. " + \
                         "Please make sure install the header file of nvshmem and " + \


### PR DESCRIPTION
This PR tries to skip nvSHMEM lit test cases when the nvshmem.h header is unavailable in the machine.