### PR TITLE
Add unsupported CUDA version for nvSHMEM tests

### DIFF
--- a/clang/test/dpct/nvshmem/library_setup_exit_query.cu
+++ b/clang/test/dpct/nvshmem/library_setup_exit_query.cu
@@ -1,5 +1,5 @@
 // REQUIRES: system-linux
-// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.2
+// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.2, cuda-11.3, cuda-11.4, cuda-11.5, cuda-11.6, cuda-11.7
 // RUN: dpct --format-range=none -out-root %T/nvshmem %s --cuda-include-path="%cuda-path/include"
 // RUN: FileCheck %s --match-full-lines --input-file %T/nvshmem/library_setup_exit_query.dp.cpp
 // RUN: %if build_lit %{icpx -c -fsycl -DNO_BUILD_TEST %T/nvshmem/library_setup_exit_query.dp.cpp -o %T/nvshmem/library_setup_exit_query.dp.o %}

--- a/clang/test/dpct/nvshmem/mem_mgmt.cu
+++ b/clang/test/dpct/nvshmem/mem_mgmt.cu
@@ -1,5 +1,5 @@
 // REQUIRES: system-linux
-// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.2
+// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.2, cuda-11.3, cuda-11.4, cuda-11.5, cuda-11.6, cuda-11.7
 // RUN: dpct --format-range=none -out-root %T/nvshmem %s --cuda-include-path="%cuda-path/include"
 // RUN: FileCheck %s --match-full-lines --input-file %T/nvshmem/mem_mgmt.dp.cpp
 // RUN: %if build_lit %{icpx -c -fsycl -DNO_BUILD_TEST %T/nvshmem/mem_mgmt.dp.cpp -o %T/nvshmem/mem_mgmt.dp.o %}

--- a/clang/test/dpct/nvshmem/rma_nbi.cu
+++ b/clang/test/dpct/nvshmem/rma_nbi.cu
@@ -1,5 +1,5 @@
 // REQUIRES: system-linux
-// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.2
+// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.2, cuda-11.3, cuda-11.4, cuda-11.5, cuda-11.6, cuda-11.7
 // RUN: dpct --format-range=none -out-root %T/nvshmem %s --cuda-include-path="%cuda-path/include"
 // RUN: FileCheck %s --match-full-lines --input-file %T/nvshmem/rma_nbi.dp.cpp
 // RUN: %if build_lit %{icpx -c -fsycl -DNO_BUILD_TEST %T/nvshmem/rma_nbi.dp.cpp -o %T/nvshmem/rma_nbi.dp.o %}

--- a/clang/test/dpct/nvshmem/sig_ops.cu
+++ b/clang/test/dpct/nvshmem/sig_ops.cu
@@ -1,5 +1,5 @@
 // REQUIRES: system-linux
-// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.2
+// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.2, cuda-11.3, cuda-11.4, cuda-11.5, cuda-11.6, cuda-11.7
 // RUN: dpct --format-range=none -out-root %T/nvshmem %s --cuda-include-path="%cuda-path/include"
 // RUN: FileCheck %s --match-full-lines --input-file %T/nvshmem/sig_ops.dp.cpp
 // RUN: %if build_lit %{icpx -c -fsycl -DNO_BUILD_TEST %T/nvshmem/sig_ops.dp.cpp -o %T/nvshmem/sig_ops.dp.o %}

--- a/clang/test/dpct/nvshmem/team_mgmt.cu
+++ b/clang/test/dpct/nvshmem/team_mgmt.cu
@@ -1,5 +1,5 @@
 // REQUIRES: system-linux
-// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.2
+// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.2, cuda-11.3, cuda-11.4, cuda-11.5, cuda-11.6, cuda-11.7
 // RUN: dpct --format-range=none -out-root %T/nvshmem %s --cuda-include-path="%cuda-path/include"
 // RUN: FileCheck %s --match-full-lines --input-file %T/nvshmem/team_mgmt.dp.cpp
 // RUN: %if build_lit %{icpx -c -fsycl -DNO_BUILD_TEST %T/nvshmem/team_mgmt.dp.cpp -o %T/nvshmem/team_mgmt.dp.o %}

