### PR TITLE
[SYCLomatic] Refine file renaming migration logic for `#include stmt` consistent with migrated file name

### DIFF
--- a/clang/lib/DPCT/AnalysisInfo.cpp
+++ b/clang/lib/DPCT/AnalysisInfo.cpp
@@ -1487,21 +1487,23 @@ std::string DpctGlobalInfo::getStringForRegexReplacement(StringRef MatchedStr) {
         HelperFuncType::HFT_DefaultQueuePtr, Index);
   case 'E': {
     auto &Vec = DpctGlobalInfo::getInstance().getCSourceFileList();
-     SourceProcessType FileType = GetSourceFileType(Vec[Index]);
-     if (Vec[Index + 1] == ".h")
-       return DpctGlobalInfo::hasCUDASyntax(Vec[Index]) &&
-                      (FileType & SPT_CppSource)
-                  ? ("h" + DpctGlobalInfo::getSYCLSourceExtension())
-                  : "h";
-     if (Vec[Index + 1] == ".cc")
-       return DpctGlobalInfo::hasCUDASyntax(Vec[Index])&&
-                      (FileType & SPT_CppSource)
-                  ? ("cc" + DpctGlobalInfo::getSYCLSourceExtension())
-                  : "cc";
+    SourceProcessType FileType = GetSourceFileType(Vec[Index]);
 
-     return DpctGlobalInfo::hasCUDASyntax(Vec[Index]) 
-                ? ("c" + DpctGlobalInfo::getSYCLSourceExtension())
-                : "c";
+    const bool HasCUDASyntax = DpctGlobalInfo::hasCUDASyntax(Vec[Index]);
+    const bool IsCppSource = (FileType & SPT_CppSource);
+    const auto Extention = Vec[Index + 1];
+
+    if (Extention == ".h") {
+      return (HasCUDASyntax && IsCppSource)
+                 ? "h" + DpctGlobalInfo::getSYCLSourceExtension()
+                 : "h";
+    }
+    if (Extention == ".cc") {
+      return (HasCUDASyntax && IsCppSource)
+                 ? "cc" + DpctGlobalInfo::getSYCLSourceExtension()
+                 : "cc";
+    }
+    return HasCUDASyntax ? "c" + DpctGlobalInfo::getSYCLSourceExtension() : "c";
   }
   case 'P': {
     std::string ReplStr;

--- a/clang/lib/DPCT/AnalysisInfo.cpp
+++ b/clang/lib/DPCT/AnalysisInfo.cpp
@@ -1493,11 +1493,6 @@ std::string DpctGlobalInfo::getStringForRegexReplacement(StringRef MatchedStr) {
     const bool IsCppSource = (FileType & SPT_CppSource);
     const auto Extention = Vec[Index + 1];
 
-    if (Extention == ".h") {
-      return (HasCUDASyntax && IsCppSource)
-                 ? "h" + DpctGlobalInfo::getSYCLSourceExtension()
-                 : "h";
-    }
     if (Extention == ".cc") {
       return (HasCUDASyntax && IsCppSource)
                  ? "cc" + DpctGlobalInfo::getSYCLSourceExtension()

--- a/clang/lib/DPCT/AnalysisInfo.cpp
+++ b/clang/lib/DPCT/AnalysisInfo.cpp
@@ -1487,18 +1487,9 @@ std::string DpctGlobalInfo::getStringForRegexReplacement(StringRef MatchedStr) {
         HelperFuncType::HFT_DefaultQueuePtr, Index);
   case 'E': {
     auto &Vec = DpctGlobalInfo::getInstance().getCSourceFileList();
-    SourceProcessType FileType = GetSourceFileType(Vec[Index].first);
-
     const bool HasCUDASyntax = DpctGlobalInfo::hasCUDASyntax(Vec[Index].first);
-    const bool IsCppSource = (FileType & SPT_CppSource);
     const auto Extention = Vec[Index].second;
-
-    if (Extention == ".cc") {
-      return (HasCUDASyntax && IsCppSource)
-                 ? "cc" + DpctGlobalInfo::getSYCLSourceExtension()
-                 : "cc";
-    }
-    return HasCUDASyntax ? "c" + DpctGlobalInfo::getSYCLSourceExtension() : "c";
+    return HasCUDASyntax ? Extention + DpctGlobalInfo::getSYCLSourceExtension() : Extention;
   }
   case 'P': {
     std::string ReplStr;

--- a/clang/lib/DPCT/AnalysisInfo.cpp
+++ b/clang/lib/DPCT/AnalysisInfo.cpp
@@ -1487,9 +1487,21 @@ std::string DpctGlobalInfo::getStringForRegexReplacement(StringRef MatchedStr) {
         HelperFuncType::HFT_DefaultQueuePtr, Index);
   case 'E': {
     auto &Vec = DpctGlobalInfo::getInstance().getCSourceFileList();
-    return DpctGlobalInfo::hasCUDASyntax(Vec[Index])
-               ? ("c" + DpctGlobalInfo::getSYCLSourceExtension())
-               : "c";
+     SourceProcessType FileType = GetSourceFileType(Vec[Index]);
+     if (Vec[Index + 1] == ".h")
+       return DpctGlobalInfo::hasCUDASyntax(Vec[Index]) &&
+                      (FileType & SPT_CppSource)
+                  ? ("h" + DpctGlobalInfo::getSYCLSourceExtension())
+                  : "h";
+     if (Vec[Index + 1] == ".cc")
+       return DpctGlobalInfo::hasCUDASyntax(Vec[Index])&&
+                      (FileType & SPT_CppSource)
+                  ? ("cc" + DpctGlobalInfo::getSYCLSourceExtension())
+                  : "cc";
+
+     return DpctGlobalInfo::hasCUDASyntax(Vec[Index]) 
+                ? ("c" + DpctGlobalInfo::getSYCLSourceExtension())
+                : "c";
   }
   case 'P': {
     std::string ReplStr;

--- a/clang/lib/DPCT/AnalysisInfo.cpp
+++ b/clang/lib/DPCT/AnalysisInfo.cpp
@@ -1489,7 +1489,10 @@ std::string DpctGlobalInfo::getStringForRegexReplacement(StringRef MatchedStr) {
     auto &Vec = DpctGlobalInfo::getInstance().getCSourceFileList();
     const bool HasCUDASyntax = DpctGlobalInfo::hasCUDASyntax(Vec[Index].first);
     const auto Extention = Vec[Index].second;
-    return HasCUDASyntax ? Extention + DpctGlobalInfo::getSYCLSourceExtension() : Extention;
+    SourceProcessType FileType = GetSourceFileType(Vec[Index].first);
+    return HasCUDASyntax && (FileType & SPT_CppSource)
+               ? Extention + DpctGlobalInfo::getSYCLSourceExtension()
+               : Extention;
   }
   case 'P': {
     std::string ReplStr;

--- a/clang/lib/DPCT/AnalysisInfo.cpp
+++ b/clang/lib/DPCT/AnalysisInfo.cpp
@@ -1487,11 +1487,11 @@ std::string DpctGlobalInfo::getStringForRegexReplacement(StringRef MatchedStr) {
         HelperFuncType::HFT_DefaultQueuePtr, Index);
   case 'E': {
     auto &Vec = DpctGlobalInfo::getInstance().getCSourceFileList();
-    SourceProcessType FileType = GetSourceFileType(Vec[Index]);
+    SourceProcessType FileType = GetSourceFileType(Vec[Index].first);
 
-    const bool HasCUDASyntax = DpctGlobalInfo::hasCUDASyntax(Vec[Index]);
+    const bool HasCUDASyntax = DpctGlobalInfo::hasCUDASyntax(Vec[Index].first);
     const bool IsCppSource = (FileType & SPT_CppSource);
-    const auto Extention = Vec[Index + 1];
+    const auto Extention = Vec[Index].second;
 
     if (Extention == ".cc") {
       return (HasCUDASyntax && IsCppSource)
@@ -2532,7 +2532,9 @@ bool DpctGlobalInfo::CVersionCUDALaunchUsedFlag = false;
 unsigned int DpctGlobalInfo::ColorOption = 1;
 std::unordered_map<int, std::shared_ptr<DeviceFunctionInfo>>
     DpctGlobalInfo::CubPlaceholderIndexMap;
-std::vector<tooling::UnifiedPath> DpctGlobalInfo::CSourceFileList;
+std::vector<std::pair<tooling::UnifiedPath /*including filename*/,
+                      std::string /*extention name*/>>
+    DpctGlobalInfo::CSourceFileList;
 bool DpctGlobalInfo::OptimizeMigrationFlag = false;
 std::unordered_map<std::string, std::shared_ptr<PriorityReplInfo>>
     DpctGlobalInfo::PriorityReplInfoMap;

--- a/clang/lib/DPCT/AnalysisInfo.h
+++ b/clang/lib/DPCT/AnalysisInfo.h
@@ -1450,7 +1450,9 @@ public:
   getCubPlaceholderIndexMap() {
     return CubPlaceholderIndexMap;
   }
-  std::vector<tooling::UnifiedPath> &getCSourceFileList() {
+  std::vector<std::pair<tooling::UnifiedPath /*including filename*/,
+                        std::string /*extention name*/>> &
+  getCSourceFileList() {
     return CSourceFileList;
   }
   static std::unordered_map<std::string, std::shared_ptr<PriorityReplInfo>> &
@@ -1703,7 +1705,9 @@ private:
   static unsigned int ColorOption;
   static std::unordered_map<int, std::shared_ptr<DeviceFunctionInfo>>
       CubPlaceholderIndexMap;
-  static std::vector<tooling::UnifiedPath> CSourceFileList;
+  static std::vector<std::pair<tooling::UnifiedPath /*including filename*/,
+                               std::string /*extention name*/>>
+      CSourceFileList;
   static bool OptimizeMigrationFlag;
   static std::unordered_map<std::string, std::shared_ptr<PriorityReplInfo>>
       PriorityReplInfoMap;

--- a/clang/lib/DPCT/FileGenerator/GenFiles.cpp
+++ b/clang/lib/DPCT/FileGenerator/GenFiles.cpp
@@ -204,7 +204,6 @@ void rewriteFileName(std::string &FileName, const std::string &FullPathName) {
   SmallString<512> CanonicalPathStr(FullPathName);
   const auto Extension = path::extension(CanonicalPathStr);
   SourceProcessType FileType = GetSourceFileType(FullPathName);
-
   // If user does not specify which extension need be changed, we change all the
   // SPT_CudaSource, SPT_CppSource and SPT_CudaHeader files.
   if (DpctGlobalInfo::getChangeExtensions().empty() ||

--- a/clang/lib/DPCT/FileGenerator/GenFiles.cpp
+++ b/clang/lib/DPCT/FileGenerator/GenFiles.cpp
@@ -205,7 +205,6 @@ void rewriteFileName(std::string &FileName, const std::string &FullPathName) {
   const auto Extension = path::extension(CanonicalPathStr);
   SourceProcessType FileType = GetSourceFileType(FullPathName);
 
-  printf("FileType:%d %s\n", FileType, FullPathName.c_str());
   // If user does not specify which extension need be changed, we change all the
   // SPT_CudaSource, SPT_CppSource and SPT_CudaHeader files.
   if (DpctGlobalInfo::getChangeExtensions().empty() ||
@@ -215,20 +214,10 @@ void rewriteFileName(std::string &FileName, const std::string &FullPathName) {
                               DpctGlobalInfo::getSYCLSourceExtension());
     } else if ((FileType & SPT_CppSource) &&
                DpctGlobalInfo::hasCUDASyntax(FileName)) {
-      if (Extension == ".c") {
-        path::replace_extension(CanonicalPathStr,
-                                Extension +
-                                    DpctGlobalInfo::getSYCLSourceExtension());
+      path::replace_extension(CanonicalPathStr,
+                              Extension +
+                                  DpctGlobalInfo::getSYCLSourceExtension());
 
-      } else {
-        printf("######################## %s\n", FileName.c_str());
-        path::replace_extension(CanonicalPathStr,
-                                Extension +
-                                    DpctGlobalInfo::getSYCLSourceExtension());
-        printf("CanonicalPathStr:%s\n", CanonicalPathStr.c_str());
-         printf("########################0  %s\n", Extension.str().c_str());
-          printf("########################1 %s\n", DpctGlobalInfo::getSYCLSourceExtension().c_str());
-      }
     } else if (FileType & SPT_CudaHeader) {
       path::replace_extension(CanonicalPathStr,
                               DpctGlobalInfo::getSYCLHeaderExtension());

--- a/clang/lib/DPCT/FileGenerator/GenFiles.cpp
+++ b/clang/lib/DPCT/FileGenerator/GenFiles.cpp
@@ -204,6 +204,8 @@ void rewriteFileName(std::string &FileName, const std::string &FullPathName) {
   SmallString<512> CanonicalPathStr(FullPathName);
   const auto Extension = path::extension(CanonicalPathStr);
   SourceProcessType FileType = GetSourceFileType(FullPathName);
+
+  printf("FileType:%d %s\n", FileType, FullPathName.c_str());
   // If user does not specify which extension need be changed, we change all the
   // SPT_CudaSource, SPT_CppSource and SPT_CudaHeader files.
   if (DpctGlobalInfo::getChangeExtensions().empty() ||
@@ -211,17 +213,21 @@ void rewriteFileName(std::string &FileName, const std::string &FullPathName) {
     if (FileType & SPT_CudaSource) {
       path::replace_extension(CanonicalPathStr,
                               DpctGlobalInfo::getSYCLSourceExtension());
-    } else if (FileType & SPT_CppSource) {
+    } else if ((FileType & SPT_CppSource) &&
+               DpctGlobalInfo::hasCUDASyntax(FileName)) {
       if (Extension == ".c") {
-        if (DpctGlobalInfo::hasCUDASyntax(FileName)) {
-          path::replace_extension(CanonicalPathStr,
-                                  Extension +
-                                      DpctGlobalInfo::getSYCLSourceExtension());
-        }
-      } else {
         path::replace_extension(CanonicalPathStr,
                                 Extension +
                                     DpctGlobalInfo::getSYCLSourceExtension());
+
+      } else {
+        printf("######################## %s\n", FileName.c_str());
+        path::replace_extension(CanonicalPathStr,
+                                Extension +
+                                    DpctGlobalInfo::getSYCLSourceExtension());
+        printf("CanonicalPathStr:%s\n", CanonicalPathStr.c_str());
+         printf("########################0  %s\n", Extension.str().c_str());
+          printf("########################1 %s\n", DpctGlobalInfo::getSYCLSourceExtension().c_str());
       }
     } else if (FileType & SPT_CudaHeader) {
       path::replace_extension(CanonicalPathStr,

--- a/clang/lib/DPCT/RulesInclude/InclusionHeaders.cpp
+++ b/clang/lib/DPCT/RulesInclude/InclusionHeaders.cpp
@@ -175,7 +175,7 @@ void IncludesCallbacks::InclusionDirective(
     const auto Extension = path::extension(FileName);
     SmallString<512> NewFileName(FileName.str());
 
-    if (Extension == ".c" || Extension == ".h" || Extension == ".cc") {
+    if (Extension == ".c" || Extension == ".cc") {
       auto &Vec = DpctGlobalInfo::getInstance().getCSourceFileList();
       path::replace_extension(
           NewFileName, "{{NEEDREPLACEE" + std::to_string(Vec.size()) + "}}");

--- a/clang/lib/DPCT/RulesInclude/InclusionHeaders.cpp
+++ b/clang/lib/DPCT/RulesInclude/InclusionHeaders.cpp
@@ -175,14 +175,18 @@ void IncludesCallbacks::InclusionDirective(
     const auto Extension = path::extension(FileName);
     SmallString<512> NewFileName(FileName.str());
 
-    if (Extension == ".c") {
+    SourceProcessType FileType = GetSourceFileType(FileName);
+    if (Extension == ".c" || Extension == ".h" || Extension == ".cc") {
       auto &Vec = DpctGlobalInfo::getInstance().getCSourceFileList();
       path::replace_extension(
           NewFileName, "{{NEEDREPLACEE" + std::to_string(Vec.size()) + "}}");
       Vec.push_back(IncludedFile);
+      Vec.push_back(Extension);
     } else {
       clang::tooling::UnifiedPath NewFilePath = FileName;
+      printf("IncludedFile:%s\n", IncludedFile.getCanonicalPath().str().c_str());
       rewriteFileName(NewFilePath, IncludedFile);
+      printf("NewFilePath:%s\n", NewFilePath.getCanonicalPath().str().c_str());
       path::remove_filename(NewFileName);
       path::append(NewFileName, path::filename(NewFilePath.getCanonicalPath()));
       NewFileName = path::convert_to_slash(NewFileName, path::Style::native);

--- a/clang/lib/DPCT/RulesInclude/InclusionHeaders.cpp
+++ b/clang/lib/DPCT/RulesInclude/InclusionHeaders.cpp
@@ -180,8 +180,8 @@ void IncludesCallbacks::InclusionDirective(
       auto &Vec = DpctGlobalInfo::getInstance().getCSourceFileList();
       path::replace_extension(
           NewFileName, "{{NEEDREPLACEE" + std::to_string(Vec.size()) + "}}");
-      Vec.push_back(std::pair<tooling::UnifiedPath, std::string>(IncludedFile,
-                                                                 Extension));
+      Vec.push_back(std::pair<tooling::UnifiedPath, std::string>(
+          IncludedFile, Extension.substr(1)));
     } else {
       clang::tooling::UnifiedPath NewFilePath = FileName;
       rewriteFileName(NewFilePath, IncludedFile);

--- a/clang/lib/DPCT/RulesInclude/InclusionHeaders.cpp
+++ b/clang/lib/DPCT/RulesInclude/InclusionHeaders.cpp
@@ -10,6 +10,7 @@
 #include "PreProcessor.h"
 #include "UserDefinedRules/UserDefinedRules.h"
 #include <optional>
+#include <string>
 
 namespace clang {
 namespace dpct {
@@ -179,8 +180,8 @@ void IncludesCallbacks::InclusionDirective(
       auto &Vec = DpctGlobalInfo::getInstance().getCSourceFileList();
       path::replace_extension(
           NewFileName, "{{NEEDREPLACEE" + std::to_string(Vec.size()) + "}}");
-      Vec.push_back(IncludedFile);
-      Vec.push_back(Extension);
+      Vec.push_back(std::pair<tooling::UnifiedPath, std::string>(IncludedFile,
+                                                                 Extension));
     } else {
       clang::tooling::UnifiedPath NewFilePath = FileName;
       rewriteFileName(NewFilePath, IncludedFile);

--- a/clang/lib/DPCT/RulesInclude/InclusionHeaders.cpp
+++ b/clang/lib/DPCT/RulesInclude/InclusionHeaders.cpp
@@ -10,7 +10,6 @@
 #include "PreProcessor.h"
 #include "UserDefinedRules/UserDefinedRules.h"
 #include <optional>
-#include <string>
 
 namespace clang {
 namespace dpct {

--- a/clang/lib/DPCT/RulesInclude/InclusionHeaders.cpp
+++ b/clang/lib/DPCT/RulesInclude/InclusionHeaders.cpp
@@ -175,7 +175,6 @@ void IncludesCallbacks::InclusionDirective(
     const auto Extension = path::extension(FileName);
     SmallString<512> NewFileName(FileName.str());
 
-    SourceProcessType FileType = GetSourceFileType(FileName);
     if (Extension == ".c" || Extension == ".h" || Extension == ".cc") {
       auto &Vec = DpctGlobalInfo::getInstance().getCSourceFileList();
       path::replace_extension(
@@ -184,9 +183,7 @@ void IncludesCallbacks::InclusionDirective(
       Vec.push_back(Extension);
     } else {
       clang::tooling::UnifiedPath NewFilePath = FileName;
-      printf("IncludedFile:%s\n", IncludedFile.getCanonicalPath().str().c_str());
       rewriteFileName(NewFilePath, IncludedFile);
-      printf("NewFilePath:%s\n", NewFilePath.getCanonicalPath().str().c_str());
       path::remove_filename(NewFileName);
       path::append(NewFileName, path::filename(NewFilePath.getCanonicalPath()));
       NewFileName = path::convert_to_slash(NewFileName, path::Style::native);

--- a/clang/test/dpct/include/main.cu
+++ b/clang/test/dpct/include/main.cu
@@ -66,7 +66,7 @@
 // CHECK: #include "test9.cc.dp.cpp"
 #include "test9.cc"
 // case 10: source file has CUDA syntax, not in database.
-// CHECK: #include "test10.cc"
+// CHECK: #include "test10.cc.dp.cpp"
 #include "test10.cc"
 // case 11: source file does not have CUDA syntax, in database.
 // CHECK: #include "test11.cc"

--- a/clang/test/dpct/include/main.cu
+++ b/clang/test/dpct/include/main.cu
@@ -53,9 +53,6 @@
 // case 4: cuh file not in database.
 // CHECK: #include "test4.dp.hpp"
 #include "test4.cuh"
-// case 5: header file has CUDA syntax, in database.
-// CHECK: #include "test5.h.dp.cpp"
-#include "test5.h"
 // case 6: header file has CUDA syntax, not in database.
 // CHECK: #include "test6.h"
 #include "test6.h"

--- a/clang/test/dpct/include/main.cu
+++ b/clang/test/dpct/include/main.cu
@@ -66,7 +66,7 @@
 // CHECK: #include "test9.cc.dp.cpp"
 #include "test9.cc"
 // case 10: source file has CUDA syntax, not in database.
-// CHECK: #include "test10.cc.dp.cpp"
+// CHECK: #include "test10.cc"
 #include "test10.cc"
 // case 11: source file does not have CUDA syntax, in database.
 // CHECK: #include "test11.cc"

--- a/clang/test/dpct/yaml_has_cuda_syntax/MainSourceFiles.ref
+++ b/clang/test/dpct/yaml_has_cuda_syntax/MainSourceFiles.ref
@@ -1,0 +1,7 @@
+// CHECK: MainSourceFilesDigest:
+// CHECK-NEXT:   - MainSourceFile:  '{{(.+)}}common.cpp'
+// CHECK-NEXT:     Digest:          {{(.+)}}
+// CHECK-NEXT:     HasCUDASyntax:   false
+// CHECK-NEXT:   - MainSourceFile:  '{{(.+)}}yaml_has_cuda_syntax/utils.cpp'
+// CHECK-NEXT:     Digest:          {{(.+)}}
+// CHECK-NEXT:     HasCUDASyntax:   true

--- a/clang/test/dpct/yaml_has_cuda_syntax/common.cpp
+++ b/clang/test/dpct/yaml_has_cuda_syntax/common.cpp
@@ -17,7 +17,7 @@
 // RUN: %if build_lit %{icpx -c -fsycl %T/out/common.cpp -o %T/out/common.o %}
 
 // RUN: FileCheck %S/utils.cpp --match-full-lines --input-file %T/out/utils.cpp.dp.cpp
-// RUN: %if build_lit %{icpx -c -fsycl %T/out/utils.cpp.dp.cpp -o %T/out/ utils.cpp.dp.o %}
+// RUN: %if build_lit %{icpx -c -fsycl %T/out/utils.cpp.dp.cpp -o %T/out/utils.cpp.dp.o %}
 
 // RUN: cat %S/MainSourceFiles.ref > %T/out/check_MainSourceFiles.yaml
 // RUN: cat %T/out/MainSourceFiles.yaml >>%T/out/check_MainSourceFiles.yaml

--- a/clang/test/dpct/yaml_has_cuda_syntax/common.cpp
+++ b/clang/test/dpct/yaml_has_cuda_syntax/common.cpp
@@ -1,0 +1,32 @@
+// UNSUPPORTED: system-windows
+// RUN: echo "[" > %T/compile_commands.json
+// RUN: echo "    {" >> %T/compile_commands.json
+// RUN: echo "        \"command\": \"nvcc %S/common.cpp\"," >> %T/compile_commands.json
+// RUN: echo "        \"directory\": \"%T\"," >> %T/compile_commands.json
+// RUN: echo "        \"file\": \"%S/common.cpp\"" >> %T/compile_commands.json
+// RUN: echo "    }," >> %T/compile_commands.json
+// RUN: echo "    {" >> %T/compile_commands.json
+// RUN: echo "        \"command\": \"nvcc %S/utils.cpp\"," >> %T/compile_commands.json
+// RUN: echo "        \"directory\": \"%T\"," >> %T/compile_commands.json
+// RUN: echo "        \"file\": \"%S/utils.cpp\"" >> %T/compile_commands.json
+// RUN: echo "    }" >> %T/compile_commands.json
+// RUN: echo "]" >> %T/compile_commands.json
+
+// RUN: dpct -in-root=%S -p=%T --out-root=%T/out --cuda-include-path="%cuda-path/include"
+// RUN: FileCheck %s --match-full-lines --input-file %T/out/common.cpp
+// RUN: %if build_lit %{icpx -c -fsycl %T/out/common.cpp -o %T/out/common.o %}
+
+// RUN: FileCheck %S/utils.cpp --match-full-lines --input-file %T/out/utils.cpp.dp.cpp
+// RUN: %if build_lit %{icpx -c -fsycl %T/out/utils.cpp.dp.cpp -o %T/out/ utils.cpp.dp.o %}
+
+// RUN: cat %S/MainSourceFiles.ref > %T/out/check_MainSourceFiles.yaml
+// RUN: cat %T/out/MainSourceFiles.yaml >>%T/out/check_MainSourceFiles.yaml
+// RUN: FileCheck --match-full-lines --input-file %T/out/check_MainSourceFiles.yaml %T/out/check_MainSourceFiles.yaml
+
+// CHECK: #include <cmath>
+
+void test() {
+  int a = -1;
+  // CHECK: abs(a);
+  abs(a);
+}

--- a/clang/test/dpct/yaml_has_cuda_syntax/utils.cpp
+++ b/clang/test/dpct/yaml_has_cuda_syntax/utils.cpp
@@ -1,0 +1,10 @@
+// UNSUPPORTED: system-windows
+// RUN: echo "empty command"
+
+
+#include <iostream>
+#include <cuda_runtime.h>
+
+// CHECK: void test_foo(){
+__device__ void test_foo(void){
+}


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>
