### PR TITLE
[SYCLomatic][Bugfix] Store the image wrapper for the given handle

### DIFF
--- a/clang/runtime/dpct-rt/include/dpct/bindless_images.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/bindless_images.hpp
@@ -1690,6 +1690,7 @@ public:
         _addressing_mode, _coordinate_normalization_mode, _filtering_mode);
     _img = sycl::ext::oneapi::experimental::create_image(
         mem->get_handle(), samp, mem->get_desc(), q);
+    set_img_mem(_img, mem);
   }
 
   /// Attach image memory to bindless image.


### PR DESCRIPTION
The link between the DPCT image wrapper and the handle using the wrapper, must be stored to support the API `cuTexRefGetMipmappedArray`.

Signed-off-by: [Deepak Raj H R](Deepak.raj.h.r@intel.com)