### PR TITLE
Add backwards compatibility with older oneAPI compilers for non-uniform group APIs

### DIFF
--- a/clang/runtime/dpct-rt/include/dpct/util.hpp
+++ b/clang/runtime/dpct-rt/include/dpct/util.hpp
@@ -602,11 +602,21 @@ T shift_sub_group_left(sycl::sub_group sg, T input, int delta, int last_item,
   return result;
 #else
   if ((1U << sg.get_local_linear_id()) & member_mask) {
+#if defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER < 20260000
+    auto inner = sycl::ext::oneapi::experimental::get_tangle_group(sg);
+#else
     auto inner = sycl::ext::oneapi::experimental::entangle(sg);
+#endif
     sycl::group_barrier(inner);
   }
+#if defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER < 20260000
+  auto partition =
+      sycl::ext::oneapi::experimental::get_fixed_size_group<LogicSubGroupSize>(
+          sg);
+#else
   auto partition =
       sycl::ext::oneapi::experimental::chunked_partition<LogicSubGroupSize>(sg);
+#endif
   int id = partition.get_local_linear_id();
   T result = sycl::shift_group_left(partition, input, delta);
   if ((id + delta) > last_item)
@@ -639,11 +649,21 @@ T shift_sub_group_right(sycl::sub_group sg, T input, int delta, int first_item,
   return result;
 #else
   if ((1U << sg.get_local_linear_id()) & member_mask) {
+#if defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER < 20260000
+    auto inner = sycl::ext::oneapi::experimental::get_tangle_group(sg);
+#else
     auto inner = sycl::ext::oneapi::experimental::entangle(sg);
+#endif
     sycl::group_barrier(inner);
   }
+#if defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER < 20260000
+  auto partition =
+      sycl::ext::oneapi::experimental::get_fixed_size_group<LogicSubGroupSize>(
+          sg);
+#else
   auto partition =
       sycl::ext::oneapi::experimental::chunked_partition<LogicSubGroupSize>(sg);
+#endif
   int id = sg.get_local_linear_id();
   T result = sycl::shift_group_right(partition, input, delta);
   if ((id - first_item) < delta)


### PR DESCRIPTION
Follow-up to https://github.com/oneapi-src/SYCLomatic/commit/fe2a343d69a6668919a27d5be6ae161b1bbbc2ba as we have use cases to maintain compatibility with different compiler versions.

If a user is using a compiler built from https://github.com/intel/llvm, then this patch expects it to be a recent build using the latest version of the non-uniform group APIs. All oneAPI compilers that support the non-uniform group extension are supported.