### PR TITLE
Use indirectly_device_accessible not "is_passed_directly"

### DIFF
--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/iterator_adaptor.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/iterator_adaptor.h
@@ -36,7 +36,12 @@ protected:
 public:
   // It is the user's responsibility to ensure extra data is available on the
   // device if they want to use this iterator with device execution policies
-  using is_passed_directly = ::std::true_type;
+  // TODO: consider deferring this indirectly device accessible check to the
+  // base iterator, rather than returning true
+  friend auto is_onedpl_indirectly_device_accessible(iterator_adaptor)
+      -> ::std::true_type {
+    return {};
+  }
   using iterator_category = ::std::random_access_iterator_tag;
 
   iterator_adaptor() {}

--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/iterators.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/iterators.h
@@ -78,7 +78,10 @@ oneapi::dpl::counting_iterator<T> make_counting_iterator(const T &input) {
 template <typename _Tp> class constant_iterator {
 public:
   typedef std::false_type is_hetero;
-  typedef std::true_type is_passed_directly;
+  friend auto is_onedpl_indirectly_device_accessible(constant_iterator)
+      -> std::true_type {
+    return {};
+  }
   typedef std::ptrdiff_t difference_type;
   typedef _Tp value_type;
   typedef _Tp *pointer;

--- a/clang/runtime/dpct-rt/include/dpct/dpl_extras/memory.h
+++ b/clang/runtime/dpct-rt/include/dpct/dpl_extras/memory.h
@@ -233,7 +233,6 @@ public:
   using reference = value_type &;
   using iterator_category = std::random_access_iterator_tag;
   using is_hetero = std::true_type; // required
-  using is_passed_directly = std::false_type;
   static constexpr sycl::access_mode mode = Mode; // required
 
   device_pointer(sycl::buffer<value_type, 1> in, std::size_t i = 0)
@@ -280,7 +279,6 @@ public:
   using reference = T &;
   using iterator_category = std::random_access_iterator_tag;
   using is_hetero = std::true_type; // required
-  using is_passed_directly = std::false_type;
   static constexpr sycl::access_mode mode = Mode; // required
 
   device_pointer(sycl::buffer<T, 1> in, std::size_t i = 0) : base_type(in, i) {}
@@ -376,8 +374,11 @@ public:
   using reference = value_type &;
   using const_reference = const value_type &;
   using iterator_category = std::random_access_iterator_tag;
-  using is_hetero = std::false_type;         // required
-  using is_passed_directly = std::true_type; // required
+  using is_hetero = std::false_type; // required
+  friend auto is_onedpl_indirectly_device_accessible(device_pointer)
+      -> std::true_type {
+    return {};
+  }
 
   device_pointer(void *p) : base_type(static_cast<value_type *>(p)) {}
   // needed for malloc_device, count is number of bytes to allocate
@@ -420,8 +421,11 @@ public:
   using reference = T &;
   using const_reference = const T &;
   using iterator_category = std::random_access_iterator_tag;
-  using is_hetero = std::false_type;         // required
-  using is_passed_directly = std::true_type; // required
+  using is_hetero = std::false_type; // required
+  friend auto is_onedpl_indirectly_device_accessible(device_pointer)
+      -> std::true_type {
+    return {};
+  }
 
   device_pointer(T *p) : base_type(p) {}
   // needed for malloc_device, count is number of bytes to allocate
@@ -469,7 +473,6 @@ public:
   using reference = T &;
   using iterator_category = std::random_access_iterator_tag;
   using is_hetero = std::true_type;                // required
-  using is_passed_directly = std::false_type;      // required
   static constexpr sycl::access_mode mode = Mode; // required
 
   device_iterator() : Base() {}
@@ -563,8 +566,11 @@ public:
   using pointer = typename Base::pointer;
   using reference = typename Base::reference;
   using iterator_category = std::random_access_iterator_tag;
-  using is_hetero = std::false_type;         // required
-  using is_passed_directly = std::true_type; // required
+  using is_hetero = std::false_type; // required
+  friend auto is_onedpl_indirectly_device_accessible(device_iterator)
+      -> std::true_type {
+    return {};
+  }
   static constexpr sycl::access_mode mode =
       sycl::access_mode::read_write; // required
 
@@ -730,7 +736,10 @@ public:
   using reference = T &;
   using iterator_category = std::random_access_iterator_tag;
   using is_hetero = ::std::false_type;
-  using is_passed_directly = std::true_type;
+  friend auto is_onedpl_indirectly_device_accessible(tagged_pointer)
+      -> std::true_type {
+    return {};
+  }
 
   tagged_pointer() : m_ptr(nullptr) {}
   tagged_pointer(T *ptr) : m_ptr(ptr) {}


### PR DESCRIPTION
Replace is_passed_directly unofficial interface with the new indirectly device accessible customization point everywhere in SYCLomatic.