### PR TITLE
[SYCLomatic][CMake] Remove the option "-extended-lambda" in the migrated CMake script

### DIFF
--- a/clang/test/dpct/cmake_migration/case_069/case_069_extended_lambda.cpp
+++ b/clang/test/dpct/cmake_migration/case_069/case_069_extended_lambda.cpp
@@ -1,0 +1,5 @@
+// RUN: rm -rf %T && mkdir -p %T
+// RUN: cd %T
+// RUN: cp %S/input.cmake ./input.cmake
+// RUN: dpct -in-root ./ -out-root out  ./input.cmake --migrate-build-script-only --cuda-include-path="%cuda-path/include" --rule-file=%T/../../../../../../../extensions/cmake_rules/cmake_script_migration_rule_optional.yaml
+// RUN: diff --strip-trailing-cr %S/expected.txt %T/out/input.cmake >> %T/diff.txt

--- a/clang/test/dpct/cmake_migration/case_069/expected.txt
+++ b/clang/test/dpct/cmake_migration/case_069/expected.txt
@@ -1,0 +1,1 @@
+set(CUDA_FLAGS -ffast-math )

--- a/clang/test/dpct/cmake_migration/case_069/input.cmake
+++ b/clang/test/dpct/cmake_migration/case_069/input.cmake
@@ -1,0 +1,1 @@
+set(CUDA_FLAGS -use_fast_math -extended-lambda)

--- a/clang/tools/dpct/extensions/cmake_rules/cmake_script_migration_rule.yaml
+++ b/clang/tools/dpct/extensions/cmake_rules/cmake_script_migration_rule.yaml
@@ -2923,16 +2923,28 @@
       In: -Xcudafe=${arg}
       Out: ""
 
-- Rule: rule_extended_lambda_remove
+- Rule: rule_dash_dash_extended_lambda_remove
   Kind: CMakeRule
   Priority: Fallback
-  CmakeSyntax: extended_lambda_remove
+  CmakeSyntax: dash_dash_extended_lambda_remove
   In: ${func_name}(${value})
   Out: ${func_name}(${value})
   Subrules:
     value:
       MatchMode: Full
       In: --extended-lambda
+      Out: ""
+
+- Rule: rule_dash_extended_lambda_remove
+  Kind: CMakeRule
+  Priority: Fallback
+  CmakeSyntax: dash_extended_lambda_remove
+  In: ${func_name}(${value})
+  Out: ${func_name}(${value})
+  Subrules:
+    value:
+      MatchMode: Full
+      In:  -extended-lambda
       Out: ""
 
 - Rule: rule_expt_relaxed_constexpr_remove


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>