--- a/clang/test/dpct/query_api_mapping/nvSHMEM/test_library_setup_exit_query.cu
+++ b/clang/test/dpct/query_api_mapping/nvSHMEM/test_library_setup_exit_query.cu
@@ -1,5 +1,5 @@
 // REQUIRES: system-linux
-// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.2
+// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.2, cuda-11.3, cuda-11.4, cuda-11.5, cuda-11.6, cuda-11.7
 
 // RUN: dpct --cuda-include-path="%cuda-path/include" --query-api-mapping=nvshmem_finalize | FileCheck %s -check-prefix=NVSHMEM_FINALIZE
 // NVSHMEM_FINALIZE: CUDA API:

--- a/clang/test/dpct/query_api_mapping/nvSHMEM/test_mem_mgmt.cu
+++ b/clang/test/dpct/query_api_mapping/nvSHMEM/test_mem_mgmt.cu
@@ -1,5 +1,5 @@
 // REQUIRES: system-linux
-// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.2
+// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.2, cuda-11.3, cuda-11.4, cuda-11.5, cuda-11.6, cuda-11.7
 
 // RUN: dpct --cuda-include-path="%cuda-path/include" --query-api-mapping=nvshmem_align | FileCheck %s -check-prefix=NVSHMEM_ALIGN
 // NVSHMEM_ALIGN: CUDA API:

--- a/clang/test/dpct/query_api_mapping/nvSHMEM/test_rma_nbi.cu
+++ b/clang/test/dpct/query_api_mapping/nvSHMEM/test_rma_nbi.cu
@@ -1,5 +1,5 @@
 // REQUIRES: system-linux
-// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.2
+// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.2, cuda-11.3, cuda-11.4, cuda-11.5, cuda-11.6, cuda-11.7
 
 // RUN: dpct --cuda-include-path="%cuda-path/include" --query-api-mapping=nvshmem_putmem_nbi | FileCheck %s -check-prefix=NVSHMEM_PUTMEM_NBI
 // NVSHMEM_PUTMEM_NBI: CUDA API:

--- a/clang/test/dpct/query_api_mapping/nvSHMEM/test_sig_ops.cu
+++ b/clang/test/dpct/query_api_mapping/nvSHMEM/test_sig_ops.cu
@@ -1,5 +1,5 @@
 // REQUIRES: system-linux
-// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.2
+// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.2, cuda-11.3, cuda-11.4, cuda-11.5, cuda-11.6, cuda-11.7
 
 // RUN: dpct --cuda-include-path="%cuda-path/include" --query-api-mapping=nvshmem_putmem_signal_nbi | FileCheck %s -check-prefix=NVSHMEM_PUTMEM_SIGNAL_NBI
 // NVSHMEM_PUTMEM_SIGNAL_NBI: CUDA API:

--- a/clang/test/dpct/query_api_mapping/nvSHMEM/test_team_mgmt.cu
+++ b/clang/test/dpct/query_api_mapping/nvSHMEM/test_team_mgmt.cu
@@ -1,5 +1,5 @@
 // REQUIRES: system-linux
-// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.2
+// UNSUPPORTED: cuda-8.0, cuda-9.0, cuda-9.1, cuda-9.2, cuda-10.0, cuda-10.1, cuda-10.2, cuda-11.0, cuda-11.2, cuda-11.3, cuda-11.4, cuda-11.5, cuda-11.6, cuda-11.7
 
 // RUN: dpct --cuda-include-path="%cuda-path/include" --query-api-mapping=nvshmem_team_destroy | FileCheck %s -check-prefix=NVSHMEM_TEAM_DESTROY
 // NVSHMEM_TEAM_DESTROY: CUDA API:


### PR DESCRIPTION
According to https://github.com/oneapi-src/SYCLomatic/pull/2886, nvSHMEM v3.0.6 supports from CUDA toolkit 11.8. Need to add more unsupported CUDA versions.